### PR TITLE
Add outputFormatting (minified output) support to the tps site build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,8 +167,16 @@ plain CLI, by design.
   (`lib/netstandard2.0/Transpose.dll`), and the translator tests run end-to-end against it.
 - **`outputBy` file-layout modes** (Class/ClassPath/Namespace/…): `ClassPath` (used by the runtime
   build above) is implemented; the other layouts still emit a single bundle.
-- **Bundle minification and source maps** for the emitted bundle (Release only selects pre-minified
-  resource variants today).
+- **Bundle minification (done).** `outputFormatting` (`Formatted`/`Minified`/`Both`, read from
+  `tps.json` and a merged `tps.<Configuration>.json` overlay) drives NUglify-based minification
+  (pinned to `NUglify 1.20.7`, the version the legacy compiler uses) via `JsMinifier`. Packages ship
+  their compiled JS in both a formatted and a pre-minified variant — the runtime (`tps.min.js` /
+  `tps.meta.min.js`, embedded by `tps --build-runtime`) and library packages (`CollectEmbeddableItems`)
+  — so a site build reuses those and only minifies the per-project bundle/metadata/shim itself (with a
+  compile-time fallback for older packages that predate the `.min.js`). `OutputBuilder` emits
+  `index.html` (formatted) and `index.min.html` (minified) and collapses them per build configuration
+  (Release keeps the minified one as `index.html`, Debug the formatted one) — a port of the legacy
+  `HtmlGenerator`. **Source maps** for the emitted bundle are still remaining.
 - **Reference resolution beyond the NuGet cache** — `<Reference HintPath>` and `tps.json`
   `references`/`referencesPath` (partially covered by `--reference`).
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).

--- a/Transpose/Transpose.Compiler/JsMinifier.cs
+++ b/Transpose/Transpose.Compiler/JsMinifier.cs
@@ -1,0 +1,87 @@
+using NUglify;
+using NUglify.JavaScript;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// Minifies emitted JavaScript with NUglify, mirroring the legacy compiler's settings so the
+/// <c>outputFormatting</c> <c>Minified</c>/<c>Both</c> variants match what tps has always produced.
+///
+/// The runtime core files (tps.js / tps.collections.js) get a distinct settings profile from
+/// user/project code, and everything defaults to a "safe" profile that keeps local variable
+/// names (<see cref="LocalRenaming.KeepAll"/>) unless local-variable crunching is requested.
+/// These map directly onto the legacy <c>MinifierCodeSettings*</c> definitions.
+/// </summary>
+internal static class JsMinifier
+{
+    // The runtime core files, matched by name — they get the "internal" settings profile.
+    private static readonly HashSet<string> InternalFileNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "tps.js", "tps.min.js", "tps.collections.js", "tps.collections.min.js",
+    };
+
+    // Safe profile: never rename locals, terminate statements with semicolons, escape non-ASCII.
+    private static CodeSettings Safe() => new()
+    {
+        EvalTreatment        = EvalTreatment.MakeAllSafe,
+        LocalRenaming        = LocalRenaming.KeepAll,
+        TermSemicolons       = true,
+        StrictMode           = false,
+        RemoveUnneededCode   = false,
+        AlwaysEscapeNonAscii = true,
+    };
+
+    // Safe profile but crunch local variable names (smaller output; opted into per project).
+    private static CodeSettings SafeCrunchLocal() => new()
+    {
+        EvalTreatment        = EvalTreatment.MakeAllSafe,
+        LocalRenaming        = LocalRenaming.CrunchAll,
+        TermSemicolons       = true,
+        StrictMode           = false,
+        RemoveUnneededCode   = false,
+        AlwaysEscapeNonAscii = true,
+    };
+
+    // Runtime-core profile (tps.js, …): as safe but without the eval/local-renaming overrides.
+    private static CodeSettings Internal() => new()
+    {
+        TermSemicolons       = true,
+        StrictMode           = false,
+        RemoveUnneededCode   = false,
+        AlwaysEscapeNonAscii = true,
+    };
+
+    /// <summary>
+    /// Minifies <paramref name="source"/>. The settings are chosen from <paramref name="fileName"/>:
+    /// the runtime core files use the internal profile; everything else uses the safe profile
+    /// (crunching locals only when <paramref name="minifyLocalVariables"/> is set).
+    /// </summary>
+    public static string Minify(string source, string fileName, bool minifyLocalVariables = false, bool noStrictMode = false)
+    {
+        if (string.IsNullOrEmpty(source)) return source;
+
+        CodeSettings settings;
+        if (InternalFileNames.Contains(Path.GetFileName(fileName)))
+        {
+            settings = Internal();
+        }
+        else
+        {
+            settings = minifyLocalVariables ? SafeCrunchLocal() : Safe();
+            if (noStrictMode) settings.StrictMode = false;
+        }
+
+        var result = Uglify.Js(source, settings);
+
+        // NUglify raises non-fatal analysis diagnostics (e.g. JS1300 "assignment to undefined
+        // variable" for the runtime's intentional implicit globals) but still emits valid code — the
+        // legacy compiler takes result.Code regardless of HasErrors, so we do the same. Only a null
+        // Code signals a genuine failure to minify.
+        if (result.Code is null)
+        {
+            var first = result.Errors.Count > 0 ? result.Errors[0].ToString() : "produced no output";
+            throw new InvalidOperationException($"Minification of {fileName} failed: {first}");
+        }
+        return result.Code;
+    }
+}

--- a/Transpose/Transpose.Compiler/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler/OutputBuilder.cs
@@ -9,6 +9,15 @@ namespace Transpose.Compiler;
 /// JavaScript each referenced package embeds (tps.js, newtonsoft.json.js, … — listed in the
 /// assembly's <c>Transpose.Resources.json</c>), copies the tps.json resource files (CSS/images), and
 /// generates index.html — mirroring what the existing tps compiler produces.
+///
+/// When <c>outputFormatting</c> is <c>Minified</c> or <c>Both</c>, every compiler-produced JS output
+/// (the extracted runtime, the compiled bundle and its reflection metadata, and referenced library
+/// code) is minified with NUglify into a <c>.min.js</c> sibling. The generated HTML then follows the
+/// legacy compiler's rule: index.html links the formatted variants, index.min.html links the
+/// minified variants, and the active build configuration collapses the pair to a single index.html
+/// (Release keeps the minified one, Debug the formatted one). tps.json resource files are taken as
+/// authored (never re-minified) — a project ships both a <c>foo.js</c> and a <c>foo.min.js</c> group
+/// when it wants both variants, exactly as before.
 /// </summary>
 internal static class OutputBuilder
 {
@@ -29,76 +38,147 @@ internal static class OutputBuilder
 </body>
 </html>";
 
-    public static string Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, bool minified = false, string? metadataJavascript = null)
+    /// <summary>A JavaScript output as it should appear in the generated HTML — a direct port of the
+    /// legacy compiler's <c>TranslatorOutputItem</c> routing. <see cref="Path"/> is the formatted
+    /// path; <see cref="MinifiedPath"/> is its minified sibling when both were produced (Both mode).
+    /// <see cref="IsEmpty"/> marks a formatted variant that was not written (Minified mode) — the
+    /// formatted HTML then falls back to the minified path, exactly like <c>GetOutputPath</c>.
+    /// <see cref="IsMinified"/> marks a standalone authored <c>.min.js</c> resource, which appears
+    /// only in the minified HTML.</summary>
+    private sealed class JsOut
+    {
+        public string Path = "";
+        public string? MinifiedPath;
+        public bool IsEmpty;
+        public bool IsMinified;
+    }
+
+    public static string Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, string configuration, string? metadataJavascript = null)
     {
         Directory.CreateDirectory(outputDir);
 
-        var runtimeScripts = new List<string>();   // tps.js, newtonsoft.json.js, …
-        var libraryScripts = new List<string>();    // tss.js, tss.meta.js, tss-dep.js from referenced projects
-        var resourceScripts = new List<string>();   // tss-dep.js, … (this project's own tps.json resources)
+        var fmt = config.OutputFormatting;
+        var wantFormatted = fmt != JsOutputFormatting.Minified;   // Formatted or Both
+        var wantMinified  = fmt != JsOutputFormatting.Formatted;  // Minified or Both
+        var minifyLocals  = project.MinifyLocalVariables;
+
+        var jsOuts = new List<JsOut>();    // JS in load order (runtime → libs → resources → app)
         var cssLinks = new List<string>();
+
+        var utf8 = new UTF8Encoding(false);
+
+        void WriteText(string rel, string content)
+        {
+            var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            File.WriteAllText(dest, content, utf8);
+        }
+
+        // A per-project compiler output (the app bundle, its reflection metadata, the shim): there
+        // is no pre-built variant to reuse, so minify at compile time per outputFormatting.
+        void EmitCompilerJs(string rel, string content)
+        {
+            var o = new JsOut { Path = rel };
+            if (wantFormatted) WriteText(rel, content); else o.IsEmpty = true;
+            if (wantMinified)
+            {
+                var minRel = ToMinName(rel);
+                WriteText(minRel, JsMinifier.Minify(content, Path.GetFileName(rel), minifyLocals));
+                o.MinifiedPath = minRel;
+            }
+            jsOuts.Add(o);
+        }
+
+        // Routes a package's already-loaded JS resources (runtime bundles, library code) into the
+        // output. A package ships both a formatted and a pre-minified variant of each file, so we
+        // reuse them as-is: the formatted variant links from index.html, the pre-minified from
+        // index.min.html — no re-minification. Only when a package predates the pre-minified variant
+        // (no .min.js sibling) do we minify the formatted one as a fallback. Files are written to disk
+        // on demand so a Formatted build never materialises the .min.js (and vice-versa).
+        void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
+        {
+            var present = jsFiles.Select(f => f.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var byName = jsFiles.ToDictionary(f => f.FileName, f => f, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var f in jsFiles)
+            {
+                if (IsMinifiedName(f.FileName))
+                {
+                    // A .min.js whose formatted sibling is also in the package is written by that
+                    // sibling below; a standalone .min.js links only from the minified HTML.
+                    if (present.Contains(CounterpartName(f.FileName))) continue;
+                    if (wantMinified) { WriteText(f.Rel, f.Text); jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = true }); }
+                    continue;
+                }
+
+                var o = new JsOut { Path = f.Rel };
+                if (wantFormatted) WriteText(f.Rel, f.Text); else o.IsEmpty = true;
+                if (wantMinified)
+                {
+                    var minName = CounterpartName(f.FileName);
+                    if (byName.TryGetValue(minName, out var pre))
+                    {
+                        WriteText(pre.Rel, pre.Text);       // pre-built .min.js shipped in the package
+                        o.MinifiedPath = pre.Rel;
+                    }
+                    else
+                    {
+                        var minRel = ToMinName(f.Rel);      // fallback: minify at compile time
+                        WriteText(minRel, JsMinifier.Minify(f.Text, f.FileName, minifyLocals));
+                        o.MinifiedPath = minRel;
+                    }
+                }
+                jsOuts.Add(o);
+            }
+        }
 
         // In separate-assembly mode, referenced *projects* are consumed as DLLs (their JS is
         // extracted, not recompiled) — exclude them from the runtime-package JS loop below.
         var projectDlls = new HashSet<string>(project.ReferencedProjectDlls, StringComparer.OrdinalIgnoreCase);
 
         // 1. Runtime JS embedded in referenced packages, in dependency order (Transpose core first).
+        var runtimeJs = new List<EmbeddedJs>();
         foreach (var dll in OrderRuntimeAssemblies(project.ReferencePaths.Where(p => !projectDlls.Contains(p))))
-        {
             foreach (var (fileName, text) in ExtractEmbeddedJs(dll))
-            {
-                File.WriteAllText(Path.Combine(outputDir, fileName), text);
-                runtimeScripts.Add(fileName);
-            }
-        }
+                runtimeJs.Add(new EmbeddedJs(fileName, fileName, text));
+        RoutePackageJs(runtimeJs);
 
         // The TransposeR shim (the translator's language-level helpers over tps.js) loads right after
         // the Transpose runtime and before any generated code that calls into it.
-        File.WriteAllText(Path.Combine(outputDir, "tps.shim.js"), RoslynTranslator.RuntimeShim);
-        runtimeScripts.Add("tps.shim.js");
+        EmitCompilerJs("tps.shim.js", RoslynTranslator.RuntimeShim);
 
         // 1b. Referenced project assemblies: extract their embedded JS/CSS/resources (deepest
         //     dependency first) so a library loads before the app that uses it.
         foreach (var dll in Enumerable.Reverse(project.ReferencedProjectDlls))
-            ExtractProjectDllResources(dll, outputDir, libraryScripts, cssLinks, minified);
+            RoutePackageJs(ExtractProjectDllResources(dll, outputDir, cssLinks, utf8));
 
         // 2. tps.json resource files from every project in the closure — referenced projects
         //    first (a library's JS deps load before the app that uses them). A resource group
         //    whose name is a .js/.css file concatenates its files into that one bundle; other
-        //    groups (globbed images, etc.) copy each file through.
+        //    groups (globbed images, etc.) copy each file through. Resource JS is taken as authored:
+        //    a .js group routes to index.html, a .min.js group to index.min.html.
         foreach (var projectDir in Enumerable.Reverse(project.ProjectDirs))
         {
-            var cfg = projectDir == project.ProjectDir ? config : TransposeJson.TryLoad(projectDir);
+            var cfg = projectDir == project.ProjectDir ? config : TransposeJson.TryLoad(projectDir, configuration);
             if (cfg is null) continue;
-            // The bundle group names whose files actually resolve in this project — used to
-            // decide, for a minified/non-minified pair, which variant the current build takes.
-            var bundleNames = cfg.Resources
-                .Where(g => g.Files.SelectMany(p => ExpandGlob(projectDir, p)).Any())
-                .Select(g => g.Name ?? "")
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var group in cfg.Resources)
-                ProcessResourceGroup(projectDir, outputDir, group, resourceScripts, cssLinks, bundleNames, minified);
+                ProcessResourceGroup(projectDir, outputDir, group, jsOuts, cssLinks);
         }
 
         // 3. The compiled bundle — loads last, after runtime + library deps are in place.
-        File.WriteAllText(Path.Combine(outputDir, config.FileName), javascript);
-
-        var appScripts = new List<string> { config.FileName };
+        EmitCompilerJs(config.FileName, javascript);
 
         // 3b. Reflection metadata as a separate file (reflection.target: "file") — loads right
         //     after the bundle whose types it describes, matching the existing compiler.
         if (metadataJavascript is not null)
         {
             var metaName = Path.GetFileNameWithoutExtension(config.FileName) + ".meta.js";
-            File.WriteAllText(Path.Combine(outputDir, metaName), metadataJavascript);
-            appScripts.Add(metaName);
+            EmitCompilerJs(metaName, metadataJavascript);
         }
 
-        var scripts = runtimeScripts.Concat(libraryScripts).Concat(resourceScripts).Concat(appScripts).ToList();
-
-        // 4. index.html.
+        // 4. index.html (and index.min.html when both variants exist).
         if (!config.HtmlDisabled)
-            WriteHtml(project, config, outputDir, scripts, cssLinks);
+            WriteHtml(project, config, outputDir, jsOuts, cssLinks, configuration, utf8);
 
         return outputDir;
     }
@@ -106,20 +186,28 @@ internal static class OutputBuilder
     /// <summary>
     /// The resources a library assembly embeds so a referencing project can extract them: the
     /// compiled JS (and its .meta.js) plus every tps.json resource group (bundled or copied),
-    /// each tagged with its output subdirectory. Both minified and non-minified resource-group
-    /// variants are embedded — the consumer picks per build configuration.
+    /// each tagged with its output subdirectory. The compiled JS is embedded in both a formatted
+    /// and a pre-minified (<c>.min.js</c>) variant, so a referencing build never has to minify
+    /// library code itself — it just extracts the variant the build configuration calls for.
     /// </summary>
     public static List<EmbeddedItem> CollectEmbeddableItems(
-        string projectDir, TransposeJson config, string mainJsName, string javascript, string? metadataJavascript)
+        string projectDir, TransposeJson config, string mainJsName, string javascript, string? metadataJavascript,
+        bool minifyLocalVariables = false)
     {
         var items = new List<EmbeddedItem>();
         var utf8 = new UTF8Encoding(false);
 
+        // The compiled bundle + its reflection metadata, each in a formatted and a pre-minified
+        // variant. Shipping the .min.js in the package is deliberate: minifying library code is
+        // work the consumer would otherwise repeat on every build (see BuildRuntime for the same
+        // for the runtime bundles).
         items.Add(new EmbeddedItem(mainJsName, utf8.GetBytes(javascript), null));
+        items.Add(new EmbeddedItem(ToMinName(mainJsName), utf8.GetBytes(JsMinifier.Minify(javascript, mainJsName, minifyLocalVariables)), null));
         if (metadataJavascript is not null)
         {
             var metaName = Path.GetFileNameWithoutExtension(mainJsName) + ".meta.js";
             items.Add(new EmbeddedItem(metaName, utf8.GetBytes(metadataJavascript), null));
+            items.Add(new EmbeddedItem(ToMinName(metaName), utf8.GetBytes(JsMinifier.Minify(metadataJavascript, metaName, minifyLocalVariables)), null));
         }
 
         foreach (var group in config.Resources)
@@ -146,22 +234,29 @@ internal static class OutputBuilder
         return items;
     }
 
