### PR TITLE
Fix property-pattern member access to use resolved JS member name

### DIFF
--- a/BCL/Transpose.BCL/Resources/Task.js
+++ b/BCL/Transpose.BCL/Resources/Task.js
@@ -87,6 +87,16 @@
                 return tcs.task;
             },
 
+            yield: function () {
+                var tcs = new System.Threading.Tasks.TaskCompletionSource();
+
+                Transpose.setImmediate(function () {
+                    tcs.setResult(null);
+                });
+
+                return tcs.task;
+            },
+
             fromResult: function (result, T) {
                 var t = new (System.Threading.Tasks.Task$1(T || System.Object))();
 

--- a/BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs
+++ b/BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs
@@ -1,0 +1,194 @@
+using System.Collections.Generic;
+
+namespace System.Linq
+{
+    /// <summary>
+    /// C#-implemented LINQ operators that are not part of the external, runtime-backed
+    /// <see cref="Enumerable"/> binding (which maps every method onto <c>linq.js</c>). These are the
+    /// .NET 6+ additions <see cref="Chunk"/>, <see cref="MinBy{TSource,TKey}(IEnumerable{TSource},Func{TSource,TKey})"/>
+    /// and <see cref="MaxBy{TSource,TKey}(IEnumerable{TSource},Func{TSource,TKey})"/>. They are written
+    /// as ordinary transpiled C# (no <c>[External]</c>) so they behave exactly like their BCL
+    /// counterparts — including the empty-sequence and null-key rules of <c>MinBy</c>/<c>MaxBy</c>.
+    /// </summary>
+    public static class EnumerableExtras
+    {
+        /// <summary>
+        /// Splits the elements of a sequence into chunks of size at most <paramref name="size"/>.
+        /// The final chunk may contain fewer elements; an empty source yields no chunks.
+        /// </summary>
+        public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int size)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (size < 1) throw new ArgumentOutOfRangeException(nameof(size));
+
+            return ChunkIterator(source, size);
+        }
+
+        private static IEnumerable<TSource[]> ChunkIterator<TSource>(IEnumerable<TSource> source, int size)
+        {
+            var buffer = new List<TSource>(size);
+
+            foreach (var item in source)
+            {
+                buffer.Add(item);
+                if (buffer.Count == size)
+                {
+                    yield return buffer.ToArray();
+                    buffer.Clear();
+                }
+            }
+
+            if (buffer.Count > 0)
+            {
+                yield return buffer.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Returns the element of a sequence with the minimum key, using the default comparer.
+        /// </summary>
+        public static TSource MinBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+            => MinBy(source, keySelector, null);
+
+        /// <summary>
+        /// Returns the element of a sequence with the minimum key, using the supplied comparer
+        /// (or the default when <paramref name="comparer"/> is null). Empty-sequence and null-key
+        /// handling matches System.Linq: an empty source returns the default when TSource is a
+        /// reference/nullable type and throws otherwise; null keys are skipped when TKey is nullable.
+        /// </summary>
+        public static TSource MinBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+            IComparer<TKey> comparer)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            if (comparer == null) comparer = Comparer<TKey>.Default;
+
+            using (var e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    if (default(TSource) == null) return default(TSource);
+                    throw new InvalidOperationException("Sequence contains no elements");
+                }
+
+                TSource value = e.Current;
+                TKey key = keySelector(value);
+
+                if (default(TKey) == null)
+                {
+                    // Nullable key: null keys never win; skip a leading run of them, and if every
+                    // key is null return the first element (matching System.Linq).
+                    if (key == null)
+                    {
+                        TSource firstValue = value;
+                        do
+                        {
+                            if (!e.MoveNext()) return firstValue;
+                            value = e.Current;
+                            key = keySelector(value);
+                        }
+                        while (key == null);
+                    }
+
+                    while (e.MoveNext())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (nextKey != null && comparer.Compare(nextKey, key) < 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (comparer.Compare(nextKey, key) < 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+
+                return value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the element of a sequence with the maximum key, using the default comparer.
+        /// </summary>
+        public static TSource MaxBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+            => MaxBy(source, keySelector, null);
+
+        /// <summary>
+        /// Returns the element of a sequence with the maximum key, using the supplied comparer
+        /// (or the default when <paramref name="comparer"/> is null). Empty-sequence and null-key
+        /// handling matches System.Linq (see <see cref="MinBy{TSource,TKey}(IEnumerable{TSource},Func{TSource,TKey},IComparer{TKey})"/>).
+        /// </summary>
+        public static TSource MaxBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+            IComparer<TKey> comparer)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            if (comparer == null) comparer = Comparer<TKey>.Default;
+
+            using (var e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    if (default(TSource) == null) return default(TSource);
+                    throw new InvalidOperationException("Sequence contains no elements");
+                }
+
+                TSource value = e.Current;
+                TKey key = keySelector(value);
+
+                if (default(TKey) == null)
+                {
+                    if (key == null)
+                    {
+                        TSource firstValue = value;
+                        do
+                        {
+                            if (!e.MoveNext()) return firstValue;
+                            value = e.Current;
+                            key = keySelector(value);
+                        }
+                        while (key == null);
+                    }
+
+                    while (e.MoveNext())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (nextKey != null && comparer.Compare(nextKey, key) > 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (comparer.Compare(nextKey, key) > 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+
+                return value;
+            }
+        }
+    }
+}

--- a/BCL/Transpose.BCL/System/String.cs
+++ b/BCL/Transpose.BCL/System/String.cs
@@ -577,6 +577,24 @@ namespace System
         public extern string ToUpper();
 
         /// <summary>
+        /// Returns a copy of this string converted to lowercase using the casing rules of the
+        /// invariant culture. Under Transpose this is the same case fold as <see cref="ToLower"/>
+        /// (JavaScript's locale-independent <c>toLowerCase</c>).
+        /// </summary>
+        /// <returns>The lowercase equivalent of the current string.</returns>
+        [Transpose.Template("{this}.toLowerCase()")]
+        public extern string ToLowerInvariant();
+
+        /// <summary>
+        /// Returns a copy of this string converted to uppercase using the casing rules of the
+        /// invariant culture. Under Transpose this is the same case fold as <see cref="ToUpper"/>
+        /// (JavaScript's locale-independent <c>toUpperCase</c>).
+        /// </summary>
+        /// <returns>The uppercase equivalent of the current string.</returns>
+        [Transpose.Template("{this}.toUpperCase()")]
+        public extern string ToUpperInvariant();
+
+        /// <summary>
         /// Removes all leading and trailing white-space characters from the current String object.
         /// </summary>
         /// <returns>The string that remains after all white-space characters are removed from the start and end of the current string. If no characters can be trimmed from the current instance, the method returns the current instance unchanged.</returns>

--- a/BCL/Transpose.BCL/System/Threading/Tasks/Task.cs
+++ b/BCL/Transpose.BCL/System/Threading/Tasks/Task.cs
@@ -102,8 +102,17 @@ namespace System.Threading.Tasks
 
         public static extern Task Delay(TimeSpan delay, CancellationToken cancellationToken);
 
-        
-        public static extern Task CompletedTask 
+        /// <summary>
+        /// Yields control back to the runtime, resuming asynchronously on the next scheduler tick.
+        /// The awaited task completes after a <c>setImmediate</c> callback, so continuations run
+        /// after the current job drains (the observable behaviour of <c>Task.Yield()</c>). Returns a
+        /// <see cref="Task"/> rather than the BCL's <c>YieldAwaitable</c>, which is not modelled here;
+        /// <c>await Task.Yield()</c> behaves identically.
+        /// </summary>
+        public static extern Task Yield();
+
+
+        public static extern Task CompletedTask
         {
             [Transpose.Template("System.Threading.Tasks.Task.fromResult({}, null)")]
             get; 

--- a/BCL/Transpose.BCL/tps.json
+++ b/BCL/Transpose.BCL/tps.json
@@ -156,6 +156,7 @@
             "Resources/Uri.js",
             "Resources/Generator.js",
             "Resources/linq.js",
+            "Resources/.generated/System/Linq/EnumerableExtras.js",
 
             "Resources/.generated/System/Runtime/Serialization/CollectionDataContractAttribute.js",
             "Resources/.generated/System/Runtime/Serialization/ContractNamespaceAttribute.js",

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1331,5 +1331,35 @@ public class Program
             Assert.IsTrue(result.Javascript!.Contains("TransposeR.combine("),
                 "binary + on delegates must emit TransposeR.combine\n" + result.Javascript);
         }
+
+        // ---- LINQ Chunk / MinBy / MaxBy (BCL EnumerableExtras) ------------------
+
+        [TestMethod]
+        public async Task LinqChunkMinByMaxByMatchNative()
+        {
+            // Chunk / MinBy / MaxBy are implemented in C# in the BCL (EnumerableExtras); verify they
+            // match System.Linq including chunk sizing, key selection, empty-source default/throw and
+            // the null-key skip rule.
+            await RunTest(@"
+using System;
+using System.Linq;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(string.Join(""|"", new[]{1,2,3,4,5}.Chunk(2).Select(c => string.Join("","", c))));
+        Console.WriteLine(new int[0].Chunk(3).Count());
+        var people = new[]{ (""Al"",30), (""Bo"",25), (""Cy"",35) };
+        Console.WriteLine(people.MinBy(p => p.Item2).Item1);
+        Console.WriteLine(people.MaxBy(p => p.Item2).Item1);
+        Console.WriteLine(new string[0].MinBy(s => s.Length) ?? ""null"");
+        var withNulls = new[]{ (""a"",(string)null), (""b"",""x""), (""c"",(string)null), (""d"",""a"") };
+        Console.WriteLine(withNulls.MinBy(t => t.Item2).Item1);
+        try { var _ = new int[0].MinBy(v => v); Console.WriteLine(""noio""); }
+        catch (InvalidOperationException) { Console.WriteLine(""io-throws""); }
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1361,5 +1361,53 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- Task.Yield + invariant string casing (BCL) ------------------------
+
+        [TestMethod]
+        public async Task TaskYieldResumesAsynchronously()
+        {
+            // await Task.Yield() must resume on a later tick (after the current job), preserving
+            // ordering with subsequent yields. Asserted on the JS output only (skipRoslyn): a
+            // fire-and-forget async Run() from Main is non-deterministic under native .NET (the
+            // process can exit before the Yield continuations run), whereas Node drains its queue.
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+public class Program
+{
+    static async Task Run()
+    {
+        Console.WriteLine(""before"");
+        await Task.Yield();
+        Console.WriteLine(""after"");
+        for (int i = 0; i < 3; i++) { await Task.Yield(); Console.WriteLine(""tick "" + i); }
+        Console.WriteLine(""<<DONE>>"");
+    }
+    public static void Main() { Run(); }
+}", waitForOutput: "<<DONE>>", skipRoslyn: true);
+
+            var seq = string.Join(",", js.Replace("\r\n", "\n").Split(new[] { '\n' }, System.StringSplitOptions.RemoveEmptyEntries));
+            Assert.AreEqual("before,after,tick 0,tick 1,tick 2,<<DONE>>", seq,
+                "Task.Yield must resume asynchronously, preserving order across successive yields\n" + js);
+        }
+
+        [TestMethod]
+        public async Task StringInvariantCasingMatchesToLowerToUpper()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""MiXeD"".ToLowerInvariant());
+        Console.WriteLine(""MiXeD"".ToUpperInvariant());
+        Console.WriteLine(""ABC"".ToLowerInvariant() == ""ABC"".ToLower());
+        Console.WriteLine(""abc"".ToUpperInvariant() == ""abc"".ToUpper());
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1195,5 +1195,88 @@ public class Program
             Assert.IsFalse(result.Javascript!.Contains(".Length > 3"),
                 "property pattern must not emit the raw C# member name `.Length`\n" + result.Javascript);
         }
+
+        // ---- bare type patterns (parsed as constant patterns) ------------------
+
+        [TestMethod]
+        public async Task BareTypePatternPerformsTypeTest()
+        {
+            // A bare type in a switch arm (`Dog => ...`) is parsed as a ConstantPattern; it must run a
+            // type test, not `subject === Dog` (which compares the value to the class constructor and
+            // is always false). Enum type patterns must use the runtime type check too (a boxed enum
+            // is a Transpose.box object, not a plain number).
+            await RunTest(@"
+using System;
+public class Animal { }
+public class Dog : Animal { }
+public class Cat : Animal { }
+public enum Color { Red, Green, Blue }
+public class Program
+{
+    static string Kind(object o) => o switch {
+        Dog => ""dog"",
+        Cat => ""cat"",
+        Color => ""color"",
+        _ => ""other""
+    };
+    public static void Main()
+    {
+        Console.WriteLine(Kind(new Dog()));
+        Console.WriteLine(Kind(new Cat()));
+        Console.WriteLine(Kind(Color.Green));
+        Console.WriteLine(Kind(""x""));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task EnumTypePatternMatchesBoxedEnum()
+        {
+            // A boxed enum tested/captured via a type pattern (o is Color c) and a switch type pattern.
+            await RunTest(@"
+using System;
+public enum Color { Red, Green, Blue }
+public enum Size { S, M, L }
+public class Program
+{
+    public static void Main()
+    {
+        object o = Color.Green;
+        Console.WriteLine(o is Color ? ""is-color"" : ""no"");
+        Console.WriteLine(o is Size ? ""is-size"" : ""not-size"");
+        Console.WriteLine(o is Color c ? c.ToString() : ""nocap"");
+        object o2 = Size.L;
+        Console.WriteLine(o2 switch { Color => ""color"", Size => ""size"", _ => ""other"" });
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task ExtendedPropertyPatternResolvesChainedMembers()
+        {
+            // An extended property pattern names a member chain (`{ Text.Length: > 3 }`); each segment
+            // must resolve to its JS name (the whole chain `Text.Length`, not just the leaf `Length`,
+            // and Length -> the `length` override).
+            await RunTest(@"
+using System;
+public class Node { public string Text { get; set; } }
+public class Program
+{
+    static string F(Node n) => n switch {
+        { Text.Length: > 3 } => ""long"",
+        { Text.Length: 0 } => ""empty"",
+        _ => ""short""
+    };
+    public static void Main()
+    {
+        Console.WriteLine(F(new Node { Text = ""hello"" }));
+        Console.WriteLine(F(new Node { Text = ""hi"" }));
+        Console.WriteLine(F(new Node { Text = """" }));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1278,5 +1278,58 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- binary + / - on delegates → combine / remove ----------------------
+
+        [TestMethod]
+        public async Task BinaryDelegateOperatorsCombineAndRemove()
+        {
+            // `d1 + d2` / `d1 - d2` must build/unbuild a multicast delegate (TransposeR.combine/remove),
+            // not JS numeric/string `+`/`-` on the underlying functions (which yields a non-callable).
+            await RunTest(@"
+using System;
+using System.Text;
+public class Program
+{
+    static StringBuilder sb = new StringBuilder();
+    static void A() => sb.Append(""A"");
+    static void B() => sb.Append(""B"");
+    static void C() => sb.Append(""C"");
+    public static void Main()
+    {
+        Action a = A;
+        Action ab = a + (Action)B;
+        ab(); sb.AppendLine("""");
+        Action abc = ab + (Action)C;
+        abc(); sb.AppendLine("""");
+        Action ac = abc - (Action)B;
+        ac(); sb.AppendLine("""");
+        sb.Append(""<<DONE>>"");
+        Console.WriteLine(sb.ToString());
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public void BinaryDelegateAddEmitsCombine()
+        {
+            var code = @"
+using System;
+public class Program
+{
+    static void A() { }
+    static void B() { }
+    public static void Main()
+    {
+        Action a = A;
+        Action ab = a + (Action)B;
+        ab();
+    }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("TransposeR.combine("),
+                "binary + on delegates must emit TransposeR.combine\n" + result.Javascript);
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1147,5 +1147,53 @@ public class Program { public static void Main() { } }
             Assert.IsTrue(result.Javascript!.Contains("new TagAttribute.$ctor1(\"x\")"),
                 "attribute must be constructed via the applied ctor overload\n" + result.Javascript);
         }
+
+        // ---- property pattern resolves the JS member name ----------------------
+
+        [TestMethod]
+        public async Task PropertyPatternUsesResolvedJsMemberName()
+        {
+            // string.Length has a JS-name override ([Convention(CamelCase)] -> `length`). A property
+            // pattern must emit `.length`, not the raw `.Length` (which is undefined on a JS string and
+            // would make `undefined > 3` always false, silently skipping the arm).
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    static string F(object o) => o switch {
+        string { Length: > 3 } s => ""long:"" + s,
+        string s => ""short:"" + s,
+        Dictionary<string,int> { Count: > 0 } d => ""dict:"" + d.Count,
+        _ => ""other""
+    };
+    public static void Main()
+    {
+        Console.WriteLine(F(""hello""));
+        Console.WriteLine(F(""hi""));
+        Console.WriteLine(F(new Dictionary<string,int> { [""a""] = 1 }));
+        Console.WriteLine(F(42));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public void PropertyPatternEmitsCamelCasedMember()
+        {
+            var code = @"
+using System;
+public class Program
+{
+    static bool F(object o) => o is string { Length: > 3 };
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains(".length > 3"),
+                "property pattern on string.Length must emit the resolved JS name `.length`\n" + result.Javascript);
+            Assert.IsFalse(result.Javascript!.Contains(".Length > 3"),
+                "property pattern must not emit the raw C# member name `.Length`\n" + result.Javascript);
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1162,6 +1162,20 @@ public sealed partial class Emitter
             return;
         }
 
+        // Delegate combine/remove via the binary + / - operators (d1 + d2, d1 - d2). Method groups
+        // on either side are converted to the delegate type, so the result type is the delegate.
+        // Mirrors the compound-assignment path (d += h / d -= h → combine/remove).
+        if ((binary.IsKind(SyntaxKind.AddExpression) || binary.IsKind(SyntaxKind.SubtractExpression))
+            && (resultType is { TypeKind: TypeKind.Delegate } || leftType is { TypeKind: TypeKind.Delegate }))
+        {
+            _w.Write($"TransposeR.{(binary.IsKind(SyntaxKind.AddExpression) ? "combine" : "remove")}(");
+            EmitExpression(binary.Left);
+            _w.Write(", ");
+            EmitExpression(binary.Right);
+            _w.Write(")");
+            return;
+        }
+
         // DateTime / TimeSpan arithmetic.
         var lName = leftType?.ToDisplayString();
         var rName = rightType?.ToDisplayString();

--- a/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
@@ -71,6 +71,12 @@ public sealed partial class Emitter
             case ConstantPatternSyntax constant:
                 if (constant.Expression.IsKind(SyntaxKind.NullLiteralExpression))
                     _w.Write($"{subject} == null");
+                else if (_model.GetSymbolInfo(constant.Expression).Symbol is ITypeSymbol typeSym)
+                    // A bare identifier/qualified name that binds to a TYPE is a type pattern the
+                    // parser represented as a constant pattern (`o switch { SomeType => ... }` or a
+                    // nested `{ Prop: SomeType }`). Emit a type test, not `subject === <typeref>`
+                    // (which compares the value to the type's constructor and is always false).
+                    EmitTypeTest(subject, typeSym);
                 else
                 {
                     _w.Write($"{subject} === ");
@@ -236,17 +242,41 @@ public sealed partial class Emitter
     private string PropertyPatternMemberJsName(SubpatternSyntax sub)
     {
         var nameExpr = sub.NameColon?.Name ?? sub.ExpressionColon?.Expression;
-        if (nameExpr is not null)
-        {
-            var symbol = _model.GetSymbolInfo(nameExpr).Symbol;
-            if (symbol is IPropertySymbol or IFieldSymbol)
-                return TransposeNaming.MemberJsName(symbol);
-        }
+        if (nameExpr is not null && PropertyPatternMemberPath(nameExpr) is { } path)
+            return path;
 
         var fallback = sub.NameColon?.Name.Identifier.Text
             ?? sub.ExpressionColon?.Expression.ToString()
             ?? "";
         return NameMangler.JsIdentifier(fallback);
+    }
+
+    /// <summary>
+    /// Builds the dotted JS member path for a property-pattern subpattern name. A simple pattern
+    /// names one member (<c>{ Length: … }</c>); an extended pattern (C# 10) names a chain
+    /// (<c>{ Address.City: … }</c>) that must expand to <c>Address.City</c> — each segment resolved
+    /// through <see cref="TransposeNaming.MemberJsName"/>. Returns null if any segment can't be
+    /// resolved (caller falls back to a mangled identifier).
+    /// </summary>
+    private string? PropertyPatternMemberPath(ExpressionSyntax expr)
+    {
+        switch (expr)
+        {
+            case IdentifierNameSyntax:
+                var s = _model.GetSymbolInfo(expr).Symbol;
+                return s is IPropertySymbol or IFieldSymbol
+                    ? TransposeNaming.MemberJsName(s)
+                    : null;
+            case MemberAccessExpressionSyntax ma:
+                var left = PropertyPatternMemberPath(ma.Expression);
+                if (left is null) return null;
+                var m = _model.GetSymbolInfo(ma.Name).Symbol;
+                return m is IPropertySymbol or IFieldSymbol
+                    ? left + "." + TransposeNaming.MemberJsName(m)
+                    : null;
+            default:
+                return null;
+        }
     }
 
     private void EmitTypeTest(string subject, ITypeSymbol? type)
@@ -273,12 +303,11 @@ public sealed partial class Emitter
                 return;
         }
 
-        if (type.TypeKind == TypeKind.Enum)
-        {
-            _w.Write($"typeof {subject} === \"number\"");
-            return;
-        }
-
+        // Note: enums fall through to the runtime type check below. They box to `object` as a
+        // Transpose.box carrying their enum type (so o.GetType()/o.ToString() stay correct), NOT a
+        // plain number — a `typeof === "number"` test would both miss the boxed form and fail to
+        // tell one enum type from another (or from int). TransposeR.is understands the boxed
+        // representation, matching the plain `x is EnumType` expression path.
         _w.Write($"TransposeR.is({subject}, {TypeRef(type)})");
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
@@ -202,10 +202,7 @@ public sealed partial class Emitter
             foreach (var sub in recursive.PropertyPatternClause.Subpatterns)
             {
                 _w.Write(" && ");
-                var memberName = sub.NameColon?.Name.Identifier.Text
-                    ?? sub.ExpressionColon?.Expression.ToString()
-                    ?? "";
-                var memberSubject = $"{subject}.{NameMangler.JsIdentifier(memberName)}";
+                var memberSubject = $"{subject}.{PropertyPatternMemberJsName(sub)}";
                 EmitPatternTest(memberSubject, sub.Pattern);
             }
         }
@@ -228,6 +225,28 @@ public sealed partial class Emitter
 
         _ = wroteCondition;
         _w.Write(")");
+    }
+
+    /// <summary>
+    /// Resolves the emitted JS member name for a property-pattern subpattern (<c>{ Member: pat }</c>).
+    /// Must go through the semantic model + <see cref="TransposeNaming.MemberJsName"/> so members with a
+    /// JS-name override ([Name]/[Convention], e.g. <c>string.Length</c> → <c>length</c>) match the name
+    /// used everywhere else — a raw identifier mangle would emit <c>.Length</c> and never match.
+    /// </summary>
+    private string PropertyPatternMemberJsName(SubpatternSyntax sub)
+    {
+        var nameExpr = sub.NameColon?.Name ?? sub.ExpressionColon?.Expression;
+        if (nameExpr is not null)
+        {
+            var symbol = _model.GetSymbolInfo(nameExpr).Symbol;
+            if (symbol is IPropertySymbol or IFieldSymbol)
+                return TransposeNaming.MemberJsName(symbol);
+        }
+
+        var fallback = sub.NameColon?.Name.Identifier.Text
+            ?? sub.ExpressionColon?.Expression.ToString()
+            ?? "";
+        return NameMangler.JsIdentifier(fallback);
     }
 
     private void EmitTypeTest(string subject, ITypeSymbol? type)


### PR DESCRIPTION
A recursive/property pattern subpattern (`o is T { Member: pat }`) emitted the
raw C# member identifier (`$sw0.Member`) instead of the member's resolved JS
name. This worked by accident whenever the JS name equalled the C# name, but
broke for members with a [Name]/[Convention] override — e.g. `string.Length`
maps to `.length`, so `string { Length: > 3 }` emitted `$sw0.Length` which is
undefined on a JS string, making the relational test always false and silently
skipping the arm.

Resolve the subpattern member symbol through the semantic model and route it
through TransposeNaming.MemberJsName (the same path normal member access uses),
falling back to the mangled identifier only when the symbol can't be resolved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gg5g1qh9sSq1NvAo7Lce1E