### PR TITLE
Match remaining H5 "managed" user-code defaults (bounds checks, cast …

### DIFF
--- a/Transpose/Transpose.Translator.Tests/PrimitiveCastTests.cs
+++ b/Transpose/Transpose.Translator.Tests/PrimitiveCastTests.cs
@@ -301,6 +301,86 @@ public class Program
         }
 
         [TestMethod]
+        public async Task ArrayBoundsCheckingAsync()
+        {
+            // ArrayIndex = Managed (H5/Tesserae default): out-of-range access throws
+            // IndexOutOfRangeException instead of reading/writing `undefined`.
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        int[] a = { 10, 20, 30 };
+        Console.WriteLine(a[1]);                 // 20
+        a[2] = 99; Console.WriteLine(a[2]);      // 99
+        try { int x = a[5]; Console.WriteLine(x); } catch (IndexOutOfRangeException) { Console.WriteLine(""IOR read""); }
+        try { a[10] = 1; } catch (IndexOutOfRangeException) { Console.WriteLine(""IOR write""); }
+        try { int y = a[-1]; } catch (IndexOutOfRangeException) { Console.WriteLine(""IOR neg""); }
+        int sum = 0; for (int i = 0; i < a.Length; i++) sum += a[i];
+        Console.WriteLine(sum);                  // 129
+        int[][] j = new int[2][]; j[0] = new[] { 1, 2 };
+        Console.WriteLine(j[0][1]);              // 2
+        string[] s = { ""x"", ""y"" }; Console.WriteLine(s[1]);   // y
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task CheckedReferenceAndUnboxCastsAsync()
+        {
+            // IgnoreCast = false (H5/Tesserae default): an invalid reference downcast or unboxing
+            // throws InvalidCastException; upcasts / valid casts / null pass through.
+            await RunTest(@"
+using System;
+public class Animal { public virtual string S() => ""a""; }
+public class Dog : Animal { public override string S() => ""dog""; }
+public class Cat : Animal { public override string S() => ""cat""; }
+interface IThing { int V(); }
+public class Thing : IThing { public int V() => 7; }
+public class Program
+{
+    public static void Main()
+    {
+        Animal a = new Cat();
+        try { Dog d = (Dog)a; Console.WriteLine(d.S()); } catch (InvalidCastException) { Console.WriteLine(""IC down""); }
+        Dog ok = (Dog)(Animal)new Dog(); Console.WriteLine(ok.S());        // dog
+        object o = ""hi"";
+        try { int n = (int)o; Console.WriteLine(n); } catch (InvalidCastException) { Console.WriteLine(""IC unbox""); }
+        object bi = 42; Console.WriteLine((int)bi);                        // 42
+        object t = new Thing(); Console.WriteLine(((IThing)t).V());        // 7
+        Animal up = new Dog(); Console.WriteLine(up.S());                  // dog (upcast)
+        object n2 = null; string sn = (string)n2; Console.WriteLine(sn == null); // True
+        object so = ""world""; Console.WriteLine((string)so);              // world
+        try { object io = 5; Console.WriteLine((string)io); } catch (InvalidCastException) { Console.WriteLine(""IC str""); }
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task EnumBoxedToObjectKeepsTypeAsync()
+        {
+            await RunTest(@"
+using System;
+enum Color { Red, Green, Blue }
+public class Program
+{
+    public static void Main()
+    {
+        object e = DayOfWeek.Monday;
+        Console.WriteLine(e.GetType().Name);   // DayOfWeek
+        Console.WriteLine(e.ToString());       // Monday
+        Console.WriteLine(e);                  // Monday
+        object c = Color.Green;
+        Console.WriteLine(c.GetType().Name);   // Color
+        Console.WriteLine(c.ToString());       // Green
+        Console.WriteLine(c.Equals(Color.Green)); // True
+        Console.WriteLine((int)Color.Blue);    // 2
+    }
+}");
+        }
+
+        [TestMethod]
         public async Task UnsignedFormattingRoundTripAsync()
         {
             // The original Guid.ToString() breakage: a negative int cast to uint kept its sign and

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -277,17 +277,32 @@ public sealed partial class Emitter
             return;
         }
 
-        // Enum → object/string uses the enum's name (System.Enum.toString) — but only for
-        // the Name/default modes, whose runtime value is numeric. Under Emit.Value the value
-        // is already the number, and under the Emit.StringName* modes it is already the name
-        // string, so those box to themselves without a lookup.
+        // Enum → string / object (boxing). Under a StringName* mode (2–6) the runtime value is
+        // already the name string, so it stringifies and boxes to itself (a raw string — matching
+        // Transpose's StringName contract, where the boxed value `is string`). Under the numeric
+        // modes: enum → string looks up the name (System.Enum.toString); enum → object / interface
+        // boxes the value with its enum type so GetType() is the enum (not Int32) and ToString() is
+        // the name, rather than boxing to a bare number.
         if (sourceType is { TypeKind: TypeKind.Enum }
-            && targetType?.SpecialType is SpecialType.System_Object or SpecialType.System_String
-            && TransposeNaming.EnumEmitMode(sourceType) is not (2 or 3 or 4 or 5 or 6))
+            && targetType is { IsReferenceType: true })
         {
-            _w.Write($"System.Enum.toString({TypeRef(sourceType)}, ");
-            EmitExpression(expr);
-            _w.Write(")");
+            var stringMode = TransposeNaming.EnumEmitMode(sourceType) is 2 or 3 or 4 or 5 or 6;
+            if (stringMode)
+            {
+                EmitExpression(expr); // already a name string
+            }
+            else if (targetType.SpecialType == SpecialType.System_String)
+            {
+                _w.Write($"System.Enum.toString({TypeRef(sourceType)}, ");
+                EmitExpression(expr);
+                _w.Write(")");
+            }
+            else
+            {
+                _w.Write($"Transpose.box(");
+                EmitExpression(expr);
+                _w.Write($", {TypeRef(sourceType)}, function ($v) {{ return System.Enum.toString({TypeRef(sourceType)}, $v); }})");
+            }
             return;
         }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1557,10 +1557,39 @@ public sealed partial class Emitter
             return;
         }
 
-        // char <-> int (chars are their code point), int → 64-bit float, widening, and reference
-        // casts are all representation-preserving and so erased.
+        // Reference downcast / unboxing conversion → a checked cast (Transpose.cast throws
+        // InvalidCastException) matching .NET (H5 IgnoreCast=false). `(Dog)someAnimal`, `(IFoo)obj`,
+        // `(int)someObject` all verify the runtime type. Upcasts, identity, numeric/enum, boxing,
+        // user-defined operators, dynamic, `null`, casts to a type parameter, and casts to an
+        // external (native-JS) type stay erased — the same set H5's CastBlock skips.
+        if (targetType is not null && sourceType is not null
+            && targetType.TypeKind is not (TypeKind.TypeParameter or TypeKind.Dynamic)
+            && targetType.SpecialType != SpecialType.System_Object
+            && !targetType.IsTupleType
+            && !IsUncheckableExternalCast(targetType)
+            && !expr.IsKind(SyntaxKind.NullLiteralExpression))
+        {
+            var conv = _compilation.ClassifyConversion(sourceType, targetType);
+            if ((conv.IsReference && conv.IsExplicit) || conv.IsUnboxing)
+            {
+                _w.Write("Transpose.cast(");
+                EmitExpression(expr);
+                _w.Write($", {TypeRef(targetType)})");
+                return;
+            }
+        }
+
+        // char <-> int (chars are their code point), int → 64-bit float, widening, and safe
+        // reference conversions are representation-preserving and so erased.
         EmitExpression(expr);
     }
+
+    /// <summary>A cast target that can't be runtime type-checked: an external (native-JS) type
+    /// from a DOM / binding library. The base BCL (assembly "Transpose") marks primitives like
+    /// System.String/Int32 [External] too, but those ARE checkable, so they are NOT excluded here —
+    /// matching H5, which erases H5.Core casts yet checks System.* casts.</summary>
+    private static bool IsUncheckableExternalCast(ITypeSymbol type)
+        => TransposeNaming.IsExternalType(type) && type.ContainingAssembly?.Name != "Transpose";
 
     /// <summary>A ≤32-bit integer or char target — a narrowing/reinterpretation to a fixed
     /// bit width. Enums (SpecialType.None) are excluded: they carry their underlying value as-is.</summary>
@@ -1734,7 +1763,19 @@ public sealed partial class Emitter
             return;
         }
 
-        // Arrays: native element access.
+        // Arrays: bounds-checked element access (ArrayIndex = Managed). `arr[System.Array.index(i,
+        // arr)]` throws IndexOutOfRangeException for an out-of-range index, matching .NET (plain JS
+        // would read/write undefined). Used for both reads and — when this is an assignment target —
+        // writes. Non-array element access (dynamic, etc.) stays a plain bracket access.
+        if (_model.GetTypeInfo(element.Expression).Type is IArrayTypeSymbol)
+        {
+            var arr = Capture(() => EmitExpression(element.Expression));
+            _w.Write($"{arr}[System.Array.index(");
+            EmitArgumentList(element.ArgumentList);
+            _w.Write($", {arr})]");
+            return;
+        }
+
         EmitExpression(element.Expression);
         _w.Write("[");
         EmitArgumentList(element.ArgumentList);


### PR DESCRIPTION
…checks, enum boxing)

Investigation of every H5 codegen rule/config default vs Transpose (comparing against H5's user-assembly defaults, DefaultIfNotH5() — exactly what Tesserae's h5.json uses). Findings:

- Plain-defaulted rules (AnonymousType, AutoProperty, Lambda, ExternalCast, InlineComment) already match H5's plain emission — including anonymous-type Equals/ToString, which differ from native .NET but are faithful to H5.
- UseTypedArrays / StrictNullChecks / OverflowMode defaults already match.
- Boxing=Managed already mostly matched (int/double/bool/struct GetType, ToString, equality, value-copy) — except enums.

Three Managed/checked behaviors diverged and are now implemented:

1. ArrayIndex=Managed — array element access is bounds-checked via arr[System.Array.index(i, arr)], throwing IndexOutOfRangeException on an out-of-range read/write instead of returning/writing undefined.

2. IgnoreCast=false — reference downcasts and unboxing conversions emit a checked Transpose.cast(x, T), throwing InvalidCastException like .NET. Upcasts, identity, numeric/enum, boxing, user-defined, dynamic, null, type parameters, and casts to external (native-JS/DOM) types stay erased — the same set H5's CastBlock skips. System.* (BCL) casts ARE checked; only truly external (Core/Packages) types are erased.

3. Boxing of an enum to object/interface now boxes it with its enum type (Transpose.box) for the numeric modes, so GetType() returns the enum (not Int32/String) and ToString() the name. StringName* enum modes (2-6) keep their raw-string representation (enumVal is string == true), preserving Transpose's StringName contract.

Verified against native .NET and the full suite (366 passing). New tests: ArrayBoundsCheckingAsync, CheckedReferenceAndUnboxCastsAsync, EnumBoxedToObjectKeepsTypeAsync.


Claude-Session: https://claude.ai/code/session_0186oe7wqAscVWUc7uLKZGK4