### PR TITLE
Update package versions to latest

### DIFF
--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2760" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2859" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.2685">
+<Project Sdk="Transpose.Build.Target/26.7.2692">
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <!-- Inherits LangVersion=latest from the Transpose.Build.Target SDK; pin an older
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="25.11.62743" />
-        <PackageReference Include="Transpose.Core" Version="25.11.62746" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="25.11.62749" />
-        <PackageReference Include="Tesserae" Version="2026.1.63737" />
+        <PackageReference Include="Transpose.BCL" Version="26.7.2859" />
+        <PackageReference Include="Transpose.Core" Version="26.7.2862" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2866" />
+        <PackageReference Include="Tesserae" Version="2026.7.68399" />
     </ItemGroup>
 </Project>

--- a/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj
+++ b/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="MSTest" Version="4.3.2" />
   </ItemGroup>
 

--- a/Transpose/Transpose.Translator/Transpose.Translator.csproj
+++ b/Transpose/Transpose.Translator/Transpose.Translator.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump NuGet package references across the toolchain and template to their
current versions:

- Microsoft.CodeAnalysis.CSharp 5.3.0 -> 5.6.0 (Translator + Tests)
- Transpose.BCL 26.7.2760 -> 26.7.2859 (Transpose.Core)
- Template: Transpose.BCL/Core/Newtonsoft.Json to 26.7.x latest,
  Tesserae 2026.1 -> 2026.7, Build.Target SDK 26.7.2685 -> 26.7.2692

NUglify stays pinned at 1.20.7 (matches the legacy compiler, per CLAUDE.md);
MSTest and Mono.Cecil are already at their latest.

Validated: toolchain builds on Roslyn 5.6.0, full translator test suite
passes (457 passed, 0 failed), and bootstrap transpiles all six binding
libraries.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018T76Nb3rtKR32HcB5mWKbi