### PR TITLE
Fix dotnet tool install command in SDK documentation

### DIFF
--- a/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
+++ b/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
@@ -457,7 +457,7 @@
 
   <!-- The Transpose (tps) compiler is a plain Roslyn-based CLI: no compilation server and no
        online check. It is invoked once per project. Install it as a global dotnet tool
-       (`dotnet tool install --global Transpose.Compiler`) or reference it as a local tool and set
+       (`dotnet tool install -g Transpose.Compiler`) or reference it as a local tool and set
        UseLocalTranspose=true. -->
   <Target Name="_TransposeBuild"
       DependsOnTargets="SourceFilesProjectOutputGroup;GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles;_ComputeReferenceAssemblies;_ComputeUserRuntimeAssemblies;_CopyReferenceOnlyAssembliesForBuild"


### PR DESCRIPTION
## Summary
Updated the documentation comment in the Transpose SDK targets file to use the correct short form of the `dotnet tool install` command.

## Changes
- Changed `dotnet tool install --global` to `dotnet tool install -g` in the `_TransposeBuild` target documentation comment
  - The `-g` flag is the standard short form for the `--global` option in dotnet CLI
  - This aligns with common dotnet tool installation practices and improves consistency in documentation

## Details
The comment describes how to install the Transpose compiler (`tps`) as a global dotnet tool. The change uses the more concise `-g` short form instead of the verbose `--global` flag, making the documentation example more idiomatic while maintaining the same functionality.

https://claude.ai/code/session_01PgEqXLX3whgbfK6i1TyQgL