### PR TITLE
Fix IComparer&lt;T&gt;.Compare casing and PropertyInfo.CanRead/CanWrite reflection

### DIFF
--- a/Transpose/Transpose.Translator.Tests/ReflectionAndComparerTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ReflectionAndComparerTests.cs
@@ -1,0 +1,93 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Regression tests for two runtime/reflection gaps found migrating the Tesserae toolkit:
+    ///  - <see cref="TestStringComparerOrderByAsync"/>: an <c>IComparer&lt;T&gt;</c> implemented by an
+    ///    abstract base and overridden in a derived class (StringComparer/OrdinalComparer) must emit
+    ///    the override under the interface member's camelCase name, so <c>OrderBy(.., comparer)</c>
+    ///    (and any caller) reaches <c>.compare</c> rather than a PascalCase <c>.Compare</c>.
+    ///  - <see cref="TestPropertyInfoCanReadWriteAsync"/>: a field-backed auto-property must emit its
+    ///    g/s accessor records so <c>PropertyInfo.CanRead</c>/<c>CanWrite</c>/<c>GetValue</c>/<c>SetValue</c> work.
+    /// </summary>
+    [TestClass]
+    public class ReflectionAndComparerTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task TestStringComparerOrderByAsync()
+        {
+            await RunTest(
+                @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var items = new List<string> { ""Banana"", ""apple"", ""Cherry"", ""date"", ""Apple"" };
+
+        // OrderBy with StringComparer.OrdinalIgnoreCase (an IComparer<string> whose Compare is an
+        // abstract-base implementation overridden by OrdinalComparer).
+        foreach (var s in items.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+            Console.WriteLine(s);
+
+        // Direct IComparer<string>.Compare call (compare to zero, to stay culture-independent).
+        IComparer<string> c = StringComparer.OrdinalIgnoreCase;
+        Console.WriteLine(c.Compare(""a"", ""B"") < 0);
+        Console.WriteLine(c.Compare(""B"", ""a"") > 0);
+        Console.WriteLine(c.Compare(""x"", ""X"") == 0);
+    }
+}
+                ");
+        }
+
+        [TestMethod]
+        public async Task TestPropertyInfoCanReadWriteAsync()
+        {
+            await RunTest(
+                @"
+using System;
+using System.Reflection;
+
+public class Person
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+    public string ReadOnlyId { get; } = ""id-1"";
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var t = typeof(Person);
+
+        var name = t.GetProperty(""Name"");
+        var age  = t.GetProperty(""Age"");
+        var ro   = t.GetProperty(""ReadOnlyId"");
+
+        Console.WriteLine(name.CanRead + "" "" + name.CanWrite);
+        Console.WriteLine(age.CanRead + "" "" + age.CanWrite);
+        Console.WriteLine(ro.CanRead + "" "" + ro.CanWrite);
+
+        var p = new Person { Name = ""Ada"", Age = 36 };
+        Console.WriteLine(name.GetValue(p));
+        Console.WriteLine(age.GetValue(p));
+        Console.WriteLine(ro.GetValue(p));
+
+        name.SetValue(p, ""Grace"");
+        age.SetValue(p, 45);
+        Console.WriteLine(p.Name + "" "" + p.Age);
+
+        // Instance public properties are discoverable via BindingFlags.
+        Console.WriteLine(t.GetProperties(BindingFlags.Public | BindingFlags.Instance).Length);
+    }
+}
+                ");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Reflection.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Reflection.cs
@@ -274,9 +274,16 @@ public sealed partial class Emitter
         }
 
         var fn = TransposeNaming.MemberJsName(prop);
-        if (prop.GetMethod is { } getter && !SkipMember(getter))
+        // Emit the getter/setter as the property's g/s accessor records (each carries fg/fs = the
+        // backing-field name, so midel reads/writes field-backed auto-properties directly). These
+        // records back PropertyInfo.CanRead/CanWrite (`!!this.g` / `!!this.s`) and GetValue/SetValue.
+        // Do NOT gate this on the general SkipMember, which blanket-skips every PropertyGet/PropertySet
+        // accessor (and any member with an AssociatedSymbol) — that left every property with no g/s,
+        // so CanRead/CanWrite were always false. Only explicit-interface and [NonScriptable] accessors
+        // are excluded here.
+        if (prop.GetMethod is { } getter && !SkipAccessor(getter))
             o.Raw("g", ConstructAccessor(getter, fn, isGetter: true, prop));
-        if (prop.SetMethod is { } setter && !SkipMember(setter))
+        if (prop.SetMethod is { } setter && !SkipAccessor(setter))
             o.Raw("s", ConstructAccessor(setter, fn, isGetter: false, prop));
         if (!prop.IsIndexer) o.Str("fn", fn);
         return o.ToString();
@@ -384,6 +391,17 @@ public sealed partial class Emitter
         if (SkipMember(m)) return false;
         if (m is IMethodSymbol { MethodKind: MethodKind.Constructor }) return true;
         return m.Kind is SymbolKind.Method or SymbolKind.Field or SymbolKind.Property or SymbolKind.Event;
