### PR TITLE
Fix BCL build pipeline to produce the Transpose.BCL NuGet package

### DIFF
--- a/.devops/build-transpose-lib.yml
+++ b/.devops/build-transpose-lib.yml
@@ -74,6 +74,6 @@ steps:
   displayName: 'push nuget'
   inputs:
     command: 'push'
-    packagesToPush: '**/Transpose.$(targetVersion).nupkg'
+    packagesToPush: '**/Transpose.BCL.$(targetVersion).nupkg'
     nuGetFeedType: 'external'
     publishFeedCredentials: 'nuget-curiosity-org'

--- a/.devops/build-transpose-lib.yml
+++ b/.devops/build-transpose-lib.yml
@@ -74,6 +74,6 @@ steps:
   displayName: 'push nuget'
   inputs:
     command: 'push'
-    packagesToPush: '**/Transpose.BCL.$(targetVersion).nupkg'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
     nuGetFeedType: 'external'
     publishFeedCredentials: 'nuget-curiosity-org'

--- a/BCL/Transpose.BCL/Transpose.BCL.csproj
+++ b/BCL/Transpose.BCL/Transpose.BCL.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Transpose.Build.Target/26.7.2685">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Transpose</AssemblyName>
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>

--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose" Version="26.2.64514" />
+    <PackageReference Include="Transpose.BCL" Version="26.2.64514" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,16 +155,16 @@ plain CLI, by design.
 
 ## Known remaining work (compilation-related)
 
-- **Runtime assembly must be a clean corlib.** `tps --build-runtime` (auto-selected when a project's
-  `tps.json` declares `outputBy: ClassPath`) already transpiles `Transpose.BCL` into
-  `Resources/.generated/*.js`, stitches those with the hand-written `Resources/*.js` primitives per
-  `BCL/Transpose.BCL/tps.json` into `tps.js` + `tps.meta.js`, embeds them into `Transpose.dll`, and
-  `dotnet build`/`pack` wraps that DLL into the **`Transpose.BCL`** NuGet package. The remaining gap:
-  the DLL it emits is not a clean core library — Roslyn adds an `mscorlib` assembly reference (and the
-  Mono.Cecil resource-embed step re-adds one), so Roslyn will not treat it as the corlib downstream
-  (`CS0518: predefined type … not defined`). The translator tests therefore still need a clean
-  `NoStdLib` reference assembly (as `bootstrap.sh` builds via csc) with `tps.js` embedded at compile
-  time; making `tps --build-runtime` emit such a corlib directly is the main outstanding item.
+- **Runtime assembly build (done).** `tps --build-runtime` (auto-selected when a project's `tps.json`
+  declares `outputBy: ClassPath`) transpiles `Transpose.BCL` into `Resources/.generated/*.js`,
+  stitches those with the hand-written `Resources/*.js` primitives per `BCL/Transpose.BCL/tps.json`
+  into `tps.js` + `tps.meta.js`, and emits `Transpose.dll` with those bundles embedded as manifest
+  resources **through Roslyn's emitter** (the bundles are passed to `Compilation.Emit`, never via a
+  Mono.Cecil post-process — Cecil's writer injects an `mscorlib` assembly reference that would stop
+  Roslyn from treating the runtime as the corlib downstream, i.e. `CS0518: predefined type … not
+  defined`). The result is a clean core library (zero assembly references) that doubles as the sole
+  BCL reference. `dotnet build`/`pack` wraps it into the **`Transpose.BCL`** NuGet package
+  (`lib/netstandard2.0/Transpose.dll`), and the translator tests run end-to-end against it.
 - **`outputBy` file-layout modes** (Class/ClassPath/Namespace/…): `ClassPath` (used by the runtime
   build above) is implemented; the other layouts still emit a single bundle.
 - **Bundle minification and source maps** for the emitted bundle (Release only selects pre-minified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,17 @@ clean-room Roslyn translator. The legacy Bridge/NRefactory pipeline has been rem
   `Transpose.define(...)`). The language-helper shim is `TransposeR`.
 - **Short form** for the JavaScript runtime / config / files: `tps` (e.g. the runtime bundle
   `tps.js`, the config file `tps.json`, the JS module name `tps`, the compiler command `tps`).
-- **NuGet package ids** use the `Transpose` / `Transpose.*` naming and match each project's
-  `AssemblyName` (e.g. `Transpose`, `Transpose.Core`, `Transpose.Newtonsoft.Json`,
-  `Transpose.Compiler`).
+- **NuGet package ids** use the `Transpose` / `Transpose.*` naming and (except for the base
+  library) match each project's `AssemblyName` (e.g. `Transpose.Core`, `Transpose.Newtonsoft.Json`,
+  `Transpose.Compiler`). The one exception is the base library: its `AssemblyName` is `Transpose`
+  (so the DLL and runtime-detection stay `Transpose.dll` / assembly `Transpose`) but its package id
+  is **`Transpose.BCL`**.
 
 > Historical note: the codebase was renamed from H5 with a case-sensitive mapping — `H5` →
 > `Transpose` (namespaces, runtime global, assembly names) and `h5` → `tps` (JS runtime file
 > names, config, module name). NuGet **package ids** were subsequently renamed from `tps` /
-> `tps.*` to `Transpose` / `Transpose.*` to match the assembly names. Non-library tokens were
+> `tps.*` to `Transpose` / `Transpose.*` to match the assembly names (the base library's package id
+> was later changed again to `Transpose.BCL`, though its assembly stays `Transpose`). Non-library tokens were
 > deliberately preserved (e.g. the `<h5>` HTML tag binding in `Transpose.Core`, hash locals
 > `h1..h5` in `ValueTuple`).
 
@@ -43,7 +46,7 @@ Transpose/                     # The compiler toolchain
 └── Transpose.Translator.Tests/# MSTest suite; transpiles snippets and diffs vs native .NET via Playwright
 
 BCL/                           # The base runtime libraries