+    /// <summary>A JavaScript resource loaded from a package (a runtime bundle or embedded library
+    /// code), with its file name (for pairing a formatted variant with its <c>.min.js</c>), the
+    /// output-relative path it extracts to, and its text.</summary>
+    private readonly record struct EmbeddedJs(string FileName, string Rel, string Text);
+
     /// <summary>
-    /// Extracts every resource a referenced project assembly embedded (via its Transpose.Resources.json
-    /// manifest) into the output folder, honouring each entry's output subdirectory and the
-    /// Debug/Release minified-variant selection. Adds scripts/CSS links (in manifest order) to the
-    /// supplied lists. This is the consuming half of the package protocol.
+    /// Extracts a referenced project assembly's embedded resources (listed in its
+    /// Transpose.Resources.json manifest) into the output folder: CSS is written and linked here,
+    /// and the JS resources are returned for <c>RoutePackageJs</c> to place (which picks the
+    /// formatted vs pre-minified variant per build). Non-JS/CSS resources (images, fonts) are
+    /// copied through under their output subdirectory.
     /// </summary>
-    private static void ExtractProjectDllResources(
-        string dllPath, string outputDir, List<string> scripts, List<string> cssLinks, bool minified)
+    private static IReadOnlyList<EmbeddedJs> ExtractProjectDllResources(
+        string dllPath, string outputDir, List<string> cssLinks, UTF8Encoding utf8)
     {
-        if (!File.Exists(dllPath)) return;
+        var jsFiles = new List<EmbeddedJs>();
+        if (!File.Exists(dllPath)) return jsFiles;
         Assembly asm;
-        try { asm = Assembly.LoadFrom(dllPath); } catch { return; }
+        try { asm = Assembly.LoadFrom(dllPath); } catch { return jsFiles; }
 
         var names = asm.GetManifestResourceNames();
         var manifestName = names.FirstOrDefault(n => n.EndsWith("Transpose.Resources.json", StringComparison.OrdinalIgnoreCase));
-        if (manifestName is null) return;
+        if (manifestName is null) return jsFiles;
 
         List<(string fileName, string? path)> entries;
         using (var ms = asm.GetManifestResourceStream(manifestName)!)
@@ -177,30 +272,37 @@ internal static class OutputBuilder
                 .ToList();
         }
 
-        // For a minified/non-minified pair, keep only the variant this configuration wants.
-        var present = entries.Select(e => e.fileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        string Rel(string fileName, string? path) => string.IsNullOrEmpty(path) ? fileName : path!.Replace('\\', '/') + "/" + fileName;
+
         foreach (var (fileName, path) in entries)
         {
-            if (IsMinifiedName(fileName) == !minified && present.Contains(CounterpartName(fileName)))
-                continue;
-
             var resName = names.FirstOrDefault(n => n.Equals(fileName, StringComparison.OrdinalIgnoreCase))
                           ?? names.FirstOrDefault(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
             if (resName is null) continue;
 
-            var rel = string.IsNullOrEmpty(path) ? fileName : path!.Replace('\\', '/') + "/" + fileName;
-            var dest = Path.Combine(outputDir, rel);
-            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-            using (var s = asm.GetManifestResourceStream(resName)!)
-            using (var fs = File.Create(dest))
-                s.CopyTo(fs);
+            var rel = Rel(fileName, path);
 
-            if (rel.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) cssLinks.Add(rel);
-            else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) scripts.Add(rel);
+            if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+            {
+                using var s = asm.GetManifestResourceStream(resName)!;
+                using var reader = new StreamReader(s);
+                jsFiles.Add(new EmbeddedJs(fileName, rel, reader.ReadToEnd()));
+            }
+            else
+            {
+                // CSS and copy-through resources (images, fonts): write to disk now.
+                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                using (var s = asm.GetManifestResourceStream(resName)!)
+                using (var fs = File.Create(dest))
+                    s.CopyTo(fs);
+                if (rel.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) cssLinks.Add(rel);
+            }
         }
+        return jsFiles;
     }
 
-    /// <summary>A resource group name for a minified bundle (ends in <c>.min.js</c>/<c>.min.css</c>).</summary>
+    /// <summary>A file name for a minified bundle (ends in <c>.min.js</c>/<c>.min.css</c>).</summary>
     private static bool IsMinifiedName(string name)
         => name.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
            || name.EndsWith(".min.css", StringComparison.OrdinalIgnoreCase);
@@ -218,37 +320,44 @@ internal static class OutputBuilder
         return name;
     }
 
+    /// <summary>The minified sibling of a JS path: <c>x.js</c> → <c>x.min.js</c> (idempotent).</summary>
+    private static string ToMinName(string rel)
+    {
+        if (IsMinifiedName(rel)) return rel;
+        if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+            return rel.Substring(0, rel.Length - ".js".Length) + ".min.js";
+        return rel;
+    }
+
     private static void ProcessResourceGroup(
         string projectDir, string outputDir, TransposeJson.ResourceGroup group,
-        List<string> resourceScripts, List<string> cssLinks, HashSet<string> bundleNames, bool minified)
+        List<JsOut> jsOuts, List<string> cssLinks)
     {
         var destSub = (group.Output ?? "").Replace('\\', '/');
         var files = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
         if (files.Count == 0) return;
 
         var name = group.Name ?? "";
-
-        // Transpose emits resource groups in minified/non-minified pairs (e.g. tss-dep.js and
-        // tss-dep.min.js — see the "outputFormatting": "Both" note in Tesserae's tps.json). When
-        // BOTH variants of a bundle are available, a referencing project built in Debug takes the
-        // non-minified one and a Release build takes the .min.js one. When only one variant
-        // exists, it is used regardless of configuration — otherwise both variants of a matched
-        // pair would load and the dependency bundle would run twice.
-        if (IsMinifiedName(name) == !minified && bundleNames.Contains(CounterpartName(name)))
-            return;
-
         var isBundle = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
                        || name.EndsWith(".css", StringComparison.OrdinalIgnoreCase);
+
+        void RouteJs(string rel)
+        {
+            // Resource JS is taken as authored (never re-minified): a .min.js links only from
+            // index.min.html; a plain .js links only from index.html — matching the legacy compiler.
+            if (IsMinifiedName(rel)) jsOuts.Add(new JsOut { Path = rel, IsMinified = true });
+            else jsOuts.Add(new JsOut { Path = rel });
+        }
 
         if (isBundle)
         {
             // Concatenate the group's files into a single named output (e.g. tss-dep.js).
             var rel = string.IsNullOrEmpty(destSub) ? name : destSub + "/" + name;
-            var dest = Path.Combine(outputDir, rel);
+            var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
             Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
             File.WriteAllText(dest, string.Join("\n", files.Select(File.ReadAllText)));
             if (name.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) cssLinks.Add(rel);
-            else resourceScripts.Add(rel);
+            else RouteJs(rel);
         }
         else
         {
@@ -256,11 +365,11 @@ internal static class OutputBuilder
             foreach (var src in files)
             {
                 var rel = string.IsNullOrEmpty(destSub) ? Path.GetFileName(src) : destSub + "/" + Path.GetFileName(src);
-                var dest = Path.Combine(outputDir, rel);
+                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
                 File.Copy(src, dest, overwrite: true);
                 if (rel.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) cssLinks.Add(rel);
-                else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) resourceScripts.Add(rel);
+                else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) RouteJs(rel);
             }
         }
     }
@@ -317,24 +426,68 @@ internal static class OutputBuilder
             : File.Exists(Path.Combine(searchDir, file)) ? new[] { Path.Combine(searchDir, file) } : Enumerable.Empty<string>();
     }
 
-    private static void WriteHtml(ResolvedProject project, TransposeJson config, string outputDir, List<string> scripts, List<string> cssLinks)
+    /// <summary>
+    /// Writes index.html (formatted scripts) and/or index.min.html (minified scripts), then collapses
+    /// the pair to a single index.html for the active build configuration — a port of the legacy
+    /// HtmlGenerator: Release keeps the minified variant as index.html, Debug keeps the formatted one,
+    /// and an empty configuration keeps both (index.html + index.min.html).
+    /// </summary>
+    private static void WriteHtml(
+        ResolvedProject project, TransposeJson config, string outputDir,
+        List<JsOut> jsOuts, List<string> cssLinks, string configuration, UTF8Encoding utf8)
     {
         var css = new StringBuilder();
         foreach (var link in cssLinks)
             css.Append("\n    ").Append($"<link rel=\"stylesheet\" href=\"{link}\">");
 
         var js = new StringBuilder();
-        foreach (var script in scripts)
-            js.Append("\n    ").Append($"<script src=\"{script}\" defer></script>");
+        var jsMin = new StringBuilder();
+        var minSeen = new HashSet<string>();
+        foreach (var o in jsOuts)
+        {
+            if (o.IsMinified)
+            {
+                // A standalone minified resource — minified HTML only.
+                if (minSeen.Add(o.Path))
+                    jsMin.Append("\n    ").Append($"<script src=\"{o.Path}\" defer></script>");
+                continue;
+            }
 
-        var html = HtmlTemplate
+            // Formatted HTML links the formatted variant, falling back to the minified path when the
+            // formatted one was not written (Minified mode) — mirrors the legacy GetOutputPath().
+            var formattedPath = o.IsEmpty ? o.MinifiedPath : o.Path;
+            if (formattedPath is not null)
+                js.Append("\n    ").Append($"<script src=\"{formattedPath}\" defer></script>");
+
+            // Minified HTML links the minified sibling when the formatted variant exists (Both mode).
+            if (!o.IsEmpty && o.MinifiedPath is not null && minSeen.Add(o.MinifiedPath))
+                jsMin.Append("\n    ").Append($"<script src=\"{o.MinifiedPath}\" defer></script>");
+        }
+
+        string? htmlName = (js.Length > 0 || css.Length > 0) ? "index.html" : null;
+        string? htmlMinName = jsMin.Length > 0 ? (htmlName is null ? "index.html" : "index.min.html") : null;
+
+        // Collapse to a single index.html for the requested configuration (legacy behaviour).
+        if (string.Equals(configuration, "Release", StringComparison.OrdinalIgnoreCase))
+        {
+            if (htmlMinName is not null) { htmlName = null; htmlMinName = "index.html"; }
+        }
+        else if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase))
+        {
+            if (htmlMinName is not null && htmlName is not null) htmlMinName = null;
+        }
+
+        string Render(string scripts) => HtmlTemplate
             .Replace("{META}", config.HtmlMeta)
             .Replace("{TITLE}", config.HtmlTitle ?? project.AssemblyName)
             .Replace("{CSS}", css.ToString().TrimStart())
-            .Replace("{SCRIPT}", js.ToString().TrimStart())
+            .Replace("{SCRIPT}", scripts.TrimStart())
             .Replace("{HEAD}", config.HtmlHead)
             .Replace("{BODY}", config.HtmlBody);
 
-        File.WriteAllText(Path.Combine(outputDir, "index.html"), html);
+        if (htmlName is not null)
+            File.WriteAllText(Path.Combine(outputDir, htmlName), Render(js.ToString()), utf8);
+        if (htmlMinName is not null)
+            File.WriteAllText(Path.Combine(outputDir, htmlMinName), Render(jsMin.ToString()), utf8);
     }
 }

--- a/Transpose/Transpose.Compiler/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler/OutputBuilder.cs
@@ -459,9 +459,13 @@ internal static class OutputBuilder
             if (formattedPath is not null)
                 js.Append("\n    ").Append($"<script src=\"{formattedPath}\" defer></script>");
 
