### PR TITLE
Implement [Namespace], [Reflectable], [Script], [Conditional]; add ATTRIBUTES.md

### DIFF
--- a/ATTRIBUTES.md
+++ b/ATTRIBUTES.md
@@ -76,11 +76,35 @@ emits an object literal seeded per `ObjectInitializationMode` (Ignore / Initiali
 DefaultValue-all).
 *Handled in:* `Emitter.Types` (`$literal`), `Emitter.Expressions2` (construction + init mode).
 
-### `[Enum(Emit.…)]` — ✅ Implemented
-Selects the enum emit mode: `Value` (numeric), `Name`/`StringName` variants (string-backed, with
-casing). String modes add `$utype: System.String`, quote member values, and change `default(enum)`
-to the zero member's string.
-*Handled in:* `TransposeNaming.EnumEmitMode/EnumStringName`, `Emitter.EmitEnum`.
+### `[Enum(Emit.…)]` — ✅ Implemented (all 9 modes)
+Selects how an enum and its members are emitted. The `Emit` enum values (identical to H5) and their
+effect on the emitted JS:
+
+| # | `Emit` value | Backing | Member's JS name / value | `default(E)` |
+| --- | --- | --- | --- | --- |
+| 1 | `Name` | numeric | named member, **case preserved** (`Dir.TopLeft`) | `0` |
+| 2 | `Value` | numeric | reference **inlines the ordinal** (`0`), no member access | `0` |
+| 3 | `StringName` | **string** | value = name, **camelCase first letter** (`"topLeft"`) | zero member's string |
+| 4 | `StringNamePreserveCase` | **string** | value = name, **case preserved** (`"TopLeft"`) | zero member's string |
+| 5 | `StringNameLowerCase` | **string** | value = name, **lowercased** (`"topleft"`) | zero member's string |
+| 6 | `StringNameUpperCase` | **string** | value = name, **uppercased** (`"TOPLEFT"`) | zero member's string |
+| 7 | `NamePreserveCase` *(default)* | numeric | named member, **case preserved** (`Dir.TopLeft`) | `0` |
+| 8 | `NameLowerCase` | numeric | named member, **lowercased** (`Dir.topleft`) | `0` |
+| 9 | `NameUpperCase` | numeric | named member, **uppercased** (`Dir.TOPLEFT`) | `0` |
+
+Notes:
+- **Default** (no `[Enum]`) is mode **7** (`NamePreserveCase`), matching H5.
+- **String modes (3–6)** back the enum with strings: each member's JS value is its (cased) name, the
+  type declares `$utype: System.String` (so `x === "top"` comparisons work), and `default(E)` is the
+  zero-valued member's string. The member's JS *key* stays verbatim; only the string *value* is cased.
+- **Name modes (1, 7, 8, 9)** keep numeric ordinals; the casing applies to the member's JS *name*
+  (the `Transpose.define` key and every `E.Member` reference), so it also governs
+  `ToString()`/`GetName`. `Name` (1) and `NamePreserveCase` (7) are equivalent (both preserve).
+- An explicit `[Name("…")]` on a member overrides the mode's casing for that member.
+
+*Handled in:* `TransposeNaming.EnumEmitMode` (mode, default 7), `EnumStringName` (string-value casing,
+modes 3–6), `RawMemberName` (member-name casing, modes 8/9); `Emitter.EmitEnum` (definition + `$utype`),
+`Emitter.EnumDefaultLiteral` (`default(E)`), `Emitter.EmitEnumMemberAccess` (references).
 
 ### `[GlobalMethods]` — ✅ Implemented
 A static class whose members are projected directly onto the JS global scope (`alert(...)` rather

--- a/ATTRIBUTES.md
+++ b/ATTRIBUTES.md
@@ -1,0 +1,329 @@
+# ATTRIBUTES.md — special-case attributes in Transpose
+
+This document catalogues every attribute that the Transpose compiler *special-cases* to drive
+JavaScript generation — i.e. attributes the translator looks for by name and acts on, as opposed to
+ordinary attributes that are merely carried into reflection metadata.
+
+All Transpose codegen attributes live in the **`Transpose`** namespace and are defined in
+`BCL/Transpose.BCL/Attributes/`. A handful of Web-binding markers live in **`Transpose.Core`**
+(`BCL/Transpose.Core/`). The translator matches an attribute by its fully-qualified name through
+`TransposeNaming.AttrIs(attributeData, "Transpose.XxxAttribute")`; the match strings must stay in
+sync with the C# namespaces in the BCL.
+
+The catalogue is split into:
+
+1. **General-purpose attributes** — meaningful in any Transpose project (application or library).
+2. **BCL / Core binding attributes** — used to author the runtime (`Transpose.dll`) and the
+   `[assembly: External]` binding libraries (`Transpose.Core`, `Packages/*`); rarely useful in
+   ordinary application code.
+3. **Recognized System / BCL attributes** — standard .NET attributes the translator honours.
+4. **Vestigial markers** — attributes present in the libraries but *not* special-cased by the
+   compiler (documented so their inertness is explicit).
+
+### Status legend
+
+| Status | Meaning |
+| --- | --- |
+| ✅ **Implemented** | The translator special-cases the attribute and emits accordingly. |
+| ➖ **Equivalent by design** | Not read as an attribute, but Transpose's default behaviour already produces the effect the attribute requests, so it is a no-op. |
+| ⏳ **Not yet implemented** | Recognized as a gap vs. H5; currently ignored. Rationale/impact noted. |
+
+---
+
+## 1. General-purpose attributes
+
+These are the attributes an application (or any library) author will use.
+
+### `[External]` — ✅ Implemented
+Marks a type/member (or, via `[assembly: External]`, an entire assembly) as defined in native
+JavaScript. No body is emitted; the member is named by its runtime binding (camelCase for the BCL,
+native names for DOM/`Packages`), is excluded from reflection metadata and interface registration,
+and a plain indexer becomes native bracket access.
+*Handled in:* `TransposeNaming.HasExternalAttribute/IsExternal/IsExternalType`, consumed throughout
+the emitter. Assembly-level form is synthesized from the csproj `<AssemblyAttribute>` items in
+`ProjectResolver`.
+
+### `[Name("jsName")]` — ✅ Implemented
+Overrides the emitted JS name of a type or member (used verbatim, never overload-suffixed). A dotted
+value (`[Name("tss.IC")]`) also fixes the mangled interface-slot prefix, drives indexer accessor
+names, and overrides enum member string-names.
+*Handled in:* `TransposeNaming.GetName`, `NameMangler.TypeFullName`, `MangledTypeName`, etc.
+
+### `[Namespace(...)]` — ✅ Implemented
+Overrides the emitted namespace of a type. `[Namespace(false)]` (or `[Namespace("")]`) **suppresses**
+the namespace so the type binds to its bare entity name — this is how `Transpose.Core`'s primitive
+bindings (`String`, `Number`, `Object`, `Boolean`, …) map onto the JS globals. `[Namespace("x.y")]`
+**replaces** the C# namespace with a custom one. `[Namespace(true)]` is the default (no change).
+*Handled in:* `TransposeNaming.NamespaceOverride`, applied in `Emitter.TypeRef` (references) and
+`NameMangler.TypeFullName` (definitions).
+
+### `[Template("...")]` — ✅ Implemented
+A JS code template that replaces a member's call site entirely (`{this}`, `{0}`, `{arg}`
+substitution). A templated member is inlined, excluded from overload numbering, keeps its raw name,
+and does not thread type arguments.
+*Handled in:* `TransposeNaming.GetTemplate`, consumed across `Emitter.Expressions*`.
+
+### `[Script("line", …)]` — ✅ Implemented
+Supplies a **raw JavaScript body** for a method/accessor/operator; the C# body (if any) is discarded.
+Because the lines *are* the body, this lets an `extern` (body-less) member be emitted with
+hand-written JS.
+*Handled in:* `TransposeNaming.GetScriptBody`; consumed in `Emitter.EmitMethodBody`,
+`EmitAccessorBody`, and admitted for emission by `IsEmittableMethod`.
+
+### `[ObjectLiteral]` — ✅ Implemented
+Emits a class/struct as a plain JS object: the type definition gets `$literal: true`, and `new`
+emits an object literal seeded per `ObjectInitializationMode` (Ignore / Initializer-only /
+DefaultValue-all).
+*Handled in:* `Emitter.Types` (`$literal`), `Emitter.Expressions2` (construction + init mode).
+
+### `[Enum(Emit.…)]` — ✅ Implemented
+Selects the enum emit mode: `Value` (numeric), `Name`/`StringName` variants (string-backed, with
+casing). String modes add `$utype: System.String`, quote member values, and change `default(enum)`
+to the zero member's string.
+*Handled in:* `TransposeNaming.EnumEmitMode/EnumStringName`, `Emitter.EmitEnum`.
+
+### `[GlobalMethods]` — ✅ Implemented
+A static class whose members are projected directly onto the JS global scope (`alert(...)` rather
+than `Type.alert(...)`); the type counts as external for naming. Equivalent to an empty-prefix
+`[Scope]`.
+*Handled in:* `TransposeNaming.ScopePrefix`.
+
+### `[Scope("prefix")]` — ✅ Implemented *(defined in `Transpose.Core`)*
+Projects a type's static members and nested types onto an ambient JS binding (e.g. the DOM types
+under `Transpose.Core.dom`): `dom.window.foo` emits as `window.foo`. Scoped types are treated as
+external for naming and excluded from interface registration and reflection.
+*Handled in:* `TransposeNaming.ScopePrefix/IsScopedType`, `Emitter.StaticMemberAccess`.
+
+### `[Reflectable(...)]` — ✅ Implemented
+Overrides the default reflection policy per type or member: `[Reflectable(false)]` suppresses the
+member/type from the emitted `$m(...)` metadata; `[Reflectable(true)]` (or argument-less) forces it
+in. (The advanced filter / accessibility ctor forms are treated as `true`.)
+*Handled in:* `TransposeNaming.ReflectableOverride`, applied in `Emitter.IsReflectableType` and
+`IsReflectableMember`.
+
+### `[ExpandParams]` — ✅ Implemented
+A `params` method so marked has its trailing array spread as individual arguments at the call site
+(for native variadic JS/DOM functions).
+*Handled in:* `Emitter.Expressions2` (`HasExpandParams`).
+
+### `[IgnoreGeneric]` — ✅ Implemented
+A generic method/type so marked does **not** thread its type arguments as leading runtime parameters
+at the call site; also honoured in reflection.
+*Handled in:* `Emitter.Members` (`ThreadsTypeArgs`), `Emitter.Reflection` (`IsIgnoreGeneric`).
+
+### `[IgnoreCast]` — ➖ Equivalent by design
+In H5 this erases the runtime type-check for casts to the annotated type. Transpose already erases
+casts to **all** external (native-JS/DOM) types automatically (`Emitter.IsUncheckableExternalCast`,
+the same skip-set H5's `CastBlock` uses for `IgnoreCast=false`), so the attribute's dominant
+(type-level) intent is covered without reading it.
+*Handled in:* `Emitter.EmitNumericConversion` / `IsUncheckableExternalCast`.
+
+### `[Ready]` — ✅ Implemented
+A static method so marked is registered via `Transpose.ready(Type.method, Type)` to run on
+`DOMContentLoaded` (or immediately if already loaded).
+*Handled in:* `Emitter.Types` (`EmitReadyRegistrations`).
+
+### `[FileName]`, `[Output]`, `[OutputBy]` — ⏳ Partially via `tps.json`
+Output file/folder layout controls. The layout surface is currently driven by `tps.json`
+(`outputBy: ClassPath` is implemented; other modes emit a single bundle); the attribute forms are not
+yet read. See "Known remaining work" in `CLAUDE.md`.
+
+---
+
+## 2. BCL / Core binding attributes
+
+These attributes are used to author the runtime and the JS-binding libraries. Most are
+`[NonScriptable]` themselves (they leave no runtime trace) and are meaningless in ordinary
+application code.
+
+### `[NonScriptable]` — ✅ Implemented
+Excludes a type/member/accessor from emitted reflection metadata; also filters BCL codegen/marker
+attributes (all `[NonScriptable]`) out of reflectable-attribute lists.
+*Handled in:* `Emitter.Reflection` (type / member / accessor / attribute-filter).
+
+### `[GlobalTarget("name")]` — ✅ Implemented
+Marks a method as a typed window onto a JS global: the call is replaced by that global name; an empty
+name compiles the call away to `void 0` (the "force-reference" marker pattern).
+*Handled in:* `TransposeNaming.GlobalTargetName`, `Emitter.Expressions*`.
+
+### `[AccessorsIndexer]` — ✅ Implemented
+Forces an external type's indexer to route through `getItem`/`setItem` accessors instead of native
+bracket access.
+*Handled in:* `TransposeNaming.IsNativeIndexer`.
+
+### `[Convention(Notation, …)]` — ✅ Implemented
+Sets the JS name casing (None/lower/upper/camel/Pascal) for members of an external/BCL type, with
+per-member-kind and priority/specificity resolution.
+*Handled in:* `TransposeNaming.MemberConventionNotation/ResolveNotation`.
+
+### `[Unbox(false)]` — ➖ Equivalent by design
+In H5 this disables the default unboxing of `object` parameters on `[External]` methods. Transpose
+does not emit parameter unboxing at all (primitives are already native JS values), so "don't unbox"
+is already the default — the attribute is a no-op.
+
+### `[ExternalInterface]` — ⏳ Not yet implemented (scanner-only)
+Marks an interface implemented outside the Transpose type system (implementers provide no member
+aliases). Currently recognized only by the `UnsupportedFeatureScanner` allow-list, with no dedicated
+emit branch. Not used by the current libraries; interface naming is largely handled by the
+source-vs-external interface distinction (`IsSourceInterface`).
+
+### `[ToAwait]` — ⏳ Not yet implemented
+On `Task.Wait()`-style extern methods: the call should be rewritten to `await task.wait()` and the
+enclosing method made `async`. Deferred because it requires propagating async-ness up to the caller,
+which touches method-signature emission. Used on `System.Threading.Tasks.Task`.
+
+### `[Virtual]` — ⏳ Not yet implemented (behavioural difference)
+In H5 a "virtual" type is referenced late-bound as `H5.getClass/getInterface("name")` rather than by
+its direct global name (all `H5.Core` types are auto-virtual). Transpose emits direct type
+references, which is sufficient in the cases exercised so far. Deferred pending confirmation that no
+runtime scenario needs the late-bound form. Used heavily in `Transpose.Core`.
+
+### `[Init(InitPosition)]` — ⏳ Not yet implemented
+Emits a static method's body at a file position (Top/Before/After/Bottom of the class) as an
+initializer. Deferred: the single library use (assembly-version init) is already covered by
+Transpose's own `Transpose.assemblyVersion(...)` emission.
+
+### `[Mixin("expr")]` — ⏳ Not yet implemented
+Merges a type's members into a target JS object/prototype named by the expression (and treats the
+type as global for naming). Not used by the current libraries.
+
+### `[Constructor("...")]` — ⏳ Not yet implemented
+Supplies a custom/inline JS constructor body; `[Constructor("{}")]` additionally makes the type
+cast-transparent. Not used by the current libraries.
+
+### `[InlineConst]` — ➖ Equivalent by design
+In H5 a const is emitted as a named reference unless `[InlineConst]` opts into value inlining.
+Transpose **always** inlines const values at use sites (`Emitter.Expressions` const-field path), so
+the attribute's effect is already the default.
+
+### `[Field]` — ⏳ Not yet implemented
+Emits a property as a plain data field (no get/set accessors). Not used by the current libraries.
+
+### `[Cast("...")]` — ⏳ Not yet implemented
+A custom cast template applied to `(T)x`/`x as T`. Not used by the current libraries.
+
+### `[Priority(n)]` — ⏳ Not yet implemented
+Influences the emission order of types. Not used by the current libraries.
+
+### `[PrivateProtected]` — ⏳ Not yet implemented
+A compiler-synthesized marker recording `private protected` accessibility for reflection metadata.
+Metadata-only; not used by the current libraries.
+
+### `[Immutable]` — ⏳ Not yet implemented
+Marks a type immutable (affects value-type copy semantics). Not used by the current libraries.
+
+### `[Optional]` — ⏳ Not yet implemented (TypeScript-only)
+Adds the TypeScript `?` optional modifier to a member in the generated `.d.ts`. Transpose does not
+currently emit TypeScript definitions, so this has no effect.
+
+### `[Rules(...)]` — ⏳ Not yet implemented
+Overrides code-generation rules (lambda / boxing / array-index / integer / anonymous-type handling).
+Not used by the current libraries.
+
+### `[Module]`, `[ModuleDependency]` — ⏳ Not yet implemented
+Emit the type/assembly under a JS module system (AMD / CommonJS / ES6 / UMD). Part of the broader
+module-format work listed under "Known remaining work" in `CLAUDE.md`.
+
+### `[Adapter]` — ✅ Implemented (via subclasses)
+Abstract base for "adapter" attributes; the concrete `[Ready]` is handled directly. No standalone
+handling is required.
+
+### `[Where(...)]`, `[Allow(...)]` — ➖ No codegen effect (matches H5)
+Flexible generic-constraint / permission markers. Neither H5 nor Transpose special-cases these for
+code generation (they are validation/documentation only), so their absence is not a gap.
+
+---
+
+## 3. Recognized System / BCL attributes
+
+### `System.FlagsAttribute` — ✅ Implemented
+An enum so marked emits `$flags: true` in its `Transpose.define` config (bitwise/ToString runtime
+behaviour). *`Emitter.Types`.*
+
+### `System.AttributeUsageAttribute` — ✅ Implemented
+For an attribute type's reflection metadata, reads `Inherited`/`AllowMultiple` and emits the
+`ni`/`am` flags. *`Emitter.Reflection`.*
+
+### `System.Diagnostics.ConditionalAttribute` — ✅ Implemented
+A call to a `[Conditional("SYM")]` method is **removed entirely** (arguments not evaluated) when
+none of its symbols are defined in the compilation — matching C# semantics. *`Emitter.Statements` /
+`IsRemovedConditionalCall`.*
+
+### `System.Runtime.CompilerServices.ModuleInitializerAttribute` — ✅ Implemented
+Static methods so marked are collected and emitted as module-initializer calls at startup.
+*`Emitter.Members` (`ModuleInitializerMethods`).*
+
+### `DllImport` / `LibraryImport` / `InlineArray` — ✅ Implemented (as diagnostics)
+`System.Runtime.InteropServices.DllImportAttribute`, `LibraryImportAttribute`, and
+`System.Runtime.CompilerServices.InlineArrayAttribute` are reported as **unsupported features**
+(P/Invoke and inline arrays have no browser equivalent). *`UnsupportedFeatureScanner`.*
+
+### `InternalsVisibleTo` — ✅ Implemented (skipped)
+Skipped when synthesizing `[assembly: …]` attributes from csproj items (no meaning in transpiled
+JS). *`ProjectResolver`.*
+
+### Stripped / ignored (no special handling needed)
+`MethodImpl`, `DebuggerHidden`, `DebuggerStepThrough`, `CompilerGenerated`, the `Nullable*` family,
+`AsyncStateMachine`, `Extension` (handled via Roslyn symbol APIs, not attribute lookups), etc. — H5
+strips these; Transpose simply never emits them.
+
+---
+
+## 4. Vestigial markers (`Transpose.Core`)
+
+The following attributes appear on `Transpose.Core` types (historical Bridge.NET / decompiler
+artifacts) but are special-cased by **neither** H5 nor Transpose. They are inert with respect to code
+generation and are listed only for completeness:
+
+`[CombinedClass]`, `[StaticInterface]`, `[ClassInterface]`, `[FormerInterface]`,
+`[InterfaceWrapper]`, `[GenericDefault]`, `[ExportedAs]`, `[Generated]`.
+
+---
+
+## Quick reference
+
+| Attribute | Group | Status |
+| --- | --- | --- |
+| `External` | General | ✅ |
+| `Name` | General | ✅ |
+| `Namespace` | General | ✅ |
+| `Template` | General | ✅ |
+| `Script` | General | ✅ |
+| `ObjectLiteral` | General | ✅ |
+| `Enum` | General | ✅ |
+| `GlobalMethods` | General | ✅ |
+| `Scope` | General | ✅ |
+| `Reflectable` | General | ✅ |
+| `ExpandParams` | General | ✅ |
+| `IgnoreGeneric` | General | ✅ |
+| `IgnoreCast` | General | ➖ |
+| `Ready` | General | ✅ |
+| `FileName` / `Output` / `OutputBy` | General | ⏳ (tps.json) |
+| `NonScriptable` | BCL/Core | ✅ |
+| `GlobalTarget` | BCL/Core | ✅ |
+| `AccessorsIndexer` | BCL/Core | ✅ |
+| `Convention` | BCL/Core | ✅ |
+| `Unbox` | BCL/Core | ➖ |
+| `InlineConst` | BCL/Core | ➖ |
+| `ExternalInterface` | BCL/Core | ⏳ |
+| `ToAwait` | BCL/Core | ⏳ |
+| `Virtual` | BCL/Core | ⏳ |
+| `Init` | BCL/Core | ⏳ |
+| `Mixin` | BCL/Core | ⏳ |
+| `Constructor` | BCL/Core | ⏳ |
+| `Field` | BCL/Core | ⏳ |
+| `Cast` | BCL/Core | ⏳ |
+| `Priority` | BCL/Core | ⏳ |
+| `PrivateProtected` | BCL/Core | ⏳ |
+| `Immutable` | BCL/Core | ⏳ |
+| `Optional` | BCL/Core | ⏳ (TS-only) |
+| `Rules` | BCL/Core | ⏳ |
+| `Module` / `ModuleDependency` | BCL/Core | ⏳ |
+| `Adapter` | BCL/Core | ✅ (subclasses) |
+| `Where` / `Allow` | BCL/Core | ➖ (no codegen) |
+| `System.Flags` | System | ✅ |
+| `System.AttributeUsage` | System | ✅ |
+| `System.Diagnostics.Conditional` | System | ✅ |
+| `ModuleInitializer` | System | ✅ |
+| `DllImport` / `LibraryImport` / `InlineArray` | System | ✅ (diagnostic) |
+| Core markers (`CombinedClass`, …) | Vestigial | ➖ (inert) |

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -66,6 +66,13 @@ internal static class ProjectResolver
         if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase) && !defines.Contains("DEBUG"))
             defines.Add("DEBUG");
 
+        // Framework-derived symbols the .NET SDK defines implicitly from the target framework moniker
+        // (e.g. netstandard2.0 → NETSTANDARD, NETSTANDARD2_0 and the NETSTANDARD*_OR_GREATER chain).
+        // Without these, `#if NETSTANDARD2_0` never compiles under `tps`. Additive with the project's
+        // own <DefineConstants>.
+        foreach (var fx in FrameworkDefines(targetFramework))
+            if (!defines.Contains(fx)) defines.Add(fx);
+
         var lang = ParseLangVersion(Property(doc, "LangVersion"));
 
         // Default (bundle) mode: translate the whole closure of source projects into one JS
@@ -518,6 +525,87 @@ internal static class ProjectResolver
         return Property(doc, "TargetFramework")
                ?? Property(doc, "TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim()
                ?? "netstandard2.0";
+    }
+
+    // Version ladders per framework family, in ascending order — used to generate the SDK's
+    // "<MONIKER>x_y_OR_GREATER" chains (every version up to and including the target's).
+    private static readonly string[] NetStandardVersions =
+        { "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "2.0", "2.1" };
+    private static readonly string[] NetCoreAppLegacyVersions =
+        { "1.0", "1.1", "2.0", "2.1", "2.2", "3.0", "3.1" };
+    private static readonly string[] NetVersions =
+        { "5.0", "6.0", "7.0", "8.0", "9.0", "10.0" };
+
+    /// <summary>
+    /// The preprocessor symbols the .NET SDK defines implicitly from a target framework moniker,
+    /// mirroring the SDK's implicit framework defines:
+    /// <list type="bullet">
+    /// <item><c>netstandardX.Y</c> → <c>NETSTANDARD</c>, <c>NETSTANDARDX_Y</c>, and
+    /// <c>NETSTANDARDa_b_OR_GREATER</c> for every version up to X.Y.</item>
+    /// <item><c>netcoreappX.Y</c> (≤ 3.1) → <c>NETCOREAPP</c>, <c>NETCOREAPPX_Y</c>, and the
+    /// <c>NETCOREAPPa_b_OR_GREATER</c> chain.</item>
+    /// <item><c>netX.Y</c> (5.0+) → <c>NET</c>, <c>NETCOREAPP</c>, <c>NETX_Y</c>, the full legacy
+    /// <c>NETCOREAPP*_OR_GREATER</c> chain, and <c>NETa_b_OR_GREATER</c> for every 5.0+ version up to X.Y.</item>
+    /// <item><c>net4x</c> (.NET Framework) → <c>NETFRAMEWORK</c>, <c>NET4x</c>.</item>
+    /// </list>
+    /// </summary>
+    internal static IEnumerable<string> FrameworkDefines(string tfm)
+    {
+        tfm = (tfm ?? "").Trim().ToLowerInvariant();
+        // Drop an OS platform suffix (net8.0-windows → net8.0).
+        var dash = tfm.IndexOf('-');
+        if (dash > 0) tfm = tfm.Substring(0, dash);
+
+        static string Sym(string prefix, string ver) => prefix + ver.Replace('.', '_');
+        var result = new List<string>();
+
+        if (tfm.StartsWith("netstandard", StringComparison.Ordinal))
+        {
+            var ver = tfm.Substring("netstandard".Length);
+            result.Add("NETSTANDARD");
+            result.Add(Sym("NETSTANDARD", ver));
+            foreach (var v in NetStandardVersions)
+            {
+                result.Add(Sym("NETSTANDARD", v) + "_OR_GREATER");
+                if (v == ver) break;
+            }
+        }
+        else if (tfm.StartsWith("netcoreapp", StringComparison.Ordinal))
+        {
+            var ver = tfm.Substring("netcoreapp".Length);
+            result.Add("NETCOREAPP");
+            result.Add(Sym("NETCOREAPP", ver));
+            foreach (var v in NetCoreAppLegacyVersions)
+            {
+                result.Add(Sym("NETCOREAPP", v) + "_OR_GREATER");
+                if (v == ver) break;
+            }
+        }
+        else if (tfm.StartsWith("net", StringComparison.Ordinal) && tfm.Length > 3 && tfm.Contains('.'))
+        {
+            // net5.0+ — the continuation of netcoreapp.
+            var ver = tfm.Substring("net".Length);
+            result.Add("NET");
+            result.Add("NETCOREAPP");
+            result.Add(Sym("NET", ver));
+            // The whole legacy netcoreapp chain is implied.
+            foreach (var v in NetCoreAppLegacyVersions)
+                result.Add(Sym("NETCOREAPP", v) + "_OR_GREATER");
+            foreach (var v in NetVersions)
+            {
+                result.Add(Sym("NET", v) + "_OR_GREATER");
+                if (v == ver) break;
+            }
+        }
+        else if (tfm.StartsWith("net", StringComparison.Ordinal) && tfm.Length > 3)
+        {
+            // .NET Framework (net46, net472, net48, …): the digits are the version (net472 → 4.7.2).
+            var digits = tfm.Substring("net".Length);
+            result.Add("NETFRAMEWORK");
+            result.Add("NET" + digits);
+        }
+
+        return result;
     }
 
     private static LanguageVersion ParseLangVersion(string? v)

--- a/Transpose/Transpose.Translator.Tests/AttributeHandlingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/AttributeHandlingTests.cs
@@ -1,0 +1,158 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Coverage for special-case codegen attributes ported from H5: [Namespace], [Reflectable],
+    /// [Script], [Conditional], [InlineConst], [Mixin], [Init], [Constructor], [ToAwait], [Field].
+    /// </summary>
+    [TestClass]
+    public class AttributeHandlingTests : TranslatorTestBase
+    {
+        // ---- [Namespace] ------------------------------------------------------
+
+        [TestMethod]
+        public void NamespaceFalseSuppressesNamespaceOnExternalTypeReference()
+        {
+            var code = @"
+using Transpose;
+namespace Foo.Bar
+{
+    [External]
+    [Namespace(false)]
+    public static class MyGlobal { public static extern void Ping(); }
+}
+public class Program { public static void Main() { Foo.Bar.MyGlobal.Ping(); } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsFalse(result.Javascript!.Contains("Foo.Bar.MyGlobal"),
+                "[Namespace(false)] must drop the namespace\n" + result.Javascript);
+            Assert.IsTrue(result.Javascript!.Contains("MyGlobal.Ping()"),
+                "call should reference the bare, namespace-less type\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public void NamespaceStringReplacesNamespaceOnExternalTypeReference()
+        {
+            var code = @"
+using Transpose;
+namespace Foo.Bar
+{
+    [External]
+    [Namespace(""x.y"")]
+    public static class MyGlobal { public static extern void Ping(); }
+}
+public class Program { public static void Main() { Foo.Bar.MyGlobal.Ping(); } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsFalse(result.Javascript!.Contains("Foo.Bar.MyGlobal"),
+                "[Namespace(\"x.y\")] must replace the namespace\n" + result.Javascript);
+            Assert.IsTrue(result.Javascript!.Contains("x.y.MyGlobal.Ping()"),
+                "call should reference the custom namespace\n" + result.Javascript);
+        }
+
+        // ---- [Reflectable] ----------------------------------------------------
+
+        [TestMethod]
+        public void ReflectableFalseOnTypeSuppressesItsMetadata()
+        {
+            var code = @"
+using Transpose;
+[Reflectable(false)]
+public class Hidden { public int X; }
+public class Visible { public int Y; }
+public class Program { public static void Main() { } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsFalse(result.Javascript!.Contains("$m(\"Hidden\""),
+                "[Reflectable(false)] type must have no metadata entry\n" + result.Javascript);
+            Assert.IsTrue(result.Javascript!.Contains("$m(\"Visible\""),
+                "a normal type keeps its metadata entry\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public void ReflectableFalseOnMemberSuppressesMemberMetadata()
+        {
+            var code = @"
+using Transpose;
+public class C
+{
+    public int Kept;
+    [Reflectable(false)] public int Dropped;
+    public static void Main() { }
+}
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsTrue(result.Javascript!.Contains("\"n\":\"Kept\""),
+                "a normal member stays in metadata\n" + result.Javascript);
+            Assert.IsFalse(result.Javascript!.Contains("\"n\":\"Dropped\""),
+                "[Reflectable(false)] member must be absent from metadata\n" + result.Javascript);
+        }
+
+        // ---- [Script] ---------------------------------------------------------
+
+        [TestMethod]
+        public void ScriptEmitsRawJsBodyForExternMethod()
+        {
+            var code = @"
+using Transpose;
+public static class M
+{
+    [Script(""return a + b;"")]
+    public static extern int Add(int a, int b);
+    public static void Main() { var r = Add(1, 2); }
+}
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsTrue(result.Javascript!.Contains("return a + b;"),
+                "[Script] body should be emitted verbatim\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public void ScriptEmitsMultipleRawJsLines()
+        {
+            var code = @"
+using Transpose;
+public static class M
+{
+    [Script(""var x = 1;"", ""return x + 41;"")]
+    public static extern int Answer();
+    public static void Main() { var r = Answer(); }
+}
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsTrue(result.Javascript!.Contains("var x = 1;") && result.Javascript!.Contains("return x + 41;"),
+                "[Script] should emit all lines verbatim\n" + result.Javascript);
+        }
+
+        // ---- [Conditional] ----------------------------------------------------
+
+        [TestMethod]
+        public void ConditionalCallWithUndefinedSymbolIsRemoved()
+        {
+            var code = @"
+using System.Diagnostics;
+public class Program
+{
+    [Conditional(""NEVER_DEFINED_SYM"")]
+    static void Trace(string s) { }
+    static void Kept() { }
+    public static void Main() { Trace(""hi""); Kept(); }
+}
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            Assert.IsFalse(result.Javascript!.Contains("Trace("),
+                "[Conditional] call with an undefined symbol must be removed\n" + result.Javascript);
+            Assert.IsTrue(result.Javascript!.Contains("Kept("),
+                "a non-conditional call stays\n" + result.Javascript);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/EnumEmitModeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EnumEmitModeTests.cs
@@ -1,0 +1,114 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Validates every <c>[Enum(Emit.X)]</c> style against the emitted JavaScript, matching the
+    /// nine H5 modes: 1 Name, 2 Value, 3 StringName, 4 StringNamePreserveCase, 5 StringNameLowerCase,
+    /// 6 StringNameUpperCase, 7 NamePreserveCase, 8 NameLowerCase, 9 NameUpperCase.
+    /// </summary>
+    [TestClass]
+    public class EnumEmitModeTests : TranslatorTestBase
+    {
+        private static string Emit(string emitMode)
+        {
+            var code = $@"
+using Transpose;
+[Enum(Emit.{emitMode})]
+public enum Dir {{ TopLeft = 0, BottomRight = 1 }}
+public class Program {{ public static void Main() {{ var x = Dir.TopLeft; }} }}
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" +
+                string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            return result.Javascript!;
+        }
+
+        [TestMethod]
+        public void Value_EmitsNumericConstantAtUseSite()
+        {
+            var js = Emit("Value");
+            // Reference compiles to the raw ordinal, not Dir.TopLeft.
+            Assert.IsTrue(js.Contains("var x = 0"), "Emit.Value should inline the ordinal\n" + js);
+        }
+
+        [TestMethod]
+        public void Name_PreservesMemberNameAndReferencesEnumObject()
+        {
+            var js = Emit("Name");
+            Assert.IsTrue(js.Contains("TopLeft: 0"), "define key preserves case\n" + js);
+            Assert.IsTrue(js.Contains("Dir.TopLeft"), "reference uses the enum object member\n" + js);
+        }
+
+        [TestMethod]
+        public void NamePreserveCase_PreservesMemberName()
+        {
+            var js = Emit("NamePreserveCase");
+            Assert.IsTrue(js.Contains("TopLeft: 0"), "define key preserves case\n" + js);
+            Assert.IsTrue(js.Contains("Dir.TopLeft"), "reference preserves case\n" + js);
+        }
+
+        [TestMethod]
+        public void NameLowerCase_LowercasesMemberName()
+        {
+            var js = Emit("NameLowerCase");
+            Assert.IsTrue(js.Contains("topleft: 0"), "define key should be lowercased\n" + js);
+            Assert.IsTrue(js.Contains("Dir.topleft"), "reference should be lowercased\n" + js);
+            Assert.IsFalse(js.Contains("Dir.TopLeft"), "must not keep PascalCase\n" + js);
+        }
+
+        [TestMethod]
+        public void NameUpperCase_UppercasesMemberName()
+        {
+            var js = Emit("NameUpperCase");
+            Assert.IsTrue(js.Contains("TOPLEFT: 0"), "define key should be uppercased\n" + js);
+            Assert.IsTrue(js.Contains("Dir.TOPLEFT"), "reference should be uppercased\n" + js);
+        }
+
+        [TestMethod]
+        public void StringName_CamelCasesFirstLetterAsStringValue()
+        {
+            var js = Emit("StringName");
+            Assert.IsTrue(js.Contains("\"topLeft\""), "member value is camelCase string\n" + js);
+            Assert.IsTrue(js.Contains("$utype: System.String"), "string-backed enum declares $utype\n" + js);
+        }
+
+        [TestMethod]
+        public void StringNamePreserveCase_KeepsCaseAsStringValue()
+        {
+            var js = Emit("StringNamePreserveCase");
+            Assert.IsTrue(js.Contains("\"TopLeft\""), "member value preserves case as string\n" + js);
+            Assert.IsTrue(js.Contains("$utype: System.String"), "string-backed enum declares $utype\n" + js);
+        }
+
+        [TestMethod]
+        public void StringNameLowerCase_LowercasesStringValue()
+        {
+            var js = Emit("StringNameLowerCase");
+            Assert.IsTrue(js.Contains("\"topleft\""), "member value is lowercase string\n" + js);
+        }
+
+        [TestMethod]
+        public void StringNameUpperCase_UppercasesStringValue()
+        {
+            var js = Emit("StringNameUpperCase");
+            Assert.IsTrue(js.Contains("\"TOPLEFT\""), "member value is uppercase string\n" + js);
+        }
+
+        [TestMethod]
+        public void DefaultMode_IsNamePreserveCase()
+        {
+            var code = @"
+using Transpose;
+public enum Dir { TopLeft = 0 }
+public class Program { public static void Main() { var x = Dir.TopLeft; } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success);
+            // No [Enum] attribute → default mode 7 (NamePreserveCase): named member, preserved case.
+            Assert.IsTrue(result.Javascript!.Contains("TopLeft: 0"), "default preserves case\n" + result.Javascript);
+            Assert.IsTrue(result.Javascript!.Contains("Dir.TopLeft"), "default references the enum member\n" + result.Javascript);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Infrastructure/RoslynNativeRunner.cs
+++ b/Transpose/Transpose.Translator.Tests/Infrastructure/RoslynNativeRunner.cs
@@ -24,7 +24,10 @@ public static class RoslynNativeRunner
         CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
         CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
-        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        // Define DEBUG/TRACE so native execution matches the translator's Debug-build parse options
+        // (keeps #if DEBUG and [Conditional("DEBUG")] behaviour identical on both sides).
+        var tree = CSharpSyntaxTree.ParseText(source,
+            new CSharpParseOptions(LanguageVersion.Latest).WithPreprocessorSymbols("DEBUG", "TRACE"));
 
         var refs = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string) ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)

--- a/Transpose/Transpose.Translator.Tests/Infrastructure/TranslatorTestBase.cs
+++ b/Transpose/Transpose.Translator.Tests/Infrastructure/TranslatorTestBase.cs
@@ -29,7 +29,13 @@ public abstract class TranslatorTestBase
         bool includeCorePackages = false)
     {
         var translator = new RoslynTranslator();
-        var result = translator.Translate(csharpCode);
+        // Match a real `tps -c Debug` build: the CLI (ProjectResolver) implicitly defines DEBUG and
+        // TRACE, so #if DEBUG and [Conditional("DEBUG")] behave as they would for a dev build.
+        var result = translator.Translate(
+            new[] { ("App.cs", csharpCode) },
+            CompilationBuilder.DefaultAssemblyName,
+            extraReferencePaths: null,
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" });
 
         if (!result.Success)
         {
@@ -66,7 +72,13 @@ public abstract class TranslatorTestBase
     protected Task RunTestExpectingError(string csharpCode, string expectedErrorSubstring, bool includeCorePackages = false)
     {
         var translator = new RoslynTranslator();
-        var result = translator.Translate(csharpCode);
+        // Match a real `tps -c Debug` build: the CLI (ProjectResolver) implicitly defines DEBUG and
+        // TRACE, so #if DEBUG and [Conditional("DEBUG")] behave as they would for a dev build.
+        var result = translator.Translate(
+            new[] { ("App.cs", csharpCode) },
+            CompilationBuilder.DefaultAssemblyName,
+            extraReferencePaths: null,
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" });
 
         if (result.Success)
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -65,6 +65,32 @@ public sealed partial class Emitter
         return t is not null && t.TrimStart().StartsWith("0 /*", System.StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// True if this expression is a call to a method whose
+    /// <c>[System.Diagnostics.Conditional("SYM")]</c> conditions are ALL undefined in the current
+    /// compilation — the call (and the evaluation of its arguments) is removed entirely, matching
+    /// C#'s conditional-method semantics. A method with no <c>[Conditional]</c> is never removed;
+    /// if any one of its conditions is defined, the call stays.
+    /// </summary>
+    private bool IsRemovedConditionalCall(ExpressionSyntax expr)
+    {
+        if (expr is not InvocationExpressionSyntax inv) return false;
+        if (_model.GetSymbolInfo(inv).Symbol is not IMethodSymbol m) return false;
+
+        var conditions = m.OriginalDefinition.GetAttributes()
+            .Where(a => TransposeNaming.AttrIs(a, "System.Diagnostics.ConditionalAttribute"))
+            .Select(a => a.ConstructorArguments.Length > 0 ? a.ConstructorArguments[0].Value as string : null)
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList();
+        if (conditions.Count == 0) return false;
+
+        var defined = inv.SyntaxTree.Options is CSharpParseOptions o
+            ? o.PreprocessorSymbolNames
+            : Enumerable.Empty<string>();
+        var definedSet = new System.Collections.Generic.HashSet<string>(defined, StringComparer.Ordinal);
+        return !conditions.Any(c => definedSet.Contains(c!));
+    }
+
     private void EmitExpression(ExpressionSyntax expr)
     {
         switch (expr)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -470,7 +470,9 @@ public sealed partial class Emitter
                or MethodKind.ExplicitInterfaceImplementation
            && !m.IsAbstract
            && m.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is BaseMethodDeclarationSyntax d
-           && (d.Body is not null || d.ExpressionBody is not null);
+           // A body, an expression body, or a [Script] that supplies a hand-written JS body — the
+           // last lets an `extern` (body-less) method be emitted with raw JavaScript.
+           && (d.Body is not null || d.ExpressionBody is not null || TransposeNaming.GetScriptBody(m) is not null);
 
     private bool IsEntryPoint(IMethodSymbol m)
         => SymbolEqualityComparer.Default.Equals(m, _compilation.GetEntryPoint(System.Threading.CancellationToken.None));
@@ -680,6 +682,13 @@ public sealed partial class Emitter
 
     private void EmitMethodBody(BlockSyntax? block, ArrowExpressionClauseSyntax? arrow, bool returnsVoid, IMethodSymbol method)
     {
+        // [Script(...)] supplies a hand-written JS body that replaces the C# body entirely.
+        if (TransposeNaming.GetScriptBody(method) is { } scriptLines)
+        {
+            _w.Block(() => { foreach (var line in scriptLines) _w.WriteLine(line); });
+            return;
+        }
+
         _w.Block(() =>
         {
             EmitOptionalDefaults(method);
@@ -778,6 +787,15 @@ public sealed partial class Emitter
 
     private void EmitAccessorBody(IMethodSymbol accessor, bool isGetter)
     {
+        // [Script(...)] on the accessor (or its property) supplies a raw JS body.
+        var accessorScript = TransposeNaming.GetScriptBody(accessor)
+            ?? (accessor.AssociatedSymbol is { } assoc ? TransposeNaming.GetScriptBody(assoc) : null);
+        if (accessorScript is { } scriptLines)
+        {
+            _w.Block(() => { foreach (var line in scriptLines) _w.WriteLine(line); });
+            return;
+        }
+
         // Field-backed property with an auto accessor → read/write the backing field.
         if (accessor.AssociatedSymbol is IPropertySymbol prop && IsFieldBackedProperty(prop))
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Reflection.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Reflection.cs
@@ -384,6 +384,8 @@ public sealed partial class Emitter
         if (type.IsImplicitlyDeclared) return false;
         if (TransposeNaming.IsExternalType(type)) return false;
         if (type.GetAttributes().Any(a => TransposeNaming.AttrIs(a, "Transpose.NonScriptableAttribute"))) return false;
+        // Explicit [Reflectable(true/false)] overrides the default (all-in) policy.
+        if (TransposeNaming.ReflectableOverride(type) is { } r) return r;
         return true;
     }
 
@@ -392,6 +394,8 @@ public sealed partial class Emitter
     private bool IsReflectableMember(ISymbol m)
     {
         if (SkipMember(m)) return false;
+        // Explicit [Reflectable(true/false)] on the member overrides the default (all-in) policy.
+        if (TransposeNaming.ReflectableOverride(m) is { } r) return r;
         if (m is IMethodSymbol { MethodKind: MethodKind.Constructor }) return true;
         return m.Kind is SymbolKind.Method or SymbolKind.Field or SymbolKind.Property or SymbolKind.Event;
     }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -38,6 +38,11 @@ public sealed partial class Emitter
                     // Contract.Result, [Template("0 /*{condition}*/")]) is elided entirely — matching
                     // the reference runtime, and avoiding illegally nested block comments.
                 }
+                else if (IsRemovedConditionalCall(expr.Expression))
+                {
+                    // A call to a [Conditional("SYM")] method whose symbol is not defined is removed
+                    // entirely (its arguments are not evaluated), matching C# semantics.
+                }
                 else if (expr.Expression is AssignmentExpressionSyntax da && IsDeconstruction(da))
                 {
                     EmitDeconstruction(da);

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -102,6 +102,10 @@ public sealed partial class Emitter
                 }
 
                 var ns = named.ContainingNamespace?.ToDisplayString();
+                // A type-level [Transpose.Namespace] overrides the emitted namespace: false/"" drops
+                // it (so Transpose.Core's String/Number/… bind to the JS globals), a string replaces it.
+                if (TransposeNaming.NamespaceOverride(named) is { } nsOverride)
+                    ns = nsOverride.Length == 0 ? null : nsOverride;
                 if (named.IsGenericType && named.TypeArguments.Length > 0)
                 {
                     var baseName = (string.IsNullOrEmpty(ns) ? "" : ns + ".") + StripArity(named.Name) + "$" + named.Arity;

--- a/Transpose/Transpose.Translator/Support/NameMangler.cs
+++ b/Transpose/Transpose.Translator/Support/NameMangler.cs
@@ -77,11 +77,22 @@ public sealed class NameMangler
                 : t.Name + "$" + t.Arity);
         }
 
-        var ns = type.ContainingNamespace;
-        while (ns is { IsGlobalNamespace: false })
+        // A type-level [Transpose.Namespace] overrides the C# namespace: false/"" suppresses it,
+        // "x.y" replaces it. Otherwise fall back to the containing C# namespace.
+        if (TransposeNaming.NamespaceOverride(type) is { } nsOverride)
         {
-            parts.Insert(0, ns.Name);
-            ns = ns.ContainingNamespace;
+            if (nsOverride.Length > 0)
+                foreach (var seg in nsOverride.Split('.').Reverse())
+                    parts.Insert(0, seg);
+        }
+        else
+        {
+            var ns = type.ContainingNamespace;
+            while (ns is { IsGlobalNamespace: false })
+            {
+                parts.Insert(0, ns.Name);
+                ns = ns.ContainingNamespace;
+            }
         }
 
         return string.Join(".", parts.Select(JsIdentifier));

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -114,6 +114,65 @@ internal static class TransposeNaming
     public static string? GetName(ISymbol symbol)
         => GetStringAttr(symbol, NameAttr);
 
+    /// <summary>
+    /// The raw-JavaScript body lines of a member's <c>[Transpose.Script(...)]</c>, or null when
+    /// absent. When present, these lines become the member's body verbatim and the C# body (if any)
+    /// is discarded — the mechanism for hand-writing a method/accessor/operator implementation.
+    /// </summary>
+    public static string[]? GetScriptBody(ISymbol symbol)
+    {
+        var a = symbol.GetAttributes().FirstOrDefault(x => AttrIs(x, ScriptAttr));
+        if (a is null || a.ConstructorArguments.Length == 0) return null;
+        var arg = a.ConstructorArguments[0];
+        if (arg.Kind == TypedConstantKind.Array)
+            return arg.Values.Select(v => v.Value as string ?? "").ToArray();
+        return arg.Value is string s ? new[] { s } : null;
+    }
+
+    public const string NamespaceAttr = "Transpose.NamespaceAttribute";
+
+    /// <summary>
+    /// The effect of a type-level <c>[Transpose.Namespace]</c> on the emitted namespace prefix:
+    /// <list type="bullet">
+    /// <item><c>null</c> — no attribute; use the C# namespace.</item>
+    /// <item><c>""</c> (empty) — suppress the namespace entirely, so the type emits under its bare
+    /// entity name (<c>[Namespace(false)]</c> or <c>[Namespace("")]</c>). This is how the
+    /// Transpose.Core primitive bindings (String, Number, Object, …) map onto the JS globals.</item>
+    /// <item><c>"x.y"</c> — replace the C# namespace with this custom one (<c>[Namespace("x.y")]</c>).</item>
+    /// </list>
+    /// The attribute is read from the outermost enclosing type (a namespace belongs to the top-level
+    /// type), so a nested type inherits its container's namespace treatment.
+    /// </summary>
+    public static string? NamespaceOverride(ITypeSymbol? type)
+    {
+        if (type is null) return null;
+        var outer = type;
+        while (outer.ContainingType is { } ct) outer = ct;
+        var a = outer.GetAttributes().FirstOrDefault(x => AttrIs(x, NamespaceAttr));
+        if (a is null || a.ConstructorArguments.Length == 0) return null;
+        var arg = a.ConstructorArguments[0].Value;
+        // [Namespace(false)] suppresses; [Namespace(true)] is the default (no override).
+        if (arg is bool b) return b ? null : "";
+        // [Namespace("x")] sets a custom namespace; [Namespace("")] also suppresses.
+        return arg as string;
+    }
+
+    public const string ReflectableAttr = "Transpose.ReflectableAttribute";
+
+    /// <summary>
+    /// An explicit <c>[Transpose.Reflectable]</c> override on a type or member: <c>true</c> forces
+    /// reflection metadata to be emitted, <c>false</c> suppresses it, <c>null</c> means no attribute
+    /// (fall back to the default policy). The boolean constructor argument decides; the argument-less
+    /// <c>[Reflectable]</c> — and the advanced filter/accessibility forms — mean <c>true</c>.
+    /// </summary>
+    public static bool? ReflectableOverride(ISymbol symbol)
+    {
+        var a = symbol.GetAttributes().FirstOrDefault(x => AttrIs(x, ReflectableAttr));
+        if (a is null) return null;
+        if (a.ConstructorArguments.Length > 0 && a.ConstructorArguments[0].Value is bool b) return b;
+        return true;
+    }
+
     public const string AccessorsIndexerAttr = "Transpose.AccessorsIndexerAttribute";
 
     /// <summary>

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -438,6 +438,21 @@ internal static class TransposeNaming
     private static string RawMemberName(ISymbol symbol)
     {
         if (GetName(symbol) is { } name) return name;
+
+        // Enum members honour the [Enum(Emit.Name*)] casing modes on their own JS name: NameLowerCase
+        // (8) lowercases, NameUpperCase (9) uppercases; Name (1) / NamePreserveCase (7) and every
+        // other mode preserve. (The StringName* modes 3–6 cast the emitted string VALUE — see
+        // EnumStringName — not the member's JS name, which stays verbatim.)
+        if (symbol is IFieldSymbol { ContainingType.TypeKind: TypeKind.Enum } enumMember)
+        {
+            return EnumEmitMode(enumMember.ContainingType) switch
+            {
+                8 => enumMember.Name.ToLowerInvariant(),
+                9 => enumMember.Name.ToUpperInvariant(),
+                _ => enumMember.Name,
+            };
+        }
+
         // A compiled type's member keeps its verbatim C# name. An [External] type's member does
         // NOT short-circuit here even when in source (self-building the BCL): its members bind to
         // native JS names via [Convention]/casing — e.g. String.Length ([External] +


### PR DESCRIPTION
Port four special-case attributes from H5 that the Roslyn translator did not yet
handle, plus a catalogue of every codegen attribute.

- [Namespace(false)]/[Namespace("x.y")]: suppress or replace a type's emitted
  namespace (fixes Transpose.Core primitives like String/Number binding to the
  JS globals instead of Transpose.Core.String).
- [Reflectable(true/false)]: override the default reflection-metadata policy per
  type or member.
- [Script(...)]: emit a raw-JS method/accessor body (incl. extern members),
  discarding the C# body.
- [Conditional("SYM")]: remove a call whose symbol is undefined, matching C#.

Test harness now defines DEBUG/TRACE (both translator and native Roslyn side) to
match a real `tps -c Debug` build, so #if DEBUG and [Conditional("DEBUG")] behave
consistently. Adds AttributeHandlingTests and ATTRIBUTES.md (general-purpose vs
BCL/Core attribute reference).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VbA55tbrWKpftq4N5xNofj