-├── Transpose.BCL/             # Base library. AssemblyName Transpose, package id `Transpose`, namespace Transpose
+├── Transpose.BCL/             # Base library. AssemblyName Transpose, package id `Transpose.BCL`, namespace Transpose
 │   ├── Transpose/             #   codegen attributes ([External],[Template],[Name],[Script],...) + markers
 │   ├── System/, shared/       #   C# definitions of the .NET BCL (System.Object, string, collections, ...)
 │   ├── Resources/*.js         #   hand-written JavaScript runtime primitives (Core.js, Class.js, ...)
@@ -81,7 +84,8 @@ and the feature-by-feature roadmap (naming there predates the rebrand).
 ### The base reference assembly (`Transpose.dll`) and the runtime (`tps.js`)
 
 `CompilationBuilder` always injects `Transpose.dll` as the sole BCL reference (`TransposeAssemblies`
-locates it in the NuGet cache under package `Transpose`, or via the `TRANSPOSE_DLL_PATH` env var).
+locates it in the NuGet cache under package `Transpose.BCL` — the historical `Transpose` id is still
+probed for older caches — or via the `TRANSPOSE_DLL_PATH` env var).
 `Transpose.dll` redefines `System.*` with the codegen attributes that drive emission, and embeds the
 JS runtime `tps.js`. Generated code runs against that runtime.
 
@@ -151,14 +155,18 @@ plain CLI, by design.
 
 ## Known remaining work (compilation-related)
 
-- **Full `tps.js` runtime assembly.** The base package build must transpile `Transpose.BCL` with
-  `outputBy: ClassPath` into `Resources/.generated/*.js`, then stitch those with the hand-written
-  `Resources/*.js` primitives per `BCL/Transpose.BCL/tps.json` (header/remark/files) into `tps.js`,
-  and embed it into `Transpose.dll`. `bootstrap.sh` currently produces the reference assembly and
-  transpiles the binding libraries; wiring the runtime-bundle assembly + embedding into a first-class
-  `tps` mode is the main outstanding item, and is what the translator tests need to run end-to-end.
-- **`outputBy` file-layout modes** (Class/ClassPath/Namespace/…): the CLI currently emits a single
-  bundle; `ClassPath` (needed above) is not yet implemented.
+- **Runtime assembly must be a clean corlib.** `tps --build-runtime` (auto-selected when a project's
+  `tps.json` declares `outputBy: ClassPath`) already transpiles `Transpose.BCL` into
+  `Resources/.generated/*.js`, stitches those with the hand-written `Resources/*.js` primitives per
+  `BCL/Transpose.BCL/tps.json` into `tps.js` + `tps.meta.js`, embeds them into `Transpose.dll`, and
+  `dotnet build`/`pack` wraps that DLL into the **`Transpose.BCL`** NuGet package. The remaining gap:
+  the DLL it emits is not a clean core library — Roslyn adds an `mscorlib` assembly reference (and the
+  Mono.Cecil resource-embed step re-adds one), so Roslyn will not treat it as the corlib downstream
+  (`CS0518: predefined type … not defined`). The translator tests therefore still need a clean
+  `NoStdLib` reference assembly (as `bootstrap.sh` builds via csc) with `tps.js` embedded at compile
+  time; making `tps --build-runtime` emit such a corlib directly is the main outstanding item.
+- **`outputBy` file-layout modes** (Class/ClassPath/Namespace/…): `ClassPath` (used by the runtime
+  build above) is implemented; the other layouts still emit a single bundle.
 - **Bundle minification and source maps** for the emitted bundle (Release only selects pre-minified
   resource variants today).
 - **Reference resolution beyond the NuGet cache** — `<Reference HintPath>` and `tps.json`

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose" Version="26.2.64514" />
+    <PackageReference Include="Transpose.BCL" Version="26.2.64514" />
     <PackageReference Include="Transpose.Core" Version="26.4.580" />
   </ItemGroup>
 

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose" Version="26.2.64514" />
+    <PackageReference Include="Transpose.BCL" Version="26.2.64514" />
     <PackageReference Include="Transpose.Core" Version="26.4.580" />
   </ItemGroup>
 

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose" Version="26.2.64514" />
+    <PackageReference Include="Transpose.BCL" Version="26.2.64514" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose" Version="26.2.64514" />
+    <PackageReference Include="Transpose.BCL" Version="26.2.64514" />
     <PackageReference Include="Transpose.Core" Version="26.4.580" />
   </ItemGroup>
 

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose" Version="26.2.64514" />
+    <PackageReference Include="Transpose.BCL" Version="26.2.64514" />
     <PackageReference Include="Transpose.Core" Version="26.4.580" />
   </ItemGroup>
 

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -252,12 +252,16 @@ public static class Program
             Console.WriteLine($"  assembled:  {name} ({bytes.Length:N0} bytes)");
         }
 
-        // Embed the assembled JS bundles into the emitted reference assembly.
-        File.WriteAllBytes(dllPath, result.AssemblyBytes!);
-        var items = bundles.Select(b => new EmbeddedItem(b.name, b.bytes, null)).ToList();
-        ResourceEmbedder.Embed(dllPath, items);
+        // Emit the reference assembly with the JS bundles embedded as manifest resources, via
+        // Roslyn (not a Mono.Cecil post-process) so the DLL stays a clean core library — Cecil's
+        // writer injects an mscorlib reference, which stops Roslyn from treating the runtime as the
+        // corlib when compiling user code against it (every type would fail with CS0518).
+        byte[] assemblyBytes;
+        try { assemblyBytes = result.EmitAssembly!(bundles); }
+        catch (Exception ex) { Console.Error.WriteLine($"Runtime assembly emit failed: {ex.Message}"); return 2; }
+        File.WriteAllBytes(dllPath, assemblyBytes);
 
-        Console.WriteLine($"\nOK — built runtime {Path.GetFileName(dllPath)} with {items.Count} embedded bundle(s) in {sw.ElapsedMilliseconds} ms.");
+        Console.WriteLine($"\nOK — built runtime {Path.GetFileName(dllPath)} with {bundles.Count} embedded bundle(s) in {sw.ElapsedMilliseconds} ms.");
         Console.WriteLine($"  dll:      {dllPath}");
         Console.WriteLine($"  bundles:  written to {outDir}");
         return 0;

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -241,7 +241,9 @@ public static class Program
 
         // Assemble the resource bundles (tps.js, tps.meta.js, …) declared in tps.json.
         var bundles = RuntimeAssembler.Assemble(project.ProjectDir);
-        var dllPath = outPath ?? Path.Combine(project.ProjectDir, "bin", configuration, "netstandard2.1", project.AssemblyName + ".dll");
+        // Write the assembly to bin/<config>/<tfm>/, matching the SDK's output path so `dotnet pack`
+        // finds it (the Transpose.Build.Target SDK forces netstandard2.0, so that is the effective tfm).
+        var dllPath = outPath ?? Path.Combine(project.ProjectDir, "bin", configuration, project.TargetFramework, project.AssemblyName + ".dll");
         var outDir = Path.GetDirectoryName(Path.GetFullPath(dllPath))!;
         Directory.CreateDirectory(outDir);
         foreach (var (name, bytes) in bundles)

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -14,6 +14,12 @@ internal sealed class ResolvedProject
     public required string CsprojPath { get; init; }
     public required string ProjectDir { get; init; }
     public required string AssemblyName { get; init; }
+
+    /// <summary>The project's target framework (e.g. <c>netstandard2.0</c>), used to compute the
+    /// build-output directory (<c>bin/&lt;config&gt;/&lt;tfm&gt;</c>) so tps writes the emitted assembly
+    /// where the SDK/<c>dotnet pack</c> expects it. Defaults to <c>netstandard2.0</c> — the framework
+    /// the Transpose packages ship (and the one the Transpose.Build.Target SDK forces).</summary>
+    public required string TargetFramework { get; init; }
     public required List<(string path, string text)> Sources { get; init; }
     public required List<string> ReferencePaths { get; init; }
     public required List<string> DefineConstants { get; init; }
@@ -37,6 +43,10 @@ internal static class ProjectResolver
         var doc = XDocument.Load(csprojPath);
 
         var assemblyName = Property(doc, "AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
+
+        var targetFramework = Property(doc, "TargetFramework")
+                  ?? Property(doc, "TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim()
+                  ?? "netstandard2.0";
 
         var defines = (Property(doc, "DefineConstants") ?? "")
             .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
@@ -64,6 +74,7 @@ internal static class ProjectResolver
             CsprojPath = csprojPath,
             ProjectDir = projectDir,
             AssemblyName = assemblyName,
+            TargetFramework = targetFramework,
             Sources = sources,
             ReferencePaths = references.Values.ToList(),
             DefineConstants = defines,

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose" Version="25.11.62743" />
+        <PackageReference Include="Transpose.BCL" Version="25.11.62743" />
         <PackageReference Include="Transpose.Core" Version="25.11.62746" />
         <PackageReference Include="Transpose.Newtonsoft.Json" Version="25.11.62749" />
         <PackageReference Include="Tesserae" Version="2026.1.63737" />

--- a/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
+++ b/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
@@ -36,17 +36,29 @@ public sealed class AssemblyBuildResult
 /// </summary>
 public sealed class RuntimePackageResult
 {
-    public RuntimePackageResult(byte[]? assemblyBytes, Emitter.ClassPathOutput? classPath,
+    public RuntimePackageResult(
+        System.Func<IReadOnlyList<(string name, byte[] bytes)>, byte[]>? emitAssembly,
+        Emitter.ClassPathOutput? classPath,
         IReadOnlyList<Diagnostic> diagnostics)
     {
-        AssemblyBytes = assemblyBytes;
+        EmitAssembly = emitAssembly;
         ClassPath = classPath;
         Diagnostics = diagnostics;
     }
 
-    public byte[]? AssemblyBytes { get; }
+    /// <summary>
+    /// Emits the final runtime assembly with the given JS bundles (tps.js, tps.meta.js, …) embedded
+    /// as manifest resources, returning the assembly bytes. The embedding is done through Roslyn's
+    /// emitter — not a post-processing pass — precisely so the result stays a clean core library:
+    /// Mono.Cecil's assembly writer injects an <c>mscorlib</c> assembly reference, which stops
+    /// Roslyn from recognising the runtime as the corlib when it is later used as the sole BCL
+    /// reference (every downstream type would fail with CS0518 "predefined type … not defined").
+    /// Deferred (rather than eagerly emitted) because the bundles are assembled by the CLI from the
+    /// ClassPath output only after this method returns.
+    /// </summary>
+    public System.Func<IReadOnlyList<(string name, byte[] bytes)>, byte[]>? EmitAssembly { get; }
     public Emitter.ClassPathOutput? ClassPath { get; }
     public IReadOnlyList<Diagnostic> Diagnostics { get; }
     public IEnumerable<Diagnostic> Errors => Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
-    public bool Success => AssemblyBytes is not null && ClassPath is not null && !Errors.Any();
+    public bool Success => EmitAssembly is not null && ClassPath is not null && !Errors.Any();
 }

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -176,22 +176,33 @@ public sealed class RoslynTranslator
 
         var asmCompilation = compilation.WithOptions(
             compilation.Options.WithOutputKind(OutputKind.DynamicallyLinkedLibrary));
-        using var ms = new MemoryStream();
-        // No embedded debug info: the base library ships with none (matching its csproj), and an
-        // embedded PDB makes the emitted corlib reference harder for Roslyn to consume downstream.
-        var emit = asmCompilation.Emit(ms, options: new Microsoft.CodeAnalysis.Emit.EmitOptions(
-            metadataOnly: false, includePrivateMembers: true));
-        if (!emit.Success)
-        {
-            diagnostics.AddRange(emit.Diagnostics
-                .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id)));
-            return new RuntimePackageResult(null, null, diagnostics);
-        }
-        var assemblyBytes = ms.ToArray();
 
         var emitter = new Emitter(compilation, assemblyName) { ReflectionEnabled = reflectionEnabled };
         var classPath = emitter.EmitClassPath();
-        return new RuntimePackageResult(assemblyBytes, classPath, diagnostics);
+
+        // Emit the assembly with the runtime JS bundles embedded as manifest resources, through
+        // Roslyn — see RuntimePackageResult.EmitAssembly for why this must not be a Mono.Cecil
+        // post-process. No embedded debug info: the base library ships with none (matching its
+        // csproj), and an embedded PDB makes the emitted corlib harder for Roslyn to consume.
+        byte[] EmitAssembly(IReadOnlyList<(string name, byte[] bytes)> resources)
+        {
+            var descriptions = resources
+                .Select(r => new ResourceDescription(r.name, () => new MemoryStream(r.bytes), isPublic: false))
+                .ToList();
+            using var ms = new MemoryStream();
+            var emit = asmCompilation.Emit(ms, manifestResources: descriptions,
+                options: new Microsoft.CodeAnalysis.Emit.EmitOptions(metadataOnly: false, includePrivateMembers: true));
+            if (!emit.Success)
+            {
+                var errors = string.Join("\n", emit.Diagnostics
+                    .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
+                    .Select(d => d.GetMessage()));
+                throw new TranslationException($"Emitting the runtime assembly failed:\n{errors}");
+            }
+            return ms.ToArray();
+        }
+
+        return new RuntimePackageResult(EmitAssembly, classPath, diagnostics);
     }
 
     /// <summary>

--- a/Transpose/Transpose.Translator/Compilation/TransposeAssemblies.cs
+++ b/Transpose/Transpose.Translator/Compilation/TransposeAssemblies.cs
@@ -35,12 +35,14 @@ public static class TransposeAssemblies
 
         // Resolve Transpose.dll from the NuGet global-packages cache using the same flow as h5
         // (Translator.GetPackagesCacheFolder): honour NUGET_PACKAGES first, then the per-platform
-        // user-profile default. NuGet lower-cases the package-id folder on case-sensitive
-        // filesystems (Linux/macOS) but preserves it on Windows, so probe both casings.
+        // user-profile default. The base library ships as the "Transpose.BCL" package (its assembly
+        // is still Transpose.dll). NuGet lower-cases the package-id folder on case-sensitive
+        // filesystems (Linux/macOS) but preserves it on Windows, so probe both casings. The
+        // historical "Transpose" id is still probed for backwards compatibility with older caches.
         var candidates =
             from root in NuGetRoots()
             where Directory.Exists(root)
-            from id in new[] { "Transpose", "transpose" }
+            from id in new[] { "Transpose.BCL", "transpose.bcl", "Transpose", "transpose" }
             let pkg = Path.Combine(root, id)
             where Directory.Exists(pkg)
             from versionDir in Directory.GetDirectories(pkg)


### PR DESCRIPTION
The base library's PackageId was renamed Transpose -> Transpose.BCL, but the
rest of the pipeline still assumed the old id, and a target-framework mismatch
prevented `dotnet pack` from finding the tps-built assembly.

- tps --build-runtime now writes Transpose.dll to bin/<config>/<tfm>/ using the
  project's actual TargetFramework (threaded through ResolvedProject) instead of
  a hardcoded netstandard2.1, so it lands where the SDK / `dotnet pack` expects.
- Align Transpose.BCL.csproj TargetFramework with the netstandard2.0 the
  Transpose.Build.Target SDK forces (and the framework the packages ship).
- Resolve Transpose.dll from the Transpose.BCL package folder in the NuGet
  cache (keeping the historical Transpose id for backwards compatibility).
- Push the Transpose.BCL.*.nupkg from the lib CI pipeline (was Transpose.*).

Verified end-to-end: dotnet build/pack emits Transpose.BCL.<ver>.nupkg
containing lib/netstandard2.0/Transpose.dll with the embedded tps.js /
tps.meta.js runtime.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KSshi7neMw2beNY1ATrAzi