### PR TITLE
Predeclare inline vars with var (not let) outside loops

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -606,7 +606,9 @@ public class Program
 }";
             var result = new RoslynTranslator().Translate(code);
             Assert.IsTrue(result.Success, "translation should succeed");
-            Assert.IsTrue(result.Javascript!.Contains("let s;"),
+            // Predeclared outside a loop → `var` (matching regular locals, so it coexists with any
+            // same-named function-scoped local).
+            Assert.IsTrue(result.Javascript!.Contains("var s;"),
                 "an is-pattern variable in an expression-bodied property must be predeclared\n" + result.Javascript);
         }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -139,12 +139,18 @@ public sealed partial class Emitter
         var names = new List<string>();
         CollectInlineDesignations(scope, isRoot: true, names);
 
+        // Match EmitLocalDeclaration's keyword rule: `let` inside a loop (fresh per-iteration binding
+        // for closures), `var` otherwise. Using `var` outside loops is what lets a predeclared
+        // out-var coexist with a same-named regular local elsewhere in the function (both flattened
+        // to function scope) — a `let` predeclaration would collide with such a `var` local
+        // ("Identifier 'x' has already been declared").
+        var kw = _loopDepth > 0 && _gotoContexts.Count == 0 ? "let" : "var";
         var blockScope = _predeclaredInScope.Count > 0 ? _predeclaredInScope.Peek() : null;
         foreach (var name in names.Distinct())
         {
             var jsName = NameMangler.JsIdentifier(name);
             if (blockScope is not null && !blockScope.Add(jsName)) continue; // already declared in this block
-            _w.WriteLine($"let {jsName};");
+            _w.WriteLine($"{kw} {jsName};");
         }
     }
 


### PR DESCRIPTION
Predeclared out-var / pattern vars were always emitted as `let`, but regular locals outside a loop are emitted as `var` (function-scoped, to tolerate the same-name redeclarations across flattened C# scopes that the emit model relies on). A `let` predeclaration whose name also existed as such a `var` local in the same function threw "Identifier 'x' has already been declared" — e.g. RenderedSearchResultCommands with a `var source = node.GetString("Source")` and a later `else if (searchHit.Node.TryGetSource(out var source))` (surfaced by the previous commit, which started predeclaring else-if out-vars).

PredeclareInlineVars now uses the same keyword rule as EmitLocalDeclaration: `let` inside a loop (fresh per-iteration binding for closures), `var` otherwise. Updates the expression-bodied-property predeclaration test accordingly.


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa