### PR TITLE
Fix package assembly emission for binding libraries

### DIFF
--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -66,15 +66,20 @@ public static class Program
             return 1;
         }
 
-        // When the Transpose SDK invokes `tps --project` for a plain library — no explicit `--out`,
-        // not the `--build-runtime` corlib, and no `tps.json` (so it is neither the ClassPath runtime
-        // nor an app that builds a site) — produce the distributable package assembly, exactly as
+        // When the Transpose SDK invokes `tps --project` for a library — no explicit `--out` and not
+        // the `--build-runtime` corlib — produce the distributable package assembly, exactly as
         // `--emit-package` does: the .NET DLL (with the compiled JS + Transpose.Resources.json manifest
         // embedded) that `dotnet pack` wraps into `lib/<tfm>/<Assembly>.dll`. Without this the SDK
-        // build emits only a stray .js and `dotnet pack` fails with NU5026 (<Assembly>.dll not found).
+        // build emits only a stray .js (or a runnable site folder) and `dotnet pack` fails with
+        // NU5026 (<Assembly>.dll not found).
+        //
+        // A binding library needs this even when it carries a tps.json (which only configures its JS
+        // layout / embedded resources): tps.json presence alone does not make it a site app. Only a
+        // *non-packable* project with a tps.json builds a runnable site; a packable one is a library.
         // Projects that pass `--out` (bootstrap, tooling) keep writing a single .js bundle unchanged.
         if (!emitPackage && !buildRuntime && outPath is null
-            && TransposeJson.TryLoad(Path.GetDirectoryName(csproj)!) is null)
+            && (ProjectResolver.IsPackable(csproj)
+                || TransposeJson.TryLoad(Path.GetDirectoryName(csproj)!) is null))
         {
             emitPackage = true;
             separateAssemblies = true;
@@ -120,10 +125,15 @@ public static class Program
         // outputBy: ClassPath, stitch the per-class files with the hand-written Resources primitives
         // into tps.js per the project's tps.json, and embed tps.js + tps.meta.js into Transpose.dll.
         //
-        // A project that declares outputBy: ClassPath in its tps.json *defines* the BCL (it is the
-        // base runtime library), so it is always built this way — self-contained, with no
-        // Transpose.dll reference — even when the SDK invokes tps without an explicit --build-runtime.
-        if (buildRuntime || string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase))
+        // This path is ONLY for the base library, which *defines* the BCL and therefore references no
+        // Transpose.dll of its own. A binding library (Transpose.Newtonsoft.Json, Transpose.WebGL2, …)
+        // may also declare outputBy: ClassPath for its JS layout, but it references the Transpose BCL
+        // and must bind against it — compiling it self-contained would leave System.Object and every
+        // other predefined type undefined (CS0518 ×N). Such libraries fall through to the package path.
+        var referencesTransposeBcl = project.ReferencePaths.Any(p =>
+            string.Equals(Path.GetFileNameWithoutExtension(p), "Transpose", StringComparison.OrdinalIgnoreCase));
+        if (buildRuntime
+            || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && !referencesTransposeBcl))
             return BuildRuntime(project, configuration, sw, outPath);
 
         // Reflection settings come from the project's tps.json (target inline vs a .meta.js file).

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -44,9 +44,7 @@ internal static class ProjectResolver
 
         var assemblyName = Property(doc, "AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
 
-        var targetFramework = Property(doc, "TargetFramework")
-                  ?? Property(doc, "TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim()
-                  ?? "netstandard2.0";
+        var targetFramework = EffectiveTargetFramework(doc);
 
         var defines = (Property(doc, "DefineConstants") ?? "")
             .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
@@ -216,6 +214,20 @@ internal static class ProjectResolver
     public static string? OutputDll(string csprojPath, string configuration) => ProjectOutputDll(csprojPath, configuration);
 
     /// <summary>
+    /// True when the project produces a NuGet package (<c>GeneratePackageOnBuild</c> or
+    /// <c>IsPackable</c> set to true). Such a project must emit the package assembly that
+    /// <c>dotnet pack</c> wraps — even when it also carries a tps.json (which only configures its JS
+    /// layout / embedded resources), so it must not be mistaken for a runnable site app.
+    /// </summary>
+    public static bool IsPackable(string csprojPath)
+    {
+        if (!File.Exists(csprojPath)) return false;
+        var doc = XDocument.Load(csprojPath);
+        static bool IsTrue(string? v) => string.Equals(v?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+        return IsTrue(Property(doc, "GeneratePackageOnBuild")) || IsTrue(Property(doc, "IsPackable"));
+    }
+
+    /// <summary>
     /// True if <paramref name="csprojPath"/>'s package DLL is present, carries embedded Transpose resources
     /// (i.e. was built by the translator, not a plain csc build), and is newer than the project's
     /// .csproj, all its source files, and every referenced project's DLL — the same incremental
@@ -259,9 +271,7 @@ internal static class ProjectResolver
         var doc = XDocument.Load(csprojPath);
         var dir = Path.GetDirectoryName(csprojPath)!;
         var asm = Property(doc, "AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
-        var tfm = Property(doc, "TargetFramework")
-                  ?? Property(doc, "TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()
-                  ?? "netstandard2.0";
+        var tfm = EffectiveTargetFramework(doc);
         var binBase = Path.Combine(dir, "bin", configuration, tfm);
         var dll = Path.Combine(binBase, asm + ".dll");
         return dll;
@@ -392,6 +402,27 @@ internal static class ProjectResolver
 
     private static string? Property(XDocument doc, string name)
         => doc.Descendants().FirstOrDefault(e => e.Name.LocalName == name)?.Value;
+
+    /// <summary>
+    /// The target framework the build actually produces its assembly under — the path
+    /// <c>dotnet pack</c> then looks for it at (<c>bin/&lt;config&gt;/&lt;tfm&gt;/&lt;Assembly&gt;.dll</c>).
+    /// The Transpose.Build.Target SDK forcibly overrides <c>&lt;TargetFramework&gt;</c> to
+    /// <c>netstandard2.0</c> in its Sdk.targets (regardless of what the csproj declares), so a
+    /// binding library that declares e.g. <c>netstandard2.1</c> is still built and packed as
+    /// <c>netstandard2.0</c>. Honour that here, otherwise tps writes the DLL under the declared tfm
+    /// and <c>dotnet pack</c> fails with NU5026 (<c>&lt;Assembly&gt;.dll</c> not found).
+    /// </summary>
+    private static string EffectiveTargetFramework(XDocument doc)
+    {
+        var sdk = doc.Root?.Attribute("Sdk")?.Value
+                  ?? doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "Sdk")?.Attribute("Name")?.Value
+                  ?? "";
+        if (sdk.StartsWith("Transpose.Build.Target", StringComparison.OrdinalIgnoreCase))
+            return "netstandard2.0";
+        return Property(doc, "TargetFramework")
+               ?? Property(doc, "TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim()
+               ?? "netstandard2.0";
+    }
 
     private static LanguageVersion ParseLangVersion(string? v)
     {


### PR DESCRIPTION
## Summary

Fixes package assembly emission for binding libraries (Transpose.Newtonsoft.Json, Transpose.WebGL2, etc.) to ensure `dotnet pack` succeeds. The compiler now correctly identifies packable projects and emits the distributable DLL even when they carry a `tps.json` configuration file.

## Key Changes

- **Extract target framework resolution**: Created `EffectiveTargetFramework()` method to centralize logic for determining the actual build target framework. This accounts for the `Transpose.Build.Target` SDK's forced override to `netstandard2.0`, ensuring the compiler writes DLLs to the correct output path that `dotnet pack` expects.

- **Add `IsPackable()` check**: New public method to detect whether a project produces a NuGet package (via `GeneratePackageOnBuild` or `IsPackable` properties). This distinguishes binding libraries from runnable site apps.

- **Refine package emission logic**: Updated `Program.cs` to emit the package assembly for:
  - Projects with no explicit `--out` and not the `--build-runtime` corlib, AND
  - Either marked as packable OR lacking a `tps.json` file
  
  This ensures binding libraries with `tps.json` (which only configures JS layout) still emit their distributable DLL, while non-packable site apps continue to build runnable output.

- **Fix ClassPath compilation path**: Added check to prevent binding libraries that declare `outputBy: ClassPath` from being compiled self-contained. Such libraries reference the Transpose BCL and must bind against it; self-contained compilation would leave predefined types undefined (CS0518). Only the base runtime library (which defines the BCL itself) uses the self-contained path.

- **Correct logo paths**: Fixed relative paths in binding library `.csproj` files from `..\..\..\..\logo\` to `..\..\logo\` to match the actual repository structure.

## Implementation Details

- `EffectiveTargetFramework()` checks the project's SDK attribute to detect `Transpose.Build.Target` and returns `netstandard2.0` accordingly, matching the SDK's build-time override.
- The package emission decision now uses `ProjectResolver.IsPackable()` as the primary indicator, with `tps.json` absence as a fallback for backward compatibility.
- Binding library detection in the ClassPath path uses `ReferencePaths` to check for a `Transpose` assembly reference.

https://claude.ai/code/session_01Bx4uFAQPLF7hfzSCyX57Zm