-            // Minified HTML links the minified sibling when the formatted variant exists (Both mode).
-            if (!o.IsEmpty && o.MinifiedPath is not null && minSeen.Add(o.MinifiedPath))
-                jsMin.Append("\n    ").Append($"<script src=\"{o.MinifiedPath}\" defer></script>");
+            // Minified HTML links the minified sibling, falling back to the formatted path when no
+            // minified variant exists. (The legacy compiler dropped such files from the minified
+            // HTML entirely — so a resource declared once, with no .min sibling, silently failed to
+            // load in a Release build. Transpose keeps it: a missing .min just loads the plain file.)
+            var minifiedPath = o.MinifiedPath ?? (o.IsEmpty ? null : o.Path);
+            if (minifiedPath is not null && minSeen.Add(minifiedPath))
+                jsMin.Append("\n    ").Append($"<script src=\"{minifiedPath}\" defer></script>");
         }
 
         string? htmlName = (js.Length > 0 || css.Length > 0) ? "index.html" : null;

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -118,8 +118,9 @@ public static class Program
         Console.WriteLine($"  defines:    {string.Join(";", project.DefineConstants)}");
         Console.WriteLine($"  lang:       {project.LanguageVersion}");
 
-        // The project's tps.json drives runtime-package detection and reflection settings.
-        var tpscfg = TransposeJson.TryLoad(project.ProjectDir);
+        // The project's tps.json drives runtime-package detection and reflection settings. A
+        // tps.<Configuration>.json overlay (e.g. tps.Release.json) is merged on top when present.
+        var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
 
         // Base runtime package build: compile Transpose.BCL self-contained, transpile it with
         // outputBy: ClassPath, stitch the per-class files with the hand-written Resources primitives
@@ -181,7 +182,6 @@ public static class Program
         var js = result.Javascript!;
         if (!quiet) ReportDiagnostics(result.Diagnostics, maxErrors); // surface warnings
         var config = tpscfg;
-        var minified = configuration.Equals("Release", StringComparison.OrdinalIgnoreCase);
 
         // Package mode: compile this project as a distributable assembly — emit the .NET DLL and
         // embed its JS (+ tps.json resources) so another project can reference it and extract them.
@@ -200,7 +200,7 @@ public static class Program
         if (config is not null && outPath is null)
         {
             var outDir = siteDir ?? ResolveOutputDir(config, project.ProjectDir, configuration);
-            OutputBuilder.Build(project, config, js, outDir, minified, result.MetadataJavascript);
+            OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript);
             Console.WriteLine($"\nOK — built site in {outDir} ({js.Length:N0} bytes of {config.FileName}) in {sw.ElapsedMilliseconds} ms.");
             Console.WriteLine($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
             return 0;
@@ -222,7 +222,7 @@ public static class Program
     /// </summary>
     private static int BuildRuntime(ResolvedProject project, string configuration, Stopwatch sw, string? outPath)
     {
-        var cfg = TransposeJson.TryLoad(project.ProjectDir);
+        var cfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
         var reflectionEnabled = !(cfg?.ReflectionDisabled ?? false);
 
         RuntimePackageResult result;
@@ -263,8 +263,22 @@ public static class Program
             foreach (var (t, why) in result.ClassPath.Skipped.Take(20)) Console.WriteLine($"                - {t}: {why}");
         }
 
-        // Assemble the resource bundles (tps.js, tps.meta.js, …) declared in tps.json.
+        // Assemble the resource bundles (tps.js, tps.meta.js, …) declared in tps.json, then add a
+        // pre-minified variant of each next to it. Embedding the .min.js in the runtime package
+        // means a referencing build never re-minifies the (large) runtime — it just picks the
+        // variant its configuration wants, exactly as it does for the formatted/minified pair.
         var bundles = RuntimeAssembler.Assemble(project.ProjectDir);
+        var minBundles = new List<(string name, byte[] bytes)>();
+        foreach (var (name, bytes) in bundles)
+        {
+            var minName = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && !name.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
+                ? name.Substring(0, name.Length - ".js".Length) + ".min.js"
+                : null;
+            if (minName is null) continue;
+            var minText = JsMinifier.Minify(System.Text.Encoding.UTF8.GetString(bytes), name, project.MinifyLocalVariables);
+            minBundles.Add((minName, System.Text.Encoding.UTF8.GetBytes(minText)));
+        }
+        bundles = bundles.Concat(minBundles).ToList();
         // Write the assembly to bin/<config>/<tfm>/, matching the SDK's output path so `dotnet pack`
         // finds it (the Transpose.Build.Target SDK forces netstandard2.0, so that is the effective tfm).
         var dllPath = outPath ?? Path.Combine(project.ProjectDir, "bin", configuration, project.TargetFramework, project.AssemblyName + ".dll");
@@ -339,7 +353,7 @@ public static class Program
         try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
         catch (Exception ex) { Console.Error.WriteLine($"    resolve failed: {ex.Message}"); return false; }
 
-        var tpscfg = TransposeJson.TryLoad(project.ProjectDir);
+        var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
         var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
 
         AssemblyBuildResult result;
@@ -374,7 +388,7 @@ public static class Program
         File.WriteAllBytes(dllPath, result.AssemblyBytes!);
 
         var items = config is not null
-            ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript)
+            ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables)
             : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) };
         ResourceEmbedder.Embed(dllPath, items);
         return (dllPath, items);

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -25,6 +25,11 @@ internal sealed class ResolvedProject
     public required List<string> DefineConstants { get; init; }
     public required LanguageVersion LanguageVersion { get; init; }
 
+    /// <summary>The csproj <c>&lt;MinifyLocalVariables&gt;</c> property — when true, the minified
+    /// bundle crunches local variable names (smaller output). Defaults to false, mirroring the
+    /// legacy compiler's safe minifier profile that keeps local names.</summary>
+    public bool MinifyLocalVariables { get; init; }
+
     /// <summary>Directories of every project in the closure — the root first, then the
     /// referenced projects it pulls in (each may contribute tps.json resources).</summary>
     public required List<string> ProjectDirs { get; init; }
@@ -77,6 +82,7 @@ internal static class ProjectResolver
             ReferencePaths = references.Values.ToList(),
             DefineConstants = defines,
             LanguageVersion = lang,
+            MinifyLocalVariables = string.Equals(Property(doc, "MinifyLocalVariables")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
             ProjectDirs = projectDirs,
             ReferencedProjectDlls = projectDlls,
         };

--- a/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
+++ b/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
@@ -30,6 +30,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Transpose.Translator\Transpose.Translator.csproj" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <!-- JS minifier for the "outputFormatting": "Minified"/"Both" bundle variants. Pinned to the
+         same version the legacy compiler uses so the emitted .min.js is byte-for-byte comparable. -->
+    <PackageReference Include="NUglify" Version="1.20.7" />
   </ItemGroup>
 
 </Project>

--- a/Transpose/Transpose.Compiler/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler/TransposeJson.cs
@@ -3,9 +3,29 @@ using System.Text.Json;
 namespace Transpose.Compiler;
 
 /// <summary>
+/// Which variants of the emitted JavaScript the build produces — mirrors the legacy compiler's
+/// <c>JavaScriptOutputType</c> (the <c>outputFormatting</c> tps.json setting).
+/// </summary>
+internal enum JsOutputFormatting
+{
+    /// <summary>Only the formatted (beautified) JS. Good for debugging.</summary>
+    Formatted = 1,
+    /// <summary>Only the minified JS. Good for production.</summary>
+    Minified = 2,
+    /// <summary>Both variants — a referencing build (or index.html generation) then picks one.</summary>
+    Both = 3,
+}
+
+/// <summary>
 /// The subset of a project's <c>tps.json</c> the CLI acts on: where output goes, the bundle
 /// file name, HTML generation, and the resource files (CSS/images) copied into the output
 /// and linked from index.html. JSONC (comments + trailing commas) is tolerated.
+///
+/// A configuration-specific overlay (<c>tps.&lt;Configuration&gt;.json</c>, e.g. <c>tps.Release.json</c>)
+/// is merged on top of the base <c>tps.json</c> when present, matching the legacy compiler's
+/// <c>ConfigHelper.ReadConfig</c>: scalar settings from the overlay win, and resource arrays are
+/// concatenated (base first, then overlay). This is how the front-end projects flip
+/// <c>outputFormatting</c> to <c>Both</c> for Release while keeping <c>Formatted</c> for Debug.
 /// </summary>
 internal sealed class TransposeJson
 {
@@ -21,6 +41,12 @@ internal sealed class TransposeJson
     public string HtmlHead { get; init; } = "";
     public string HtmlMeta { get; init; } = "";
     public List<ResourceGroup> Resources { get; init; } = new();
+
+    /// <summary>
+    /// <c>outputFormatting</c> — whether to emit the formatted JS, the minified JS, or both.
+    /// Defaults to <see cref="JsOutputFormatting.Both"/>, matching the legacy compiler.
+    /// </summary>
+    public JsOutputFormatting OutputFormatting { get; init; } = JsOutputFormatting.Both;
 
     /// <summary>
     /// <c>outputBy</c> — the file-layout mode (Class/ClassPath/Namespace/…). The base runtime
@@ -43,11 +69,85 @@ internal sealed class TransposeJson
         public string? Output { get; init; }
     }
 
-    public static TransposeJson? TryLoad(string projectDir)
+    /// <summary>
+    /// Loads <c>tps.json</c> from <paramref name="projectDir"/>, merging a
+    /// <c>tps.&lt;configuration&gt;.json</c> overlay on top when one exists.
+    /// </summary>
+    public static TransposeJson? TryLoad(string projectDir, string? configuration = null)
     {
-        var path = Path.Combine(projectDir, "tps.json");
-        if (!File.Exists(path)) return null;
+        var basePath = Path.Combine(projectDir, "tps.json");
+        var baseDraft = File.Exists(basePath) ? ReadDraft(basePath) : null;
 
+        Draft? overlayDraft = null;
+        if (!string.IsNullOrWhiteSpace(configuration))
+        {
+            var overlayPath = Path.Combine(projectDir, $"tps.{configuration}.json");
+            if (File.Exists(overlayPath)) overlayDraft = ReadDraft(overlayPath);
+        }
+
+        if (baseDraft is null && overlayDraft is null) return null;
+
+        // Merge base + overlay: overlay scalars win; resource arrays concatenate (base first).
+        var merged = Draft.Merge(baseDraft ?? new Draft(), overlayDraft);
+
+        return new TransposeJson
+        {
+            Output = merged.Output,
+            OutputBy = merged.OutputBy,
+            FileName = merged.FileName ?? "app.js",
+            ExplicitFileName = merged.FileName,
+            OutputFormatting = merged.OutputFormatting ?? JsOutputFormatting.Both,
+            HtmlDisabled = merged.HtmlDisabled ?? false,
+            HtmlTitle = merged.HtmlTitle,
+            HtmlBody = merged.HtmlBody ?? "",
+            HtmlHead = merged.HtmlHead ?? "",
+            HtmlMeta = merged.HtmlMeta ?? "",
+            Resources = merged.Resources,
+            ReflectionDisabled = merged.ReflectionDisabled ?? false,
+            ReflectionTarget = merged.ReflectionTarget ?? "file",
+        };
+    }
+
+    /// <summary>A single tps.json file parsed into nullable fields (null = the key was absent),
+    /// so a configuration overlay can be merged field-by-field.</summary>
+    private sealed class Draft
+    {
+        public string? Output;
+        public string? OutputBy;
+        public string? FileName;
+        public JsOutputFormatting? OutputFormatting;
+        public bool? HtmlDisabled;
+        public string? HtmlTitle;
+        public string? HtmlBody;
+        public string? HtmlHead;
+        public string? HtmlMeta;
+        public List<ResourceGroup> Resources = new();
+        public bool? ReflectionDisabled;
+        public string? ReflectionTarget;
+
+        public static Draft Merge(Draft b, Draft? o)
+        {
+            if (o is null) return b;
+            return new Draft
+            {
+                Output           = o.Output           ?? b.Output,
+                OutputBy         = o.OutputBy          ?? b.OutputBy,
+                FileName         = o.FileName          ?? b.FileName,
+                OutputFormatting = o.OutputFormatting  ?? b.OutputFormatting,
+                HtmlDisabled     = o.HtmlDisabled      ?? b.HtmlDisabled,
+                HtmlTitle        = o.HtmlTitle         ?? b.HtmlTitle,
+                HtmlBody         = o.HtmlBody          ?? b.HtmlBody,
+                HtmlHead         = o.HtmlHead          ?? b.HtmlHead,
+                HtmlMeta         = o.HtmlMeta          ?? b.HtmlMeta,
+                Resources        = b.Resources.Concat(o.Resources).ToList(),
+                ReflectionDisabled = o.ReflectionDisabled ?? b.ReflectionDisabled,
+                ReflectionTarget = o.ReflectionTarget  ?? b.ReflectionTarget,
+            };
+        }
+    }
+
+    private static Draft ReadDraft(string path)
+    {
         var options = new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
         using var doc = JsonDocument.Parse(File.ReadAllText(path), options);
         var root = doc.RootElement;
@@ -57,6 +157,7 @@ internal sealed class TransposeJson
 
         var html = root.TryGetProperty("html", out var h) && h.ValueKind == JsonValueKind.Object ? h : default;
         var reflection = root.TryGetProperty("reflection", out var rfl) && rfl.ValueKind == JsonValueKind.Object ? rfl : default;
+
         var resources = new List<ResourceGroup>();
         if (root.TryGetProperty("resources", out var res) && res.ValueKind == JsonValueKind.Array)
         {
@@ -70,21 +171,34 @@ internal sealed class TransposeJson
             }
         }
 
-        return new TransposeJson
+        return new Draft
         {
             Output = Str(root, "output"),
             OutputBy = Str(root, "outputBy"),
-            FileName = Str(root, "fileName") ?? "app.js",
-            ExplicitFileName = Str(root, "fileName"),
-            HtmlDisabled = html.ValueKind == JsonValueKind.Object && html.TryGetProperty("disabled", out var d) && d.ValueKind == JsonValueKind.True,
+            FileName = Str(root, "fileName"),
+            OutputFormatting = ParseFormatting(Str(root, "outputFormatting")),
+            HtmlDisabled = html.ValueKind == JsonValueKind.Object && html.TryGetProperty("disabled", out var d)
+                ? d.ValueKind == JsonValueKind.True
+                : (bool?)null,
             HtmlTitle = html.ValueKind == JsonValueKind.Object ? Str(html, "title") : null,
-            HtmlBody = (html.ValueKind == JsonValueKind.Object ? Str(html, "body") : null) ?? "",
-            HtmlHead = (html.ValueKind == JsonValueKind.Object ? Str(html, "head") : null) ?? "",
-            HtmlMeta = (html.ValueKind == JsonValueKind.Object ? Str(html, "meta") : null) ?? "",
+            HtmlBody = html.ValueKind == JsonValueKind.Object ? Str(html, "body") : null,
+            HtmlHead = html.ValueKind == JsonValueKind.Object ? Str(html, "head") : null,
+            HtmlMeta = html.ValueKind == JsonValueKind.Object ? Str(html, "meta") : null,
             Resources = resources,
-            ReflectionDisabled = reflection.ValueKind == JsonValueKind.Object
-                && reflection.TryGetProperty("disabled", out var rd) && rd.ValueKind == JsonValueKind.True,
-            ReflectionTarget = (reflection.ValueKind == JsonValueKind.Object ? Str(reflection, "target") : null) ?? "file",
+            ReflectionDisabled = reflection.ValueKind == JsonValueKind.Object && reflection.TryGetProperty("disabled", out var rd)
+                ? rd.ValueKind == JsonValueKind.True
+                : (bool?)null,
+            ReflectionTarget = reflection.ValueKind == JsonValueKind.Object ? Str(reflection, "target") : null,
         };
     }
+
+    /// <summary>Parses the <c>outputFormatting</c> string (case-insensitive) into the enum; null/unknown → absent.</summary>
+    private static JsOutputFormatting? ParseFormatting(string? s)
+        => s?.Trim().ToLowerInvariant() switch
+        {
+            "formatted" => JsOutputFormatting.Formatted,
+            "minified" => JsOutputFormatting.Minified,
+            "both" => JsOutputFormatting.Both,
+            _ => null,
+        };
 }


### PR DESCRIPTION
Ports the legacy H5 compiler's "generate both normal and minified JS"
behaviour to Transpose so the `outputFormatting` tps.json option
(Formatted/Minified/Both) works end to end.

- TransposeJson: parse `outputFormatting`, and merge a
  `tps.<Configuration>.json` overlay (e.g. tps.Release.json) on top of the
  base tps.json — scalars from the overlay win, resource arrays concat —
  mirroring the legacy ConfigHelper. This is how a project keeps Formatted
  for Debug and flips to Both for Release.
- JsMinifier: minify with NUglify 1.20.7 (the same library/version the
  legacy compiler uses), porting its safe / crunch-locals / runtime-core
  CodeSettings profiles and the file-name → settings selection.
- Packages ship both variants: the runtime bundles (tps.min.js /
  tps.meta.min.js, embedded by `tps --build-runtime`) and library packages
  (CollectEmbeddableItems) now embed a pre-minified variant of their
  compiled JS, so a referencing build reuses them instead of re-minifying
  large runtime/library code. A site build only minifies its own
  bundle/metadata/shim, with a compile-time fallback for older packages
  that predate the .min.js.
- OutputBuilder: emit index.html (formatted) and index.min.html (minified)
  and collapse them per build configuration (Release keeps the minified
  one as index.html, Debug the formatted one) — a faithful port of the
  legacy HtmlGenerator, including its file-import selection.

Verified against a real H5 Release build of an equivalent project: the
emitted .min.js is valid (node --check) and executes correctly, and the
index.html / index.min.html file selection matches across the
Formatted / Minified / Both × Debug / Release / (neither) matrix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SJ4B9t6WJJ1wSuZzLuf5oZ