### PR TITLE
Emit typeof(open generic) as the type definition, not an application …

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -204,6 +204,55 @@ public class Program
 }");
         }
 
+        // ---- typeof(open generic) ---------------------------------------------
+
+        [TestMethod]
+        public async Task TypeOfOpenGenericComparesAgainstGenericTypeDefinitionAsync()
+        {
+            // typeof(IObs<>) is an UNBOUND generic — it must emit the type definition (IObs$1), not
+            // IObs$1(T) which references an undefined `T` (ReferenceError at runtime). This is exactly
+            // Tesserae's PossibleObservableHelpers.IsObservable pattern (ObservableDictionary<,> ctor).
+            await RunTest(@"
+using System;
+public interface IObs<T> { T Value { get; } }
+public class Box<T> : IObs<T> { public T Value { get; set; } }
+public class Program
+{
+    static bool IsObs(Type type)
+    {
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IObs<>)) return true;
+        foreach (var i in type.GetInterfaces())
+            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IObs<>)) return true;
+        return false;
+    }
+    public static void Main()
+    {
+        Console.WriteLine(IsObs(typeof(IObs<string>)));   // True
+        Console.WriteLine(IsObs(typeof(Box<int>)));        // True (implements IObs<int>)
+        Console.WriteLine(IsObs(typeof(string)));          // False
+    }
+}");
+        }
+
+        [TestMethod]
+        public void TypeOfOpenGenericEmitsDefinitionWithoutArgs()
+        {
+            var code = @"
+using System;
+public interface IObs<T> { T Value { get; } }
+public class Program
+{
+    static bool Check(Type t) => t.GetGenericTypeDefinition() == typeof(IObs<>);
+    public static void Main() { Console.WriteLine(Check(typeof(IObs<int>))); }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("=== IObs$1;"),
+                "typeof(IObs<>) should emit the definition IObs$1, not IObs$1(T)\n" + result.Javascript);
+            Assert.IsFalse(result.Javascript!.Contains("IObs$1(T)"),
+                "typeof(IObs<>) must not apply the unbound type parameter as an argument\n" + result.Javascript);
+        }
+
         [TestMethod]
         public void IteratorLocalFunctionEmitsGenerator()
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -49,6 +49,13 @@ public sealed partial class Emitter
 
         if (type is INamedTypeSymbol named)
         {
+            // An UNBOUND generic — `typeof(Foo<>)` — has no concrete type arguments; its
+            // TypeArguments are the type PARAMETERS (T, TKey, …), which have no runtime value. Its
+            // JS value is the generic type DEFINITION itself (what Type.GetGenericTypeDefinition()
+            // returns), so emit the arity-suffixed name WITHOUT applying arguments — `Foo$1`, never
+            // `Foo$1(T)` (which references an undefined `T`).
+            var unbound = named.IsUnboundGenericType;
+
             // External (BCL / DOM) types are named by their runtime binding: [Name], a
             // [Scope]/[GlobalMethods] global (e.g. Transpose.Core.dom's HTMLElement), or the dotted
             // metadata name. [Name] applies ONLY here — an Transpose-compiled type ignores it.
@@ -67,7 +74,7 @@ public sealed partial class Emitter
                 {
                     var nestedArgs = EffectiveTypeArguments(named);
                     var nestedName = named.Arity > 0 ? _names.TypeFullName(named) + "$" + named.Arity : _names.TypeFullName(named);
-                    return nestedArgs.Count > 0
+                    return nestedArgs.Count > 0 && !unbound
                         ? $"{nestedName}({string.Join(", ", nestedArgs.Select(TypeRef))})"
                         : nestedName;
                 }
@@ -76,6 +83,7 @@ public sealed partial class Emitter
                 if (named.IsGenericType && named.TypeArguments.Length > 0)
                 {
                     var baseName = (string.IsNullOrEmpty(ns) ? "" : ns + ".") + StripArity(named.Name) + "$" + named.Arity;
+                    if (unbound) return baseName;
                     var args = string.Join(", ", named.TypeArguments.Select(TypeRef));
                     return $"{baseName}({args})";
                 }
@@ -90,7 +98,7 @@ public sealed partial class Emitter
             // IconToggle<int>.Item) resolves to tss.IconToggle.Item(System.Int32).
             var effArgs = EffectiveTypeArguments(named);
             var defName = named.Arity > 0 ? _names.TypeFullName(named) + "$" + named.Arity : _names.TypeFullName(named);
-            if (effArgs.Count > 0)
+            if (effArgs.Count > 0 && !unbound)
                 return $"{defName}({string.Join(", ", effArgs.Select(TypeRef))})";
             return defName;
         }


### PR DESCRIPTION
…with unbound params

`typeof(Foo<>)` (an unbound generic) was emitted as `Foo$1(T)` — applying the type DEFINITION's own parameters (T, TKey, …) as if they were arguments. Those parameters have no runtime value in the enclosing scope, so the reference threw `ReferenceError: T is not defined` at runtime. This surfaced in Tesserae's PossibleObservableHelpers.IsAnIObservableInterface (`typeof(IObservable<>)`), hit while constructing an ObservableDictionary<string, bool> (its ctor calls IsObservable(typeof(TValue))).

An unbound generic's runtime value is the generic type DEFINITION itself — what Type.GetGenericTypeDefinition() returns — so TypeRef now emits the arity-suffixed name WITHOUT applying arguments (`Foo$1`, `G2$2`, `Outer$1.Inner`, `Outer$1.InnerG$1`). Bound references where the type argument is an in-scope (threaded) parameter — e.g. `typeof(List<T>)` inside a generic class → `List$1(T)` — are unchanged. C# forbids partial binding in an unbound typeof, so mixed bound/unbound cannot occur.

Tests: EmitRegressionTests covers the IObservable<>-style pattern behaviorally (transpile + run in Node, diff vs native .NET — including GetInterfaces and GetGenericTypeDefinition equality) and by emit inspection.


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa