### PR TITLE
Fix compound-assign-to-indexer/property emit, ?? minify break, and se…

### DIFF
--- a/Transpose/Transpose.Compiler/JsMinifier.cs
+++ b/Transpose/Transpose.Compiler/JsMinifier.cs
@@ -20,6 +20,14 @@ internal static class JsMinifier
         "tps.js", "tps.min.js", "tps.collections.js", "tps.collections.min.js",
     };
 
+    // NUglify's `if (cond) stmt;` → `cond && stmt;` collapse is unsafe for our output: when `cond`
+    // is a null-coalescing expression (e.g. `x ?? false`, emitted for C#'s `a ?? b`), it strips the
+    // parentheses and yields `x ?? false && stmt`, which is a SYNTAX ERROR — ES2020 forbids mixing
+    // `??` with `&&`/`||` unparenthesized. Disabling this one tree modification keeps `if (cond) stmt;`
+    // intact (a negligible size cost) and never produces the invalid mix. The legacy compiler never hit
+    // this because it lowered `?.`/`??` through runtime helpers instead of emitting native `??`.
+    private const long KillIfConditionCollapse = (long)TreeModifications.IfConditionCallToConditionAndCall;
+
     // Safe profile: never rename locals, terminate statements with semicolons, escape non-ASCII.
     private static CodeSettings Safe() => new()
     {
@@ -29,6 +37,7 @@ internal static class JsMinifier
         StrictMode           = false,
         RemoveUnneededCode   = false,
         AlwaysEscapeNonAscii = true,
+        KillSwitch           = KillIfConditionCollapse,
     };
 
     // Safe profile but crunch local variable names (smaller output; opted into per project).
@@ -40,6 +49,7 @@ internal static class JsMinifier
         StrictMode           = false,
         RemoveUnneededCode   = false,
         AlwaysEscapeNonAscii = true,
+        KillSwitch           = KillIfConditionCollapse,
     };
 
     // Runtime-core profile (tps.js, …): as safe but without the eval/local-renaming overrides.
@@ -49,6 +59,7 @@ internal static class JsMinifier
         StrictMode           = false,
         RemoveUnneededCode   = false,
         AlwaysEscapeNonAscii = true,
+        KillSwitch           = KillIfConditionCollapse,
     };
 
     /// <summary>

--- a/Transpose/Transpose.Compiler/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler/OutputBuilder.cs
@@ -98,7 +98,10 @@ internal static class OutputBuilder
         void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
         {
             var present = jsFiles.Select(f => f.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var byName = jsFiles.ToDictionary(f => f.FileName, f => f, StringComparer.OrdinalIgnoreCase);
+            // Tolerate a duplicate file name in an older/hand-authored manifest (last wins) instead of
+            // throwing — the embed side dedupes, but a package built before that fix could still carry one.
+            var byName = new Dictionary<string, EmbeddedJs>(StringComparer.OrdinalIgnoreCase);
+            foreach (var f in jsFiles) byName[f.FileName] = f;
 
             foreach (var f in jsFiles)
             {
@@ -285,7 +288,20 @@ internal static class OutputBuilder
         }
 
         defaults.AddRange(items);
-        return defaults;
+
+        // Dedupe by output name: a resource manifest is keyed by name, so two groups that resolve to
+        // the same file (e.g. the base tps.json embeds Curiosity.FrontEnd.meta.js from .meta.js while
+        // the tps.Release.json overlay re-declares it from .meta.min.js) must collapse to one. The
+        // overlay is concatenated after the base, so last-wins gives it override precedence; we keep
+        // each name at its first position to preserve load order.
+        var seen = new Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+        var deduped = new List<EmbeddedItem>(defaults.Count);
+        foreach (var item in defaults)
+        {
+            if (seen.TryGetValue(item.Name, out var at)) deduped[at] = item;   // override in place
+            else { seen[item.Name] = deduped.Count; deduped.Add(item); }
+        }
+        return deduped;
     }
 
     /// <summary>A JavaScript resource loaded from a package (a runtime bundle or embedded library

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -127,6 +127,83 @@ public class Program
 }");
         }
 
