### PR TITLE
Newtonsoft: deserialize JSON arrays into IEnumerable<T>-only targets

### DIFF
--- a/Packages/Transpose.Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/Packages/Transpose.Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -1400,6 +1400,33 @@
                                 list.add(Newtonsoft.Json.JsonConvert.DeserializeObject(raw[i], typeElement, settings, true));
                             }
                             return list;
+                        } else if (Transpose.isArray(raw) && Newtonsoft.Json.JsonConvert.getEnumerableElementType(type) != null) {
+                            // A JSON array whose target is an IEnumerable<T>-only type that is backed by a
+                            // plain JS array at runtime (e.g. tss.ROA / ReadOnlyArray<T>, or an
+                            // IEnumerable<T> / IReadOnlyList<T> / IReadOnlyCollection<T> property). The
+                            // System.Array / IList / ICollection / IDictionary / HashSet branches above do
+                            // not match it, so materialize the elements into a JS array (which satisfies
+                            // the contract) instead of falling through to object deserialization (which
+                            // left such properties null — e.g. SchemasResponse.Nodes on an empty graph).
+                            var typeName = raw["$type"];
+
+                            if (typeName != null) {
+                                type = Newtonsoft.Json.JsonConvert.BindToType(settings, typeName, type);
+                                raw = raw["$values"];
+                            }
+
+                            if (raw == null || raw.length === undefined) {
+                                return [];
+                            }
+
+                            var typeElement = Newtonsoft.Json.JsonConvert.getEnumerableElementType(type) || System.Object;
+                            var arr = new Array();
+
+                            for (var i = 0; i < raw.length; i++) {
+                                arr[i] = Newtonsoft.Json.JsonConvert.DeserializeObject(raw[i], typeElement, settings, true);
+                            }
+
+                            return arr;
                         } else {
                             var typeName = raw["$type"];
 


### PR DESCRIPTION
DeserializeObject dispatched JSON arrays to System.Array / IList / ICollection / IDictionary / HashSet targets, but had no branch for a type whose only collection contract is IEnumerable<T> and whose runtime representation is a plain JS array — notably Tesserae's ReadOnlyArray<T> (tss.ROA), and IReadOnlyList<T> / IReadOnlyCollection<T> / IEnumerable<T> properties. Such a property fell through to object deserialization and ended up null.

In the Curiosity front end this surfaced as a swallowed NullReferenceException on an empty graph: SchemasResponse.Nodes (ReadOnlyArray<SchemaDefinition>) deserialized to null from {"Nodes":[]}, so SchemaManager's Nodes.Concat(...).ToDictionary(...) threw "Cannot read properties of null (reading 'moveNext')".

Adds a fall-through branch (after the IList/IDictionary/HashSet checks, gated on the raw value being an array) that materializes the elements into a JS array via the existing getEnumerableElementType helper, mirroring the System.Array branch. A JS array satisfies the IEnumerable<T>/IReadOnly* contract at runtime.

Verified end-to-end: the schema admin page, previously throwing on load, is now clean.


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa