### PR TITLE
Add debugging / h5-audit / runtime-and-BCL skills for the compiler

### DIFF
--- a/.claude/skills/transpose-debugging/SKILL.md
+++ b/.claude/skills/transpose-debugging/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: transpose-debugging
+description: >-
+  Reproduce, inspect, and diagnose how the Transpose C#→JS compiler translates a construct, using a
+  fast emit→Node→native-.NET loop. Use this WHENEVER you are investigating a suspected
+  mis-compilation, a runtime error in emitted JS, or "what JavaScript does Transpose produce for
+  X?" — including reproducing a bug report, checking a snippet before/after an emitter change, or
+  confirming a fix behaves like native .NET. Triggers on any work in the transpose repo that
+  involves running or inspecting emitted JavaScript, comparing transpose output to native .NET, or
+  debugging the emitter (Transpose/Transpose.Translator/Emit/*.cs) or runtime (BCL Resources/*.js,
+  tps.shim.js). Prefer this over ad-hoc `dotnet run` or hand-built test projects.
+---
+
+# Debugging the Transpose compiler
+
+Transpose compiles C# to JavaScript via Roslyn. The fastest way to understand or fix a
+mis-compilation is to translate a tiny C# snippet, look at the emitted JS, run it in Node, and diff
+the result against what native .NET does. This skill sets up that loop and captures the pitfalls
+that otherwise cost hours.
+
+## One-time setup (per session/container)
+
+Run the setup script — it builds the Release translator and three tiny runner projects in `/tmp`,
+and builds the runtime `Transpose.dll` if missing:
+
+```bash
+bash .claude/skills/transpose-debugging/scripts/setup-toolkit.sh
+```
+
+Then export the runtime path it prints (every runner needs it — it makes the runner use YOUR
+freshly-built runtime, not the NuGet-cached one):
+
+```bash
+export TRANSPOSE_DLL_PATH=<repo>/BCL/Transpose.BCL/bin/Debug/netstandard2.0/Transpose.dll
+```
+
+## The loop
+
+Write a **full-program** snippet to `/tmp` (keep it OUT of the runner dirs — a stray `.cs` there
+gives "more than one entry point"):
+
+```csharp
+using System;
+public class Program { public static void Main() { Console.WriteLine("hi " + (1+2)); } }
+```
+
+Then:
+
+```bash
+# 1. See the emitted JS (no execution) — read it to spot the wrong construct
+dotnet /tmp/emitrunner/bin/Debug/net10.0/emitrunner.dll /tmp/snippet.cs
+
+# 2. Run it in Node — the runtime auto-runs Main()
+dotnet /tmp/emitrunner/bin/Debug/net10.0/emitrunner.dll /tmp/snippet.cs --run 2>&1 | node
+
+# 3. Compare against native .NET. Usually you can reason out native behaviour; when unsure, run it:
+#    (cd /tmp && rm -rf nat && mkdir nat && cd nat && dotnet new console -o . >/dev/null \
+#      && cp /tmp/snippet.cs Program.cs && dotnet run)
+```
+
+A **behavioural bug** is any case where transpose's Node output differs from native .NET's. Cosmetic
+differences in the emitted JS (variable names, spacing) are NOT bugs — only observable behaviour is.
+
+If translation *fails* (a `TRANSLATION FAILED` banner), run without `--run` to read the Roslyn/emit
+diagnostics. Distinguish a **real C# error in your snippet** (e.g. positional-pattern on `object`
+has no `Deconstruct`) from a **missing BCL API** (`'string' does not contain a definition for X` — a
+BCL gap, not a silent behavioural bug) from an **emitter crash**.
+
+## Finding and fixing the root cause
+
+The emitter is a syntax-tree walk under `Transpose/Transpose.Translator/Emit/`:
+`Emitter.Expressions*.cs`, `Emitter.Statements.cs`, `Emitter.Members.cs`, `Emitter.Patterns.cs`,
+`Emitter.Types.cs`, `Emitter.ValueTypes.cs`, `Emitter.Query.cs`, `Emitter.Reflection.cs`. Member/JS
+name resolution lives in `Support/TransposeNaming.cs` and `Support/NameMangler.cs`. The language shim
+is `Transpose/Transpose.Translator/Runtime/tps.shim.js`; the hand-written runtime primitives are
+`BCL/Transpose.BCL/Resources/*.js`.
+
+Typical diagnosis: grep the emitter for how the *working* form is emitted (e.g. normal member access
+→ `TransposeNaming.MemberJsName(symbol)`) and compare with the broken path (e.g. a pattern emitting a
+raw identifier). The fix is usually routing the broken path through the same resolver.
+
+## Pitfalls that waste time — read these
+
+- **Rebuild the RIGHT thing, and confirm it.** The emit runner references the **Release**
+  `Transpose.Translator.dll`; the `tps` compiler / `--build-runtime` / the test suite use the
+  **Debug** build. After editing the emitter, rebuild **both** configs. `dotnet build -v q | tail`
+  HIDES compile errors — always confirm `Build succeeded / 0 Error(s)`, or the runner silently uses
+  the previous DLL.
+- **Rebuild the runner too.** The runner copies `Transpose.Translator.dll` into its own `bin/`, so
+  after rebuilding the Release translator you must `dotnet build /tmp/emitrunner/emitrunner.csproj`
+  (re-running `setup-toolkit.sh` does this) or it keeps using the stale copy. This is the #1 "my fix
+  didn't take" trap.
+- **Rebuild the runtime when you touch runtime JS or the BCL.** Changes to `Resources/*.js` or the
+  BCL C# need `--build-runtime` (see the `transpose-runtime-and-bcl` skill). Shim changes
+  (`tps.shim.js`) are embedded in the **translator** — rebuild the translator, not the runtime.
+- **Node vs browser.** With no DOM, `Transpose.ready` fires synchronously — don't rely on
+  load-order-sensitive ordering in Node-only checks.
+- **`Console.Write` (no newline) appends a newline per call** under the Node harness (console.log
+  semantics, shared with h5). Build a string and `WriteLine` once rather than asserting on
+  `Console.Write` spacing.
+- **Boxed value types.** Enums box to a `Transpose.box` object (carrying the enum type) — not a
+  plain number; primitives (int/string/bool) box to plain JS values. `Transpose.getDefaultValue(type)`
+  is the runtime-dispatched default (handles BCL structs).
+
+## Related skills
+
+- Hunting for divergences systematically against the proven-correct h5 output → **transpose-h5-audit**.
+- Rebuilding the runtime/BCL, adding a BCL API, or adding a regression test → **transpose-runtime-and-bcl**.

--- a/.claude/skills/transpose-debugging/scripts/setup-toolkit.sh
+++ b/.claude/skills/transpose-debugging/scripts/setup-toolkit.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Sets up the Transpose emit/debug toolkit used to inspect and validate the JavaScript that the
+# compiler emits for a C# snippet, and to run it in Node and compare against native .NET.
+#
+# What it builds (idempotent — safe to re-run):
+#   * The Release Transpose.Translator.dll (referenced by the runners).
+#   * /tmp/jsdumper   — dumps embedded .js manifest resources from a DLL (h5 corpus + built packages).
+#   * /tmp/emitrunner — prints/`--run`s the transpose output for a plain C# snippet.
+#   * /tmp/jsonrunner — same but with the Transpose.Newtonsoft.Json binding referenced + prepended.
+#
+# It also builds the runtime Transpose.dll (BCL) if it is missing and prints the TRANSPOSE_DLL_PATH
+# you must export before invoking any runner.
+#
+# Usage:  bash .claude/skills/transpose-debugging/scripts/setup-toolkit.sh
+#         (then follow the printed `export TRANSPOSE_DLL_PATH=...` line)
+set -euo pipefail
+
+REPO="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+TR_REL_DLL="$REPO/Transpose/Transpose.Translator/bin/Release/net10.0/Transpose.Translator.dll"
+RUNTIME_DLL="$REPO/BCL/Transpose.BCL/bin/Debug/netstandard2.0/Transpose.dll"
+
+echo "repo: $REPO"
+
+echo "==> building Release Transpose.Translator (referenced by the runners)"
+dotnet build "$REPO/Transpose/Transpose.Translator/Transpose.Translator.csproj" -c Release \
+  | grep -E "error|Build succeeded" | tail -3
+
+# --- jsdumper -------------------------------------------------------------------------------------
+mkdir -p /tmp/jsdumper
+cat > /tmp/jsdumper/jsdumper.csproj <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <AssemblyName>jsdumper</AssemblyName>
+  </PropertyGroup>
+</Project>
+EOF
+cat > /tmp/jsdumper/Program.cs <<'EOF'
+using System;
+using System.IO;
+using System.Reflection;
+class P {
+  static void Main(string[] args) {
+    var dll = args[0]; var outDir = args[1];
+    Directory.CreateDirectory(outDir);
+    var asm = Assembly.LoadFrom(Path.GetFullPath(dll));
+    foreach (var name in asm.GetManifestResourceNames()) {
+      using var s = asm.GetManifestResourceStream(name);
+      if (s == null) continue;
+      using var ms = new MemoryStream(); s.CopyTo(ms);
+      var bytes = ms.ToArray();
+      File.WriteAllBytes(Path.Combine(outDir, name.Replace(Path.DirectorySeparatorChar, '_')), bytes);
+      Console.WriteLine($"{name}\t{bytes.Length}");
+    }
+  }
+}
+EOF
+
+# --- emitrunner -----------------------------------------------------------------------------------
+mkdir -p /tmp/emitrunner
+cat > /tmp/emitrunner/emitrunner.csproj <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>emitrunner</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Transpose.Translator"><HintPath>$TR_REL_DLL</HintPath></Reference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+  </ItemGroup>
+</Project>
+EOF
+cat > /tmp/emitrunner/Program.cs <<'EOF'
+using System;
+using System.IO;
+using Transpose.Translator;
+class P {
+    static void Main(string[] args) {
+        if (args.Length == 0) { Console.Error.WriteLine("usage: <file.cs> [--run]"); return; }
+        var r = new RoslynTranslator().Translate(File.ReadAllText(args[0]));
+        if (!r.Success) {
+            Console.Error.WriteLine("TRANSLATION FAILED:");
+            foreach (var d in r.Diagnostics) Console.Error.WriteLine("  " + d.GetMessage());
+            return;
+        }
+        Console.WriteLine(args.Length > 1 && args[1] == "--run"
+            ? RoslynTranslator.LoadRuntime() + "\n" + r.Javascript
+            : r.Javascript);
+    }
+}
+EOF
+
+# --- jsonrunner (Newtonsoft) ----------------------------------------------------------------------
+NSJ_DLL="$REPO/Packages/Transpose.Newtonsoft.Json/bin/Debug/netstandard2.0/Transpose.Newtonsoft.Json.dll"
+mkdir -p /tmp/jsonrunner
+cat > /tmp/jsonrunner/jsonrunner.csproj <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>jsonrunner</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Transpose.Translator"><HintPath>$TR_REL_DLL</HintPath></Reference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+  </ItemGroup>
+</Project>
+EOF
+cat > /tmp/jsonrunner/Program.cs <<EOF
+using System;
+using System.IO;
+using Transpose.Translator;
+class P {
+    static void Main(string[] args) {
+        if (args.Length == 0) { Console.Error.WriteLine("usage: <file.cs> [--run]"); return; }
+        var nsjRef = "$NSJ_DLL";
+        var r = new RoslynTranslator().Translate(new[] { ("App.cs", File.ReadAllText(args[0])) }, "App", new[] { nsjRef });
+        if (!r.Success) {
+            Console.Error.WriteLine("TRANSLATION FAILED:");
+            foreach (var d in r.Diagnostics) Console.Error.WriteLine("  " + d.GetMessage());
+            return;
+        }
+        if (args.Length > 1 && args[1] == "--run") {
+            var nsjJs   = File.ReadAllText("/tmp/nsjjs/newtonsoft.json.js");
+            var nsjMeta = File.ReadAllText("/tmp/nsjjs/generated.meta.js");
+            Console.WriteLine(RoslynTranslator.LoadRuntime() + "\n" + nsjJs + "\n" + nsjMeta + "\n" + r.Javascript);
+        } else {
+            Console.WriteLine(r.Javascript);
+        }
+    }
+}
+EOF
+
+echo "==> building the runner projects"
+for r in jsdumper emitrunner jsonrunner; do
+  dotnet build "/tmp/$r/$r.csproj" -c Debug | grep -E "error|Build succeeded" | tail -1
+done
+
+if [ ! -f "$RUNTIME_DLL" ]; then
+  echo "==> runtime Transpose.dll missing — building it (~25s)"
+  dotnet "$REPO/Transpose/Transpose.Compiler/bin/Debug/net10.0/tps.dll" \
+    --project "$REPO/BCL/Transpose.BCL/Transpose.BCL.csproj" --build-runtime -c Debug \
+    -o "$RUNTIME_DLL" | tail -3
+fi
+
+cat <<EOF
+
+================================================================================
+Toolkit ready. Before invoking any runner, export the runtime path:
+
+  export TRANSPOSE_DLL_PATH=$RUNTIME_DLL
+
+Inspect emitted JS:   dotnet /tmp/emitrunner/bin/Debug/net10.0/emitrunner.dll /tmp/snippet.cs
+Run in Node:          dotnet /tmp/emitrunner/bin/Debug/net10.0/emitrunner.dll /tmp/snippet.cs --run 2>&1 | node
+Dump JS from a DLL:   dotnet /tmp/jsdumper/bin/Debug/net10.0/jsdumper.dll <path-to.dll> <outdir>
+
+Snippets must be a full program: class Program { public static void Main() { ... } }
+Keep snippets in /tmp (NOT in a runner dir — a stray .cs there breaks the build).
+================================================================================
+EOF

--- a/.claude/skills/transpose-h5-audit/SKILL.md
+++ b/.claude/skills/transpose-h5-audit/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: transpose-h5-audit
+description: >-
+  Systematically audit the Transpose C#→JS compiler for behavioural discrepancies against the
+  proven-correct h5 baseline (h5 is the predecessor Transpose was forked from), using the Curiosity
+  front-end as a real-world corpus. Use this WHENEVER the task is to hunt for compiler bugs, validate
+  a language feature or BCL area against h5/native, run a broad correctness sweep, or answer "does
+  Transpose handle X the same as h5/.NET?". Triggers on requests to audit/validate/compare the
+  compiler, investigate a checklist area (async, pattern matching, LINQ, formatting, delegates,
+  generics, Newtonsoft, collections, exceptions, static init), or confirm a construct matches h5.
+  Builds on the transpose-debugging skill for the per-construct loop.
+---
+
+# Auditing Transpose against the h5 baseline
+
+h5 is the mature predecessor Transpose was rebuilt from; its emitted JavaScript is the known-good
+reference. An audit lines up **three** things for a sampled construct and looks for divergence:
+
+1. the **h5-emitted JS** (extracted from shipped h5 NuGet DLLs — the corpus),
+2. the **transpose-emitted JS** (regenerate with the emit/JSON runners),
+3. the **C# source and native .NET behaviour**.
+
+## The rule for a real finding
+
+> A finding is real ONLY if transpose diverges from **BOTH** native .NET **AND** h5.
+
+Many apparent divergences are intentional h5-compatible contracts (e.g. a boxed `[Enum(Emit.Value)]`
+enum stringifies to its number — NOT a bug). Before filing anything, grep the extracted h5 corpus for
+how h5 emits the same construct. If h5 shares a divergence from native, note it but treat it as low
+priority — it is a deliberate contract far more often than a bug.
+
+## Setup
+
+1. Set up the runners (see the **transpose-debugging** skill): `setup-toolkit.sh`, then
+   `export TRANSPOSE_DLL_PATH=...`.
+2. Download the h5 corpus DLLs and extract their embedded `.js` manifest resources with `jsdumper`.
+   The Curiosity front-end packages are the corpus (versions may differ — check nuget.org):
+
+```bash
+mkdir -p /tmp/h5pkg && cd /tmp/h5pkg
+V=26.7.2802   # bump to the current Curiosity.FrontEnd version if needed
+for p in curiosity.frontend curiosity.frontend.admin curiosity.frontend.api curiosity.frontend.core; do
+  curl -sSL -o "$p.$V.nupkg" "https://api.nuget.org/v3-flatcontainer/$p/$V/$p.$V.nupkg"
+  mkdir -p "${p}_x" && (cd "${p}_x" && unzip -oq "../$p.$V.nupkg")
+  dll=$(find "${p}_x/lib" -name "*.dll"); short="${p##*.}"
+  dotnet /tmp/jsdumper/bin/Debug/net10.0/jsdumper.dll "$dll" "/tmp/h5js/$short"
+done
+```
+
+This yields the known-good h5 output under `/tmp/h5js/{frontend,admin,api,core}/*.js`. Grep these to
+confirm how h5 emits a construct (h5 uses the `H5.` runtime global and `H5.is(...)` type tests, so
+translate names mentally: `Transpose.` ↔ `H5.`, `TransposeR` ↔ helper).
+
+## Picking what to sample
+
+The matching transpose-based C# source is in the **mosaik** repo under
+`FrontEnd/Mosaik.FrontEnd{,.Admin,.API,.Core}` (assembly names `Curiosity.FrontEnd*`). Read it first
+to pick classes/methods worth comparing, and grep it to gauge what the corpus actually uses (bias
+toward high-frequency constructs):
+
+```bash
+grep -rhoE '\.ToString\("[^"]+"\)' --include=*.cs FrontEnd | sort | uniq -c | sort -rn | head
+```
+
+Random-sample by class and method name across the checklist areas below.
+
+## Checklist areas to scrutinise
+
+Write deterministic snippets (avoid wall-clock races; sequence async work with awaited
+`Task.FromResult`/`TaskCompletionSource`). For each: run in Node, compare to native, then grep the h5
+corpus before filing.
+
+- **async/await**: `Task.WhenAll`/`WhenAny` ordering, `ContinueWith`, `TaskCompletionSource`,
+  exception surfacing (single vs aggregate), cancellation, `ConfigureAwait` as a no-op, `async void`.
+- **pattern matching**: switch expressions with property/positional/relational/list patterns, `when`
+  guards, `not`/`and`/`or`, `var` captures, tuple patterns (real ValueTuple instances), exhaustiveness.
+- **string/number/date formatting**: `ToString(format)` (N/F/X/D/G/E/P/C + custom `0.##`/`#,##0`),
+  DateTime/TimeSpan format+parse, alignment+format combos, `StringBuilder`, `double` "R" round-trip.
+- **LINQ**: GroupBy (element/result selectors), ToLookup, Join/GroupJoin, SelectMany-with-result,
+  OrderBy stability, DefaultIfEmpty, SequenceEqual, Aggregate(seed[,resultSelector]), deferred
+  execution + multiple enumeration, Cast/OfType, comparer overloads.
+- **events & delegates**: `+=`/`-=` and binary `+`/`-` combine/remove order, multicast return value,
+  `handler?.Invoke()`, delegate equality, method-group vs lambda identity, Func/Action variance.
+- **generics & variance**: constrained generics, generic virtual dispatch, `IEnumerable<out T>` /
+  `IComparer<in T>`, per-closed-type generic static fields, `default(T)` in ref/out/array positions.
+- **Newtonsoft** (use the JSON runner): TypeNameHandling `$type`, custom `JsonConverter`,
+  `JsonSerializerSettings`, collection target types, StringEnumConverter, JObject/JArray, PopulateObject,
+  `[JsonProperty]`/`[JsonIgnore]`.
+- **collections**: custom `IEqualityComparer`/`IComparer`, Sorted*/LinkedList/Stack/Queue,
+  `TryGetValue` out semantics, indexer-throw vs ContainsKey, dup-Add throw.
+- **numeric edge cases**: `Math.Round` MidpointRounding, `Convert.ToInt32` overflow/banker's rounding,
+  bit ops on `long`, `double` special values.
+- **exceptions**: finally ordering with return/throw, exception filters (`when`), rethrow vs
+  `throw e`, `using` disposal order, try/catch around `await`.
+- **static ctor / init order**: field-init order vs cctor, `beforefieldinit` laziness, cross-type deps.
+
+## Newtonsoft JSON runner
+
+`Transpose.Newtonsoft.Json` needs its binding referenced and its runtime JS prepended. Build it once
+(after `./bootstrap.sh` produces the Core ref assembly), passing the base `Transpose.dll` explicitly
+as a `--reference` so `tps` doesn't misclassify the ClassPath-outputBy package as a runtime build:
+
+```bash
+CORE=$(find artifacts/bootstrap/refs -name Transpose.Core.dll)
+dotnet Transpose/Transpose.Compiler/bin/Debug/net10.0/tps.dll \
+  --project Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj -c Debug --emit-package \
+  -o Packages/Transpose.Newtonsoft.Json/bin/Debug/netstandard2.0/Transpose.Newtonsoft.Json.dll \
+  --reference "$TRANSPOSE_DLL_PATH" --reference "$CORE"
+dotnet /tmp/jsdumper/bin/Debug/net10.0/jsdumper.dll \
+  Packages/Transpose.Newtonsoft.Json/bin/Debug/netstandard2.0/Transpose.Newtonsoft.Json.dll /tmp/nsjjs
+```
+
+Then `dotnet /tmp/jsonrunner/bin/Debug/net10.0/jsonrunner.dll /tmp/snippet.cs --run 2>&1 | node`
+(the runner prepends `/tmp/nsjjs/newtonsoft.json.js` + `generated.meta.js`).
+
+## Workflow per finding
+
+Investigate a batch and **record findings first** (repro + emitted JS + native/h5 comparison + root
+cause `file:line`) in a temp folder, then fix serially. For each fix: reproduce minimally → confirm
+the emitted JS is wrong → fix the emitter/runtime → add a regression test → run the FULL suite → commit.
+See **transpose-runtime-and-bcl** for the rebuild/test/commit mechanics.
+
+Consider spawning parallel investigation agents, one per checklist area, each writing a findings file —
+then fix serially. (Agents share the pre-built runners; tell them NOT to build anything, only invoke
+the runner DLLs, to avoid races.)
+
+## Working efficiently
+
+- Bias toward areas the corpus actually uses heavily and areas not yet deeply covered by prior
+  sessions — check the repo's recent git log / any `PORT_PLAN`/findings notes for what's already fixed,
+  and don't re-investigate those.
+- A missing BCL API surfaces as a *translation failure*, not a silent wrong result — that's a feature
+  gap, not the behavioural-divergence this audit targets (unless the corpus depends on it).

--- a/.claude/skills/transpose-runtime-and-bcl/SKILL.md
+++ b/.claude/skills/transpose-runtime-and-bcl/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: transpose-runtime-and-bcl
+description: >-
+  Rebuild the Transpose runtime, add or change BCL APIs and runtime JavaScript, and add/run the
+  translator regression tests — the "make and validate a fix" side of Transpose work. Use this
+  WHENEVER a change touches the runtime JS (BCL/Transpose.BCL/Resources/*.js, tps.shim.js) or the BCL
+  C# (System.*), when adding a missing BCL method/type (e.g. a LINQ operator, a string/Task API),
+  when the emitted metadata/init changes, or when adding a regression test to
+  EmitRegressionTests.cs and running the suite. Triggers on "add X to the BCL", "rebuild the
+  runtime", "implement this .NET API in transpose", "add a regression test", or "run the transpose
+  tests". Pairs with transpose-debugging (inspection) and transpose-h5-audit (finding bugs).
+---
+
+# Runtime, BCL changes, and regression tests
+
+## How the pieces fit
+
+- **`BCL/Transpose.BCL/`** *defines* the C# BCL. Most `System.*` types are `[Transpose.External]` and
+  bind to hand-written JS in `Resources/*.js` via `[Template]`/`[Name]`/`[Convention]`; other types
+  are ordinary C# that gets transpiled. The whole assembly compiles to a self-contained reference
+  assembly **`Transpose.dll`** (also the sole BCL reference for every compile) with the runtime JS
+  bundles embedded.
+- **The runtime bundle `tps.js`** is stitched from `Resources/*.js` + the transpiled
+  `Resources/.generated/*.js` per the explicit ordered file list in `BCL/Transpose.BCL/tps.json`.
+- **The language shim `tps.shim.js`** (`Transpose/Transpose.Translator/Runtime/`) is embedded in the
+  **translator**, not the runtime.
+
+## Rebuilding the runtime
+
+After changing BCL C# or `Resources/*.js`, rebuild `Transpose.dll` (~25s):
+
+```bash
+dotnet Transpose/Transpose.Compiler/bin/Debug/net10.0/tps.dll \
+  --project BCL/Transpose.BCL/Transpose.BCL.csproj --build-runtime -c Debug \
+  -o BCL/Transpose.BCL/bin/Debug/netstandard2.0/Transpose.dll
+```
+
+This transpiles the BCL into `Resources/.generated/*.js`, stitches the bundles per `tps.json`, and
+emits `Transpose.dll` with them embedded. Both the runners and the test suite read this DLL via
+`TRANSPOSE_DLL_PATH`. (For a **shim** change, rebuild the translator/compiler instead — the shim is
+embedded there.)
+
+## Adding a BCL API — two paths
+
+Pick based on whether the behaviour is best expressed in JS or C#:
+
+**A. `extern` + `[Template]` binding to runtime JS** — the norm for the external BCL types. Declare the
+member `extern` on the (external) type and either give it a `[Template("...js...")]` or rely on the
+type's `[Convention(CamelCase)]` to map the name (e.g. `Delay` → runtime `delay`). Then implement the
+matching function in the type's `Resources/*.js`. Example: `Task.Yield()` → declare
+`public static extern Task Yield();` on the CamelCase-convention `Task`, and add a `yield: function(){
+var tcs = new System.Threading.Tasks.TaskCompletionSource(); Transpose.setImmediate(function(){
+tcs.setResult(null); }); return tcs.task; }` to `Resources/Task.js`. Redirects are trivial — give the
+new member the SAME `[Template]` as the existing one (e.g. `ToLowerInvariant()` reuses
+`{this}.toLowerCase()`).
+
+**B. Real C# in a NON-external class** — for logic cleaner to write in C#. `[External]` types emit no
+bodies, so put the code in a new, non-`[External]` class; it transpiles like user code (iterators →
+`function*`, etc.). Example: LINQ `Chunk`/`MinBy`/`MaxBy` live in a new `EnumerableExtras` class (the
+`Enumerable` binding is external). **Then add the generated file to `tps.json`** — the bundle is a
+manual ordered list, so a new `Resources/.generated/System/.../Foo.js` must be inserted (after its
+dependencies, e.g. right after `linq.js`) or it compiles but never loads at runtime. Symptom of a
+forgotten entry: `Cannot read properties of undefined (reading 'YourMethod')` and a byte-identical
+`tps.js` size after `--build-runtime`.
+
+Match native .NET semantics exactly — that is the whole point (empty-sequence throw-vs-default, null
+handling, comparer overloads, validation exceptions). Note the `.generated/*.js` files are gitignored
+build artifacts; commit the C# source + `tps.json`, not the generated JS.
+
+## Regression tests
+
+Tests live in `Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs` (and the `Ported/` suites).
+`RunTest(code, waitForOutput?, skipRoslyn?)` transpiles the snippet, runs it in Node, AND asserts the
+output equals native .NET's. Two flavours:
+
+- **Behavioural** (default): `await RunTest(code, waitForOutput: "<<DONE>>");` — compares Node output
+  to native. End the program with a sentinel `Console.WriteLine("<<DONE>>")`.
+- **Emit-shape / Transpose-only**: `new RoslynTranslator().Translate(code)` then assert on
+  `result.Javascript` (e.g. `Contains("TransposeR.combine(")`). Use for things that are a no-op in
+  native, or pass `skipRoslyn: true` to `RunTest` and assert on the returned JS output string.
+
+Harness gotchas:
+
+- `Console.Write` (no newline) appends a newline per call under Node — build a string and `WriteLine`
+  once, or the native comparison mismatches.
+- **Fire-and-forget async is non-deterministic under native.** `static void Main() { Run(); }` where
+  `Run` truly yields (e.g. `await Task.Yield()`) can let the native process exit before continuations
+  run, while Node drains its queue — so a native-comparison test flakes. Use `skipRoslyn: true` and
+  assert on the JS output sequence instead.
+- Tests use the DEBUG translator (project reference) and read the runtime via `TRANSPOSE_DLL_PATH` —
+  rebuild the runtime first if your change touched it.
+
+Run the suite:
+
+```bash
+export TRANSPOSE_DLL_PATH=<repo>/BCL/Transpose.BCL/bin/Debug/netstandard2.0/Transpose.dll
+# whole suite (~2 min):
+dotnet test Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj -c Debug
+# a subset while iterating (unqualified substring match):
+dotnet test Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj -c Debug --filter MyNewTest
+```
+
+The suite MUST stay fully green before committing. Confirm the `Passed! - Failed: 0` line — a
+non-zero exit / any `Failed` line means regressions.
+
+## Commit discipline
+
+Group related fixes into separate, descriptive commits (one concern each). Reproduce → confirm wrong
+JS → fix → regression test → full suite green → commit. Write commit messages with a file (`git commit
+-F msg.txt`) when they contain backticks, so the shell doesn't run command-substitution on them.
+
+## Related skills
+
+- Inspecting emitted JS / the fast per-construct loop → **transpose-debugging**.
+- Finding the bugs to fix, systematically, against h5 → **transpose-h5-audit**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,23 @@ plain CLI, by design.
 
 Caching and the compilation server are intentionally **out of scope**.
 
+## Debugging, testing & auditing skills
+
+Reusable workflows for working on the compiler live under `.claude/skills/` (auto-discovered by
+Claude Code; read the `SKILL.md` directly in other contexts):
+
+- **`transpose-debugging`** — set up the emit→Node→native-.NET loop (`scripts/setup-toolkit.sh` builds
+  the Release translator + the `/tmp` emit/JSON/dump runners) and inspect/reproduce how a C# snippet
+  compiles. Start here for any "what/why does Transpose emit X?" question. Captures the stale-build
+  and runner-rebuild pitfalls.
+- **`transpose-h5-audit`** — systematically hunt behavioural divergences against the proven-correct
+  **h5** baseline, using the Curiosity front-end (in the *mosaik* repo) as the corpus. Includes the
+  h5-JS corpus extraction, the "diverges from BOTH native AND h5" rule, the checklist areas, and the
+  Newtonsoft JSON runner.
+- **`transpose-runtime-and-bcl`** — rebuild the runtime (`--build-runtime`), add/modify BCL APIs
+  (extern+`[Template]`+`Resources/*.js` vs. real C# in a non-external class + a `tps.json` bundle
+  entry), and add/run regression tests in `EmitRegressionTests.cs`.
+
 ## Conventions when editing
 
 - Emitted JS identifiers use the `Transpose` global and `TransposeR` helpers; keep new emit code and


### PR DESCRIPTION
Capture the workflow for testing, debugging, validating and auditing the Transpose compiler as reusable Claude Code skills under .claude/skills/, so new sessions can pick them up without re-deriving the toolkit:

- transpose-debugging: the emit->Node->native-.NET inspection loop, with a setup-toolkit.sh that builds the Release translator and the /tmp emit/JSON/dump runners, plus the stale-build / runner-rebuild pitfalls.
- transpose-h5-audit: systematic hunt for behavioural divergences against the proven-correct h5 baseline (Curiosity front-end corpus), the "diverges from BOTH native AND h5" rule, the checklist areas, and the Newtonsoft JSON runner.
- transpose-runtime-and-bcl: rebuilding the runtime (--build-runtime), adding BCL APIs (extern+[Template]+Resources JS vs real C# + a tps.json bundle entry), and adding/running EmitRegressionTests.

Also cross-reference the skills from CLAUDE.md so they surface outside skill-aware contexts.


Claude-Session: https://claude.ai/code/session_01Gg5g1qh9sSq1NvAo7Lce1E