### PR TITLE
Auto-enable package emission for plain library projects

### DIFF
--- a/BCL/Transpose.BCL/Transpose.BCL.csproj
+++ b/BCL/Transpose.BCL/Transpose.BCL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.2685">
+<Project Sdk="Transpose.Build.Target/26.7.2692">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Transpose</AssemblyName>

--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Transpose.Build.Target/26.7.2692">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Transpose.Core</AssemblyName>
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>

--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.2685">
+<Project Sdk="Transpose.Build.Target/26.7.2692">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.Core</AssemblyName>

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -66,6 +66,20 @@ public static class Program
             return 1;
         }
 
+        // When the Transpose SDK invokes `tps --project` for a plain library — no explicit `--out`,
+        // not the `--build-runtime` corlib, and no `tps.json` (so it is neither the ClassPath runtime
+        // nor an app that builds a site) — produce the distributable package assembly, exactly as
+        // `--emit-package` does: the .NET DLL (with the compiled JS + Transpose.Resources.json manifest
+        // embedded) that `dotnet pack` wraps into `lib/<tfm>/<Assembly>.dll`. Without this the SDK
+        // build emits only a stray .js and `dotnet pack` fails with NU5026 (<Assembly>.dll not found).
+        // Projects that pass `--out` (bootstrap, tooling) keep writing a single .js bundle unchanged.
+        if (!emitPackage && !buildRuntime && outPath is null
+            && TransposeJson.TryLoad(Path.GetDirectoryName(csproj)!) is null)
+        {
+            emitPackage = true;
+            separateAssemblies = true;
+        }
+
         Console.WriteLine($"tps: compiling {Path.GetFileName(csproj)}");
         var sw = Stopwatch.StartNew();
 


### PR DESCRIPTION
## Summary

When the Transpose SDK invokes the compiler on a plain library project (no explicit `--out`, not a runtime build, and no `tps.json`), automatically enable package emission mode to produce the distributable assembly that `dotnet pack` expects.

## Changes

- **Transpose.Compiler/Program.cs**: Added logic to detect plain library projects and automatically set `emitPackage = true` and `separateAssemblies = true`. This ensures that the `.NET DLL` with embedded compiled JS and manifest is produced, which `dotnet pack` wraps into `lib/<tfm>/<Assembly>.dll`. Without this, the SDK build would emit only a stray `.js` file and `dotnet pack` would fail with error NU5026.

- **BCL/Transpose.Core/Transpose.Core.csproj**: Updated SDK version from `26.7.2685` to `26.7.2692` and changed target framework from `netstandard2.1` to `netstandard2.0` for broader compatibility.

- **BCL/Transpose.BCL/Transpose.BCL.csproj**: Updated SDK version from `26.7.2685` to `26.7.2692`.

## Implementation Details

The auto-detection logic checks three conditions:
- `!emitPackage` — package emission not already explicitly requested
- `!buildRuntime` — not building the corlib runtime
- `outPath is null` — no explicit output path specified (bootstrap/tooling projects pass `--out`)
- `TransposeJson.TryLoad(...) is null` — no `tps.json` present (neither ClassPath runtime nor app building a site)

When all conditions are met, the compiler treats the project as a plain library and enables package emission, matching the behavior of explicit `--emit-package`.

https://claude.ai/code/session_014aGVwzZPjfSS9NZWHJXquv