+        // ---- compound assignment to a collection indexer ----------------------
+
+        [TestMethod]
+        public async Task CompoundAssignmentToDictionaryIndexerRunsAsync()
+        {
+            // `d[k] += v` on an int dictionary must route through setItem — emitting the getItem read as
+            // the write target (`d.getItem(k) = …`) is an "assignment to rvalue" (invalid JS).
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        var d = new Dictionary<string,int>();
+        d[""a""] = 1;
+        d[""a""] += 5;
+        d[""a""] *= 3;
+        d[""a""] -= 2;
+        Console.WriteLine(d[""a""]);            // (1+5)*3-2 = 16
+
+        var s = new Dictionary<string,string>();
+        s[""x""] = ""a"";
+        s[""x""] += ""b"";
+        Console.WriteLine(s[""x""]);            // ab
+
+        var list = new List<int> { 10, 20 };
+        list[0] += 5;
+        Console.WriteLine(list[0]);            // 15
+    }
+}");
+        }
+
+        [TestMethod]
+        public void CompoundAssignmentToDictionaryIndexerEmitsSetItem()
+        {
+            var code = @"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        var d = new Dictionary<string,int>();
+        d[""a""] += 5;
+    }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains(".setItem(\"a\", Transpose.Int.clip32("),
+                "d[k] += v should store through setItem with the clipped new value\n" + result.Javascript);
+            Assert.IsFalse(result.Javascript!.Contains(".getItem(\"a\") ="),
+                "the write target must never be an indexer getItem read (assignment to rvalue)\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public async Task CompoundAssignmentToTemplateSetterPropertyRunsAsync()
+        {
+            // `sb.Length -= 2` targets a [Template]-setter property (getLength/setLength); the write must
+            // go through setLength, not emit `sb.getLength() = …` (assignment to rvalue).
+            await RunTest(@"
+using System;
+using System.Text;
+public class Program
+{
+    public static void Main()
+    {
+        var sb = new StringBuilder();
+        sb.Append(""hello world"");
+        sb.Length -= 6;
+        Console.WriteLine(sb.ToString());   // hello
+        sb.Length = 3;
+        Console.WriteLine(sb.ToString());   // hel
+    }
+}");
+        }
+
         [TestMethod]
         public void IteratorLocalFunctionEmitsGenerator()
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1406,6 +1406,44 @@ public sealed partial class Emitter
             return;
         }
 
+        // Compound assignment to a collection indexer that stores via setItem: `coll[i] op= v` becomes
+        // `coll.setItem(i, <coll[i] op v>)`. The generic compound branches below emit the write target
+        // as `coll.getItem(i)` — correct to READ but invalid as an assignment target (`getItem(i) = …`
+        // assigns to an rvalue). Route the write through setItem here, computing the new element value
+        // with the same rules the plain-lvalue paths use. A native-bracket or [Template]-setter indexer
+        // is a real JS lvalue (`d[i] op= v`) and falls through unchanged.
+        if (op != "=" && assignment.Left is ElementAccessExpressionSyntax cea
+            && _model.GetSymbolInfo(cea).Symbol is IPropertySymbol { IsIndexer: true } cidx
+            && cidx.ContainingType.SpecialType != SpecialType.System_String
+            && !TransposeNaming.IsNativeIndexer(cidx)
+            && !(cidx.SetMethod is { } cset && TransposeNaming.GetTemplate(cset.OriginalDefinition) is not null))
+        {
+            EmitExpression(cea.Expression);
+            _w.Write("." + TransposeNaming.IndexerAccessorName(cidx, isGet: false) + "(");
+            EmitArgumentList(cea.ArgumentList);
+            _w.Write(", ");
+            EmitCompoundElementValue(assignment, op, leftType, rightType);
+            _w.Write(")");
+            return;
+        }
+
+        // Compound assignment to a property with a [Template] setter: `obj.P op= v` becomes
+        // `<setter template>(<obj.P op v>)` — e.g. StringBuilder.Length (getLength/setLength). As with
+        // indexers, the plain-lvalue branches would emit the getter template (`obj.getLength()`) as the
+        // write target, which is invalid ("assignment to rvalue").
+        if (op != "=" && _model.GetSymbolInfo(assignment.Left).Symbol is IPropertySymbol { SetMethod: { } cpSetter } cpProp
+            && !cpProp.IsIndexer
+            && TransposeNaming.GetTemplate(cpSetter.OriginalDefinition) is { } cpSetTemplate)
+        {
+            var recv = cpProp.IsStatic ? TypeRef(cpProp.ContainingType)
+                : assignment.Left is MemberAccessExpressionSyntax csma ? Capture(() => EmitExpression(csma.Expression))
+                : "this";
+            var val = Capture(() => EmitCompoundElementValue(assignment, op, leftType, rightType));
+            WriteTemplate(cpSetTemplate, cpProp.IsStatic, isExtension: false, recv,
+                new() { ["value"] = val }, new() { val });
+            return;
+        }
+
         // Delegate / event subscription: d += h, d -= h, ev += h, ev -= h → combine/remove.
         if ((op == "+=" || op == "-=")
             && (leftType is { TypeKind: TypeKind.Delegate }
@@ -1480,6 +1518,76 @@ public sealed partial class Emitter
         EmitExpression(assignment.Left);
         _w.Write($" {op} ");
         EmitExpressionConverted(assignment.Right, leftType);
+    }
+
+    /// <summary>
+    /// Emits the NEW element value for a compound assignment to a collection indexer — the second
+    /// argument of <c>coll.setItem(i, …)</c>. Mirrors the value computation of the plain-lvalue
+    /// compound-assignment branches (delegate combine, string concat, narrow-integer clip, or a plain
+    /// binary op), reading the current element via <c>coll.getItem(i)</c> (what <c>EmitExpression</c>
+    /// of the indexer produces).
+    /// </summary>
+    private void EmitCompoundElementValue(AssignmentExpressionSyntax assignment, string op,
+        ITypeSymbol? leftType, ITypeSymbol? rightType)
+    {
+        // Delegate / event combine-remove.
+        if ((op == "+=" || op == "-=")
+            && (leftType is { TypeKind: TypeKind.Delegate }
+                || _model.GetSymbolInfo(assignment.Left).Symbol is IEventSymbol))
+        {
+            _w.Write($"TransposeR.{(op == "+=" ? "combine" : "remove")}(");
+            EmitExpression(assignment.Left); _w.Write(", "); EmitExpression(assignment.Right); _w.Write(")");
+            return;
+        }
+
+        // String concat.
+        if (op == "+=" && IsStringType(leftType))
+        {
+            EmitConcatOperand(assignment.Left, leftType);
+            _w.Write(" + ");
+            EmitConcatOperand(assignment.Right, rightType);
+            return;
+        }
+
+        // Narrow-integer arithmetic/bitwise: reuse the exact wrapping the plain-lvalue path applies.
+        if (IsNarrowIntegerTarget(leftType)
+            && op is "+=" or "-=" or "*=" or "/=" or "%=" or "&=" or "|=" or "^=" or "<<=" or ">>=")
+        {
+            var t = leftType!.SpecialType;
+            var sub = IsSubWordIntegerTarget(leftType);
+            var binOp = op[..^1];
+
+            if (binOp == "*" && !sub)
+            {
+                _w.Write(t == SpecialType.System_UInt32 ? "Transpose.Int.umul(" : "Transpose.Int.mul(");
+                EmitExpression(assignment.Left); _w.Write(", "); EmitExpression(assignment.Right); _w.Write(")");
+                return;
+            }
+
+            var innerOp = binOp == ">>" && t == SpecialType.System_UInt32 ? ">>>" : binOp;
+            string? clip = sub ? (binOp == "%" ? null : NarrowIntegerClip(t))
+                : t == SpecialType.System_UInt32 ? (binOp is "%" or ">>" ? null : "Transpose.Int.clipu32")
+                : (binOp is "+" or "-" or "/" ? "Transpose.Int.clip32" : null);
+
+            if (clip is not null) { _w.Write(clip); _w.Write("("); }
+            if (binOp == "/")
+            {
+                _w.Write("TransposeR.idiv("); EmitExpression(assignment.Left); _w.Write(", "); EmitExpression(assignment.Right); _w.Write(")");
+            }
+            else
+            {
+                _w.Write("("); EmitExpression(assignment.Left); _w.Write($") {innerOp} ("); EmitExpression(assignment.Right); _w.Write(")");
+            }
+            if (clip is not null) _w.Write(")");
+            return;
+        }
+
+        // Plain compound (double / long / decimal / etc.): current-value binOp right.
+        _w.Write("(");
+        EmitExpression(assignment.Left);
+        _w.Write($") {op[..^1]} (");
+        EmitExpressionConverted(assignment.Right, leftType);
+        _w.Write(")");
     }
 
     private void EmitPrefixUnary(PrefixUnaryExpressionSyntax prefix)


### PR DESCRIPTION
…lf-ref resource dedupe

Verified by building the mosaik Curiosity FrontEnd (Default + Desktop, Release) with the local compiler and parsing every emitted JS file (formatted + minified, 147 files) with acorn.

Emitter — compound assignment to a setItem target (Emitter.Expressions2.cs):
  `coll[i] op= v` and `obj.P op= v` (a [Template]-setter property such as StringBuilder.Length)
  emitted the getter read as the write target — `coll.getItem(i) = …` / `sb.getLength() = …` —
  which is an assignment to an rvalue (invalid JS; V8's sloppy-mode parser accepts it but it throws
  at runtime). Both now route the write through setItem / the setter template, computing the new
  element value with the same rules the plain-lvalue paths use (delegate combine, string concat,
  narrow-integer clip, or a plain binary op) via a shared EmitCompoundElementValue helper.

Minifier — NUglify `if (cond) stmt` → `cond && stmt` collapse (JsMinifier.cs):
  when `cond` is a null-coalescing expression (`x ?? false`, emitted for C#'s `a ?? b`), NUglify
  stripped the parentheses and produced `x ?? false && stmt` — a syntax error (ES2020 forbids mixing
  `??` with `&&`/`||` unparenthesized). Disable that one TreeModification
  (IfConditionCallToConditionAndCall) across all profiles; it keeps `if (cond) stmt` intact.

OutputBuilder — self-referencing resource dedupe (OutputBuilder.cs):
  a tps.Release.json overlay can re-declare a self-ref bundle already present in the base tps.json
  (e.g. Curiosity.FrontEnd.meta.js from .meta.js in the base and from .meta.min.js in the overlay),
  which collapsed to two manifest entries with the same name and threw in the consumer. Dedupe
  embedded items by output name (overlay/last wins), and make the consumer's manifest read tolerant
  of a duplicate.

Tests: EmitRegressionTests adds dictionary/list-indexer compound assignment and StringBuilder.Length compound assignment (behavioral + emit inspection).


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa