### PR TITLE
Compiler correctness fixes from the h5-baseline audit

### DIFF
--- a/BCL/Transpose.BCL/Resources/Core.js
+++ b/BCL/Transpose.BCL/Resources/Core.js
@@ -22,6 +22,11 @@
                 throw new System.ArgumentNullException();
             }
 
+            // A JS boolean's native toString() is "true"/"false"; .NET's is "True"/"False".
+            if (typeof instance === "boolean") {
+                return System.Boolean.toString(instance);
+            }
+
             var guardItem = Transpose.$toStringGuard[Transpose.$toStringGuard.length - 1];
 
             if (instance.toString === Object.prototype.toString || guardItem && guardItem === instance) {

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,5 +1,63 @@
 # Findings
 
+## Transpose-vs-h5 compiler audit
+
+Audit of the Roslyn translator against the proven-correct h5 baseline, using the Curiosity
+front-end (`Curiosity.FrontEnd*` 26.7.2802) as the corpus. A divergence counts as a bug when the
+emitted JS behaves differently from BOTH native .NET AND h5 (cosmetic JS differences are fine);
+native-only divergences are also fixed where practical.
+
+### Fixed this session
+
+- **Reflection metadata built attributes with the wrong ctor overload.** `at:[...]` emitted a bare
+  `new T(args)` (primary ctor), dropping the arguments for any attribute applied through a
+  non-primary overload. Broke `[JsonProperty("wireName")]` (67 uses in the corpus) — Newtonsoft
+  (de)serialized under the C# member names. Now emits `new T.$ctorN(args)` like h5.
+- **`DEBUG`/`TRACE` not defined per `-c` configuration.** `tps` never added the SDK's implicit
+  symbols, so `#if DEBUG` always took the `#else` branch in a Debug build. Now defines `TRACE`
+  (always) and `DEBUG` (Debug config).
+- **long/ulong/decimal operators.** Compound assignment (`+= /= %= <<=` …), `++`/`--`, and a
+  non-decimal integer on the LEFT of a decimal operator all ran native JS operators on the boxed
+  Int64/Decimal (string-concat, integer division, precision loss, crashes). Rebuilt through the
+  runtime type's methods; `long op decimal` now promotes to decimal.
+- **`bool.ToString()`** returned "true"/"false" instead of .NET "True"/"False" (both the direct
+  call and a boxed bool via `Transpose.toString`).
+- **String-interpolation alignment** `{x,N}` / `{x,-N}` was silently dropped; now padded via
+  `System.String.alignString`.
+- **Default-value init.** Static non-primitive-struct fields/auto-props with no initializer stayed
+  `null` (member access threw); `default(T)` for a generic-*method* type parameter emitted `null`
+  regardless of the value-type argument. Both now use `Transpose.getDefaultValue`.
+- **`params` passing.** An array passed to `params object[]` was double-wrapped (element-type test:
+  `object[]` → `object` exists); an optional parameter omitted before a `params` array was dropped
+  (the array shifted into its slot). Now tests convertibility to the array type and emits `void 0`
+  for skipped optionals.
+- **for-loop closures.** A `for` header variable was emitted with `let` (fresh per-iteration ES6
+  binding); C#'s single shared variable means closures see the final value. Now `var`, like h5.
+- **`foreach` disposal.** Emitted a bare `while (moveNext())` with no try/finally+Dispose, so an
+  iterator's `finally` never ran on `break`/`return`/throw. Now wraps in try/finally and disposes
+  the enumerator (the shim's enumerator wrapper forwards `dispose`, and iterator generators run
+  their `finally` via `it.return()`).
+- **`foreach` over null** threw a raw JS `TypeError`; now throws `System.NullReferenceException`.
+
+### Known open (not fixed)
+
+- **`ValueTuple` literals emit plain `{Item1,Item2}` objects** (no `ValueTuple$N` prototype), so
+  `tuple.ToString()` → "[object Object]" (native "(1, x)") and `tuple.Equals()`/`.GetHashCode()`
+  throw. `==`, deconstruction, and dict/hashset keys work via structural helpers. h5 builds
+  `new (System.ValueTuple$N(types)).$ctor1(vals)`. Deferred: changing the representation touches
+  deconstruction/patterns/LINQ/JSON broadly — needs its own focused change + test pass.
+- **Reordered named arguments** are emitted inline in parameter order, so side-effecting argument
+  expressions evaluate in parameter order, not C# source order (values are always correct). Fixing
+  it needs source-order temp evaluation (an IIFE) around the call. Niche; deferred.
+- **`enum.ToString(format)`** (e.g. `.ToString("D")`) throws — the `{this:type}` template emits
+  `Transpose.getType(value)`, which returns Int32 for a numeric enum value. Not exercised by the
+  corpus. `[Enum(Emit.Value)]` enums (e.g. `DateTimeKind`) intentionally stringify to their number
+  when boxed — that is an h5-compatible contract, NOT a bug.
+- **`[Init]`/`[Script]`** attributes are on the unsupported-feature allow-list but have no emitter
+  handler (`[Init]` methods never run; `[Script]` extern bodies are dropped). 0 corpus usage.
+- **`Console.Write(object)`** of a boxed bool prints "true" (uses `value.toString()`), and
+  `Console.Write` appends a newline per call under Node (`console.log` semantics — shared with h5).
+
 ## Integers_ArithmeticAndBitwise Failure
 
 The test `Integers_ArithmeticAndBitwise` failed because `Console.WriteLine` with a `long` argument prints the type name `System.Int64` instead of the numeric value in H5.

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -38,17 +38,23 @@ native-only divergences are also fixed where practical.
   the enumerator (the shim's enumerator wrapper forwards `dispose`, and iterator generators run
   their `finally` via `it.return()`).
 - **`foreach` over null** threw a raw JS `TypeError`; now throws `System.NullReferenceException`.
+- **`ValueTuple` literals** emitted plain `{Item1,Item2}` objects (no `ValueTuple$N` prototype), so
+  `tuple.ToString()` → "[object Object]" and `tuple.Equals()`/`.GetHashCode()` threw. Now emit a
+  real `new (System.ValueTuple$N(types)).$ctor1(vals)` instance (matching h5); element access,
+  deconstruction, named elements, `==`, and dict/hashset keys are unaffected. Arity > 7 (nested
+  ValueTuple) still uses the plain-object fallback.
+- **`Activator.CreateInstance(type, new object[]{…})`** double-wrapped the args array (the template
+  `:array` modifier re-wrapped the already-collected params array into `[[…]]`), so the wrong ctor
+  ran. A single argument that IS the params array is now emitted JS-spread so `:array` yields the
+  array itself. (Newtonsoft `[JsonConstructor]` was already unaffected.)
+- **Reordered named arguments** were emitted inline in parameter order, so side-effecting argument
+  expressions evaluated in parameter order, not C# source order. When the arguments are effectively
+  reordered (their parameter indices aren't ascending in source order) they are now evaluated into
+  temps in source order and passed back in parameter order (an IIFE spread); in-order calls stay
+  inline. (The `params`-slot combination keeps the inline path.)
 
 ### Known open (not fixed)
 
-- **`ValueTuple` literals emit plain `{Item1,Item2}` objects** (no `ValueTuple$N` prototype), so
-  `tuple.ToString()` → "[object Object]" (native "(1, x)") and `tuple.Equals()`/`.GetHashCode()`
-  throw. `==`, deconstruction, and dict/hashset keys work via structural helpers. h5 builds
-  `new (System.ValueTuple$N(types)).$ctor1(vals)`. Deferred: changing the representation touches
-  deconstruction/patterns/LINQ/JSON broadly — needs its own focused change + test pass.
-- **Reordered named arguments** are emitted inline in parameter order, so side-effecting argument
-  expressions evaluate in parameter order, not C# source order (values are always correct). Fixing
-  it needs source-order temp evaluation (an IIFE) around the call. Niche; deferred.
 - **`enum.ToString(format)`** (e.g. `.ToString("D")`) throws — the `{this:type}` template emits
   `Transpose.getType(value)`, which returns Int32 for a numeric enum value. Not exercised by the
   corpus. `[Enum(Emit.Value)]` enums (e.g. `DateTimeKind`) intentionally stringify to their number

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -58,6 +58,14 @@ internal static class ProjectResolver
             .ToList();
         if (!defines.Contains("Transpose")) defines.Add("Transpose"); // Transpose projects always compile the Transpose branch
 
+        // Configuration-driven symbols the .NET SDK defines implicitly: TRACE in every configuration,
+        // DEBUG in the Debug configuration. Without these, `#if DEBUG` never compiles in a `-c Debug`
+        // build (it silently took the #else branch — e.g. loading the minified bundle instead of the
+        // dev one). Additive with the project's own <DefineConstants>; add only if not already present.
+        if (!defines.Contains("TRACE")) defines.Add("TRACE");
+        if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase) && !defines.Contains("DEBUG"))
+            defines.Add("DEBUG");
+
         var lang = ParseLangVersion(Property(doc, "LangVersion"));
 
         // Default (bundle) mode: translate the whole closure of source projects into one JS

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1053,6 +1053,79 @@ public class Program
 }", waitForOutput: "<<DONE>>");
         }
 
+        // ---- ValueTuple literals are real ValueTuple instances --------------------------------
+
+        [TestMethod]
+        public async Task ValueTupleInstanceBehaviourRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        var t = (1, ""x"");
+        Console.WriteLine(t.ToString());                 // (1, x)
+        Console.WriteLine(t.Item1 + ""/"" + t.Item2);       // 1/x
+        var (a, b) = t; Console.WriteLine(a + "","" + b);   // 1,x
+        var n = (id: 5, name: ""n""); Console.WriteLine(n.id + "":"" + n.name); // 5:n
+        Console.WriteLine((1, ""x"").Equals((1, ""x"")));     // True
+        Console.WriteLine((1, ""x"") == (1, ""y""));          // False
+        Console.WriteLine((1, 2, 3).ToString());          // (1, 2, 3)
+        var set = new HashSet<(int, int)> { (1, 2), (1, 2), (3, 4) };
+        Console.WriteLine(set.Count);                      // 2
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- Activator.CreateInstance with an explicit object[] of arguments ------------------
+
+        [TestMethod]
+        public async Task ActivatorCreateInstanceWithObjectArrayRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Multi
+{
+    public string V;
+    public Multi(int a) { V = ""one:"" + a; }
+    public Multi(int a, int b, int c) { V = ""three:"" + (a + b + c); }
+}
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(((Multi)Activator.CreateInstance(typeof(Multi), new object[] { 1, 2, 3 })).V); // three:6
+        Console.WriteLine(((Multi)Activator.CreateInstance(typeof(Multi), 1, 2, 3)).V);                   // three:6
+        Console.WriteLine(((Multi)Activator.CreateInstance(typeof(Multi), 9)).V);                         // one:9
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- reordered named arguments evaluate in source order -------------------------------
+
+        [TestMethod]
+        public async Task ReorderedNamedArgsEvaluateInSourceOrderRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static int Log(string tag) { Console.WriteLine(""eval "" + tag); return tag.Length; }
+    static string M(int a, int b, int c = 99) => ""a="" + a + "" b="" + b + "" c="" + c;
+    public static void Main()
+    {
+        Console.WriteLine(M(b: Log(""BB""), a: Log(""AAA"")));            // eval BB; eval AAA; a=3 b=2 c=99
+        Console.WriteLine(M(a: Log(""A""), b: Log(""BB"")));              // eval A; eval BB; a=1 b=2 c=99
+        Console.WriteLine(M(c: Log(""CCCC""), b: Log(""BB""), a: Log(""A""))); // eval CCCC; BB; A; a=1 b=2 c=4
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
         [TestMethod]
         public void AttributeNonPrimaryCtorEmitsCtorOverloadName()
         {

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -774,5 +774,61 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- attribute constructed through the correct ctor overload -----------
+        // Reflection metadata (`at:[...]`) constructed every attribute with a bare `new T(args)`,
+        // which invokes the PRIMARY ctor ("ctor") and silently drops the arguments when the attribute
+        // was applied through a non-primary overload ($ctorN). This broke, e.g., [JsonProperty("x")]
+        // (PropertyName lost -> wrong JSON wire names). h5 emits `new T.$ctorN(args)`.
+
+        [TestMethod]
+        public async Task AttributeNonPrimaryCtorArgsPreservedRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Reflection;
+[AttributeUsage(AttributeTargets.Class)]
+public class TagAttribute : Attribute
+{
+    public string Name { get; }
+    public int Order { get; }
+    public TagAttribute() { Name = ""default""; }
+    public TagAttribute(string name) { Name = name; }
+    public TagAttribute(string name, int order) { Name = name; Order = order; }
+}
+[Tag(""hello"", 7)]
+public class Widget { }
+public class Program
+{
+    public static void Main()
+    {
+        var a = (TagAttribute)typeof(Widget).GetCustomAttributes(typeof(TagAttribute), false)[0];
+        Console.WriteLine(a.Name + ""/"" + a.Order);   // hello/7 (not default/0)
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public void AttributeNonPrimaryCtorEmitsCtorOverloadName()
+        {
+            var code = @"
+using System;
+[AttributeUsage(AttributeTargets.Class)]
+public class TagAttribute : Attribute
+{
+    public TagAttribute() { }
+    public TagAttribute(string name) { }
+}
+[Tag(""x"")] public class Widget { }
+public class Program { public static void Main() { } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            // The (string) overload is the non-primary ctor ($ctor1); the attribute instance must be
+            // constructed through it, not the bare `new TagAttribute("x")` (which hits the primary ctor).
+            Assert.IsTrue(result.Javascript!.Contains("new TagAttribute.$ctor1(\"x\")"),
+                "attribute must be constructed via the applied ctor overload\n" + result.Javascript);
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -809,6 +809,111 @@ public class Program
 }", waitForOutput: "<<DONE>>");
         }
 
+        // ---- operators on long / ulong / decimal, bool.ToString, interpolation alignment ------
+
+        [TestMethod]
+        public async Task BoolToStringUsesDotNetCasingRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        bool t = true;
+        Console.WriteLine(t.ToString());     // True
+        Console.WriteLine(false.ToString()); // False
+        object o = t;
+        Console.WriteLine(o.ToString());     // True
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task IntegerOnLeftOfDecimalOperatorRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        int i = 5; decimal m = 2m; short sh = 3; long L = 5L;
+        Console.WriteLine(i + m);   // 7
+        Console.WriteLine(i / m);   // 2.5
+        Console.WriteLine(i - m);   // 3
+        Console.WriteLine(i % m);   // 1
+        Console.WriteLine(i < m);   // False
+        Console.WriteLine(sh + m);  // 5
+        Console.WriteLine(L / m);   // 2.5
+        Console.WriteLine(m + i);   // 7
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task CompoundAssignLongUlongDecimalRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        long p = 10L; p += 3L;  Console.WriteLine(p);   // 13
+        long o = 10L; o /= 4L;  Console.WriteLine(o);   // 2
+        long q = 1L;  q <<= 40; Console.WriteLine(q);   // 1099511627776
+        ulong u = 10UL; u += 3UL; Console.WriteLine(u); // 13
+        decimal d = 10m; d += 3m; Console.WriteLine(d); // 13
+        decimal e = 10m; e %= 3m; Console.WriteLine(e); // 1
+        var dict = new Dictionary<string,long>{{""k"",10L}}; dict[""k""] += 5L; Console.WriteLine(dict[""k""]); // 15
+        var lst = new List<decimal>{10m}; lst[0] += 3m; Console.WriteLine(lst[0]); // 13
+        long[] arr = { 100L }; arr[0] *= 3L; Console.WriteLine(arr[0]); // 300
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task IncrementDecrementLongDecimalRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long b = 9007199254740993L; b++; Console.WriteLine(b);   // 9007199254740994
+        decimal d = 0.1m; d++; Console.WriteLine(d);             // 1.1
+        long x = 10L; x++; long y = x * 3L; Console.WriteLine(y);// 33
+        long a = 5L; long bb = a++; Console.WriteLine(a + "" "" + bb); // 6 5
+        decimal dc = 1m; decimal ec = dc--; Console.WriteLine(dc + "" "" + ec); // 0 1
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task InterpolationAlignmentRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        int x = 42;
+        Console.WriteLine($""[{x,10}]"");   // [        42]
+        Console.WriteLine($""[{x,-10}]"");  // [42        ]
+        Console.WriteLine($""[{x,5:N1}]"");// [ 42.0]
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
         [TestMethod]
         public void AttributeNonPrimaryCtorEmitsCtorOverloadName()
         {

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -914,6 +914,145 @@ public class Program
 }", waitForOutput: "<<DONE>>");
         }
 
+        // ---- default value of static struct fields / generic-method type params ----
+
+        [TestMethod]
+        public async Task StaticStructFieldDefaultsToZeroedStructRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public struct Pt { public int X; public int Y; }
+public class St
+{
+    public static DateTime When;
+    public static Guid Id;
+    public static Pt P;
+    public static (int, string) Tup { get; set; }
+}
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(St.When == DateTime.MinValue); // True
+        Console.WriteLine(St.When.Ticks);                // 0 (no crash)
+        Console.WriteLine(St.Id == Guid.Empty);          // True
+        Console.WriteLine(St.P.X + "","" + St.P.Y);        // 0,0
+        Console.WriteLine(St.Tup.Item1 + "","" + (St.Tup.Item2 ?? ""null"")); // 0,null
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task GenericMethodDefaultOfTypeParamRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static T Def<T>() { return default(T); }
+    public static void Main()
+    {
+        Console.WriteLine(""int="" + Def<int>());           // 0
+        Console.WriteLine(""bool="" + Def<bool>());          // False
+        Console.WriteLine(""double="" + Def<double>());      // 0
+        Console.WriteLine(""dtTicks="" + Def<DateTime>().Ticks); // 0
+        Console.WriteLine(""str="" + (Def<string>() ?? ""null"")); // null
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- for-loop variable is a single shared binding (closure captures final value) ------
+
+        [TestMethod]
+        public async Task ForLoopVariableCapturedByClosureRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        var acts = new List<Func<int>>();
+        for (int i = 0; i < 3; i++) acts.Add(() => i);
+        var sb = new System.Text.StringBuilder();
+        foreach (var a in acts) sb.Append(a());   // 333 (shared for-loop var), NOT 012
+        Console.WriteLine(sb.ToString());
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- foreach disposes the enumerator on early exit (iterator finally runs) ------------
+
+        [TestMethod]
+        public async Task ForeachRunsIteratorFinallyOnEarlyExitRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    static IEnumerable<int> Gen()
+    {
+        try { yield return 1; yield return 2; yield return 3; }
+        finally { Console.WriteLine(""FINALLY""); }
+    }
+    public static void Main()
+    {
+        foreach (var x in Gen()) { if (x == 2) break; Console.WriteLine(""got "" + x); }
+        Console.WriteLine(""after"");
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- params array passing: object[] pass-through and optional-before-params -----------
+
+        [TestMethod]
+        public async Task ParamsArrayPassThroughAndOptionalRunsAsync()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    static string JO(string sep, params object[] items) => items.Length + "":"" + string.Join(sep, items);
+    static string M(string a, int b = 7, params object[] rest) => a + ""/"" + b + ""/["" + string.Join("","", rest) + ""]"";
+    public static void Main()
+    {
+        var oarr = new object[] { ""x"", ""y"" };
+        Console.WriteLine(JO("","", oarr));         // 2:x,y  (array passed through, not double-wrapped)
+        Console.WriteLine(JO("","", ""a"", ""b"", ""c""));  // 3:a,b,c
+        Console.WriteLine(JO("",""));                // 0:
+        Console.WriteLine(M(""x""));                 // x/7/[]  (optional b defaults, params empty)
+        Console.WriteLine(M(""x"", 2));              // x/2/[]
+        Console.WriteLine(M(""x"", 2, ""p"", ""q""));  // x/2/[p,q]
+        Console.WriteLine(M(""x"", rest: oarr));      // x/7/[x,y]
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task ForeachOverNullThrowsNullReferenceRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        IEnumerable<int> seq = null;
+        try { foreach (var x in seq) Console.WriteLine(x); }
+        catch (NullReferenceException) { Console.WriteLine(""caught NRE""); }
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
         [TestMethod]
         public void AttributeNonPrimaryCtorEmitsCtorOverloadName()
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -681,11 +681,16 @@ public sealed partial class Emitter
         {
             var fixedCount = method.Parameters.Length - 1;
             var first = !lead;
-            for (var i = 0; i < fixedCount && i < args.Count; i++)
+            for (var i = 0; i < fixedCount; i++)
             {
                 if (!first) _w.Write(", ");
                 first = false;
-                EmitExpressionConverted(args[i].Expression, method.Parameters[i].Type);
+                // An optional fixed parameter omitted before the params array can't be skipped in a
+                // positional JS call: emit `void 0` so the callee applies its default. Without this
+                // the params array shifted into the optional's slot (e.g. M("x") on
+                // M(string,int=7,params object[]) emitted M("x", []) — [] landed in the int slot).
+                if (i < args.Count) EmitExpressionConverted(args[i].Expression, method.Parameters[i].Type);
+                else _w.Write("void 0");
             }
 
             var trailing = args.Skip(fixedCount).ToList();
@@ -693,13 +698,15 @@ public sealed partial class Emitter
 
             var paramsType = method.Parameters[^1].Type;
             var paramsElem = ParamsElementType(paramsType);
-            // A single argument that is itself the collection (an array, a List, a collection
-            // expression — anything not convertible to the element type) is passed through as the
-            // params value; otherwise the scattered args are collected into the params collection
-            // (a bare JS array for array/span/interface params; a built instance for List<T> etc.).
+            // A single argument that is itself the params ARRAY (convertible to the array type, e.g.
+            // an object[] passed to `params object[]`, a List, a collection expression) is passed
+            // through as the params value; otherwise the scattered args are collected into the params
+            // collection. The test must be against the ARRAY type, not the element type: an object[]
+            // IS convertible to the element `object`, so an element-type test double-wrapped it into
+            // [object[]] (Length 1 instead of the array's real length).
             var soleArgType = trailing.Count == 1 ? _model.GetTypeInfo(trailing[0].Expression).Type : null;
-            if (trailing.Count == 1 && paramsElem is not null
-                && (soleArgType is null || !_compilation.ClassifyConversion(soleArgType, paramsElem).Exists))
+            if (trailing.Count == 1
+                && (soleArgType is null || _compilation.ClassifyConversion(soleArgType, paramsType).Exists))
             {
                 EmitExpressionConverted(trailing[0].Expression, paramsType);
             }
@@ -745,8 +752,10 @@ public sealed partial class Emitter
     {
         var paramsElem = ParamsElementType(paramsType);
         var argType = _model.GetTypeInfo(arg).Type;
-        if (paramsElem is not null
-            && (argType is null || !_compilation.ClassifyConversion(argType, paramsElem).Exists))
+        // Pass through when the argument IS the params array (convertible to the array type); wrap a
+        // lone element otherwise. Testing the element type wrapped an object[] into [object[]], since
+        // object[] → object exists.
+        if (argType is null || _compilation.ClassifyConversion(argType, paramsType).Exists)
         {
             EmitExpressionConverted(arg, paramsType);   // already the collection
         }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -268,11 +268,21 @@ public sealed partial class Emitter
             var p = method.Parameters[pi];
             if (p.IsParams)
             {
-                // A params argument resolves as the SPREAD (comma-joined) form by default —
-                // {args} in "System.String.format({format}, {args})" → format(fmt, a, b). A
-                // template that needs the array wraps it explicitly with the :array modifier
-                // ({values:array} → [a, b]); the array wrapping is applied in SubstituteTemplate.
-                byName[p.Name] = string.Join(", ", byPos.Skip(pi));
+                // A single trailing argument that IS the params array (e.g. an object[] passed to
+                // `params object[]`) is the array itself, not one element: emit it JS-spread so
+                // {args:array} yields the array ([...arr]) instead of double-wrapping it into [[...]]
+                // (which made Activator.CreateInstance(type, new object[]{…}) pick the wrong ctor),
+                // and a bare {args} still spreads to individual call arguments.
+                var trailingCount = byPos.Count - pi;
+                var soleArgType = trailingCount == 1 && pi < args.Count
+                    ? _model.GetTypeInfo(args[pi].Expression).Type : null;
+                byName[p.Name] = trailingCount == 1 && soleArgType is not null
+                    && _compilation.ClassifyConversion(soleArgType, p.Type).Exists
+                        ? "..." + byPos[pi]
+                        // Otherwise resolve as the SPREAD (comma-joined) form — {args} in
+                        // "System.String.format({format}, {args})" → format(fmt, a, b); a template that
+                        // needs an array uses the :array modifier ({values:array} → [a, b]).
+                        : string.Join(", ", byPos.Skip(pi));
             }
             else if (pi < byPos.Count)
             {
@@ -583,12 +593,14 @@ public sealed partial class Emitter
         if (method is not null && args.Any(a => a.NameColon is not null))
         {
             var ordered = new ExpressionSyntax?[method.Parameters.Length];
+            var paramIndexOf = new int[args.Count]; // source-arg k → the parameter index it binds to
             for (var i = 0; i < args.Count; i++)
             {
                 var arg = args[i];
                 if (arg.NameColon is not null)
                 {
                     var idx = ParameterIndex(method, arg.NameColon.Name.Identifier.Text);
+                    paramIndexOf[i] = idx;
                     if (idx >= 0) ordered[idx] = arg.Expression;
                 }
                 else if (i < ordered.Length)
@@ -600,7 +612,9 @@ public sealed partial class Emitter
                     // (e.g. Do(type, accept, retriever: fn, flag)) already claimed slot 2, and the
                     // trailing positional `flag` must land in slot 3, not overwrite slot 2.
                     ordered[i] = arg.Expression;
+                    paramIndexOf[i] = i;
                 }
+                else paramIndexOf[i] = -1;
             }
 
             // Positional JS calls can't skip a hole, so fill any omitted argument that
@@ -608,6 +622,41 @@ public sealed partial class Emitter
             // omitted optionals are left off (the callee supplies its own defaults).
             var lastProvided = -1;
             for (var i = 0; i < ordered.Length; i++) if (ordered[i] is not null) lastProvided = i;
+
+            // "Effectively reordered": the provided arguments' parameter indices are not ascending in
+            // SOURCE order, so emitting them in parameter order would change the order side-effecting
+            // argument expressions run in. C# evaluates arguments in source order; preserve that by
+            // evaluating into temps (source order) and passing them back in parameter order. (When
+            // already ascending, inline parameter-order emission is already source order — no wrap.)
+            var reordered = false;
+            for (int k = 0, prev = -1; k < paramIndexOf.Length; k++)
+            {
+                if (paramIndexOf[k] < 0) continue;
+                if (paramIndexOf[k] < prev) { reordered = true; break; }
+                prev = paramIndexOf[k];
+            }
+            var hasParams = method.Parameters.Length > 0 && method.Parameters[^1].IsParams;
+            if (reordered && !hasParams)
+            {
+                if (lead) _w.Write(", ");
+                _w.Write("...(function () { var $ = [");
+                for (var k = 0; k < args.Count; k++)
+                {
+                    if (k > 0) _w.Write(", ");
+                    var pIdx = paramIndexOf[k];
+                    var pType = pIdx >= 0 && pIdx < method.Parameters.Length ? method.Parameters[pIdx].Type : null;
+                    EmitExpressionConverted(args[k].Expression, pType);
+                }
+                _w.Write("]; return [");
+                for (var i = 0; i <= lastProvided; i++)
+                {
+                    if (i > 0) _w.Write(", ");
+                    var src = Array.IndexOf(paramIndexOf, i);
+                    _w.Write(src >= 0 ? $"$[{src}]" : "void 0");
+                }
+                _w.Write("]; })()");
+                return;
+            }
 
             var first = !lead;
             for (var i = 0; i <= lastProvided; i++)
@@ -997,10 +1046,29 @@ public sealed partial class Emitter
 
     private void EmitTuple(TupleExpressionSyntax tuple)
     {
-        // Tuples are represented as { Item1, Item2, ... }; named-element access is
-        // mapped to the corresponding ItemN at the access site.
+        var n = tuple.Arguments.Count;
+        var tupleType = (_model.GetTypeInfo(tuple).ConvertedType ?? _model.GetTypeInfo(tuple).Type) as INamedTypeSymbol;
+
+        // Emit a real System.ValueTuple$N instance so Equals / GetHashCode / ToString ("(a, b)")
+        // behave like .NET; element access still reads .ItemN so deconstruction/named-element access
+        // are unaffected. h5 emits `new (System.ValueTuple$N(types)).$ctor1(values)`. Arity > 7 uses a
+        // nested ValueTuple (TRest) — fall back to the plain {Item1,…} object there (rare).
+        if (tupleType is { IsTupleType: true } && n is >= 1 and <= 7)
+        {
+            var elements = tupleType.TupleElements;
+            _w.Write($"new ({TypeRef(tupleType.TupleUnderlyingType ?? tupleType)}).$ctor1(");
+            for (var i = 0; i < n; i++)
+            {
+                if (i > 0) _w.Write(", ");
+                EmitExpressionConverted(tuple.Arguments[i].Expression, elements[i].Type);
+            }
+            _w.Write(")");
+            return;
+        }
+
+        // Fallback (arity > 7 or a non-tuple type): a plain object; named-element access maps to ItemN.
         _w.Write("{ ");
-        for (var i = 0; i < tuple.Arguments.Count; i++)
+        for (var i = 0; i < n; i++)
         {
             if (i > 0) _w.Write(", ");
             _w.Write($"Item{i + 1}: ");

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -123,6 +123,18 @@ public sealed partial class Emitter
             return;
         }
 
+        // bool.ToString() → "True"/"False" (.NET casing). A bool is a JS primitive whose native
+        // .toString() gives "true"/"false"; route through System.Boolean.toString for parity.
+        if (symbol is { Name: "ToString", Parameters.Length: 0 }
+            && invocation.Expression is MemberAccessExpressionSyntax { Expression: { } boolRecv }
+            && _model.GetTypeInfo(boolRecv).Type?.SpecialType == SpecialType.System_Boolean)
+        {
+            _w.Write("System.Boolean.toString(");
+            EmitExpression(boolRecv);
+            _w.Write(")");
+            return;
+        }
+
         // Transpose.Script.Write(code, args) — inject raw JavaScript, substituting {0},{1}… with args.
         if (symbol is { Name: "Write" } && symbol.ContainingType?.ToDisplayString() == "Transpose.Script"
             && invocation.ArgumentList.Arguments.Count >= 1
@@ -1116,19 +1128,29 @@ public sealed partial class Emitter
         // instances with .gte/.add/… methods), so such a comparison must stay a plain operator.
         var leftDeclared = _model.GetTypeInfo(binary.Left).Type ?? leftType;
         var rightDeclared = _model.GetTypeInfo(binary.Right).Type ?? rightType;
-        if ((Is64BitInteger(leftDeclared) || Is64BitInteger(rightDeclared)) && Long64Op(binary) is not null)
+        // `long op decimal` (and vice-versa) is promoted to decimal by C#, so it must go through the
+        // decimal path below — not Int64 (which would do integer division etc.). Guard against a
+        // decimal operand here.
+        if ((Is64BitInteger(leftDeclared) || Is64BitInteger(rightDeclared)) && Long64Op(binary) is not null
+            && !IsDecimalType(leftDeclared) && !IsDecimalType(rightDeclared))
         {
             EmitLong64Binary(binary, leftDeclared, rightDeclared);
             return;
         }
 
-        // decimal arithmetic/comparison → System.Decimal method calls.
+        // decimal arithmetic/comparison → System.Decimal method calls. Decide the receiver wrap on
+        // the operand's DECLARED type (like the Int64 path above): only an actual `decimal` operand is
+        // a System.Decimal instance with .add/.div/…; an int/long promoted to decimal by C# is still a
+        // raw JS number / Int64 at runtime, so it must be lifted with System.Decimal(...). Testing the
+        // converted type instead made `i + m` emit `i.add(m)` (TypeError) and `5L / 2m` do integer
+        // division via Int64.div.
         if ((IsDecimalType(leftType) || IsDecimalType(rightType)) && DecimalOp(binary) is { } decOp)
         {
-            if (IsDecimalType(leftType)) EmitExpression(binary.Left);
+            if (IsDecimalType(leftDeclared)) EmitExpression(binary.Left);
             else { _w.Write("System.Decimal("); EmitExpression(binary.Left); _w.Write(")"); }
             _w.Write($".{decOp}(");
-            EmitExpression(binary.Right);
+            if (IsDecimalType(rightDeclared)) EmitExpression(binary.Right);
+            else { _w.Write("System.Decimal("); EmitExpression(binary.Right); _w.Write(")"); }
             _w.Write(")");
             return;
         }
@@ -1597,9 +1619,60 @@ public sealed partial class Emitter
             return;
         }
 
+        // 64-bit integer / decimal compound assignment: `lhs op= rhs` → `lhs = lhs.<method>(rhs)`.
+        // The target is a boxed Int64/UInt64/Decimal instance, so a native JS `+=`/`/=`/… would run
+        // string-concat / float ops on the object rather than the type's method (10L += 3L → "103").
+        if (op != "=" && (Is64BitInteger(leftType) || IsDecimalType(leftType))
+            && Long64OrDecimalCompoundMethod(op, leftType) is not null)
+        {
+            EmitExpression(assignment.Left);
+            _w.Write(" = ");
+            EmitLong64OrDecimalCompoundValue(assignment.Left, assignment.Right, op, leftType);
+            return;
+        }
+
         EmitExpression(assignment.Left);
         _w.Write($" {op} ");
         EmitExpressionConverted(assignment.Right, leftType);
+    }
+
+    /// <summary>The Int64/UInt64 or Decimal instance-method name for a compound-assignment operator
+    /// (<c>+=</c> → add, …), or null if the operator/type has no such method.</summary>
+    private static string? Long64OrDecimalCompoundMethod(string op, ITypeSymbol? leftType)
+    {
+        var binOp = op[..^1];
+        if (Is64BitInteger(leftType))
+            return binOp switch
+            {
+                "+" => "add", "-" => "sub", "*" => "mul", "/" => "div", "%" => "mod",
+                "&" => "and", "|" => "or", "^" => "xor", "<<" => "shl",
+                ">>" => Is64BitUnsigned(leftType) ? "shru" : "shr",
+                _ => null,
+            };
+        if (IsDecimalType(leftType))
+            return binOp switch { "+" => "add", "-" => "sub", "*" => "mul", "/" => "div", "%" => "mod", _ => null };
+        return null;
+    }
+
+    /// <summary>Emits the rebuilt value <c>left.&lt;method&gt;(right)</c> for a 64-bit / decimal compound
+    /// assignment (used by both the plain-lvalue and the indexer-element paths). Shift counts stay raw
+    /// ints; a decimal right operand that is a plain number is lifted with System.Decimal(...).</summary>
+    private void EmitLong64OrDecimalCompoundValue(ExpressionSyntax left, ExpressionSyntax right, string op, ITypeSymbol? leftType)
+    {
+        var method = Long64OrDecimalCompoundMethod(op, leftType)!;
+        EmitExpression(left);
+        _w.Write($".{method}(");
+        if (IsDecimalType(leftType) && !IsDecimalType(_model.GetTypeInfo(right).Type))
+        {
+            _w.Write("System.Decimal("); EmitExpression(right); _w.Write(")");
+        }
+        else
+        {
+            // Int64 add/sub/… and shifts both accept a plain-number right operand (the runtime
+            // coerces it), matching EmitLong64Binary which emits the right operand raw.
+            EmitExpression(right);
+        }
+        _w.Write(")");
     }
 
     /// <summary>
@@ -1664,7 +1737,16 @@ public sealed partial class Emitter
             return;
         }
 
-        // Plain compound (double / long / decimal / etc.): current-value binOp right.
+        // 64-bit integer / decimal element: `elem op= rhs` → `elem.<method>(rhs)` (see the
+        // plain-lvalue path); a native JS operator would corrupt the boxed Int64/Decimal.
+        if (op != "=" && (Is64BitInteger(leftType) || IsDecimalType(leftType))
+            && Long64OrDecimalCompoundMethod(op, leftType) is not null)
+        {
+            EmitLong64OrDecimalCompoundValue(assignment.Left, assignment.Right, op, leftType);
+            return;
+        }
+
+        // Plain compound (double / etc.): current-value binOp right.
         _w.Write("(");
         EmitExpression(assignment.Left);
         _w.Write($") {op[..^1]} (");
@@ -1723,15 +1805,77 @@ public sealed partial class Emitter
             return;
         }
 
+        // ++ / -- on a 64-bit integer or decimal: the operand is a boxed Int64/UInt64/Decimal, so a
+        // native JS ++/-- would coerce it to a plain number (precision loss above 2^53, decimal
+        // corruption). Rebuild through the type's method. Prefix yields the NEW value.
+        if ((prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression))
+            && IncDecStep(_model.GetTypeInfo(prefix.Operand).Type, prefix.IsKind(SyntaxKind.PreIncrementExpression)) is { } step)
+        {
+            _w.Write("(");
+            EmitExpression(prefix.Operand);
+            _w.Write(" = ");
+            EmitExpression(prefix.Operand);
+            _w.Write(step);
+            _w.Write(")");
+            return;
+        }
+
         _w.Write(prefix.OperatorToken.Text);
         EmitExpression(prefix.Operand);
     }
 
     private void EmitPostfixUnary(PostfixUnaryExpressionSyntax postfix)
     {
+        // ++ / -- on a 64-bit integer or decimal (see EmitPrefixUnary). Postfix must yield the OLD
+        // value; in a void (statement / for-incrementor) context the result is discarded, so the
+        // cheaper new-value form suffices.
+        if ((postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression))
+            && IncDecStep(_model.GetTypeInfo(postfix.Operand).Type, postfix.IsKind(SyntaxKind.PostIncrementExpression)) is { } step)
+        {
+            if (IsVoidContext(postfix))
+            {
+                _w.Write("(");
+                EmitExpression(postfix.Operand);
+                _w.Write(" = ");
+                EmitExpression(postfix.Operand);
+                _w.Write(step);
+                _w.Write(")");
+            }
+            else
+            {
+                _w.Write("(function ($v) { ");
+                EmitExpression(postfix.Operand);
+                _w.Write(" = $v");
+                _w.Write(step);
+                _w.Write("; return $v; })(");
+                EmitExpression(postfix.Operand);
+                _w.Write(")");
+            }
+            return;
+        }
+
         EmitExpression(postfix.Operand);
         _w.Write(postfix.OperatorToken.Text);
     }
+
+    /// <summary>The instance-method call suffix that increments/decrements a boxed 64-bit integer or
+    /// decimal (e.g. <c>.add(System.Int64(1))</c>, <c>.inc()</c>), or null for other types.</summary>
+    private static string? IncDecStep(ITypeSymbol? type, bool increment)
+    {
+        if (Is64BitInteger(type))
+        {
+            var one = Is64BitUnsigned(type) ? "System.UInt64(1)" : "System.Int64(1)";
+            return increment ? $".add({one})" : $".sub({one})";
+        }
+        if (IsDecimalType(type)) return increment ? ".inc()" : ".dec()";
+        return null;
+    }
+
+    /// <summary>True if an expression's value is discarded — it is the whole expression of an
+    /// expression-statement, or an incrementor of a <c>for</c> loop.</summary>
+    private static bool IsVoidContext(ExpressionSyntax e)
+        => e.Parent is ExpressionStatementSyntax
+           || (e.Parent is ForStatementSyntax f && f.Incrementors.Contains(e));
 
     // ---- cast --------------------------------------------------------------
 
@@ -1945,6 +2089,13 @@ public sealed partial class Emitter
                     break;
                 case InterpolationSyntax interpolation:
                     if (!first) _w.Write(" + ");
+                    // Alignment component `{x,N}` pads the formatted value to width |N| (N>0 right-,
+                    // N<0 left-aligned). Apply it to the already-stringified value so char/enum/bool
+                    // still render correctly (routing the raw value through String.format would print
+                    // a char's code point). The width is a compile-time constant.
+                    var align = interpolation.AlignmentClause is { } ac
+                        ? _model.GetConstantValue(ac.Value).Value : null;
+                    if (align is not null) _w.Write("System.String.alignString(");
                     if (interpolation.FormatClause is not null)
                     {
                         _w.Write("TransposeR.formatValue(");
@@ -1969,6 +2120,7 @@ public sealed partial class Emitter
                         EmitExpression(interpolation.Expression);
                         _w.Write(")");
                     }
+                    if (align is not null) _w.Write($", {Convert.ToInt32(align).ToString(CultureInfo.InvariantCulture)})");
                     first = false; hadContent = true;
                     break;
             }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -21,6 +21,10 @@ public sealed partial class Emitter
         }).Where(x => x is not null).Select(x => x!.Value).ToList();
 
         var staticInitAssignments = StaticInitializers(type).ToList();
+        // Static non-primitive-struct fields/auto-props with no initializer default to the zeroed
+        // struct (like the instance path), not the `null` their slot holds — otherwise a member
+        // access on an uninitialized static DateTime/Guid/… throws a JS TypeError.
+        var staticStructDefaults = StaticStructDefaults(type).ToList();
         var staticCtor = type.StaticConstructors.FirstOrDefault(c => c.DeclaringSyntaxReferences.Length > 0);
         var staticMethods = type.GetMembers().OfType<IMethodSymbol>()
             .Where(m => m.IsStatic && !m.IsImplicitlyDeclared && IsEmittableMethod(m) && !IsEntryPoint(m))
@@ -84,7 +88,7 @@ public sealed partial class Emitter
             });
         }
 
-        if (staticInitAssignments.Count > 0 || staticCtor is not null)
+        if (staticInitAssignments.Count > 0 || staticStructDefaults.Count > 0 || staticCtor is not null)
         {
             sections.Add(() =>
             {
@@ -101,6 +105,10 @@ public sealed partial class Emitter
                         // reads. A non-generic type's static init also runs with `this` = the type,
                         // so `this` is correct for both.
                         var staticRef = EffectiveTypeParameters(type).Count > 0 ? "this" : fullName;
+                        // Zero-init struct statics first (order-independent), before the explicit
+                        // initializers which run in declaration order and may reference them.
+                        foreach (var (target, slotType) in staticStructDefaults)
+                            _w.WriteLine($"{staticRef}.{target} = Transpose.getDefaultValue({TypeRef(slotType)});");
                         foreach (var (target, init) in staticInitAssignments)
                         {
                             _w.Write($"{staticRef}.{target} = ");
@@ -155,6 +163,22 @@ public sealed partial class Emitter
                 yield return (TransposeNaming.MemberJsName(f), fi);
             else if (m is IPropertySymbol p && IsAutoProperty(p) && AutoPropertyInitializerSyntax(p) is { } pi)
                 yield return (TransposeNaming.MemberJsName(p), pi);
+        }
+    }
+
+    /// <summary>Static non-primitive-struct fields/auto-props with no explicit initializer — their
+    /// slot holds <c>null</c>, so the zeroed struct default is assigned in the static <c>init</c>
+    /// (mirrors the instance-field path). Excludes primitives, enums and Nullable&lt;T&gt;.</summary>
+    private IEnumerable<(string target, ITypeSymbol type)> StaticStructDefaults(INamedTypeSymbol type)
+    {
+        foreach (var m in type.GetMembers().Where(m => m.IsStatic))
+        {
+            if (m is IFieldSymbol f && !f.IsConst && f.AssociatedSymbol is null
+                && FieldInitializerSyntax(f) is null && NeedsStructDefaultInit(f.Type))
+                yield return (TransposeNaming.MemberJsName(f), f.Type);
+            else if (m is IPropertySymbol p && IsAutoProperty(p)
+                && AutoPropertyInitializerSyntax(p) is null && NeedsStructDefaultInit(p.Type))
+                yield return (TransposeNaming.MemberJsName(p), p.Type);
         }
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Reflection.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Reflection.cs
@@ -528,7 +528,15 @@ public sealed partial class Emitter
     private string EmitAttributeInstance(AttributeData attr)
     {
         var ctorArgs = string.Join(", ", attr.ConstructorArguments.Select(TypedConstantJs));
-        var ctor = $"new {TypeRef(attr.AttributeClass!)}({ctorArgs})";
+        // Construct through the SAME ctor overload the attribute was applied with. A non-primary
+        // overload is a distinct JS slot ($ctorN); a bare `new T(args)` would invoke the primary
+        // ("ctor") and silently drop the arguments (e.g. [JsonProperty("x")] → PropertyName lost).
+        // Matches h5, which emits `new T.$ctorN(args)`.
+        var typeRef = TypeRef(attr.AttributeClass!);
+        var ctorName = attr.AttributeConstructor is { } ac ? ExternalAwareCtorName(ac) : "ctor";
+        var ctor = ctorName == "ctor"
+            ? $"new {typeRef}({ctorArgs})"
+            : $"new {typeRef}.{ctorName}({ctorArgs})";
         if (attr.NamedArguments.Length == 0) return ctor;
 
         var named = string.Join(", ", attr.NamedArguments.Select(

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -379,7 +379,10 @@ public sealed partial class Emitter
         _w.Write("for (");
         if (forStmt.Declaration is not null)
         {
-            _w.Write("let ");
+            // `var`, not `let`: a C# for-loop variable is a SINGLE binding shared across iterations,
+            // so a closure capturing it sees the final value. ES6 `let` in a for-header creates a
+            // fresh per-iteration binding (closures would capture distinct values) — wrong for C#.
+            _w.Write("var ");
             var first = true;
             foreach (var v in forStmt.Declaration.Variables)
             {
@@ -421,16 +424,26 @@ public sealed partial class Emitter
     {
         var iterVar = NameMangler.JsIdentifier(forEach.Identifier.Text);
         var enumVar = EmitEnumeratorInit(forEach, forEach.Expression);
-        _w.Write($"while ({enumVar}.moveNext()) ");
-        _breakTargets.Push(null);
-        _loopDepth++;
+        // foreach disposes the enumerator when the loop ends — including on break/return/throw. Wrap
+        // the iteration in try/finally so an iterator's own `finally` (and any IDisposable cleanup)
+        // runs on early exit, not only on full enumeration. TransposeR.dispose no-ops if not disposable.
+        _w.Write("try ");
         _w.Block(() =>
         {
-            _w.WriteLine($"let {iterVar} = {enumVar}.current;");
-            EmitForEachBody(forEach.Statement);
+            _w.Write($"while ({enumVar}.moveNext()) ");
+            _breakTargets.Push(null);
+            _loopDepth++;
+            _w.Block(() =>
+            {
+                _w.WriteLine($"let {iterVar} = {enumVar}.current;");
+                EmitForEachBody(forEach.Statement);
+            });
+            _loopDepth--;
+            _breakTargets.Pop();
+            _w.WriteLine();
         });
-        _loopDepth--;
-        _breakTargets.Pop();
+        _w.Write("finally ");
+        _w.Block(() => _w.WriteLine($"TransposeR.dispose({enumVar});"));
         _w.WriteLine();
     }
 
@@ -440,18 +453,25 @@ public sealed partial class Emitter
         var enumVar = EmitEnumeratorInit(forEach, forEach.Expression);
         var elementIsTuple = _model.GetForEachStatementInfo(forEach).ElementType is { IsTupleType: true };
         var targets = CollectDeconstructionTargets(forEach.Variable).ToList();
-        _w.Write($"while ({enumVar}.moveNext()) ");
-        _breakTargets.Push(null);
-        _loopDepth++;
+        _w.Write("try ");
         _w.Block(() =>
         {
-            var cur = enumVar + "c";
-            _w.WriteLine($"let {cur} = {enumVar}.current;");
-            EmitDeconstructionBindings(targets, cur, elementIsTuple);
-            EmitForEachBody(forEach.Statement);
+            _w.Write($"while ({enumVar}.moveNext()) ");
+            _breakTargets.Push(null);
+            _loopDepth++;
+            _w.Block(() =>
+            {
+                var cur = enumVar + "c";
+                _w.WriteLine($"let {cur} = {enumVar}.current;");
+                EmitDeconstructionBindings(targets, cur, elementIsTuple);
+                EmitForEachBody(forEach.Statement);
+            });
+            _loopDepth--;
+            _breakTargets.Pop();
+            _w.WriteLine();
         });
-        _loopDepth--;
-        _breakTargets.Pop();
+        _w.Write("finally ");
+        _w.Block(() => _w.WriteLine($"TransposeR.dispose({enumVar});"));
         _w.WriteLine();
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -540,11 +540,14 @@ public sealed partial class Emitter
         // here, so fall through to null (that nested type is emitted non-generically).
         if (type is ITypeParameterSymbol tp)
         {
-            // In scope when it is one of the effective type parameters of the type being emitted
-            // (own or from an enclosing generic type) — those are the define's JS function
-            // parameters. A method type parameter (not threaded here) falls back to null.
+            // A method type parameter is threaded as a leading JS parameter of the (generic) method
+            // (`Def: function (T) {…}`, called `Foo.Def(System.Int32)`), so getDefaultValue(T) is in
+            // scope wherever default(T) appears in the body — emit it so `default(int)` is 0, not null.
+            if (tp.TypeParameterKind == TypeParameterKind.Method)
+                return $"Transpose.getDefaultValue({TypeRef(type)})";
+            // A type's own (or enclosing generic type's) parameter is a define JS function parameter
+            // and thus in scope; a parameter from a different scope falls back to null.
             var inScope = _currentEmitType is not null
-                && tp.TypeParameterKind == TypeParameterKind.Type
                 && EffectiveTypeParameters(_currentEmitType).Any(p => SymbolEqualityComparer.Default.Equals(p, tp));
             return inScope ? $"Transpose.getDefaultValue({TypeRef(type)})" : "null";
         }

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -62,8 +62,17 @@
     };
     TransposeR.hash = function (v) { return Transpose.getHashCode ? Transpose.getHashCode(v) : 0; };
     TransposeR.getEnumerator = function (src) {
+        // foreach over a null sequence throws NullReferenceException in .NET (the implicit
+        // GetEnumerator call dereferences null), not a raw JS TypeError from a later .moveNext().
+        if (src == null) { throw new System.NullReferenceException(); }
         var wrap = function (e) {
-            return { moveNext: function () { return e.moveNext ? e.moveNext() : e.MoveNext(); }, get current() { return e.Current !== undefined ? e.Current : e.current; } };
+            return {
+                moveNext: function () { return e.moveNext ? e.moveNext() : e.MoveNext(); },
+                get current() { return e.Current !== undefined ? e.Current : e.current; },
+                // Forward disposal to the underlying enumerator so a foreach ending early still runs
+                // an iterator's finally / IDisposable cleanup (no-op when the source isn't disposable).
+                dispose: function () { if (e.dispose) { e.dispose(); } else if (e.Dispose) { e.Dispose(); } }
+            };
         };
         if (src != null) {
             // Already an enumerator (pattern-based / extension GetEnumerator result).
@@ -135,6 +144,10 @@
                 if (r.done) { return false; }
                 en.current = r.value;
                 return true;
+            }, function () {
+                // Dispose (called when a foreach ends early via break/return/throw) must run the
+                // iterator's pending `finally` blocks — return() resumes the JS generator through them.
+                if (it.return) { it.return(); }
             });
             return en;
         });


### PR DESCRIPTION
Audit of the Roslyn translator against the proven-correct h5 baseline, using the Curiosity front-end (`Curiosity.FrontEnd*` 26.7.2802) as the corpus. Each finding was reproduced minimally, compared three ways (h5-emitted JS ↔ transpose-emitted JS ↔ native .NET), fixed, and covered by a regression test that transpiles + runs in Node **and** diffs against native .NET. Full suite: **418 passed, 0 failed, 17 skipped**.

A divergence counts as a bug when the emitted JS behaves differently from **both** native .NET and h5 (cosmetic JS differences are fine); native-only divergences are also fixed where practical.

## Fixes

**Reflection / JSON**
- **Attributes built with the wrong ctor overload.** Reflection metadata (`at:[…]`) emitted a bare `new T(args)` (the primary ctor), silently dropping the arguments for any attribute applied through a non-primary overload. This broke `[JsonProperty("wireName")]` (67 uses in the corpus) — Newtonsoft (de)serialized members under their C# names. Now emits `new T.$ctorN(args)`, like h5.
- **`Activator.CreateInstance(type, new object[]{…})`** double-wrapped the args array (the template `:array` modifier re-wrapped the already-collected params array into `[[…]]`), picking the wrong ctor. A single argument that IS the params array is now emitted JS-spread.

**Compiler configuration**
- **`DEBUG`/`TRACE` not defined per `-c` configuration.** `tps` never added the SDK's implicit symbols, so `#if DEBUG` always took the `#else` branch in a Debug build (e.g. loading the minified front-end bundle instead of the dev files). Now defines `TRACE` (always) and `DEBUG` (Debug).

**Operators & formatting**
- **long/ulong/decimal operators** — compound assignment (`+= /= %= <<=` …), `++`/`--`, and a non-decimal integer on the LEFT of a decimal operator ran native JS operators on the boxed Int64/Decimal (`10L += 3L` → "103", `5L / 2m` → 2, precision loss, crashes). Rebuilt through the runtime type's methods; `long op decimal` now promotes to decimal.
- **`bool.ToString()`** returned "true"/"false" instead of .NET "True"/"False" (direct call and boxed).
- **String-interpolation alignment** `{x,N}` / `{x,-N}` was silently dropped; now padded via `System.String.alignString`.

**Default-value initialization**
- Static non-primitive-struct fields/auto-props with no initializer stayed `null` (member access threw); `default(T)` for a generic-**method** type parameter emitted `null` regardless of the value-type argument. Both now use `Transpose.getDefaultValue`.

**`params` passing**
- An array passed to `params object[]` was double-wrapped (the pass-through test used the element type, and `object[]` → `object` exists); an optional parameter omitted before a `params` array was dropped (the array shifted into its slot). Now tests convertibility to the array type and emits `void 0` for skipped optionals.

**Loops, foreach, tuples, named args**
- **for-loop closures** — the header variable was emitted with ES6 `let` (fresh per-iteration binding); C#'s single shared variable means closures see the final value. Now `var`, like h5.
- **`foreach` disposal** — a bare `while (moveNext())` with no try/finally meant an iterator's `finally` never ran on `break`/`return`/throw. Now wrapped in try/finally with enumerator disposal (the enumerator wrapper forwards `dispose`, and iterator generators run their `finally` via `return()`).
- **`foreach` over null** now throws `System.NullReferenceException` instead of a raw JS `TypeError`.
- **ValueTuple literals** were plain `{Item1,Item2}` objects, so `tuple.ToString()` gave "[object Object]" and `tuple.Equals()`/`.GetHashCode()` threw. Now emit real `new (System.ValueTuple$N(types)).$ctor1(values)` instances; access/deconstruction/named-elements/`==`/dict keys are unchanged.
- **Reordered named arguments** evaluated side-effecting expressions in parameter order, not C# source order. When effectively reordered they are now evaluated into temps in source order and passed back in parameter order (an IIFE spread); in-order calls stay inline.

## Known-open (documented in `FINDINGS.md`, not in this PR)
`enum.ToString(format)` throws; `[Init]`/`[Script]` attributes have no emitter handler; `Console.Write(object)` of a boxed bool prints "true" and `Console.Write` appends a newline per call under Node (shared with h5). None are corpus-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ELBL4XjWPq6nxFMQUZSR5)_