+    }
+
+    /// <summary>Whether a property/event accessor should NOT be emitted as a g/s/ad/r accessor
+    /// record. Unlike <see cref="SkipMember"/>, a PropertyGet/PropertySet kind (and an
+    /// AssociatedSymbol) is expected here — that is the accessor we are emitting; only
+    /// explicit-interface implementations and [NonScriptable] accessors are excluded.</summary>
+    private static bool SkipAccessor(IMethodSymbol accessor)
+    {
+        if (!accessor.ExplicitInterfaceImplementations().IsEmpty()) return true;
+        if (accessor.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == "Transpose.NonScriptableAttribute")) return true;
+        return false;
     }
 
     private static bool SkipMember(ISymbol m)

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -533,15 +533,26 @@ internal static class TransposeNaming
     /// <summary>The interface member this method implements (implicitly), or null.</summary>
     private static IMethodSymbol? ImplementedInterfaceMember(IMethodSymbol method)
     {
-        var type = method.ContainingType;
-        if (type is null) return null;
-        foreach (var iface in type.AllInterfaces)
+        // Walk the override chain: an override implements whatever interface member its overridden
+        // base declared as the implementation. Roslyn's FindImplementationForInterfaceMember resolves
+        // an interface member to the type that *declares* the implementing member (an abstract base),
+        // not a derived override — so an override must inherit its base's interface-member JS name to
+        // land in the same runtime slot. Without this, e.g. OrdinalComparer.Compare (overriding the
+        // abstract StringComparer.Compare that implements IComparer<T>.Compare) misses the interface
+        // member's camelCase [Convention] and emits PascalCase "Compare" while every caller uses
+        // camelCase "compare".
+        for (var m = method; m is not null; m = m.OverriddenMethod?.OriginalDefinition)
         {
-            foreach (var member in iface.GetMembers().OfType<IMethodSymbol>())
+            var type = m.ContainingType;
+            if (type is null) continue;
+            foreach (var iface in type.AllInterfaces)
             {
-                if (type.FindImplementationForInterfaceMember(member) is IMethodSymbol impl
-                    && SymbolEqualityComparer.Default.Equals(impl.OriginalDefinition, method.OriginalDefinition))
-                    return member.OriginalDefinition;
+                foreach (var member in iface.GetMembers().OfType<IMethodSymbol>())
+                {
+                    if (type.FindImplementationForInterfaceMember(member) is IMethodSymbol impl
+                        && SymbolEqualityComparer.Default.Equals(impl.OriginalDefinition, m.OriginalDefinition))
+                        return member.OriginalDefinition;
+                }
             }
         }
         return null;


### PR DESCRIPTION
## Summary

Fixes two reflection/naming gaps found while migrating the Tesserae UI toolkit to Transpose. Both compile from clean, idiomatic C# but fail at runtime. Each is a one-focus change in the translator, plus a regression test diffed against native .NET.

### 1. `IComparer<T>.Compare` emitted PascalCase on an overriding implementer
When an interface member is implemented by an **abstract base** method and **overridden** in a derived class — e.g. `StringComparer.Compare(string,string)` (abstract, implements `IComparer<string>.Compare`) → `OrdinalComparer.Compare` (override) — the override did not inherit the interface member's camelCase `[Convention]` name.

Roslyn's `FindImplementationForInterfaceMember` resolves an interface member to the type that *declares* the implementing member (the abstract base), not a derived override, so `ImplementedInterfaceMember` returned `null` for the override and it fell back to PascalCase `Compare`. Every caller — LINQ `OrderBy`, the hand-written `linq.js` sorter, user code — invokes camelCase `.compare`, so the lookup missed at runtime:

```
Uncaught TypeError: this.comparer.compare is not a function
```

**Fix:** `ImplementedInterfaceMember` now walks the override chain, so an override lands in its base's interface-member slot (`TransposeNaming.cs`).

### 2. `PropertyInfo.CanRead` / `CanWrite` always `false`
`CanRead`/`CanWrite` test the property's `g`/`s` accessor records (`!!this.g` / `!!this.s`), but `ConstructPropertyInfo` gated `g`/`s` emission on `!SkipMember(accessor)` — and `SkipMember` blanket-skips every `PropertyGet`/`PropertySet` (and any member with an `AssociatedSymbol`). So **no property ever got `g`/`s` records**, `CanRead`/`CanWrite` were always false, and reflection-driven forms (Tesserae's `PropertyGrid`) rendered empty.

**Fix:** a dedicated `SkipAccessor` (excluding only explicit-interface and `[NonScriptable]` accessors) now gates emission. The accessors carry `fg`/`fs` backing-field names, which `midel` already uses to read/write field-backed auto-properties via `GetValue`/`SetValue` (`Emitter.Reflection.cs`).

## Verification

- New `ReflectionAndComparerTests` (both scenarios, diffed against native .NET) — pass.
- Full translator suite: **337 passed, 0 failed, 17 skipped** — no regressions.
- End-to-end: rebuilt the runtime with these fixes and re-transpiled the Tesserae sample app — all 122 sample pages render clean. The two previously-broken pages (Searchable Grouped List, Property Grid) now match the h5 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa)_