### PR TITLE
Fix Newtonsoft.Json: array type args and SerializationBinder dispatch

### DIFF
--- a/Packages/Transpose.Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/Packages/Transpose.Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -330,12 +330,28 @@
                     }
                 },
 
+                // The ISerializationBinder method slot on the implementer. Transpose dispatches an
+                // implicit interface implementation through the plain member name (BindToName /
+                // BindToType) and an explicit one through the interface-qualified slot
+                // (Newtonsoft$Json$Serialization$ISerializationBinder$…, which is also the name the
+                // legacy h5 compiler used for every implementation) — so accept either.
+                binderMethod: function (binder, name) {
+                    if (!binder) {
+                        return null;
+                    }
+
+                    return binder[name] || binder["Newtonsoft$Json$Serialization$ISerializationBinder$" + name] || null;
+                },
+
                 BindToName: function (settings, type) {
-                    if (settings && settings.SerializationBinder && settings.SerializationBinder.Newtonsoft$Json$Serialization$ISerializationBinder$BindToName) {
+                    var binder = settings && settings.SerializationBinder,
+                        bindToName = Newtonsoft.Json.JsonConvert.binderMethod(binder, "BindToName");
+
+                    if (bindToName) {
                         var asm = {},
                             name = {};
 
-                        settings.SerializationBinder.Newtonsoft$Json$Serialization$ISerializationBinder$BindToName(type, asm, name);
+                        bindToName.call(binder, type, asm, name);
                         return name.v + (asm.v ? ", " + asm.v : "");
                     }
 
@@ -343,13 +359,16 @@
                 },
 
                 BindToType: function (settings, fullName, objectType) {
-                    var type;
-                    if (settings && settings.SerializationBinder && settings.SerializationBinder.Newtonsoft$Json$Serialization$ISerializationBinder$BindToType) {
-                        var type = Newtonsoft.Json.JsonConvert.SplitFullyQualifiedTypeName(fullName);
+                    var type,
+                        binder = settings && settings.SerializationBinder,
+                        bindToType = Newtonsoft.Json.JsonConvert.binderMethod(binder, "BindToType");
 
-                        type = settings.SerializationBinder.Newtonsoft$Json$Serialization$ISerializationBinder$BindToType(type.assemblyName, type.typeName);
+                    if (bindToType) {
+                        var split = Newtonsoft.Json.JsonConvert.SplitFullyQualifiedTypeName(fullName);
+
+                        type = bindToType.call(binder, split.assemblyName, split.typeName);
                     } else {
-                        type = Transpose.Reflection.getType(fullName); 
+                        type = Transpose.Reflection.getType(fullName);
                     }
 
                     if (!type) {

--- a/Transpose/Transpose.Translator.Tests/GenericArrayTypeArgumentTests.cs
+++ b/Transpose/Transpose.Translator.Tests/GenericArrayTypeArgumentTests.cs
@@ -1,0 +1,62 @@
+using System.Threading.Tasks;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Tests that an array type used as a generic type argument is reified to its concrete runtime
+/// array type — <c>System.Array.type(element, rank)</c> — rather than the bare <c>System.Array</c>
+/// base. The latter has no element type, so anything reflecting over the threaded argument (e.g.
+/// JsonConvert.DeserializeObject&lt;T[]&gt;) misidentifies it as a non-array.
+/// </summary>
+[TestClass]
+public class GenericArrayTypeArgumentTests : TranslatorTestBase
+{
+    [TestMethod]
+    public async Task ArrayTypeArgumentIsReflectableAsTypedArray()
+    {
+        await RunTest(@"
+using System;
+public class App
+{
+    static string Describe<T>()
+    {
+        var t = typeof(T);
+        return t.IsArray + "" "" + (t.IsArray ? t.GetElementType().Name : ""-"");
+    }
+    public static void Main()
+    {
+        Console.WriteLine(Describe<int[]>());
+        Console.WriteLine(Describe<string[]>());
+        Console.WriteLine(Describe<int>());
+    }
+}");
+    }
+
+    [TestMethod]
+    public async Task JaggedAndMultiDimArrayTypeArgumentsReify()
+    {
+        await RunTest(@"
+using System;
+public class App
+{
+    // Walk the element chain instead of the outer array's Name: a jagged array's element is itself
+    // an array (so it reifies with its own element type) whereas a rank-N array's element is the
+    // scalar — which is what distinguishes the two reifications, independent of how the runtime
+    // renders a multidimensional array's display name.
+    static string Describe<T>()
+    {
+        var t = typeof(T);
+        var e = t.IsArray ? t.GetElementType() : null;
+        var e2 = (e != null && e.IsArray) ? e.GetElementType() : null;
+        return t.IsArray + ""|"" + (e == null ? ""-"" : e.Name) + ""|"" + (e2 == null ? ""-"" : e2.Name);
+    }
+    public static void Main()
+    {
+        Console.WriteLine(Describe<int[]>());
+        Console.WriteLine(Describe<int[][]>());
+        Console.WriteLine(Describe<int[,]>());
+        Console.WriteLine(Describe<string[,,]>());
+    }
+}");
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Infrastructure/NewtonsoftJsonRunner.cs
+++ b/Transpose/Transpose.Translator.Tests/Infrastructure/NewtonsoftJsonRunner.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Compiles and runs a C# program that uses the <c>Transpose.Newtonsoft.Json</c> binding library as
+/// translated JavaScript on Node, so the package's runtime (JsonConvert.js) is exercised end-to-end.
+///
+/// The package is a JavaScript binding library ([assembly: External]): its C# is a set of external
+/// type/attribute declarations, and its real behaviour lives in the hand-written
+/// <c>Resources/Manual/JsonConvert.js</c>. To run a program against it we
+/// <list type="number">
+///   <item>compile the package's own C# once into a reference assembly (+ its emitted glue JS), so
+///     the test program can bind to <c>Newtonsoft.Json.*</c>;</item>
+///   <item>compile the test program against that reference (reflection on, so types are
+///     reflectable — TypeNameHandling and the contract walker need metadata);</item>
+///   <item>prepend the Transpose runtime, the package glue and <c>JsonConvert.js</c> to the program
+///     JS and run it on Node.</item>
+/// </list>
+/// There is no native (Roslyn) comparison: the package types are external stubs with no managed
+/// behaviour, so tests assert the expected console output directly.
+/// </summary>
+public static class NewtonsoftJsonRunner
+{
+    private const string PackageAssemblyName = "Transpose.Newtonsoft.Json";
+
+    private static readonly Lazy<PackageArtifacts> _package = new(BuildPackage, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private sealed record PackageArtifacts(string ReferenceDllPath, string GlueJavascript, string JsonConvertJavascript);
+
+    /// <summary>Repo root, derived from this source file's compile-time path.</summary>
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+        // .../Transpose/Transpose.Translator.Tests/Infrastructure/NewtonsoftJsonRunner.cs → repo root
+        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+
+    private static string PackageDir => Path.Combine(RepoRoot(), "Packages", "Transpose.Newtonsoft.Json");
+
+    private static PackageArtifacts BuildPackage()
+    {
+        var packageDir = PackageDir;
+
+        // The package's C# declarations (external stubs + attributes + enums). Exclude the JS
+        // resources (they aren't C#) and any build output.
+        var sources = Directory.EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Replace('\\', '/').Contains("/bin/") && !p.Replace('\\', '/').Contains("/obj/"))
+            .Select(p => (path: p, text: File.ReadAllText(p)))
+            .ToList();
+
+        var result = new RoslynTranslator().BuildAssembly(
+            sources,
+            PackageAssemblyName,
+            extraReferencePaths: null,
+            preprocessorSymbols: new[] { "Transpose", "TRACE" },
+            emitAssembly: true);
+
+        if (result.AssemblyBytes is null || result.Javascript is null)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Select(d => d.GetMessage()));
+            throw new InvalidOperationException($"Failed to build the Transpose.Newtonsoft.Json package:\n{errors}");
+        }
+
+        var dllPath = Path.Combine(Path.GetTempPath(), $"Transpose.Newtonsoft.Json.{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(dllPath, result.AssemblyBytes);
+
+        var jsonConvert = File.ReadAllText(Path.Combine(packageDir, "Resources", "Manual", "JsonConvert.js"));
+
+        return new PackageArtifacts(dllPath, result.Javascript, jsonConvert);
+    }
+
+    /// <summary>
+    /// Translates <paramref name="csharpCode"/> (which may use <c>Newtonsoft.Json.*</c>), runs it on
+    /// Node with the package runtime loaded, and returns the trimmed console output.
+    /// </summary>
+    public static async Task<string> RunAsync(string csharpCode)
+    {
+        var package = _package.Value;
+
+        var result = new RoslynTranslator().Translate(
+            new[] { ("App.cs", csharpCode) },
+            CompilationBuilder.DefaultAssemblyName,
+            extraReferencePaths: new[] { package.ReferenceDllPath },
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" });
+
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Errors.Select(d => d.GetMessage()));
+            throw new InvalidOperationException($"Translation failed:\n{errors}");
+        }
+
+        // Runtime + package glue (the External type/enum/attribute defines) + the hand-written
+        // JsonConvert.js behaviour + the program. tps.js auto-runs the entry point.
+        // The package's tps.json stitches JsonConvert.js between AssemblyBegin.js/AssemblyEnd.js;
+        // the only runtime state those add is the type cache, so initialise it here.
+        var full =
+            RoslynTranslator.LoadRuntime() + "\n" +
+            package.GlueJavascript + "\n" +
+            package.JsonConvertJavascript + "\n" +
+            "Newtonsoft.Json.$cache = Newtonsoft.Json.$cache || [];\n" +
+            result.Javascript;
+
+        if (Environment.GetEnvironmentVariable("TPS_DUMP_JS") is { Length: > 0 } dump)
+            File.WriteAllText(dump, full);
+
+        var output = await NodeJsRunner.RunAsync(full);
+        return Normalize(output);
+    }
+
+    private static string Normalize(string output)
+    {
+        if (string.IsNullOrEmpty(output)) return "";
+        return string.Join("\n", output.Trim()
+            .Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)
+            .Select(s => s.TrimEnd()));
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/NewtonsoftJsonTests.cs
+++ b/Transpose/Transpose.Translator.Tests/NewtonsoftJsonTests.cs
@@ -1,0 +1,214 @@
+using System.Threading.Tasks;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// End-to-end tests for the <c>Transpose.Newtonsoft.Json</c> binding library: the C# is translated
+/// and run on Node against the package's real runtime (JsonConvert.js). See
+/// <see cref="NewtonsoftJsonRunner"/> for how the package is compiled and loaded.
+/// </summary>
+[TestClass]
+public class NewtonsoftJsonTests
+{
+    // A serialization binder that mirrors the one the mosaik front-end uses with
+    // NodeRendererDefinition: TypeNameHandling.Objects + a custom ISerializationBinder that strips
+    // the assembly names from generic type parameters (so a $type emitted by a .NET Core server —
+    // where the assembly is System.Private.CoreLib — resolves on the client) and restricts
+    // deserialization to an allow-list of types.
+    private const string Binder = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Repro.Models
+{
+    public sealed class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+    }
+}
+
+public sealed class AllowListBinder : ISerializationBinder
+{
+    private readonly Type[] _allowed;
+    private AllowListBinder(Type[] allowed) { _allowed = allowed; }
+    public static AllowListBinder ForTypes(params Type[] types) => new AllowListBinder(types);
+
+    public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+    {
+        assemblyName = serializedType.Assembly.FullName;
+        typeName = serializedType.FullName;
+    }
+
+    public Type BindToType(string assemblyName, string typeName)
+    {
+        var cleaned = RemoveAssemblyNamesFromGenericTypeParams(typeName);
+        var type = Type.GetType(cleaned);
+        if (type != null && !_allowed.Any(t => t.IsAssignableFrom(type)))
+            throw new JsonSerializationException(""Type '"" + type.FullName + ""' is not allowed"");
+        return type;
+    }
+
+    private static string RemoveAssemblyNamesFromGenericTypeParams(string typeName)
+        => ReadToEndOfBracketedContent(typeName).Replace("" "", """");
+
+    private static string ReadToEndOfBracketedContent(string value)
+    {
+        var content = new StringBuilder();
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c == ']') return content.ToString();
+            else if (c == '[')
+            {
+                content.Append(c);
+                var nestedTypeName = ReadToEndOfBracketedContent(value.Substring(i + 1));
+                if (!nestedTypeName.StartsWith(""[""))
+                {
+                    var without = RemoveSingleAssemblyName(nestedTypeName);
+                    content.Append(without);
+                    content.Append(' ', nestedTypeName.Length - without.Length);
+                }
+                else content.Append(nestedTypeName);
+                i += nestedTypeName.Length;
+                content.Append(']');
+                i += 1;
+            }
+            else content.Append(c);
+        }
+        return content.ToString();
+    }
+
+    private static string RemoveSingleAssemblyName(string typeName)
+    {
+        var segments = typeName.Split(',').ToArray();
+        return string.Join("","", segments.Take(segments.Length - 1));
+    }
+}
+";
+
+    /// <summary>
+    /// Regression for the DictionaryFromJson bug: a custom ISerializationBinder was never invoked
+    /// (JsonConvert.js looked for the member only under the legacy h5 interface-mangled slot, which
+    /// Transpose does not emit for an implicit implementation), so a server-produced dictionary
+    /// $type fell through to raw Type.GetType(fullName) and failed with
+    /// "Type specified in JSON '…' was not resolved."
+    /// </summary>
+    [TestMethod]
+    public async Task DictionaryFromServerStyleJsonResolvesThroughBinder()
+    {
+        var code = Binder + @"
+public class App
+{
+    static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+    {
+        TypeNameHandling = TypeNameHandling.Objects,
+        SerializationBinder = AllowListBinder.ForTypes(typeof(Repro.Models.Item), typeof(Dictionary<string, Repro.Models.Item>))
+    };
+
+    public static void Main()
+    {
+        // $type exactly as a .NET Core server (System.Private.CoreLib) emits it.
+        var json =
+            ""{\""$type\"":\""System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[Repro.Models.Item, SomeServerAssembly]], System.Private.CoreLib\"","" +
+            ""\""a\"":{\""$type\"":\""Repro.Models.Item, SomeServerAssembly\"",\""Name\"":\""Alpha\"",\""Value\"":1},"" +
+            ""\""b\"":{\""$type\"":\""Repro.Models.Item, SomeServerAssembly\"",\""Name\"":\""Beta\"",\""Value\"":2}}"";
+
+        var back = JsonConvert.DeserializeObject<Dictionary<string, Repro.Models.Item>>(json, Settings);
+        Console.WriteLine(""Count: "" + back.Count);
+        Console.WriteLine(""a.Name: "" + back[""a""].Name);
+        Console.WriteLine(""b.Value: "" + back[""b""].Value);
+    }
+}";
+        var output = await NewtonsoftJsonRunner.RunAsync(code);
+        Assert.AreEqual("Count: 2\na.Name: Alpha\nb.Value: 2", output);
+    }
+
+    /// <summary>A full client-side round trip through the binder (serialize then deserialize) keeps
+    /// the dictionary shape and its element types.</summary>
+    [TestMethod]
+    public async Task DictionaryRoundTripsThroughBinder()
+    {
+        var code = Binder + @"
+public class App
+{
+    static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+    {
+        TypeNameHandling = TypeNameHandling.Objects,
+        SerializationBinder = AllowListBinder.ForTypes(typeof(Repro.Models.Item), typeof(Dictionary<string, Repro.Models.Item>))
+    };
+
+    public static void Main()
+    {
+        var dict = new Dictionary<string, Repro.Models.Item>
+        {
+            [""a""] = new Repro.Models.Item { Name = ""Alpha"", Value = 1 },
+            [""b""] = new Repro.Models.Item { Name = ""Beta"", Value = 2 },
+        };
+
+        var json = JsonConvert.SerializeObject(dict, Settings);
+        Console.WriteLine(""has $type: "" + json.Contains(""$type""));
+
+        var back = JsonConvert.DeserializeObject<Dictionary<string, Repro.Models.Item>>(json, Settings);
+        Console.WriteLine(""Count: "" + back.Count);
+        Console.WriteLine(""a.Name: "" + back[""a""].Name);
+        Console.WriteLine(""b.Value: "" + back[""b""].Value);
+    }
+}";
+        var output = await NewtonsoftJsonRunner.RunAsync(code);
+        Assert.AreEqual("has $type: True\nCount: 2\na.Name: Alpha\nb.Value: 2", output);
+    }
+
+    /// <summary>
+    /// Regression for the "array deserialized into an object with numeric keys" bug: a generic
+    /// method reifies its <c>T = Item[]</c> type argument, and Transpose emitted the bare
+    /// <c>System.Array</c> base (no element type) instead of <c>System.Array.type(Item)</c>. The
+    /// deserializer then failed the array branch and produced <c>{"0":…,"1":…}</c> rather than a
+    /// JS array. This mirrors LocalStorage.Get&lt;AdminSettingsItem[]&gt;(…) in the front-end.
+    /// </summary>
+    [TestMethod]
+    public async Task GenericDeserializeIntoArrayTypeArgumentProducesArray()
+    {
+        var code = Binder + @"
+public class App
+{
+    static T Get<T>(string json) => JsonConvert.DeserializeObject<T>(json);
+
+    public static void Main()
+    {
+        var json = ""[{\""Name\"":\""Alpha\"",\""Value\"":1},{\""Name\"":\""Beta\"",\""Value\"":2},{\""Name\"":\""Gamma\"",\""Value\"":3}]"";
+
+        var arr = Get<Repro.Models.Item[]>(json);
+        Console.WriteLine(""IsArray: "" + (arr is Repro.Models.Item[]));
+        Console.WriteLine(""Length: "" + arr.Length);
+        Console.WriteLine(""[0].Name: "" + arr[0].Name);
+        Console.WriteLine(""[2].Value: "" + arr[2].Value);
+    }
+}";
+        var output = await NewtonsoftJsonRunner.RunAsync(code);
+        Assert.AreEqual("IsArray: True\nLength: 3\n[0].Name: Alpha\n[2].Value: 3", output);
+    }
+
+    /// <summary>Plain (no settings) serialize/deserialize of a POCO works.</summary>
+    [TestMethod]
+    public async Task SimpleObjectRoundTrips()
+    {
+        var code = Binder + @"
+public class App
+{
+    public static void Main()
+    {
+        var item = new Repro.Models.Item { Name = ""Hello"", Value = 42 };
+        var json = JsonConvert.SerializeObject(item);
+        var back = JsonConvert.DeserializeObject<Repro.Models.Item>(json);
+        Console.WriteLine(back.Name + "" "" + back.Value);
+    }
+}";
+        var output = await NewtonsoftJsonRunner.RunAsync(code);
+        Assert.AreEqual("Hello 42", output);
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -128,7 +128,15 @@ public sealed partial class Emitter
                 return $"{defName}({string.Join(", ", effArgs.Select(TypeRef))})";
             return defName;
         }
-        if (type is IArrayTypeSymbol) return "System.Array";
+        // An array type reifies to its concrete runtime type — System.Array.type(element, rank) —
+        // NOT the bare System.Array base (which has no $elementType and fails Transpose.isArray, so a
+        // reified `T[]` type argument, e.g. DeserializeObject<AdminSettingsItem[]>, would deserialize
+        // into an object with numeric keys instead of an array). rank defaults to 1, so it is only
+        // emitted for multidimensional arrays, matching System.Array.type's signature.
+        if (type is IArrayTypeSymbol array)
+            return array.Rank > 1
+                ? $"System.Array.type({TypeRef(array.ElementType)}, {array.Rank})"
+                : $"System.Array.type({TypeRef(array.ElementType)})";
         return type.Name;
     }
 


### PR DESCRIPTION
Two related JSON bugs, both rooted in how a runtime Type is produced/used.

1) Array type argument reified as the bare System.Array base.
   Emitter.TypeRef emitted `System.Array` for any array type, so a generic
   call like `JsonConvert.DeserializeObject<AdminSettingsItem[]>(...)` threaded
   the untyped base (no $elementType). The deserializer's array branch
   (Transpose.isArray) then failed and the value came back as an object with
   numeric keys ({"0":...,"1":...}) instead of an array. Reify arrays to their
   concrete runtime type - System.Array.type(element[, rank]) - matching the
   reflection-metadata path.

2) Custom ISerializationBinder never invoked (DictionaryFromJson).
   JsonConvert.js dispatched the binder only through the legacy h5
   interface-mangled slot (Newtonsoft$Json$Serialization$ISerializationBinder$
   BindToName/BindToType). Transpose dispatches an implicit interface
   implementation through the plain member name, so the binder was skipped and
   a server-produced dictionary $type fell through to raw getType(fullName),
   failing with "Type specified in JSON '...' was not resolved." Resolve the
   binder method under the plain name, falling back to the mangled slot (which
   also covers explicit implementations).

Adds end-to-end Newtonsoft.Json tests (a runner that compiles the package and runs programs against its real JsonConvert.js on Node) plus translator tests for array type-argument reification.


Claude-Session: https://claude.ai/code/session_01H3ne4YEa8Wn3KcjxoWTsy7