### PR TITLE
Fix named/optional arg binding in ref/out invocations (Popover onClic…

### DIFF
--- a/Transpose/Transpose.Translator.Tests/RefOutNamedArgTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RefOutNamedArgTests.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Regression test for calls that combine an <c>out</c>/<c>ref</c> argument with named arguments
+    /// that skip an optional parameter. The ref/out invocation path emitted arguments in source order
+    /// without reordering named args or filling omitted-optional defaults, so a skipped optional
+    /// shifted every later argument by one. This is Tesserae's Popover crash: `Tippy.ShowFor(anchor,
+    /// content, out hide, …, manualTrigger: true, …)` (no onClickOutside) put `true` into the
+    /// onClickOutside slot, so tippy's `props.onClickOutside` was a boolean and its `.apply` threw.
+    /// </summary>
+    [TestClass]
+    public class RefOutNamedArgTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task TestOutParamWithSkippedNamedOptionalAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    static void Show(int a, int b, out Action hide,
+                     bool arrow = false, Action onHidden = null, Func<bool> onHide = null,
+                     Action<int> onClickOutside = null, bool manualTrigger = false, int border = 8)
+    {
+        hide = () => { };
+        Console.WriteLine(
+            ""arrow="" + arrow +
+            "" onHidden="" + (onHidden == null ? ""null"" : ""fn"") +
+            "" onHide="" + (onHide == null ? ""null"" : ""fn"") +
+            "" onClickOutside="" + (onClickOutside == null ? ""null"" : ""fn"") +
+            "" manual="" + manualTrigger +
+            "" border="" + border);
+    }
+
+    public static void Main()
+    {
+        Action onHiddenInternal = () => { };
+        Func<bool> shouldHide = () => true;
+
+        // Skips onClickOutside; provides later optionals by name (like Popover.ShowFor).
+        Show(1, 2, out var hide,
+             arrow: true, onHidden: onHiddenInternal, onHide: shouldHide,
+             manualTrigger: true, border: 20);
+        // Expect: arrow=True onHidden=fn onHide=fn onClickOutside=null manual=True border=20
+    }
+}
+                ");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -388,12 +388,54 @@ public sealed partial class Emitter
             EmitExpression(extReceiver);
             first = false;
         }
-        for (var i = 0; i < args.Count; i++)
+        if (args.Any(a => a.NameColon is not null))
         {
-            if (!first) _w.Write(", ");
-            first = false;
-            if (holders[i] is not null) _w.Write(holders[i]!);
-            else EmitExpressionConverted(args[i].Expression, i < symbol.Parameters.Length ? symbol.Parameters[i].Type : null);
+            // Named arguments: rebuild the positional list in parameter order and fill any omitted
+            // optional that precedes a provided one with its default (a JS call can't skip a hole).
+            // Without this a skipped optional shifted every later argument by one — e.g. Popover's
+            // `Tippy.ShowFor(anchor, content, out hide, …, manualTrigger: true, …)` (no onClickOutside)
+            // put `true` into the onClickOutside slot, so tippy's `props.onClickOutside` was a boolean
+            // and its `.apply` threw. The out/ref holders are keyed by source-arg index, so they carry
+            // across the reorder. (Any extension-method receiver was already emitted above.)
+            var slotArg = new int[symbol.Parameters.Length];
+            for (var k = 0; k < slotArg.Length; k++) slotArg[k] = -1;
+            var pos = 0;
+            for (var i = 0; i < args.Count; i++)
+            {
+                if (args[i].NameColon is { } nc)
+                {
+                    var pi = symbol.Parameters.ToList().FindIndex(p => p.Name == nc.Name.Identifier.Text);
+                    if (pi >= 0) slotArg[pi] = i;
+                }
+                else if (pos < slotArg.Length) slotArg[pos++] = i;
+            }
+            var lastSlot = -1;
+            for (var k = 0; k < slotArg.Length; k++) if (slotArg[k] >= 0) lastSlot = k;
+            for (var k = 0; k <= lastSlot; k++)
+            {
+                if (!first) _w.Write(", ");
+                first = false;
+                var ai = slotArg[k];
+                if (ai >= 0)
+                {
+                    if (holders[ai] is not null) _w.Write(holders[ai]!);
+                    else EmitExpressionConverted(args[ai].Expression, symbol.Parameters[k].Type);
+                }
+                else if (symbol.Parameters[k].HasExplicitDefaultValue)
+                    _w.Write(ConstantLiteral(symbol.Parameters[k].ExplicitDefaultValue, symbol.Parameters[k].Type));
+                else
+                    _w.Write("null");
+            }
+        }
+        else
+        {
+            for (var i = 0; i < args.Count; i++)
+            {
+                if (!first) _w.Write(", ");
+                first = false;
+                if (holders[i] is not null) _w.Write(holders[i]!);
+                else EmitExpressionConverted(args[i].Expression, i < symbol.Parameters.Length ? symbol.Parameters[i].Type : null);
+            }
         }
         _w.Write("); ");
 


### PR DESCRIPTION
…kOutside)

A call that combines an out/ref argument with named arguments skipping an optional parameter emitted its arguments in source order — the ref/out invocation path (EmitByRefInvocation) never reordered named args to parameter order nor filled the default for an omitted optional (unlike EmitArguments). A skipped optional therefore shifted every later argument by one.

This is Tesserae's Popover crash: Popover.ShowFor calls
  Tippy.ShowFor(anchor, content, out hide, …, onHide: shouldHide, manualTrigger: true, …)
with no onClickOutside. The emitter dropped the onClickOutside slot, so manualTrigger's `true` landed in it; tippy stored `props.onClickOutside = true`, and clicking an item (tippy's document handler runs `props.onClickOutside.apply(...)`) threw "onClickOutside.apply is not a function".

Fix: when a ref/out call has named arguments, rebuild the positional list in parameter order and fill omitted optionals with their defaults (the out/ref holders are keyed by source-arg index, so they carry across the reorder). Calls with no named args keep the existing path.

Adds RefOutNamedArgTests. Full suite green (342 passed).


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa