### PR TITLE
Emit interpolated strings converted to FormattableString/IFormattable…

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -253,6 +253,64 @@ public class Program
                 "typeof(IObs<>) must not apply the unbound type parameter as an argument\n" + result.Javascript);
         }
 
+        // ---- interpolated string -> FormattableString -------------------------
+
+        [TestMethod]
+        public async Task InterpolatedStringConvertedToFormattableStringRunsAsync()
+        {
+            // `$"…"` converted to FormattableString must become FormattableStringFactory.Create(...),
+            // carrying Format / GetArguments() — not a plain concatenated string (whose .GetArguments
+            // "is not a function"). Compare only culture-invariant surface (Format, count, raw args).
+            await RunTest(@"
+using System;
+public class Program
+{
+    static string Describe(FormattableString fs)
+        => fs.Format + "" :: "" + fs.ArgumentCount + "" :: "" + string.Join("","", Array.ConvertAll(fs.GetArguments(), x => x == null ? ""null"" : x.ToString()));
+    public static void Main()
+    {
+        int a = 7, b = 9;
+        FormattableString fs = $""X {a} Y {b} Z"";
+        Console.WriteLine(Describe(fs));
+        Console.WriteLine(Describe($""just {a}""));
+        Console.WriteLine(Describe($""none""));
+        Console.WriteLine(Describe($""fmt {a:D3} and brace {{lit}}""));
+    }
+}");
+        }
+
+        [TestMethod]
+        public void InterpolatedStringToFormattableStringEmitsFactory()
+        {
+            var code = @"
+using System;
+public class Program
+{
+    static void Use(FormattableString fs) { }
+    public static void Main() { int a = 1, b = 2; Use($""Hello {a} and {b}""); }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("FormattableStringFactory.Create(\"Hello {0} and {1}\", ["),
+                "an interpolated string converted to FormattableString should build a factory call\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public void InterpolatedStringToStringStaysConcatenation()
+        {
+            // The common case — target type string — must remain plain concatenation, not a factory call.
+            var code = @"
+using System;
+public class Program
+{
+    public static void Main() { int a = 1; string s = $""v={a}""; Console.WriteLine(s); }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsFalse(result.Javascript!.Contains("FormattableStringFactory"),
+                "a string-typed interpolation must not use the FormattableString factory\n" + result.Javascript);
+        }
+
         [TestMethod]
         public void IteratorLocalFunctionEmitsGenerator()
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1837,6 +1837,18 @@ public sealed partial class Emitter
 
     private void EmitInterpolatedString(InterpolatedStringExpressionSyntax interp)
     {
+        // An interpolated string CONVERTED to FormattableString / IFormattable is not a plain string:
+        // the C# compiler lowers it to FormattableStringFactory.Create("{0}…{1}", args). Emit that so
+        // the result carries Format / GetArguments() (consumers like a `t(FormattableString)` translation
+        // helper call GetArguments()). Only the string target uses concatenation.
+        var converted = _model.GetTypeInfo(interp).ConvertedType;
+        if (converted is { ContainingNamespace: { } cns } && cns.ToDisplayString() == "System"
+            && converted.Name is "FormattableString" or "IFormattable")
+        {
+            EmitFormattableString(interp);
+            return;
+        }
+
         _w.Write("(");
         var first = true;
         var hadContent = false;
@@ -1881,6 +1893,49 @@ public sealed partial class Emitter
         }
         if (!hadContent) _w.Write("\"\"");
         _w.Write(")");
+    }
+
+    /// <summary>
+    /// Emits an interpolated string that was converted to FormattableString / IFormattable as
+    /// <c>FormattableStringFactory.Create("composite {0}…", [args])</c> — the composite format string
+    /// with <c>{N[,align][:fmt]}</c> placeholders (literal braces doubled) plus the argument array,
+    /// matching the C# compiler's lowering.
+    /// </summary>
+    private void EmitFormattableString(InterpolatedStringExpressionSyntax interp)
+    {
+        var format = new System.Text.StringBuilder();
+        var args = new List<ExpressionSyntax>();
+        foreach (var content in interp.Contents)
+        {
+            switch (content)
+            {
+                case InterpolatedStringTextSyntax text:
+                    // ValueText decodes standard escape sequences (\n, \") but KEEPS composite-format
+                    // brace escaping ({{ / }}) for interpolated-string text tokens, which is exactly the
+                    // composite format string FormattableStringFactory.Create expects — use it verbatim.
+                    format.Append(text.TextToken.ValueText);
+                    break;
+                case InterpolationSyntax interpolation:
+                    format.Append('{').Append(args.Count);
+                    if (interpolation.AlignmentClause is { } align)
+                        format.Append(',').Append(align.Value.ToString());
+                    if (interpolation.FormatClause is { } fmt)
+                        format.Append(':').Append(fmt.FormatStringToken.ValueText);
+                    format.Append('}');
+                    args.Add(interpolation.Expression);
+                    break;
+            }
+        }
+        _w.Write("System.Runtime.CompilerServices.FormattableStringFactory.Create(");
+        _w.Write(JsString(format.ToString()));
+        _w.Write(", [");
+        for (var i = 0; i < args.Count; i++)
+        {
+            if (i > 0) _w.Write(", ");
+            // Arguments are object[]: box value types so the array holds boxed values, matching .NET.
+            EmitExpressionConverted(args[i], _compilation.GetSpecialType(SpecialType.System_Object));
+        }
+        _w.Write("])");
     }
 
     // ---- element access ----------------------------------------------------


### PR DESCRIPTION
… via the factory

An interpolated string ($"…") whose target type is FormattableString or IFormattable was emitted as plain string concatenation, so the result had no Format / GetArguments() — calling GetArguments() threw "formattableString.GetArguments is not a function" (hit via a t(FormattableString) translation helper in mosaik's LoginView.CheckForTokenOnURLAsync).

EmitInterpolatedString now checks the CONVERTED type: when it is System.FormattableString or System.IFormattable it lowers to FormattableStringFactory.Create("composite {0}…", [args]) — the composite format string with {N[,align][:fmt]} placeholders (ValueText already carries {{ }} brace escaping, so it's used verbatim) and the boxed argument array — matching the C# compiler. The common string-typed case is unchanged (concatenation).

Tests: EmitRegressionTests covers the FormattableString conversion behaviorally (Format, ArgumentCount, GetArguments, a format clause, and literal braces — run in Node, diffed vs native .NET), plus emit-inspection that string-typed interpolation stays concatenation.


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa