### PR TITLE
Wrap a single element passed to a params parameter by a named argument

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -451,6 +451,51 @@ public class Program { public static void Main() { } }
                 "the trailing positional argument must follow the named-argument lambda, not replace it\n" + result.Javascript);
         }
 
+        // ---- single element to a params parameter via a NAMED argument --------
+
+        [TestMethod]
+        public async Task NamedParamsArgumentWrapsSingleElementAsync()
+        {
+            // `new Nav(id, commands: singleCmd)` — a single element given to a `params` parameter BY
+            // NAME must be wrapped into the array (C# semantics), so a later `foreach` over it works.
+            // Without the fix the callee received a bare element and foreach threw "Cannot create
+            // Enumerator" (Tesserae's SidebarNav RSS_NAV: `commands: new SidebarCommand(...)`).
+            await RunTest(@"
+using System;
+public class Cmd { public int V; public Cmd(int v){V=v;} }
+public class Nav
+{
+    private Cmd[] _c;
+    public Nav(string id, params Cmd[] c) { _c = c; }
+    public int Sum() { int n=0; foreach (var x in _c) n+=x.V; return n; }
+}
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Nav(""a"", c: new Cmd(5)).Sum());                  // 5  (named single -> [cmd])
+        Console.WriteLine(new Nav(""b"", new Cmd(7)).Sum());                     // 7  (positional single)
+        Console.WriteLine(new Nav(""c"", c: new Cmd[] { new Cmd(2), new Cmd(3) }).Sum()); // 5 (named array passthrough)
+        Console.WriteLine(new Nav(""d"").Sum());                                  // 0  (omitted -> [])
+    }
+}");
+        }
+
+        [TestMethod]
+        public void NamedParamsSingleElementEmitsWrappedArray()
+        {
+            var code = @"
+using System;
+public class Cmd { public Cmd(int v){} }
+public class Nav { public Nav(string id, params Cmd[] c) { } }
+public class Program { public static void Main() { var n = new Nav(""x"", c: new Cmd(5)); } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("[new Cmd(5)]"),
+                "a single element passed to a params parameter by name should be wrapped in an array\n" + result.Javascript);
+        }
+
         [TestMethod]
         public void IteratorLocalFunctionEmitsGenerator()
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -602,14 +602,28 @@ public sealed partial class Emitter
             {
                 if (!first) _w.Write(", ");
                 first = false;
-                if (ordered[i] is not null)
-                    EmitExpressionConverted(ordered[i]!, method.Parameters[i].Type);
-                else
+                if (ordered[i] is null)
+                {
                     // An omitted optional argument that a JS call cannot skip (it precedes a provided
                     // one) is passed as `void 0` (undefined), not its default value: the callee applies
                     // its own default via `if (arg === undefined) arg = <default>`, matching the legacy
                     // compiler. Passing `null` would defeat that check when the default is non-null.
                     _w.Write("void 0");
+                }
+                else if (i == method.Parameters.Length - 1 && method.Parameters[i].IsParams && ShouldWrapParams(method))
+                {
+                    // A single element supplied to the params parameter (positionally after named args,
+                    // or BY NAME — e.g. `new SidebarNav(…, commands: cmd)`) must be wrapped into the
+                    // params array; the array/collection itself passes through. Without this the callee
+                    // receives a bare element and a later `foreach` over it throws "Cannot create
+                    // Enumerator". (The multi-element / no-named-args case is handled by the params
+                    // branch below, which this early-returning named path would otherwise skip.)
+                    EmitParamsSlot(method.Parameters[i].Type, ordered[i]!);
+                }
+                else
+                {
+                    EmitExpressionConverted(ordered[i]!, method.Parameters[i].Type);
+                }
             }
             return;
         }
@@ -711,6 +725,29 @@ public sealed partial class Emitter
     private static bool HasExpandParams(IMethodSymbol method)
         => method.OriginalDefinition.GetAttributes()
             .Any(a => TransposeNaming.AttrIs(a, "Transpose.ExpandParamsAttribute"));
+
+    /// <summary>Emits a SINGLE argument supplied to a <c>params</c> parameter: the array/collection
+    /// itself is passed through, but a lone element (convertible to the element type) is wrapped into
+    /// the params array. Shared by the named-argument path and mirrors the positional params branch.</summary>
+    private void EmitParamsSlot(ITypeSymbol paramsType, ExpressionSyntax arg)
+    {
+        var paramsElem = ParamsElementType(paramsType);
+        var argType = _model.GetTypeInfo(arg).Type;
+        if (paramsElem is not null
+            && (argType is null || !_compilation.ClassifyConversion(argType, paramsElem).Exists))
+        {
+            EmitExpressionConverted(arg, paramsType);   // already the collection
+        }
+        else
+        {
+            EmitCollectionOf(paramsType, () =>
+            {
+                _w.Write("[");
+                EmitExpressionConverted(arg, paramsElem);
+                _w.Write("]");
+            });
+        }
+    }
 
     private static bool ShouldWrapParams(IMethodSymbol method)
     {


### PR DESCRIPTION
`new SidebarNav(id, icon, text, collapsed, commands: singleCommand)` — a lone element supplied to a `params` array parameter BY NAME must be wrapped into the params array (C# semantics), exactly like the positional single-element case. The named-argument reorder path in EmitArguments emitted the value unwrapped, so the callee received a bare element; a later `foreach` over it threw "System.InvalidOperationException: Cannot create Enumerator" (hit in Tesserae's SidebarNav.RenderOpened for RSS_NAV, whose command is passed as `commands: new SidebarCommand(...)`), crashing the authenticated UI render.

The named-argument branch now routes the params slot through a shared EmitParamsSlot helper (also used conceptually by the positional params branch): a single element convertible to the element type is wrapped in `[...]`; an array/collection is passed through.

Tests: EmitRegressionTests covers named single-element (wrapped), positional single, named array (passthrough), and omitted (empty) — behavioral + emit inspection.


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa