### PR TITLE
Fix constructor ordering, numeric casts, and record equality

### DIFF
--- a/BCL/Transpose.BCL/shared/System/Random.cs
+++ b/BCL/Transpose.BCL/shared/System/Random.cs
@@ -54,14 +54,19 @@ namespace System
             //Initialize our Seed array.
             //This algorithm comes from Numerical Recipes in C (2nd Ed.)
             int subtraction = (seed == int.MinValue) ? int.MaxValue : Math.Abs(seed);
-            mj = MSEED - subtraction;
+            // The `(int)` casts on the subtractions are no-ops on .NET (the operands are already
+            // int) but are required when transpiled: this algorithm relies on 32-bit integer
+            // subtraction WRAPPING on overflow, which JavaScript's Number arithmetic does not do.
+            // Forcing the cast makes the emitter clip the result to int32 so, e.g., a time-based
+            // seed near int.MaxValue no longer corrupts SeedArray into a degenerate sequence.
+            mj = (int)(MSEED - subtraction);
             SeedArray[55] = mj;
             mk = 1;
             for (int i = 1; i < 55; i++)
             {  //Apparently the range [1..55] is special (Knuth) and so we're wasting the 0'th position.
                 ii = (21 * i) % 55;
                 SeedArray[ii] = mk;
-                mk = mj - mk;
+                mk = (int)(mj - mk);
                 if (mk < 0)
                 {
                     mk += MBIG;
@@ -72,7 +77,7 @@ namespace System
             {
                 for (int i = 1; i < 56; i++)
                 {
-                    SeedArray[i] -= SeedArray[1 + (i + 30) % 55];
+                    SeedArray[i] = (int)(SeedArray[i] - SeedArray[1 + (i + 30) % 55]);
                     if (SeedArray[i] < 0)
                     {
                         SeedArray[i] += MBIG;
@@ -110,7 +115,8 @@ namespace System
                 locINextp = 1;
             }
 
-            retVal = SeedArray[locINext] - SeedArray[locINextp];
+            // (int) cast forces 32-bit wrap when transpiled (see the ctor for why); a no-op on .NET.
+            retVal = (int)(SeedArray[locINext] - SeedArray[locINextp]);
 
             if (retVal == MBIG)
             {

--- a/Transpose/Transpose.Translator.Tests/ConstructorOrderingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ConstructorOrderingTests.cs
@@ -1,0 +1,287 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Constructor emission and initialization ordering. C#'s rules are subtle and the emitter must
+    /// reproduce them exactly:
+    ///  - a derived class's instance field initializers run BEFORE the base constructor body, so a
+    ///    virtual method called from the base ctor sees the derived fields already set;
+    ///  - a `: this(...)` delegation must NOT re-run field initializers (they run in the delegated
+    ///    ctor) and must bind to a SIBLING ctor of the same declaring type, not dynamically to the
+    ///    most-derived override (which would recurse forever in a subclass);
+    ///  - `: base(args)` / primary-constructor `: Base(args)` forward their arguments;
+    ///  - records forward positional args to a base record and chain secondary ctors to the primary.
+    /// Every test diffs Transpose's JS output against native .NET.
+    /// </summary>
+    [TestClass]
+    public class ConstructorOrderingTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task MultiLevelInheritanceBaseAndThisChainsAsync()
+        {
+            // Puppy -> Dog -> Animal with `: base(4)`, `: this()`, `: base(n)` mixed. The middle
+            // class's `: this()` must call Dog's own ctor, not Puppy's (a dynamic `this.ctor()`
+            // recursed into the subclass forever → stack overflow).
+            await RunTest(@"
+using System;
+public abstract class Animal
+{
+    public string Kind = ""animal"";
+    protected int legs;
+    public Animal() { Console.WriteLine(""Animal()""); }
+    public Animal(int l) { legs = l; Console.WriteLine(""Animal(int) legs="" + legs); }
+    public abstract string Speak();
+}
+public class Dog : Animal
+{
+    public string Name = ""Rex"";
+    private int extra = 99;
+    public Dog() : base(4) { Console.WriteLine(""Dog() Name="" + Name + "" extra="" + extra); }
+    public Dog(string n) : this() { Name = n; Console.WriteLine(""Dog(string) Name="" + Name); }
+    public override string Speak() => ""Woof from "" + Name;
+}
+public class Puppy : Dog
+{
+    public int Age = 1;
+    public Puppy(string n) : base(n) { Console.WriteLine(""Puppy(string) Age="" + Age); }
+    public override string Speak() => base.Speak() + "" (puppy age "" + Age + "")"";
+}
+public class Program
+{
+    public static void Main()
+    {
+        var d = new Dog();          Console.WriteLine(d.Speak());
+        var d2 = new Dog(""Fido"");   Console.WriteLine(d2.Speak());
+        var p = new Puppy(""Bella""); Console.WriteLine(p.Speak());
+        Console.WriteLine(""Kind="" + p.Kind);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task DerivedFieldInitRunsBeforeBaseCtorBodyAsync()
+        {
+            // The classic C# gotcha: a virtual method invoked from the base constructor dispatches
+            // to the override, which must already see the derived field initializers.
+            await RunTest(@"
+using System;
+public class Base
+{
+    public Base() { Console.WriteLine(""Base.ctor sees: "" + Describe()); }
+    public virtual string Describe() => ""base"";
+}
+public class Derived : Base
+{
+    private string tag = ""TAG-SET"";
+    public int Count = 10;
+    public Derived() { Console.WriteLine(""Derived.ctor tag="" + tag); }
+    public override string Describe() => ""derived tag="" + (tag ?? ""null"") + "" count="" + Count;
+}
+public class Program
+{
+    public static void Main()
+    {
+        var d = new Derived();
+        Console.WriteLine(d.Describe());
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task ThisChainDoesNotRerunFieldInitializersAsync()
+        {
+            // A `: this(...)` delegation must not re-run the instance field initializers after the
+            // delegated ctor already set the object up (the Random/Guid constant-value bug).
+            await RunTest(@"
+using System;
+public class Box
+{
+    public int[] Data = new int[3];
+    public Box() : this(7) { }
+    public Box(int seed) { Data[0] = seed; Data[1] = seed + 1; Data[2] = seed + 2; }
+}
+public class Program
+{
+    public static void Main()
+    {
+        var b = new Box();
+        Console.WriteLine(b.Data[0] + "","" + b.Data[1] + "","" + b.Data[2]);   // 7,8,9
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task DeepThisAndBaseChainWithStaticCtorAsync()
+        {
+            await RunTest(@"
+using System;
+public class A
+{
+    public static int Created = 0;
+    public string trace;
+    public A() : this(""default"") { trace += ""|A()""; }
+    public A(string s) { trace = ""A("" + s + "")""; Created++; }
+}
+public class B : A
+{
+    public int id = Next();
+    static int counter = 100;
+    static int Next() => ++counter;
+    public B() : base(""from-B"") { trace += ""|B() id="" + id; }
+    public B(int x) : this() { trace += ""|B(int)="" + x; }
+}
+public class Program
+{
+    public static void Main()
+    {
+        var b = new B(5);  Console.WriteLine(b.trace);
+        Console.WriteLine(""Created="" + A.Created);
+        var b2 = new B();  Console.WriteLine(b2.trace);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task GenericBaseVirtualDispatchAndThisChainAsync()
+        {
+            await RunTest(@"
+using System;
+public class Container<T>
+{
+    protected T value;
+    public Container(T v) { value = v; Setup(); }
+    protected virtual void Setup() { Console.WriteLine(""Container.Setup "" + value); }
+    public T Get() => value;
+}
+public class Named<T> : Container<T>
+{
+    public string name = ""unnamed"";
+    public Named(T v) : base(v) { Console.WriteLine(""Named ctor name="" + name); }
+    public Named(T v, string n) : this(v) { name = n; }
+    protected override void Setup() { Console.WriteLine(""Named.Setup value="" + value + "" name="" + (name ?? ""null"")); }
+}
+public class Program
+{
+    public static void Main()
+    {
+        var n = new Named<int>(42, ""answer"");
+        Console.WriteLine(n.Get() + "" / "" + n.name);
+        var n2 = new Named<string>(""hi"");
+        Console.WriteLine(n2.Get() + "" / "" + n2.name);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task StructConstructorThisChainAsync()
+        {
+            await RunTest(@"
+using System;
+public struct Point
+{
+    public int X, Y;
+    public Point(int x, int y) { X = x; Y = y; }
+    public Point(int v) : this(v, v) { }
+    public override string ToString() => $""({X},{Y})"";
+}
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Point(5));
+        Console.WriteLine(new Point(3, 7));
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task PrimaryConstructorWithBaseAndSecondaryAsync()
+        {
+            await RunTest(@"
+using System;
+public class Widget(int w, int h)
+{
+    public int W = w, H = h;
+    public Widget(int size) : this(size, size) { Console.WriteLine(""Widget(size)""); }
+}
+public class Button(string label) : Widget(10, 5)
+{
+    public string Label = label;
+    public Button() : this(""OK"") { Console.WriteLine(""Button()""); }
+}
+public class Program
+{
+    public static void Main()
+    {
+        var w = new Widget(7);
+        Console.WriteLine($""{w.W}x{w.H}"");
+        var b = new Button();
+        Console.WriteLine($""{b.Label} {b.W}x{b.H}"");
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task RecordSecondaryConstructorAndInheritanceAsync()
+        {
+            // Records: a secondary ctor chains to the positional primary; a derived record forwards
+            // its `: Base(...)` args; ToString/Equals/GetHashCode include inherited members.
+            await RunTest(@"
+using System;
+public record Shape(string Color);
+public record Circle(string Color, double Radius) : Shape(Color);
+public record Person(string Name, int Age)
+{
+    public Person(string name) : this(name, 0) { }
+}
+public class Program
+{
+    public static void Main()
+    {
+        var a = new Circle(""red"", 2.0);
+        var b = new Circle(""red"", 2.0);
+        var c = new Circle(""blue"", 2.0);
+        Console.WriteLine(a);                              // Circle { Color = red, Radius = 2 }
+        Console.WriteLine(a == b);                         // True
+        Console.WriteLine(a.Equals(b));                    // True (IEquatable<Circle>)
+        Console.WriteLine(a.Equals(c));                    // False
+        Console.WriteLine(a.Equals((object)b));            // True (object override)
+        Console.WriteLine(a.GetHashCode() == b.GetHashCode()); // True
+        var p = new Person(""Alice"");
+        Console.WriteLine(p);                              // Person { Name = Alice, Age = 0 }
+        var p2 = new Person(""Bob"", 30);
+        Console.WriteLine(p2.Equals(new Person(""Bob"", 30)));   // True
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task DefaultCtorWithFieldInitAndInheritanceAsync()
+        {
+            // No explicit derived ctor: the synthesized default must still run field initializers
+            // and chain to the base's parameterless ctor.
+            await RunTest(@"
+using System;
+public class Base
+{
+    public string b = ""base-field"";
+    public Base() { Console.WriteLine(""Base ctor b="" + b); }
+}
+public class Derived : Base
+{
+    public int n = 42;
+    public string tag = ""derived-field"";
+}
+public class Program
+{
+    public static void Main()
+    {
+        var d = new Derived();
+        Console.WriteLine(d.b + "" "" + d.n + "" "" + d.tag);
+    }
+}");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/PrimitiveCastTests.cs
+++ b/Transpose/Transpose.Translator.Tests/PrimitiveCastTests.cs
@@ -1,0 +1,285 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Exhaustive coverage of primitive-type conversions (C# `(T)x` casts and implicit numeric
+    /// conversions). C# and JavaScript disagree on integer width and overflow, so every narrowing
+    /// or reinterpreting conversion needs explicit handling in the emitter:
+    ///  - integer → narrower integer wraps (mask + sign-extend): `(short)70000` == 4464, `(sbyte)200` == -56;
+    ///  - signed ⇄ unsigned reinterpretation: `(uint)-1` == 4294967295, `(int)uint` wraps, `(long)ulong` reinterprets;
+    ///  - long/ulong → narrower reads the low bits (a plain `.toNumber()` loses precision above 2^53);
+    ///  - float/double → integer SATURATES to the target range (NaN → 0), unlike an integer cast which wraps;
+    ///  - char boxing: a boxed / ToString()'d char must render as its character, not its code point.
+    /// Each test diffs Transpose's JS output against native .NET, so the assertions are the CLR's.
+    /// </summary>
+    [TestClass]
+    public class PrimitiveCastTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task IntToNarrowerSignedAndUnsignedAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        int big = 70000;
+        P((short)big);   P((ushort)big);  P((byte)big);   P((sbyte)big);
+        int neg = -123;
+        P((byte)neg);    P((sbyte)neg);   P((short)neg);  P((ushort)neg);  P((uint)neg);
+        int p300 = 300, n200 = -200;   // via variables: a constant narrowing overflow is a compile error
+        P((sbyte)p300);  P((byte)p300);  P((sbyte)n200); P((byte)n200);
+        // re-wrapping an int overflow the C# way (JS + does not overflow on its own)
+        int a = 2000000000;
+        P((int)(a + a)); P((uint)(a + a));
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task LongAndUlongNarrowingAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        long L = 0x1_2233_4455L;
+        P((int)L);  P((uint)L);  P((short)L); P((ushort)L); P((byte)L); P((sbyte)L);
+        long Ln = -5000000000L;
+        P((int)Ln); P((uint)Ln); P((short)Ln); P((byte)Ln);
+        // signed/unsigned 64-bit reinterpretation
+        ulong ul = 18000000000000000000UL;
+        P((long)ul);
+        long neg1 = -1L;
+        P((ulong)neg1);
+        uint u = 4000000000u;
+        P((int)u);  P((short)u); P((byte)u);
+        // int widened to long via arithmetic must not overflow like a 32-bit add
+        int x = 2000000000;
+        P((long)x + x);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task FloatToIntegerSaturatesAsync()
+        {
+            // The CLR saturates an out-of-range float→integer conversion to the target's Min/Max
+            // (NaN → 0) — it does NOT wrap. Sub-word targets saturate to int32 first, then mask.
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        double[] vals = { 300.9, -3.9, 70000.5, 5e9, -5e9, 1e20, -1e20,
+                          double.NaN, double.PositiveInfinity, double.NegativeInfinity,
+                          2147483647.9, 2147483648.9, 4294967296.5 };
+        foreach (var d in vals)
+        {
+            P((sbyte)d); P((byte)d); P((short)d); P((ushort)d);
+            P((int)d);   P((uint)d); P((long)d);  P((ulong)d);
+        }
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task FloatToIntegerInRangeTruncatesTowardZeroAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        P((int)3.9);    P((int)-3.9);   P((int)3.2);   P((int)-3.2);
+        P((long)3.9);   P((long)-3.9);
+        float f = 2.75f;
+        P((int)f);      P((byte)f);
+        double huge = 12345.678;
+        P((int)huge);   P((short)huge); P((byte)huge);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task DecimalConversionsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        // decimal → integer is a CHECKED conversion in C# (throws on overflow), so stay in range
+        // and verify truncation toward zero.
+        decimal m = 200.9m;
+        P((int)m);   P((byte)m);  P((short)m);  P((long)m);
+        decimal neg = -3.9m;
+        P((int)neg); P((sbyte)neg);
+        int i = 300;
+        P((decimal)i);
+        double d = 2.5;
+        P((decimal)d);
+        decimal back = 42.5m;
+        P((double)back); P((float)back);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task CharIntConversionsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        char c = 'A';
+        Console.WriteLine((int)c);            // 65
+        int ci = 66;
+        Console.WriteLine((char)ci);          // B
+        Console.WriteLine((char)(c + 1));     // B
+        int cbig = 65601;                     // 0x10041 -> low 16 = 'A'
+        Console.WriteLine((int)(char)cbig);   // 65
+        Console.WriteLine((char)97);          // a
+        char z = (char)(90);
+        Console.WriteLine(z);                 // Z
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task CharBoxingAndToStringAsync()
+        {
+            // A char is a bare code-point number at runtime; boxing / ToString() must still render
+            // it as its character.
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        char c = 'A';
+        Console.WriteLine(c);                       // A
+        Console.WriteLine(c.ToString());            // A
+        object o = c;                               // boxed
+        Console.WriteLine(o);                       // A
+        Console.WriteLine(o.ToString());            // A
+        Console.WriteLine(""v="" + c);              // v=A
+        object[] arr = { 'X', 'Y', 'Z' };
+        Console.WriteLine(arr[0] + "","" + arr[1] + "","" + arr[2]);  // X,Y,Z
+        Console.WriteLine(string.Format(""{0}-{1}"", 'p', 'q'));      // p-q
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task ImplicitWideningConversionsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        byte b = 200;
+        int i = b;          P(i);           // 200
+        long l = i;         P(l);           // 200
+        double d = l;       P(d);           // 200
+        short s = -5;
+        int si = s;         P(si);          // -5
+        long sl = si;       P(sl);          // -5
+        float f = 3;        P(f);           // 3
+        decimal m = 42;     P(m);           // 42
+        char c = 'A';
+        int cc = c;         P(cc);          // 65
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task CompoundAssignmentNarrowingAsync()
+        {
+            // `b += x` on a narrow type compiles to `b = (T)(b + x)` and must wrap to the type width.
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        byte b = 250; b += 10;   P(b);        // 4
+        sbyte s = 120; s += 20;  P(s);        // -116
+        short sh = 32000; sh += 1000; P(sh);  // -32536
+        ushort us = 65530; us += 10; P(us);   // 4
+        byte c = 5; c -= 10;     P(c);        // 251
+        byte m = 30; m *= 10;    P(m);        // 44 (300 & 0xff)
+        short shl = 20000; shl <<= 2; P(shl); // 14464 (80000 & 0xffff, sign-extended)
+        byte bm = 200; bm %= 150; P(bm);      // 50
+        char ch = 'A'; ch += (char)1; P((int)ch); // 66
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task IncrementDecrementNarrowingAsync()
+        {
+            // ++/-- on a sub-word integer wraps at the type boundary (`byte 255 + 1` == 0), and a
+            // normal-range loop counter is unaffected.
+            await RunTest(@"
+using System;
+public class Program
+{
+    static void P(object o) => Console.WriteLine(o);
+    public static void Main()
+    {
+        byte b = 255; b++;  P(b);          // 0
+        sbyte s = 127; s++; P(s);          // -128
+        byte d = 0; d--;    P(d);          // 255
+        ushort u = 65535; ++u; P(u);       // 0
+        short sh = -32768; --sh; P(sh);    // 32767
+        // in-range increments and a byte-counted loop behave normally
+        int sum = 0;
+        for (byte i = 0; i < 10; i++) sum += i;
+        P(sum);                            // 45
+        byte n = 40; n++; P(n);            // 41
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task UnsignedFormattingRoundTripAsync()
+        {
+            // The original Guid.ToString() breakage: a negative int cast to uint kept its sign and
+            // formatted as "-7b…", breaking hex formatting.
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        int neg = -123;
+        Console.WriteLine((uint)neg);                     // 4294967173
+        Console.WriteLine(((uint)neg).ToString(""x8""));  // ffffff85
+        Console.WriteLine(((byte)200).ToString(""x2""));  // c8
+        uint u = 0xDEADBEEF;
+        Console.WriteLine(u.ToString(""X8""));            // DEADBEEF
+    }
+}");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -12,8 +12,45 @@ public sealed partial class Emitter
     /// <summary>Emits an expression used in statement position, terminated with ";".</summary>
     private void EmitExpressionStatement(ExpressionSyntax expr)
     {
+        // `x++;` / `--x;` on a sub-32-bit integer must re-narrow like `x = (T)(x ± 1)` — a bare JS
+        // `x++` skips that (T) cast, so a byte at 255 became 256 instead of wrapping to 0. Handled
+        // here (statement context: the result value is discarded, so prefix/postfix are equivalent).
+        if (TryEmitNarrowingIncDecStatement(expr)) return;
         EmitExpression(expr);
         _w.WriteLine(";");
+    }
+
+    /// <summary>Emits a stand-alone ++/-- on a sub-word integer as a width-wrapping assignment.
+    /// Restricted to side-effect-free lvalues (identifier / simple field access) because the operand
+    /// is emitted twice; anything else falls through to the plain (un-narrowed) form.</summary>
+    private bool TryEmitNarrowingIncDecStatement(ExpressionSyntax expr)
+    {
+        ExpressionSyntax operand;
+        string binOp;
+        switch (expr)
+        {
+            case PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.PostIncrementExpression } post: operand = post.Operand; binOp = "+"; break;
+            case PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.PostDecrementExpression } post: operand = post.Operand; binOp = "-"; break;
+            case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.PreIncrementExpression } pre: operand = pre.Operand; binOp = "+"; break;
+            case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.PreDecrementExpression } pre: operand = pre.Operand; binOp = "-"; break;
+            default: return false;
+        }
+
+        var t = _model.GetTypeInfo(operand).Type;
+        if (!IsSubWordIntegerTarget(t)) return false;
+        // Re-emitting a receiver with side effects (indexer, method call) would run it twice.
+        if (operand is not IdentifierNameSyntax
+            && operand is not MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax or IdentifierNameSyntax })
+            return false;
+
+        EmitExpression(operand);
+        _w.Write(" = ");
+        _w.Write(NarrowIntegerClip(t!.SpecialType));
+        _w.Write("((");
+        EmitExpression(operand);
+        _w.Write($") {binOp} 1);");
+        _w.WriteLine();
+        return true;
     }
 
     /// <summary>True if the expression is a call whose [Template] is a comment-only no-op
@@ -249,6 +286,17 @@ public sealed partial class Emitter
             && TransposeNaming.EnumEmitMode(sourceType) is not (2 or 3 or 4 or 5 or 6))
         {
             _w.Write($"System.Enum.toString({TypeRef(sourceType)}, ");
+            EmitExpression(expr);
+            _w.Write(")");
+            return;
+        }
+
+        // char → object / interface / ValueType / dynamic (a boxing conversion). A char is a bare
+        // code-point number at runtime; box it so the boxed value stringifies and compares as its
+        // character (e.g. `object o = 'A'; o.ToString()` → "A", not "65").
+        if (IsCharType(sourceType) && targetType is { IsReferenceType: true })
+        {
+            _w.Write("TransposeR.boxChar(");
             EmitExpression(expr);
             _w.Write(")");
             return;

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -86,6 +86,18 @@ public sealed partial class Emitter
             return;
         }
 
+        // char.ToString() → the single-character string. A char is a bare code-point number at
+        // runtime, so its default `.toString()` would give the number ("65") not the character.
+        if (symbol is { Name: "ToString", Parameters.Length: 0 }
+            && invocation.Expression is MemberAccessExpressionSyntax { Expression: { } charRecv }
+            && IsCharType(_model.GetTypeInfo(charRecv).Type))
+        {
+            _w.Write("String.fromCharCode(");
+            EmitExpression(charRecv);
+            _w.Write(")");
+            return;
+        }
+
         // Transpose.Script.Write(code, args) — inject raw JavaScript, substituting {0},{1}… with args.
         if (symbol is { Name: "Write" } && symbol.ContainingType?.ToDisplayString() == "Transpose.Script"
             && invocation.ArgumentList.Arguments.Count >= 1
@@ -1266,11 +1278,33 @@ public sealed partial class Emitter
         if (op == "/=" && IsIntegerType(leftType) && IsIntegerType(rightType))
         {
             EmitExpression(assignment.Left);
-            _w.Write(" = TransposeR.idiv(");
+            _w.Write(" = ");
+            if (IsSubWordIntegerTarget(leftType)) _w.Write(NarrowIntegerClip(leftType!.SpecialType) + "(");
+            _w.Write("TransposeR.idiv(");
             EmitExpression(assignment.Left);
             _w.Write(", ");
             EmitExpression(assignment.Right);
             _w.Write(")");
+            if (IsSubWordIntegerTarget(leftType)) _w.Write(")");
+            return;
+        }
+
+        // Compound arithmetic/bitwise assignment to a sub-32-bit integer (`b += x`, `sh <<= 2`, …):
+        // C# evaluates it as `b = (T)(b op x)`, re-narrowing the int-promoted result to T's width.
+        // A bare JS `b += x` skips that (T) cast, so e.g. `(byte)250 += 10` stayed 260 instead of 4.
+        // Both operands are < 2^16, so the promoted result is exact in JS and a clip wraps it exactly.
+        if (op.Length == 2 && op[1] == '=' && "+-*%&|^".IndexOf(op[0]) >= 0 && IsSubWordIntegerTarget(leftType)
+            || op is "<<=" or ">>=" && IsSubWordIntegerTarget(leftType))
+        {
+            var binOp = op.Substring(0, op.Length - 1);
+            EmitExpression(assignment.Left);
+            _w.Write(" = ");
+            _w.Write(NarrowIntegerClip(leftType!.SpecialType));
+            _w.Write("((");
+            EmitExpression(assignment.Left);
+            _w.Write($") {binOp} (");
+            EmitExpression(assignment.Right);
+            _w.Write("))");
             return;
         }
 
@@ -1330,80 +1364,148 @@ public sealed partial class Emitter
     // ---- cast --------------------------------------------------------------
 
     private void EmitCast(CastExpressionSyntax cast)
-    {
-        var targetType = _model.GetTypeInfo(cast.Type).Type;
-        var sourceType = _model.GetTypeInfo(cast.Expression).Type;
+        => EmitNumericConversion(_model.GetTypeInfo(cast.Type).Type,
+                                 _model.GetTypeInfo(cast.Expression).Type,
+                                 cast.Expression);
 
-        // 64-bit conversions: to long/ulong → wrap; from long/ulong to a 32-bit/float → number.
-        if (Is64BitInteger(targetType) && !Is64BitInteger(sourceType) && !IsDecimalType(sourceType))
+    /// <summary>
+    /// Emits an explicit numeric conversion honouring C#'s truncation / wrapping rules. Handles
+    /// every primitive-to-primitive cast: to/from 64-bit (long/ulong) and decimal, narrowing to a
+    /// ≤32-bit integer / char (with correct sign extension and bit-width wrapping), and reference
+    /// casts (erased). The <paramref name="expr"/> is emitted at most once.
+    /// </summary>
+    private void EmitNumericConversion(ITypeSymbol? targetType, ITypeSymbol? sourceType, ExpressionSyntax expr)
+    {
+        // --- to a ≤32-bit integer / char target. ---
+        // From an integer source (int/long/char/enum): truncate to the target's bit width, wrapping
+        // (`(short)70000` → 4464, `(uint)-1` → 4294967295, `(sbyte)200` → -56, `(int)(a+b)` re-wraps
+        // an overflow). From a float/double source: saturate to int32 first (CLR maps out-of-range
+        // to Min/Max and NaN → 0, NOT wrap — `(byte)5e9` → 255, `(int)1e20` → int.MaxValue), then
+        // mask to width. Runtime Transpose.Int.clip* do the final mask + sign-extend.
+        if (IsNarrowIntegerTarget(targetType) && IsNumericSource(sourceType))
         {
-            _w.Write(Is64BitUnsigned(targetType) ? "System.UInt64(" : "System.Int64(");
-            EmitExpression(cast.Expression);
-            _w.Write(")");
-            return;
-        }
-        if (Is64BitInteger(sourceType) && !Is64BitInteger(targetType) && (IsIntegerType(targetType) || IsFloatingType(targetType)))
-        {
-            if (IsFloatingType(targetType))
+            var t = targetType!.SpecialType;
+            if (IsFloatingType(sourceType) && t == SpecialType.System_Int32)
             {
-                _w.Write("("); EmitExpression(cast.Expression); _w.Write(").toNumber()");
+                _w.Write("TransposeR.fclip32("); EmitExpression(expr); _w.Write(")");
+                return;
+            }
+            if (IsFloatingType(sourceType) && t == SpecialType.System_UInt32)
+            {
+                _w.Write("TransposeR.fclipu32("); EmitExpression(expr); _w.Write(")");
+                return;
+            }
+            _w.Write(NarrowIntegerClip(t));
+            _w.Write("(");
+            if (Is64BitInteger(sourceType))
+            {
+                // Bring the 64-bit value down to its low 32-bit word (a plain JS number) first;
+                // clip* then mask/sign-extend to the final width.
+                _w.Write("System.Int64.clip32("); EmitExpression(expr); _w.Write(")");
+            }
+            else if (IsDecimalType(sourceType))
+            {
+                _w.Write("("); EmitExpression(expr); _w.Write(").toFloat()");
+            }
+            else if (IsFloatingType(sourceType))
+            {
+                // Sub-word float target: saturate to int32, then the outer clip masks to width.
+                _w.Write("TransposeR.fclip32("); EmitExpression(expr); _w.Write(")");
             }
             else
             {
-                // long → int/uint/short/… wraps to the low 32 bits (C# truncation). Use the runtime's
-                // Int64.clip32/clipu32, which read the exact low word off the Int64. Plain .toNumber()
-                // keeps the full magnitude (and loses precision above 2^53), so e.g.
-                // `(int)DateTime.Now.Ticks` stayed a huge value — giving `new Random()` a garbage seed
-                // and making Guid.NewGuid()/Random produce a constant value.
-                _w.Write(IsUnsignedIntegerTarget(targetType) ? "System.Int64.clipu32(" : "System.Int64.clip32(");
-                EmitExpression(cast.Expression);
-                _w.Write(")");
+                EmitExpression(expr);
             }
-            return;
-        }
-
-        // decimal conversions: to decimal → wrap; decimal → float/int → toFloat (truncated for int).
-        if (IsDecimalType(targetType) && !IsDecimalType(sourceType))
-        {
-            _w.Write("System.Decimal("); EmitExpression(cast.Expression); _w.Write(")");
-            return;
-        }
-        if (IsDecimalType(sourceType) && !IsDecimalType(targetType) && (IsIntegerType(targetType) || IsFloatingType(targetType)))
-        {
-            if (IsIntegerType(targetType) && !Is64BitInteger(targetType)) { _w.Write("TransposeR.trunc("); EmitExpression(cast.Expression); _w.Write(".toFloat())"); }
-            else { _w.Write("("); EmitExpression(cast.Expression); _w.Write(").toFloat()"); }
-            return;
-        }
-
-        // Numeric narrowing to an integer type truncates toward zero.
-        if (IsIntegerType(targetType) && IsFloatingType(sourceType))
-        {
-            _w.Write("TransposeR.trunc(");
-            EmitExpression(cast.Expression);
             _w.Write(")");
             return;
         }
 
-        // Integer → unsigned-integer reinterpretation (≤32-bit source). C# reinterprets the bit
-        // pattern, so a negative value becomes its unsigned equivalent; without this the cast was
-        // erased and a negative int stayed negative — e.g. `(uint)_a` in Guid.ToString() formatted
-        // as "-7b…" and broke the format regex. `>>> 0` / mask matches the reinterpretation.
-        if (IsIntegerType(sourceType) && !Is64BitInteger(sourceType) && IsUnsignedIntegerTarget(targetType))
+        // --- to 64-bit integer (long/ulong) ---
+        // From a float/double: saturate to the 64-bit range (Min/Max, NaN → 0). From another
+        // non-64-bit numeric: wrap. Between long/ulong of differing sign: reinterpret the 64 bits
+        // (`(long)ulong`, `(ulong)long`) — the Int64/UInt64 ctor does value.toSigned()/toUnsigned().
+        // Same 64-bit type is a no-op (erased below).
+        if (Is64BitInteger(targetType) && IsFloatingType(sourceType))
         {
-            var mask = targetType!.SpecialType switch
-            {
-                SpecialType.System_Byte => " & 0xff)",
-                SpecialType.System_UInt16 or SpecialType.System_Char => " & 0xffff)",
-                _ => " >>> 0)", // uint
-            };
-            _w.Write("(("); EmitExpression(cast.Expression); _w.Write(")"); _w.Write(mask);
+            _w.Write(Is64BitUnsigned(targetType) ? "TransposeR.fclipu64(" : "TransposeR.fclip64(");
+            EmitExpression(expr);
+            _w.Write(")");
+            return;
+        }
+        // decimal → long/ulong: truncate toward zero (via the numeric magnitude) then wrap to 64-bit.
+        if (Is64BitInteger(targetType) && IsDecimalType(sourceType))
+        {
+            _w.Write(Is64BitUnsigned(targetType) ? "TransposeR.fclipu64((" : "TransposeR.fclip64((");
+            EmitExpression(expr);
+            _w.Write(").toFloat())");
+            return;
+        }
+        if (Is64BitInteger(targetType) && !IsDecimalType(sourceType)
+            && !(Is64BitInteger(sourceType) && sourceType!.SpecialType == targetType!.SpecialType))
+        {
+            _w.Write(Is64BitUnsigned(targetType) ? "System.UInt64(" : "System.Int64(");
+            EmitExpression(expr);
+            _w.Write(")");
             return;
         }
 
-        // char <-> int: chars are represented as their code point (number).
-        // Other reference casts are erased.
-        EmitExpression(cast.Expression);
+        // --- from 64-bit to floating: read the numeric magnitude. ---
+        if (Is64BitInteger(sourceType) && IsFloatingType(targetType))
+        {
+            _w.Write("("); EmitExpression(expr); _w.Write(").toNumber()");
+            return;
+        }
+
+        // --- to decimal: wrap. ---
+        if (IsDecimalType(targetType) && !IsDecimalType(sourceType))
+        {
+            _w.Write("System.Decimal("); EmitExpression(expr); _w.Write(")");
+            return;
+        }
+        // --- from decimal to floating (integer targets handled above). ---
+        if (IsDecimalType(sourceType) && IsFloatingType(targetType))
+        {
+            _w.Write("("); EmitExpression(expr); _w.Write(").toFloat()");
+            return;
+        }
+
+        // char <-> int (chars are their code point), int → 64-bit float, widening, and reference
+        // casts are all representation-preserving and so erased.
+        EmitExpression(expr);
     }
+
+    /// <summary>A ≤32-bit integer or char target — a narrowing/reinterpretation to a fixed
+    /// bit width. Enums (SpecialType.None) are excluded: they carry their underlying value as-is.</summary>
+    private static bool IsNarrowIntegerTarget(ITypeSymbol? type) => type?.SpecialType is
+        SpecialType.System_SByte or SpecialType.System_Byte
+        or SpecialType.System_Int16 or SpecialType.System_UInt16
+        or SpecialType.System_Int32 or SpecialType.System_UInt32
+        or SpecialType.System_Char;
+
+    /// <summary>A numeric source that can feed an integer narrowing (int/long/float/decimal/char/enum).</summary>
+    private static bool IsNumericSource(ITypeSymbol? type)
+        => IsIntegerType(type) || IsFloatingType(type) || IsDecimalType(type) || IsCharType(type);
+
+    /// <summary>A sub-32-bit integer / char type (byte/sbyte/short/ushort/char). Arithmetic on these
+    /// is promoted to int, so a compound assignment (`b += x`) must re-narrow the result to width —
+    /// and because both operands are &lt; 2^16 the promoted result is exact in JS, so a plain JS
+    /// operation followed by a clip reproduces the CLR result exactly.</summary>
+    private static bool IsSubWordIntegerTarget(ITypeSymbol? type) => type?.SpecialType is
+        SpecialType.System_SByte or SpecialType.System_Byte
+        or SpecialType.System_Int16 or SpecialType.System_UInt16
+        or SpecialType.System_Char;
+
+    /// <summary>The runtime clip helper that truncates + wraps a JS number to the given integer
+    /// width (mask + sign-extend), matching the CLR's unchecked conversion.</summary>
+    private static string NarrowIntegerClip(SpecialType target) => target switch
+    {
+        SpecialType.System_SByte => "Transpose.Int.clip8",
+        SpecialType.System_Byte => "Transpose.Int.clipu8",
+        SpecialType.System_Int16 => "Transpose.Int.clip16",
+        SpecialType.System_UInt16 or SpecialType.System_Char => "Transpose.Int.clipu16",
+        SpecialType.System_UInt32 => "Transpose.Int.clipu32",
+        _ => "Transpose.Int.clip32", // int
+    };
 
     // ---- interpolated string -----------------------------------------------
 
@@ -1639,7 +1741,9 @@ public sealed partial class Emitter
             if (initializer.Expressions[i] is InitializerExpressionSyntax nested)
                 EmitInitializerArray(nested);
             else
-                EmitExpression(initializer.Expressions[i]);
+                // Apply the element's converted type so an element widened to the array's element
+                // type is boxed/cloned correctly (e.g. `object[] { 'A' }` boxes the char).
+                EmitExpressionConverted(initializer.Expressions[i], _model.GetTypeInfo(initializer.Expressions[i]).ConvertedType);
         }
         _w.Write("]");
     }
@@ -1828,10 +1932,4 @@ public sealed partial class Emitter
 
     private static bool Is64BitUnsigned(ITypeSymbol? type)
         => type?.SpecialType == SpecialType.System_UInt64;
-
-    /// <summary>An unsigned 32-bit-or-narrower integer target (uint/ushort/byte/char) — a
-    /// long→unsigned narrowing takes the low bits as unsigned.</summary>
-    private static bool IsUnsignedIntegerTarget(ITypeSymbol? type)
-        => type?.SpecialType is SpecialType.System_Byte or SpecialType.System_UInt16
-            or SpecialType.System_UInt32 or SpecialType.System_Char;
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -340,8 +340,13 @@ public sealed partial class Emitter
             // initialized the object, overwriting its work with the field defaults (e.g.
             // `Random() : this(seed)` reset SeedArray back to all-zeros, so Random/Guid.NewGuid
             // produced a constant value).
-            _w.Write($"this.{CtorName(thisCtor)}(");
-            EmitArguments(initializer.ArgumentList, thisCtor);
+            //
+            // Delegate type-qualified (`ThisType.ctor.call(this, …)`), NOT via `this.ctor(…)`: a
+            // dynamic member dispatch resolves to the MOST-DERIVED override, so in a subclass
+            // instance `: this()` would re-enter the subclass constructor forever. `this(...)`
+            // always targets a sibling ctor of the SAME declaring type, so bind it there.
+            _w.Write($"{TypeRef(thisCtor.ContainingType)}.{CtorName(thisCtor)}.call(this");
+            if (initializer.ArgumentList.Arguments.Count > 0) { _w.Write(", "); EmitArguments(initializer.ArgumentList, thisCtor); }
             _w.WriteLine(");");
             return;
         }

--- a/Transpose/Transpose.Translator/Emit/Emitter.ValueTypes.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.ValueTypes.cs
@@ -15,13 +15,27 @@ public sealed partial class Emitter
                 .Where(p => !p.IsStatic && !p.IsIndexer && p.IsImplicitlyDeclared && p.Name != "EqualityContract")
             : Enumerable.Empty<IPropertySymbol>();
 
-    /// <summary>All instance properties that participate in a record's value equality / ToString.</summary>
+    /// <summary>All instance properties that participate in a record's value equality / ToString,
+    /// ordered base-record members first — matching C#'s synthesized PrintMembers / Equals /
+    /// GetHashCode, which chain to the base record before the derived members. A derived record
+    /// that only listed its own members would drop the inherited ones from ToString/equality.</summary>
     private List<string> RecordValuePropNames(INamedTypeSymbol type)
-        => type.GetMembers().OfType<IPropertySymbol>()
-            .Where(p => !p.IsStatic && p.GetMethod is not null && !p.IsIndexer && p.Name != "EqualityContract")
-            .Select(p => TransposeNaming.MemberJsName(p))
-            .Distinct()
-            .ToList();
+    {
+        var chain = new List<INamedTypeSymbol>();
+        for (var t = type; t is not null && t.IsRecord; t = t.BaseType)
+            chain.Add(t);
+        chain.Reverse(); // base → derived
+
+        var names = new List<string>();
+        foreach (var t in chain)
+            foreach (var p in t.GetMembers().OfType<IPropertySymbol>()
+                         .Where(p => !p.IsStatic && p.GetMethod is not null && !p.IsIndexer && p.Name != "EqualityContract"))
+            {
+                var n = TransposeNaming.MemberJsName(p);
+                if (!names.Contains(n)) names.Add(n);
+            }
+        return names;
+    }
 
     /// <summary>Appends synthesized value-type methods (struct $clone/equals, record members).</summary>
     private void AddValueTypeMethodEntries(INamedTypeSymbol type, List<Action> entries)
@@ -64,16 +78,27 @@ public sealed partial class Emitter
                     _w.WriteLine($"return \"{type.Name} {{ \" + {parts} + \" }}\";");
                 });
             });
+            // The value-equality body, shared by the object override `equals(obj)` and the
+            // strongly-typed IEquatable<T> `equalsT(other)` a record synthesizes. Both are needed:
+            // `a.Equals(b)` binds to IEquatable<T>.Equals → `equalsT`, while ==/collections go
+            // through `equals`. Without `equalsT` a direct `.Equals(record)` call threw
+            // "equalsT is not a function".
+            void EmitRecordEqualsBody(string param)
+            {
+                _w.WriteLine($"if ({param} == null || {param}.constructor !== this.constructor) {{ return false; }}");
+                _w.Write("return ");
+                _w.Write(props.Count == 0 ? "true" : string.Join(" && ", props.Select(p => $"TransposeR.equals(this.{p}, {param}.{p})")));
+                _w.WriteLine(";");
+            }
             entries.Add(() =>
             {
                 _w.Write("equals: function (o) ");
-                _w.Block(() =>
-                {
-                    _w.WriteLine("if (o == null || o.constructor !== this.constructor) { return false; }");
-                    _w.Write("return ");
-                    _w.Write(props.Count == 0 ? "true" : string.Join(" && ", props.Select(p => $"TransposeR.equals(this.{p}, o.{p})")));
-                    _w.WriteLine(";");
-                });
+                _w.Block(() => EmitRecordEqualsBody("o"));
+            });
+            entries.Add(() =>
+            {
+                _w.Write("equalsT: function (other) ");
+                _w.Block(() => EmitRecordEqualsBody("other"));
             });
             entries.Add(() =>
             {
@@ -125,21 +150,40 @@ public sealed partial class Emitter
                 _w.WriteLine("this.$initialize();");
                 var baseType = type.BaseType;
                 if (baseType is { } bt && bt.SpecialType != SpecialType.System_Object && bt.TypeKind != TypeKind.Error && bt.IsRecord)
-                    _w.WriteLine($"{TypeRef(bt)}.ctor.call(this);");
+                {
+                    // A derived record forwards to the base record's positional ctor with the args
+                    // from `: Base(a, b)` on the record header — without them the base's positional
+                    // members stay at their defaults (e.g. `record D(...) : B(A, B)` dropped A/B).
+                    var primaryBase = recordDecl?.BaseList?.Types.OfType<PrimaryConstructorBaseTypeSyntax>().FirstOrDefault();
+                    if (primaryBase is not null && _model.GetSymbolInfo(primaryBase).Symbol is IMethodSymbol baseCtor)
+                    {
+                        _w.Write($"{TypeRef(bt)}.{ExternalAwareCtorName(baseCtor)}.call(this");
+                        if (primaryBase.ArgumentList.Arguments.Count > 0) { _w.Write(", "); EmitArguments(primaryBase.ArgumentList, baseCtor); }
+                        _w.WriteLine(");");
+                    }
+                    else
+                    {
+                        _w.WriteLine($"{TypeRef(bt)}.ctor.call(this);");
+                    }
+                }
                 foreach (var p in positional) _w.WriteLine($"this.{p} = {p};");
             });
             _w.WriteLine(explicitCtors.Count > 0 ? "," : "");
-            // explicit ctors kept as $ctorN
+            // explicit ctors kept as $ctorN. C# requires each to chain `: this(...)` back to the
+            // positional primary; emit that delegation (EmitConstructorChain) then the body — else
+            // the delegated-to primary never runs and the record's members stay unset.
             for (var i = 0; i < explicitCtors.Count; i++)
             {
-                var decl = explicitCtors[i].DeclaringSyntaxReferences[0].GetSyntax() as ConstructorDeclarationSyntax;
+                var decl = (ConstructorDeclarationSyntax)explicitCtors[i].DeclaringSyntaxReferences[0].GetSyntax();
                 _w.Write($"{CtorName(explicitCtors[i])}: function (");
                 EmitParameterList(explicitCtors[i]);
                 _w.Write(") ");
                 _w.Block(() =>
                 {
                     _w.WriteLine("this.$initialize();");
-                    if (decl?.Body is not null) foreach (var s in decl.Body.Statements) EmitStatement(s);
+                    EmitConstructorChain(explicitCtors[i], decl, type);
+                    if (decl.Body is not null) EmitStatements(decl.Body.Statements);
+                    else if (decl.ExpressionBody is not null) EmitExpressionStatement(decl.ExpressionBody.Expression);
                 });
                 _w.WriteLine(i < explicitCtors.Count - 1 ? "," : "");
             }

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -11,11 +11,41 @@
         try { return Transpose.toString(v); } catch (e) { return v.toString ? v.toString() : String(v); }
     };
     TransposeR.chr = function (code) { return String.fromCharCode(code); };
+    // Box a char (a bare code-point number at runtime) so it stringifies / compares as its
+    // character once widened to object — `object o = 'A'; o.ToString()` must be "A", not "65".
+    TransposeR.boxChar = function (c) { return Transpose.box(c, System.Char, TransposeR.chr); };
     TransposeR.is = function (v, t) { return Transpose.is(v, t); };
     TransposeR.as = function (v, t) { return Transpose.as ? Transpose.as(v, t) : (Transpose.is(v, t) ? v : null); };
     TransposeR.equals = function (a, b) { return Transpose.equals ? Transpose.equals(a, b) : a === b; };
     TransposeR.idiv = (Transpose.Int && Transpose.Int.div) ? function (a, b) { return Transpose.Int.div(a, b); } : function (a, b) { var r = a / b; return r < 0 ? Math.ceil(r) : Math.floor(r); };
     TransposeR.trunc = function (x) { return x < 0 ? Math.ceil(x) : Math.floor(x); };
+
+    // Saturating float → integer conversions (C#'s `(int)`/`(uint)`/`(long)`/`(ulong)` of a
+    // float/double). The CLR saturates out-of-range values to the target's Min/Max and maps NaN
+    // to 0 (unlike an integer→integer cast, which wraps). A narrower target (byte/short/…) first
+    // saturates to int32 here, then the emitter masks the result to width with Transpose.Int.clip*.
+    TransposeR.fclip32 = function (x) {
+        if (isNaN(x)) { return 0; }
+        if (x <= -2147483648) { return -2147483648; }
+        if (x >= 2147483647) { return 2147483647; }
+        return x < 0 ? Math.ceil(x) : Math.floor(x);
+    };
+    TransposeR.fclipu32 = function (x) {
+        if (isNaN(x) || x <= 0) { return 0; }
+        if (x >= 4294967295) { return 4294967295; }
+        return Math.floor(x);
+    };
+    TransposeR.fclip64 = function (x) {
+        if (isNaN(x)) { return System.Int64.Zero; }
+        if (x >= 9223372036854775807) { return System.Int64.MaxValue; }
+        if (x <= -9223372036854775808) { return System.Int64.MinValue; }
+        return System.Int64(TransposeR.trunc(x));
+    };
+    TransposeR.fclipu64 = function (x) {
+        if (isNaN(x) || x <= 0) { return System.UInt64.Zero; }
+        if (x >= 18446744073709551615) { return System.UInt64.MaxValue; }
+        return System.UInt64(TransposeR.trunc(x));
+    };
     TransposeR.clone = function (o) {
         if (!o) { return o; }
         if (o.$clone) { return o.$clone(); }


### PR DESCRIPTION
## Summary

This PR fixes three critical issues in the Transpose compiler:

1. **Constructor chaining** — `: this(...)` delegation now correctly calls the sibling constructor without re-running field initializers, preventing stack overflows in multi-level inheritance and ensuring field initialization order matches C#'s semantics.

2. **Numeric type conversions** — Explicit casts and compound assignments now correctly handle integer narrowing (wrapping), float-to-integer saturation, 64-bit conversions, and char boxing/ToString, matching .NET's behavior exactly.

3. **Record equality** — Records now synthesize both `equals()` and `equalsT()` methods, and derived records correctly include base record members in ToString/equality/GetHashCode.

## Key Changes

### Constructor Ordering (`Emitter.Members.cs`)
- Fixed `: this(...)` to call the sibling constructor by name (`this.CtorName(thisCtor)`) instead of dynamically, preventing infinite recursion in subclasses
- Ensured field initializers run only once per object construction, not re-run on delegation

### Numeric Conversions (`Emitter.Expressions2.cs`)
- **Integer narrowing**: Casts to byte/sbyte/short/ushort/char now wrap correctly (e.g., `(short)70000` → 4464, `(sbyte)200` → -56)
- **Float-to-integer**: Saturates out-of-range values to target Min/Max (NaN → 0), then masks to width
- **64-bit conversions**: Correctly reads low 32 bits from long/ulong and reinterprets signed/unsigned boundaries
- **Compound assignments** (`+=`, `-=`, `<<=`, etc.) on sub-word integers now re-narrow the result like C#'s `x = (T)(x op y)`
- **Increment/decrement** on sub-word integers wraps at type boundaries (e.g., `byte 255++` → 0)
- **Char conversions**: Boxing and ToString now render the character, not the code point

### Record Value Equality (`Emitter.ValueTypes.cs`)
- Records now emit both `equals(o)` and `equalsT(other)` methods (IEquatable<T> support)
- Derived records include base record members in ToString/equality/GetHashCode by walking the inheritance chain
- Fixed ToString to chain base record members before derived ones

### Expression Statements (`Emitter.Expressions.cs`)
- Added `TryEmitNarrowingIncDecStatement` to handle stand-alone `++`/`--` on sub-word integers as width-wrapping assignments

### Runtime Helpers (`tps.shim.js`)
- Added `boxChar()` to box char values so they stringify as characters
- Added `fclip32()`, `fclipu32()`, `fclip64()`, `fclipu64()` for saturating float-to-integer conversions

### Tests
- Added `ConstructorOrderingTests.cs` with 9 comprehensive tests covering multi-level inheritance, base/this chains, primary constructors, records, and default constructors
- Added `PrimitiveCastTests.cs` with 11 exhaustive tests covering all primitive conversions, narrowing, saturation, and edge cases

### BCL (`System/Random.cs`)
- Added explicit `(int)` casts to subtraction operations to ensure 32-bit wrapping behavior when transpiled to JavaScript

## Implementation Details

- The emitter now distinguishes between `IsSubWordIntegerTarget()` (byte/sbyte/short/ushort/char) and `IsNarrowIntegerTarget()` (includes int/uint for float sources)
- Narrowing clips are applied at assignment time for compound operators and increment/decrement
- Record equality walks the inheritance chain base-first to match C#'s synthesized method behavior
- Constructor delegation uses static binding (sibling ctor name) rather than dynamic dispatch to prevent recursion

https://claude.ai/code/session_0186oe7wqAscVWUc7uLKZGK4