### PR TITLE
Tag array values with their element type (System.Array.init)

### DIFF
--- a/Transpose/Transpose.Translator.Tests/ArrayValueElementTypeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ArrayValueElementTypeTests.cs
@@ -1,0 +1,90 @@
+using System.Threading.Tasks;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// An array VALUE must carry its element type at runtime — <c>arr.GetType().GetElementType()</c>
+/// (and <c>IsArray</c>, covariance, and the JSON serializer's byte[]/element-typed-array handling)
+/// depend on it. Transpose emits array literals as <c>System.Array.init([…], element)</c> (h5 tags
+/// every array literal the same way); a bare JS array literal would have no element type.
+/// </summary>
+[TestClass]
+public class ArrayValueElementTypeTests : TranslatorTestBase
+{
+    [TestMethod]
+    public async Task ArrayLiteralValueCarriesElementType()
+    {
+        await RunTest(@"
+using System;
+public class App
+{
+    public static void Main()
+    {
+        Console.WriteLine(new int[]{1,2,3}.GetType().GetElementType().Name);
+        Console.WriteLine(new byte[]{1,2}.GetType().GetElementType().Name);
+        Console.WriteLine(new string[]{""a""}.GetType().GetElementType().Name);
+        int[] implicitLocal = {4,5};
+        Console.WriteLine(implicitLocal.GetType().GetElementType().Name);
+        var inferred = new[]{1.5,2.5};
+        Console.WriteLine(inferred.GetType().GetElementType().Name);
+        Console.WriteLine(new int[3].GetType().GetElementType().Name);
+        Console.WriteLine(new int[0].GetType().GetElementType().Name);
+    }
+}");
+    }
+
+    [TestMethod]
+    public async Task CollectionExpressionArrayCarriesElementType()
+    {
+        await RunTest(@"
+using System;
+public class App
+{
+    public static void Main()
+    {
+        int[] a = [1,2,3];
+        Console.WriteLine(a.GetType().GetElementType().Name + ""|"" + a.Length + ""|"" + a[2]);
+        byte[] b = [9,8];
+        Console.WriteLine(b.GetType().GetElementType().Name);
+        int[] spread = [0, ..a, 4];
+        Console.WriteLine(spread.GetType().GetElementType().Name + ""|"" + spread.Length);
+    }
+}");
+    }
+
+    [TestMethod]
+    public async Task JaggedArrayValueElementTypeIsTheInnerArray()
+    {
+        await RunTest(@"
+using System;
+public class App
+{
+    public static void Main()
+    {
+        var jagged = new int[][]{ new int[]{1,2}, new int[]{3} };
+        var t = jagged.GetType();
+        Console.WriteLine(t.IsArray + ""|"" + t.GetElementType().Name + ""|"" + t.GetElementType().GetElementType().Name);
+        Console.WriteLine(jagged[0].GetType().GetElementType().Name);
+    }
+}");
+    }
+
+    [TestMethod]
+    public async Task ArrayCovarianceAndIsChecksUseElementType()
+    {
+        await RunTest(@"
+using System;
+public class App
+{
+    public static void Main()
+    {
+        object o = new int[]{1,2,3};
+        Console.WriteLine(o is int[]);
+        Console.WriteLine(o is string[]);
+        object b = new byte[]{1};
+        Console.WriteLine(b is byte[]);
+        Console.WriteLine(b is int[]);
+    }
+}");
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/NewtonsoftJsonTests.cs
+++ b/Transpose/Transpose.Translator.Tests/NewtonsoftJsonTests.cs
@@ -193,6 +193,56 @@ public class App
         Assert.AreEqual("IsArray: True\nLength: 3\n[0].Name: Alpha\n[2].Value: 3", output);
     }
 
+    /// <summary>
+    /// A byte[] serializes to a base64 string (not a JSON number array) and round-trips — this needs
+    /// the array VALUE to carry its element type so the serializer recognises System.Byte. Regression
+    /// for array literals emitting as bare JS arrays with no element type.
+    /// </summary>
+    [TestMethod]
+    public async Task ByteArraySerializesAsBase64()
+    {
+        var code = @"
+using System;
+using Newtonsoft.Json;
+public class M { public byte[] Data { get; set; } }
+public class App
+{
+    public static void Main()
+    {
+        var j = JsonConvert.SerializeObject(new M { Data = new byte[]{ 1, 2, 3, 255 } });
+        Console.WriteLine(j);
+        var b = JsonConvert.DeserializeObject<M>(j);
+        Console.WriteLine(b.Data.Length + ""|"" + b.Data[3]);
+        // top-level byte[] too
+        Console.WriteLine(JsonConvert.SerializeObject(new byte[]{ 0, 16, 255 }));
+    }
+}";
+        var output = await NewtonsoftJsonRunner.RunAsync(code);
+        Assert.AreEqual("{\"Data\":\"AQID/w==\"}\n4|255\n\"ABD/\"", output);
+    }
+
+    /// <summary>An array of complex objects round-trips (element type preserved on the value).</summary>
+    [TestMethod]
+    public async Task ArrayOfObjectsRoundTrips()
+    {
+        var code = @"
+using System;
+using Newtonsoft.Json;
+public class Item { public int V { get; set; } }
+public class App
+{
+    public static void Main()
+    {
+        var a = new Item[]{ new Item{V=1}, new Item{V=2}, new Item{V=3} };
+        var j = JsonConvert.SerializeObject(a);
+        var b = JsonConvert.DeserializeObject<Item[]>(j);
+        Console.WriteLine((b is Item[]) + ""|"" + b.Length + ""|"" + b[0].V + ""|"" + b[2].V);
+    }
+}";
+        var output = await NewtonsoftJsonRunner.RunAsync(code);
+        Assert.AreEqual("True|3|1|3", output);
+    }
+
     /// <summary>Plain (no settings) serialize/deserialize of a POCO works.</summary>
     [TestMethod]
     public async Task SimpleObjectRoundTrips()

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -166,7 +166,9 @@ public sealed partial class Emitter
                 EmitArrayCreation(arrayCreation);
                 break;
             case ImplicitArrayCreationExpressionSyntax implicitArray:
-                EmitInitializerArray(implicitArray.Initializer);
+                // new[] { … } → tag with the inferred element type so the value carries $elementType.
+                EmitTypedInitializerArray(implicitArray.Initializer,
+                    (_model.GetTypeInfo(implicitArray).Type ?? _model.GetTypeInfo(implicitArray).ConvertedType) is IArrayTypeSymbol ia ? ia.ElementType : null);
                 break;
             case InitializerExpressionSyntax initializer:
                 // A bare initializer targeting a multi-dimensional array (int[,] g = {{…},{…}})
@@ -174,7 +176,8 @@ public sealed partial class Emitter
                 if (_model.GetTypeInfo(initializer).ConvertedType is IArrayTypeSymbol { Rank: > 1 } mdInit)
                     EmitMultiDimArray(mdInit.ElementType, null, initializer);
                 else
-                    EmitInitializerArray(initializer);
+                    EmitTypedInitializerArray(initializer,
+                        _model.GetTypeInfo(initializer).ConvertedType is IArrayTypeSymbol { Rank: 1 } sdInit ? sdInit.ElementType : null);
                 break;
             case CollectionExpressionSyntax collection:
                 EmitCollectionExpression(collection);

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -2389,7 +2389,12 @@ public sealed partial class Emitter
     private void EmitArrayCreation(ArrayCreationExpressionSyntax array)
     {
         var rankSpec = array.Type.RankSpecifiers.FirstOrDefault();
-        var elementType = _model.GetTypeInfo(array.Type.ElementType).Type;
+        // The array's OWN element type — from the semantic type, NOT array.Type.ElementType: for a
+        // jagged `int[][]` the syntax element type is the innermost `int` (with two rank specifiers),
+        // but the array being created is `int[]`-element, so tagging must use `int[]`. The semantic
+        // IArrayTypeSymbol.ElementType gives the correct one for jagged and multidim alike.
+        var elementType = ((_model.GetTypeInfo(array).Type ?? _model.GetTypeInfo(array).ConvertedType) as IArrayTypeSymbol)?.ElementType
+            ?? _model.GetTypeInfo(array.Type.ElementType).Type;
         var rank = rankSpec?.Sizes.Count ?? 1;
 
         // Multi-dimensional array (int[,] …) → System.Array.create(default, initValues, T, dims…),
@@ -2403,20 +2408,40 @@ public sealed partial class Emitter
 
         if (array.Initializer is not null)
         {
-            EmitInitializerArray(array.Initializer);
+            EmitTypedInitializerArray(array.Initializer, elementType);
             return;
         }
 
-        // new T[n] → TransposeR.array(n, default)
+        // new T[n] → a JS array tagged with its element type (System.Array.init), so the value's
+        // runtime type carries $elementType — matching h5 (System.Array.init(...)) and native
+        // reflection (arr.GetType().GetElementType()), and letting the JSON serializer recognise a
+        // byte[] for base64, an element-typed array for covariance, etc.
         if (rankSpec is { Sizes.Count: 1 } && rankSpec.Sizes[0] is not OmittedArraySizeExpressionSyntax)
         {
-            _w.Write("TransposeR.array(");
+            _w.Write("System.Array.init(TransposeR.array(");
             EmitExpression(rankSpec.Sizes[0]);
-            _w.Write($", {DefaultValueLiteral(elementType!)})");
+            _w.Write($", {DefaultValueLiteral(elementType!)}), {TypeRef(elementType!)})");
             return;
         }
 
-        _w.Write("[]");
+        _w.Write($"System.Array.init([], {TypeRef(elementType!)})");
+    }
+
+    /// <summary>Emits a single-dimensional array-creation initializer as a JS array tagged with its
+    /// element type — <c>System.Array.init([…], element)</c> — so the resulting value's runtime type
+    /// exposes <c>$elementType</c> (h5 tags every array literal the same way). The array returned is
+    /// the same JS array, so indexing/length/spread are unaffected.</summary>
+    private void EmitTypedInitializerArray(InitializerExpressionSyntax initializer, ITypeSymbol? elementType)
+    {
+        if (elementType is null)
+        {
+            EmitInitializerArray(initializer);
+            return;
+        }
+
+        _w.Write("System.Array.init(");
+        EmitInitializerArray(initializer);
+        _w.Write($", {TypeRef(elementType)})");
     }
 
     /// <summary>Emits a multi-dimensional array via System.Array.create(defaultValue, initValues,
@@ -2514,6 +2539,16 @@ public sealed partial class Emitter
     /// </summary>
     private void EmitCollectionOf(ITypeSymbol? target, Action emitArrayLiteral)
     {
+        // A concrete array target tags the literal with its element type (System.Array.init) so the
+        // value's runtime type carries $elementType — same as a `new T[]{…}` creation.
+        if (target is IArrayTypeSymbol { Rank: 1 } arr)
+        {
+            _w.Write("System.Array.init(");
+            emitArrayLiteral();
+            _w.Write($", {TypeRef(arr.ElementType)})");
+            return;
+        }
+
         if (target is IArrayTypeSymbol
             || target is { TypeKind: TypeKind.Interface }
             || target?.OriginalDefinition.ToDisplayString() is "System.Span<T>" or "System.ReadOnlySpan<T>"


### PR DESCRIPTION
Continuing the Newtonsoft.Json audit, a broad, comparison-based sweep (real Newtonsoft 13.0.3 as the oracle) surfaced a transpose-specific array bug: a single-dimensional array VALUE was emitted as a bare JS array literal, so its runtime type carried no element type. Consequences:

  * new int[]{…}.GetType().GetElementType() returned null (native/h5: Int32);
  * byte[] serialized as a JSON number array instead of a base64 string, since JsonConvert's base64 path checks the value's $elementType === System.Byte;
  * array covariance / `is` / reflection over array values degraded.

h5 tags every array literal with System.Array.init([…], ElementType) (ArrayCreateBlock) — transpose emitted a bare `[…]`. Match h5: emit array creations and array-typed collection expressions as System.Array.init([…], element) (init returns the same JS array, just tagged, so indexing/length/spread are unaffected). The element type is taken from the semantic array type, not the syntax element type, so a jagged int[][] tags its element as int[] (the syntax element type is the innermost int).

Covers: `new T[]{…}`, `new[]{…}`, `T[] x = {…}`, `new T[n]`, `new T[0]`, collection expressions `T[] x = [ … ]`, and params arrays.

Also verified (no change needed): Dictionary / List / HashSet / arrays and the mosaik-shaped case — a polymorphic interface-array property with TypeNameHandling.Objects + a custom SerializationBinder — round-trip correctly against the oracle. Known remaining gaps that are shared with the h5 baseline (serialized property order follows the reflection MemberOrderer, not C# declaration order; TypeNameHandling.Auto does not stamp $type for an interface/ base-typed member) or are BCL type gaps (SortedDictionary; Queue/Stack/ LinkedList Count, whose BCL types carry no reflection metadata) are left as-is.


Claude-Session: https://claude.ai/code/session_01H3ne4YEa8Wn3KcjxoWTsy7