### PR TITLE
Update Transpose.Build.Target SDK to 26.7.2669

### DIFF
--- a/BCL/Transpose.BCL/Transpose.BCL.csproj
+++ b/BCL/Transpose.BCL/Transpose.BCL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose</AssemblyName>

--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.Core</AssemblyName>

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.Howler</AssemblyName>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.HttpClient</AssemblyName>

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Transpose.Build.Target/25.11.62725">
+﻿<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.Newtonsoft.Json</AssemblyName>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.P2</AssemblyName>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.WebGL2</AssemblyName>

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/25.11.62725">
+<Project Sdk="Transpose.Build.Target/26.7.2669">
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <LangVersion>7.2</LangVersion>


### PR DESCRIPTION
Bump the Transpose.Build.Target SDK version from 25.11.62725 to the latest published NuGet release 26.7.2669 across all projects that reference it (BCL, Core, the binding packages, and the project template).


Claude-Session: https://claude.ai/code/session_012e9iBRSsZZsJFSBKe3xuMR