### PR TITLE
Emit [Transpose.Ready] static methods as Transpose.ready registrations

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -609,5 +609,46 @@ public class Program
             Assert.IsTrue(result.Javascript!.Contains("let s;"),
                 "an is-pattern variable in an expression-bodied property must be predeclared\n" + result.Javascript);
         }
+
+        // ---- [Transpose.Ready] static method --------------------------------------
+        // A [Ready] static method must be scheduled via Transpose.ready so it runs on load. It was
+        // dropped entirely, so e.g. the admin package's AdminBridgeInitializer.Initialize never ran
+        // and no admin routes were registered ("Admin package not loaded.").
+
+        [TestMethod]
+        public async Task ReadyAttributeMethodRunsOnLoadAsync()
+        {
+            // [Ready] is a Transpose-only concept (a no-op in native .NET), so run JS-only and assert
+            // the scheduled method actually executed.
+            var output = await RunTest(@"
+using System;
+static class Init
+{
+    [Transpose.Ready]
+    public static void Setup() { Console.WriteLine(""ready-ran""); }
+}
+public class Program { public static void Main() { Console.WriteLine(""main-ran""); } }
+", skipRoslyn: true);
+            Assert.IsTrue(output.Contains("ready-ran"),
+                "the [Ready] static method should run on load\n" + output);
+            Assert.IsTrue(output.Contains("main-ran"), "the entry point should still run\n" + output);
+        }
+
+        [TestMethod]
+        public void ReadyAttributeEmitsTransposeReadyCall()
+        {
+            var code = @"
+static class Init
+{
+    [Transpose.Ready]
+    public static void Setup() { }
+}
+public class Program { public static void Main() { } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("Transpose.ready(Init.Setup, Init);"),
+                "a [Ready] static method must be scheduled with Transpose.ready\n" + result.Javascript);
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -35,6 +35,28 @@ public sealed partial class Emitter
         }
     }
 
+    /// <summary>
+    /// Emits <c>Transpose.ready(Type.Method, Type);</c> for every <c>[Transpose.Ready]</c> static
+    /// method. Transpose.ready runs the callback on DOMContentLoaded, or immediately when the
+    /// document is already loaded — the latter is what lets a lazily fetched package (e.g. the admin
+    /// bundle) run its initializer the moment it is loaded. Static members are referenced fully
+    /// qualified, so the <c>this</c>-scope argument is just belt-and-braces for parity with the
+    /// [Ready] adapter's FormatScope.
+    /// </summary>
+    private void EmitReadyRegistrations(IReadOnlyList<INamedTypeSymbol> types)
+    {
+        foreach (var type in types)
+        {
+            foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+            {
+                if (!method.IsStatic) continue;
+                if (!method.GetAttributes().Any(a => TransposeNaming.AttrIs(a, TransposeNaming.ReadyAttr))) continue;
+                var typeRef = TypeRef(type);
+                _w.WriteLine($"Transpose.ready({typeRef}.{TransposeNaming.MemberJsName(method)}, {typeRef});");
+            }
+        }
+    }
+
     /// <summary>Full JS name a type is registered / referenced under.</summary>
     private string TypeRef(ITypeSymbol type)
     {

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -131,6 +131,11 @@ public sealed partial class Emitter
                 _w.WriteLine();
             }
 
+            // [Transpose.Ready] static methods: schedule each via Transpose.ready so it runs on
+            // page load (or immediately when the assembly is loaded on demand, e.g. a lazily
+            // fetched package). Emitted after all defines so the referenced types are registered.
+            EmitReadyRegistrations(types);
+
             //foreach (var type in types)
             //{
             //    EmitType(type);

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -18,6 +18,7 @@ internal static class TransposeNaming
     public const string EnumAttr = "Transpose.EnumAttribute";
     public const string ScopeAttr = "Transpose.ScopeAttribute";
     public const string GlobalMethodsAttr = "Transpose.GlobalMethodsAttribute";
+    public const string ReadyAttr = "Transpose.ReadyAttribute";
 
     /// <summary>Allocation-free equivalent of <c>a.AttributeClass?.ToDisplayString() == fullName</c>.
     /// Attribute matching runs for every symbol reference during emit; <c>ToDisplayString</c> builds a


### PR DESCRIPTION
The [Ready] adapter attribute (run a static method on page load) was completely ignored by the translator, so its methods never ran. In the Curiosity front end this meant AdminBridgeInitializer.Initialize never executed and no admin routes were registered — navigating to any admin page logged "Admin package not loaded."

The emitter now emits `Transpose.ready(Type.Method, Type);` at the end of the assembly body for every [Ready] static method. Transpose.ready runs the callback on DOMContentLoaded, or immediately when the document is already loaded — the latter is exactly what makes a lazily-fetched package (the admin bundle) run its initializer the moment it loads.

Adds emit + JS-only behavioral regression tests.


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa