### PR TITLE
Default non-primitive struct fields/expressions to the zeroed struct,…

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -742,5 +742,37 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- default value of a non-primitive struct ---------------------------
+        // An uninitialized non-primitive struct field (DateTime, Guid, user struct) and a
+        // `default(T)` expression must yield the zeroed struct (C# default(T)), not null. They were
+        // emitted as null — so an uninitialized DateTime field compared/used threw
+        // "Cannot read properties of null (reading 'getTime')". Now assigned via
+        // Transpose.getDefaultValue in the ctor (fields) and default expressions.
+
+        [TestMethod]
+        public async Task DefaultStructFieldAndExpressionRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public struct Point { public int X; public int Y; }
+public class Holder { public DateTime When; public Guid Id; public Point P; public string Name = ""x""; }
+public class Program
+{
+    public static void Main()
+    {
+        var h = new Holder();
+        var h2 = new Holder();
+        Console.WriteLine(h.When == DateTime.MinValue);   // True
+        Console.WriteLine(h.When.Equals(h2.When));         // True (both default)
+        Console.WriteLine((int)DateTime.SpecifyKind(h.When, DateTimeKind.Utc).Kind); // 1 (no crash on default)
+        Console.WriteLine(h.Id == Guid.Empty);             // True
+        Console.WriteLine(h.P.X + "","" + h.P.Y);            // 0,0
+        DateTime d = default(DateTime);
+        Console.WriteLine(d == DateTime.MinValue);         // True
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -397,18 +397,47 @@ public sealed partial class Emitter
         foreach (var m in type.GetMembers())
         {
             if (m.IsStatic) continue;
-            ExpressionSyntax? init = m switch
+            ITypeSymbol? slotType = m switch
             {
-                IFieldSymbol f when !f.IsConst && f.AssociatedSymbol is null => FieldInitializerSyntax(f),
-                IPropertySymbol p when IsAutoProperty(p) => AutoPropertyInitializerSyntax(p),
+                IFieldSymbol f when !f.IsConst && f.AssociatedSymbol is null => f.Type,
+                IPropertySymbol p when IsAutoProperty(p) => p.Type,
                 _ => null,
             };
-            if (init is null) continue;
-            _w.Write($"this.{TransposeNaming.MemberJsName(m)} = ");
-            EmitExpression(init);
-            _w.WriteLine(";");
+            if (slotType is null) continue;
+
+            ExpressionSyntax? init = m switch
+            {
+                IFieldSymbol f => FieldInitializerSyntax(f),
+                IPropertySymbol p => AutoPropertyInitializerSyntax(p),
+                _ => null,
+            };
+
+            if (init is not null)
+            {
+                _w.Write($"this.{TransposeNaming.MemberJsName(m)} = ");
+                EmitExpression(init);
+                _w.WriteLine(";");
+            }
+            else if (NeedsStructDefaultInit(slotType))
+            {
+                // A non-nullable struct field/auto-property with no initializer defaults to the
+                // zeroed struct (C# default(T)), not null. The field slot is emitted as `null`
+                // (order-independence at define time), so assign the real default here in the ctor,
+                // when the struct type is defined — otherwise e.g. an uninitialized DateTime is null
+                // and `.Equals`/`.UtcDateTime` throws (reading getTime of null).
+                _w.WriteLine($"this.{TransposeNaming.MemberJsName(m)} = Transpose.getDefaultValue({TypeRef(slotType)});");
+            }
         }
     }
+
+    /// <summary>A slot whose C# <c>default(T)</c> is a zeroed struct value rather than null:
+    /// DateTime, Guid, a user struct, ValueTuple, etc. Excludes primitives (already a literal slot
+    /// default), enums (numeric slot default), Nullable&lt;T&gt; (null is correct), and type
+    /// parameters (their default defers to the runtime at construction).</summary>
+    private static bool NeedsStructDefaultInit(ITypeSymbol type)
+        => type.TypeKind == TypeKind.Struct
+           && !IsPrimitiveNumericOrBool(type)
+           && type is not INamedTypeSymbol { ConstructedFrom.SpecialType: SpecialType.System_Nullable_T };
 
     // ---- methods -----------------------------------------------------------
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -569,9 +569,13 @@ public sealed partial class Emitter
             case SpecialType.System_Decimal:
                 return "0";
         }
-        // A non-primitive struct (DateTime, Guid, a user struct) gets its zeroed value.
-        if (type is INamedTypeSymbol { TypeKind: TypeKind.Struct } st && st.Locations.Any(l => l.IsInSource))
-            return $"{TypeRef(st)}.getDefaultValue()";
+        // A non-primitive struct (DateTime, Guid, a user struct) gets its zeroed value via the
+        // runtime's Transpose.getDefaultValue, which dispatches to the struct's getDefaultValue()
+        // (and special-cases BCL structs like System.DateTime). It works for a referenced BCL struct
+        // too — the old in-source-only check returned null for `default(DateTime)` in user projects
+        // (→ "reading getTime of null") — and returns null gracefully for a struct with no default.
+        if (type is INamedTypeSymbol { TypeKind: TypeKind.Struct } st)
+            return $"Transpose.getDefaultValue({TypeRef(st)})";
         return "null";
     }
 }


### PR DESCRIPTION
… not null

A non-primitive struct (DateTime, Guid, ValueTuple, a user struct) defaulted to null instead of C# default(T):
- An uninitialized struct FIELD kept its `null` slot — nothing assigned the zeroed value (the "$initialize assigns it" comment was never implemented). So an uninitialized DateTime field compared/used threw "Cannot read properties of null (reading 'getTime')" (seen on the admin Build page).
- A `default(T)` / `default` EXPRESSION for such a struct emitted null too: DefaultValueLiteral only produced getDefaultValue() for in-source structs, so a referenced BCL struct (System.DateTime/System.Guid) in a user project became null.

Both now use `Transpose.getDefaultValue(T)`, the runtime helper that dispatches to the struct's getDefaultValue() (and special-cases BCL structs like DateTime), returning null only for a struct that genuinely has no default. EmitInstanceFieldInitializers assigns it to uninitialized non-nullable struct fields in the ctor; DefaultValueLiteral uses it for default expressions. Nullable<T> stays null (correct).

Adds a behavioral regression test (uninitialized DateTime/Guid/user-struct fields + default(DateTime) expression).


Claude-Session: https://claude.ai/code/session_013Q64jEZmFaLY1YAKW97KVa