### PR TITLE
Fix emitter bugs surfaced compiling the Curiosity FrontEnd

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1409,5 +1409,142 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- [ObjectLiteral] instance-method dispatch --------------------------
+        //
+        // An [ObjectLiteral] class's instances are plain JS objects (typically JSON-parsed) that carry
+        // NO methods of their own, so an instance method call must dispatch through the prototype —
+        // Type.prototype.Method.call(receiver, args) — not as `receiver.Method(args)` (which throws
+        // "is not a function" at runtime). This is how the Curiosity FrontEnd's Mosaik.Schema.Node /
+        // NodeOrEdge helpers (node.TryGetSource(out …), node.GetString(…)) are consumed.
+
+        [TestMethod]
+        public void ObjectLiteralInstanceCallDispatchesThroughPrototype()
+        {
+            var code = @"
+using Transpose;
+[ObjectLiteral(ObjectCreateMode.Constructor)]
+public sealed class Bag
+{
+    private Bag() { }
+    public bool TryGet(string key, out string value) { value = Script.Write<string>(""this[key]""); return value != null; }
+    public T GetAs<T>(string key) => Script.Write<T>(""this[key]"");
+}
+public class Program
+{
+    public static void Main()
+    {
+        var b = Script.Write<Bag>(""({ name: 'x' })"");
+        b.TryGet(""name"", out var v);
+        var s = b.GetAs<string>(""name"");
+    }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+            // out/ref call routes through the prototype with the receiver as the `.call` this-arg.
+            Assert.IsTrue(js.Contains("Bag.prototype.TryGet.call("),
+                "out/ref instance call on an [ObjectLiteral] type must dispatch through the prototype\n" + js);
+            // generic call: receiver precedes the threaded type argument.
+            Assert.IsTrue(js.Contains("Bag.prototype.GetAs.call(b, System.String"),
+                "generic instance call on an [ObjectLiteral] type must be Type.prototype.M.call(recv, T, args)\n" + js);
+        }
+
+        [TestMethod]
+        public async Task ObjectLiteralInstanceMethodRunsOnPlainObject()
+        {
+            // The receiver is a plain object literal (no prototype), exactly like a JSON.Parse result.
+            // Both the external call and an internal implicit-`this` sibling call must still resolve.
+            await RunTest(@"
+using System;
+using Transpose;
+[ObjectLiteral(ObjectCreateMode.Constructor)]
+public abstract class Base
+{
+    protected Base() { }
+    public bool TryGetName(out string name) => Inner(out name);      // implicit-this sibling call
+    private bool Inner(out string name) { name = GetRaw(""name""); return name != null; }
+    private string GetRaw(string key) => Script.Write<string>(""this[key]"");
+}
+[ObjectLiteral(ObjectCreateMode.Constructor)]
+public sealed class Thing : Base { private Thing() { } public int Value => Script.Write<int>(""this.Value""); }
+public class Program
+{
+    public static void Main()
+    {
+        var t = Script.Write<Thing>(""({ name: 'abc', Value: 42 })"");
+        if (t.TryGetName(out var n)) Console.WriteLine(""name="" + n + "" value="" + t.Value);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>", skipRoslyn: true);
+        }
+
+        // ---- user-defined implicit conversion at a field/property initializer ---
+        //
+        // A property/field initialized with a value of a different type must apply the user-defined
+        // implicit conversion operator, not store the raw source value. The Curiosity FrontEnd's
+        // SearchQuery.ParsedAsLanguage (type LanguageDTO, initialized `= Language.Unknown`) relied on
+        // this: without the operator the field held the raw enum number, which then serialized to a
+        // number and blew up on JSON round-trip. The operator changes the representation, so it must run.
+
+        [TestMethod]
+        public async Task ImplicitConversionOperatorAppliedAtInitializerAndAssignment()
+        {
+            await RunTest(@"
+using System;
+public struct Wrapper
+{
+    public string Code;
+    public static implicit operator Wrapper(int value) => new Wrapper { Code = ""N"" + value };
+    public static explicit operator int(Wrapper w) => int.Parse(w.Code.Substring(1));
+    public override string ToString() => ""W("" + Code + "")"";
+}
+public class Holder
+{
+    public Wrapper Prop { get; set; } = 42;   // property initializer + implicit conversion
+    public Wrapper Field = 7;                  // field initializer + implicit conversion
+}
+public class Program
+{
+    public static void Main()
+    {
+        var h = new Holder();
+        Console.WriteLine(h.Prop);             // W(N42)
+        Console.WriteLine(h.Field);            // W(N7)
+        Wrapper w = 99; Console.WriteLine(w);  // assignment: W(N99)
+        int back = (int)w; Console.WriteLine(back); // explicit op round-trips: 99
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- `this` inside the reordered-named-argument IIFE --------------------
+        //
+        // When named arguments are supplied out of parameter order, the emitter evaluates them into a
+        // temp array (source order) inside an IIFE, then hands them back in parameter order. That IIFE
+        // must be an ARROW so a `this`-qualified argument keeps the enclosing instance; a plain
+        // `function () { … }` rebinds `this` to undefined and throws "reading X of undefined". Seen in
+        // the Curiosity FrontEnd's `new SearchResultsComponent(owner: this, …, wrapResults: this._wrapResults, …)`.
+
+        [TestMethod]
+        public async Task ThisInReorderedNamedArgumentsResolvesToInstance()
+        {
+            await RunTest(@"
+using System;
+public class C
+{
+    public int X = 9;
+    private string G(int a, int b, int c) => a + "","" + b + "","" + c;
+    public string Run() => G(c: X, a: 1, b: 2); // reordered named args + this.X
+}
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new C().Run()); // 1,2,9
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1546,5 +1546,28 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- BCL implicit conversion operator (DateTime -> DateTimeOffset) ------
+        //
+        // Runtime/BCL conversion operators (assembly "Transpose") are emitted against the hand-written
+        // runtime primitives, so they must be materialised too — `DateTimeOffset x = someDate` needs
+        // op_Implicit or the value stays a DateTime and `x.AddDays(...)` throws "is not a function"
+        // (Curiosity FrontEnd MigrationsView: `DateTimeOffset startOfWeek = now.AddDays(-d).Date`).
+
+        [TestMethod]
+        public async Task BclImplicitConversionOperatorIsApplied()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        DateTimeOffset x = new DateTime(2020, 1, 1); // implicit DateTime -> DateTimeOffset
+        Console.WriteLine(x.AddDays(1).Day);          // 2 (operator materialised -> real DateTimeOffset)
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -251,7 +251,9 @@ public sealed partial class Emitter
                 EmitQuery(query);
                 break;
             case WithExpressionSyntax with:
-                _w.Write("(function ($w) { var $c = TransposeR.clone($w); ");
+                // Arrow so a `this`-qualified initializer value (record `with { X = this.Y }`)
+                // keeps the enclosing instance rather than rebinding `this` to undefined.
+                _w.Write("(($w) => { var $c = TransposeR.clone($w); ");
                 EmitInitializer("$c", with.Initializer);
                 _w.Write("return $c; })(");
                 EmitExpression(with.Expression);
@@ -276,6 +278,22 @@ public sealed partial class Emitter
     {
         // Numeric narrowing to an integer type needs truncation.
         var sourceType = _model.GetTypeInfo(expr).Type;
+
+        // User-defined IMPLICIT conversion operator. C# inserts these silently at conversion sites
+        // (assignment, argument, return, field/property initializer). The operator can change the
+        // runtime representation — e.g. LanguageDTO's `implicit operator LanguageDTO(Language)` turns
+        // an enum into its string code — so it must actually be invoked; emitting the raw source
+        // value leaks the wrong representation (and later breaks JSON round-tripping). Explicit casts
+        // go through EmitCast/EmitNumericConversion, not here.
+        if (targetType is not null && sourceType is not null
+            && !SymbolEqualityComparer.Default.Equals(sourceType, targetType)
+            && _compilation.ClassifyConversion(sourceType, targetType)
+                is { IsUserDefined: true, IsImplicit: true, MethodSymbol: IMethodSymbol convMethod }
+            && ShouldEmitUserConversion(convMethod))
+        {
+            EmitUserDefinedConversion(convMethod, expr);
+            return;
+        }
         if (targetType is not null && sourceType is not null
             && IsIntegerType(targetType) && IsFloatingType(sourceType))
         {
@@ -357,6 +375,44 @@ public sealed partial class Emitter
         }
 
         EmitExpression(expr);
+    }
+
+    /// <summary>Whether a user-defined conversion operator should be emitted as an actual call rather
+    /// than erased. We only materialise operators declared in THIS compilation's own source (or ones
+    /// carrying a [Template], which is real JS) — e.g. the FrontEnd's own LanguageDTO/UID128 structs,
+    /// whose operators change the runtime representation and must run. Operators coming from a
+    /// referenced assembly (a compiled library such as Tesserae, the BCL) or an EXTERNAL/DOM-union
+    /// type stay erased, matching how those bundles were built and the legacy compiler's behaviour:
+    /// materialising them can call a non-existent method (System.Object.op_Implicit) or re-enter a
+    /// library conversion that was compiled to expect the erased form (HSLColor → stack overflow).</summary>
+    private static bool ShouldEmitUserConversion(IMethodSymbol convMethod)
+        => TransposeNaming.GetTemplate(convMethod.OriginalDefinition) is not null
+           || TransposeNaming.GetTemplate(convMethod) is not null
+           || (convMethod.ContainingType.Locations.Any(l => l.IsInSource)
+               && !TransposeNaming.IsExternalType(convMethod.ContainingType));
+
+    /// <summary>Emits a call to a user-defined conversion operator (op_Implicit / op_Explicit),
+    /// honouring a [Template] on the operator (some BCL/binding types define theirs that way) and
+    /// otherwise emitting the static Type.op_X(operand) call.</summary>
+    private void EmitUserDefinedConversion(IMethodSymbol convMethod, ExpressionSyntax expr)
+    {
+        var template = TransposeNaming.GetTemplate(convMethod.OriginalDefinition)
+                       ?? TransposeNaming.GetTemplate(convMethod);
+        if (template is not null)
+        {
+            var argJs = Capture(() => EmitExpression(expr));
+            var byName = new Dictionary<string, string>();
+            if (convMethod.Parameters.Length > 0) byName[convMethod.Parameters[0].Name] = argJs;
+            WriteTemplate(template, isStatic: true, isExtension: false, receiver: null, byName,
+                new List<string> { argJs });
+            return;
+        }
+
+        _w.Write($"{TypeRef(convMethod.ContainingType)}.{TransposeNaming.MemberJsName(convMethod)}(");
+        // The operand may itself need converting to the operator's parameter type (e.g. an int
+        // literal widened before a `operator T(long)`); route it through the converter.
+        EmitExpressionConverted(expr, convMethod.Parameters.Length > 0 ? convMethod.Parameters[0].Type : null);
+        _w.Write(")");
     }
 
     /// <summary>A user-defined (source) struct — value-copy semantics apply. Primitive value

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -386,10 +386,28 @@ public sealed partial class Emitter
     /// materialising them can call a non-existent method (System.Object.op_Implicit) or re-enter a
     /// library conversion that was compiled to expect the erased form (HSLColor → stack overflow).</summary>
     private static bool ShouldEmitUserConversion(IMethodSymbol convMethod)
-        => TransposeNaming.GetTemplate(convMethod.OriginalDefinition) is not null
-           || TransposeNaming.GetTemplate(convMethod) is not null
-           || (convMethod.ContainingType.Locations.Any(l => l.IsInSource)
-               && !TransposeNaming.IsExternalType(convMethod.ContainingType));
+    {
+        if (TransposeNaming.GetTemplate(convMethod.OriginalDefinition) is not null
+            || TransposeNaming.GetTemplate(convMethod) is not null)
+            return true;
+
+        // External / DOM-union operators are transparent in JS and would call a non-existent method.
+        if (TransposeNaming.IsExternalType(convMethod.ContainingType)) return false;
+
+        var ct = convMethod.ContainingType;
+        // In-source (this compilation's own types, e.g. LanguageDTO/UID128) — always consistent.
+        if (ct.Locations.Any(l => l.IsInSource)) return true;
+
+        // Transpose runtime / BCL types (System.*, assembly "Transpose"/"Transpose.*"): their operators
+        // are the hand-written runtime primitives this compiler emits against (e.g. the implicit
+        // DateTime→DateTimeOffset used by `DateTimeOffset x = someDate.Date`), so materialising them is
+        // consistent. A referenced USER library (Tesserae, …) compiled by an older compiler that erased
+        // conversions is NOT consistent — calling its operator can re-enter code built for the erased
+        // form (HSLColor → stack overflow) — so those stay erased unless/until the library is rebuilt.
+        var asm = ct.ContainingAssembly?.Name;
+        return asm == "Transpose"
+               || (asm is not null && asm.StartsWith("Transpose.", System.StringComparison.Ordinal));
+    }
 
     /// <summary>Emits a call to a user-defined conversion operator (op_Implicit / op_Explicit),
     /// honouring a [Template] on the operator (some BCL/binding types define theirs that way) and

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -226,6 +226,23 @@ public sealed partial class Emitter
             return;
         }
 
+        // Instance method on an [ObjectLiteral] class → dispatch through the prototype:
+        // Type.prototype.Method.call(receiver, args). The receiver is a plain JS object (typically
+        // JSON-parsed) that carries no methods of its own, so a direct `receiver.Method(...)` would
+        // throw "is not a function". `.call` binds `this` to the receiver, then the generic type
+        // arguments and real arguments follow. Mirrors the legacy compiler's object-literal handling.
+        if (IsObjectLiteralInstanceCall(symbol))
+        {
+            _w.Write($"{TypeRef(symbol.ContainingType)}.prototype.{TransposeNaming.MemberJsName(symbol)}.call(");
+            if (receiverExpr is not null) EmitReceiverExpr(receiverExpr);
+            else if (condRecv is not null) _w.Write(condRecv);
+            else _w.Write("this");
+            var rest = Capture(() => EmitArguments(invocation.ArgumentList, symbol));
+            if (rest.Length > 0) { _w.Write(", "); _w.Write(rest); }
+            _w.Write(")");
+            return;
+        }
+
         // Ordinary call.
         if (symbol.IsStatic)
         {
@@ -450,18 +467,41 @@ public sealed partial class Emitter
         // receiver.Method(args…) — the receiver is the reduced method's first argument.
         var reduced = symbol.IsExtensionMethod ? symbol.ReducedFrom : null;
         var extReceiver = reduced is not null && invocation.Expression is MemberAccessExpressionSyntax ma ? ma.Expression : null;
+
+        // Instance method on an [ObjectLiteral] class (with out/ref args) → dispatch through the
+        // prototype, same as the ordinary path: Type.prototype.Method.call(receiver, typeArgs, args).
+        // The `.call` receiver must precede the generic type arguments.
+        var objLitCall = extReceiver is null && IsObjectLiteralInstanceCall(symbol);
+        var objLitReceiver = objLitCall && invocation.Expression is MemberAccessExpressionSyntax malit
+            && malit.Expression is not BaseExpressionSyntax ? malit.Expression : null;
+
         if (extReceiver is not null)
             _w.Write($"{TypeRef(symbol.ContainingType)}.{TransposeNaming.MemberJsName(reduced!)}");
+        else if (objLitCall)
+            _w.Write($"{TypeRef(symbol.ContainingType)}.prototype.{TransposeNaming.MemberJsName(symbol)}.call");
         else
             EmitCallee(invocation, symbol);
         _w.Write("(");
-        var lead = EmitLeadingTypeArgs(symbol);
-        var first = !lead;
-        if (extReceiver is not null)
+        bool first;
+        if (objLitCall)
         {
-            if (!first) _w.Write(", ");
-            EmitExpression(extReceiver);
+            // Receiver first (becomes `this`), then the leading generic type arguments.
+            if (objLitReceiver is not null) EmitExpression(objLitReceiver); else _w.Write("this");
+            if (ThreadsTypeArgs(symbol))
+                for (var ti = 0; ti < symbol.TypeArguments.Length; ti++)
+                    { _w.Write(", "); _w.Write(TypeRef(symbol.TypeArguments[ti])); }
             first = false;
+        }
+        else
+        {
+            var lead = EmitLeadingTypeArgs(symbol);
+            first = !lead;
+            if (extReceiver is not null)
+            {
+                if (!first) _w.Write(", ");
+                EmitExpression(extReceiver);
+                first = false;
+            }
         }
         if (args.Any(a => a.NameColon is not null))
         {
@@ -639,7 +679,10 @@ public sealed partial class Emitter
             if (reordered && !hasParams)
             {
                 if (lead) _w.Write(", ");
-                _w.Write("...(function () { var $ = [");
+                // Arrow (not `function`) so a `this`-qualified argument (e.g. a named arg
+                // `wrapResults: this._wrapResults`) resolves to the enclosing instance rather than
+                // being rebound to undefined in strict mode.
+                _w.Write("...(() => { var $ = [");
                 for (var k = 0; k < args.Count; k++)
                 {
                     if (k > 0) _w.Write(", ");
@@ -976,6 +1019,26 @@ public sealed partial class Emitter
             _w.Write(")");
         }
     }
+
+    /// <summary>True if <paramref name="type"/> or any of its base types is [ObjectLiteral]. The
+    /// attribute is Inherited, so a derived literal type counts even when only the base carries it.</summary>
+    private static bool IsObjectLiteralType(ITypeSymbol? type)
+    {
+        for (var t = type; t is not null; t = t.BaseType)
+            if (t.GetAttributes().Any(a => TransposeNaming.AttrIs(a, "Transpose.ObjectLiteralAttribute")))
+                return true;
+        return false;
+    }
+
+    /// <summary>A call to an ordinary instance method declared on an [ObjectLiteral] class. Such
+    /// instances are plain JS objects (typically JSON-parsed) with no prototype methods of their own,
+    /// so the call must dispatch through the type's prototype (Type.prototype.Method.call(receiver, …))
+    /// rather than as a direct member call. Interface members are excluded — that is a separate, rarer
+    /// form the legacy compiler routes through the runtime type instead.</summary>
+    private static bool IsObjectLiteralInstanceCall(IMethodSymbol symbol)
+        => symbol is { IsStatic: false, IsExtensionMethod: false, MethodKind: MethodKind.Ordinary }
+           && symbol.ContainingType is { TypeKind: not TypeKind.Interface }
+           && IsObjectLiteralType(symbol.ContainingType);
 
     /// <summary>The ObjectInitializationMode of an [ObjectLiteral] attribute (0=Ignore, 1=Initializer,
     /// 2=DefaultValue), or 0 when unspecified — only the ObjectInitializationMode constructor argument
@@ -1934,7 +1997,9 @@ public sealed partial class Emitter
             }
             else
             {
-                _w.Write("(function ($v) { ");
+                // Arrow so a `this`-qualified operand (e.g. `this.Count++` in expression position)
+                // resolves to the enclosing instance rather than rebinding `this` to undefined.
+                _w.Write("(($v) => { ");
                 EmitExpression(postfix.Operand);
                 _w.Write(" = $v");
                 _w.Write(step);
@@ -1971,9 +2036,25 @@ public sealed partial class Emitter
     // ---- cast --------------------------------------------------------------
 
     private void EmitCast(CastExpressionSyntax cast)
-        => EmitNumericConversion(_model.GetTypeInfo(cast.Type).Type,
-                                 _model.GetTypeInfo(cast.Expression).Type,
-                                 cast.Expression);
+    {
+        var targetType = _model.GetTypeInfo(cast.Type).Type;
+        var sourceType = _model.GetTypeInfo(cast.Expression).Type;
+
+        // A cast that resolves to a user-defined conversion operator (implicit or explicit) must
+        // invoke it — e.g. `(int)myInt` → MyInt.op_Explicit(myInt). Erasing it leaks the source
+        // value through, which then mismatches (and breaks a matching implicit conversion elsewhere).
+        if (targetType is not null && sourceType is not null
+            && !SymbolEqualityComparer.Default.Equals(sourceType, targetType)
+            && _compilation.ClassifyConversion(sourceType, targetType)
+                is { IsUserDefined: true, MethodSymbol: IMethodSymbol convMethod }
+            && ShouldEmitUserConversion(convMethod))
+        {
+            EmitUserDefinedConversion(convMethod, cast.Expression);
+            return;
+        }
+
+        EmitNumericConversion(targetType, sourceType, cast.Expression);
+    }
 
     /// <summary>
     /// Emits an explicit numeric conversion honouring C#'s truncation / wrapping rules. Handles

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -109,10 +109,10 @@ public sealed partial class Emitter
                         // initializers which run in declaration order and may reference them.
                         foreach (var (target, slotType) in staticStructDefaults)
                             _w.WriteLine($"{staticRef}.{target} = Transpose.getDefaultValue({TypeRef(slotType)});");
-                        foreach (var (target, init) in staticInitAssignments)
+                        foreach (var (target, init, slotType) in staticInitAssignments)
                         {
                             _w.Write($"{staticRef}.{target} = ");
-                            EmitExpression(init);
+                            EmitExpressionConverted(init, slotType);
                             _w.WriteLine(";");
                         }
                         if (staticCtor?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is ConstructorDeclarationSyntax { Body: { } body })
@@ -155,14 +155,14 @@ public sealed partial class Emitter
         });
     }
 
-    private IEnumerable<(string target, ExpressionSyntax init)> StaticInitializers(INamedTypeSymbol type)
+    private IEnumerable<(string target, ExpressionSyntax init, ITypeSymbol slotType)> StaticInitializers(INamedTypeSymbol type)
     {
         foreach (var m in type.GetMembers().Where(m => m.IsStatic))
         {
             if (m is IFieldSymbol f && !f.IsConst && f.AssociatedSymbol is null && FieldInitializerSyntax(f) is { } fi)
-                yield return (TransposeNaming.MemberJsName(f), fi);
+                yield return (TransposeNaming.MemberJsName(f), fi, f.Type);
             else if (m is IPropertySymbol p && IsAutoProperty(p) && AutoPropertyInitializerSyntax(p) is { } pi)
-                yield return (TransposeNaming.MemberJsName(p), pi);
+                yield return (TransposeNaming.MemberJsName(p), pi, p.Type);
         }
     }
 
@@ -439,7 +439,7 @@ public sealed partial class Emitter
             if (init is not null)
             {
                 _w.Write($"this.{TransposeNaming.MemberJsName(m)} = ");
-                EmitExpression(init);
+                EmitExpressionConverted(init, slotType);
                 _w.WriteLine(";");
             }
             else if (NeedsStructDefaultInit(slotType))


### PR DESCRIPTION
## Summary

While testing the Mosaik server front-end compiled by Transpose (navigating ~100 routes and monitoring the browser console), I found several emitter bugs that broke pages at runtime. Each was reproduced with a minimal snippet, root-caused in the emitter, fixed, covered by a regression test, and validated against the proven-correct **h5** output where applicable. The full translator test suite stays green (459 passed / 0 failed).

Overall this cut the front-end's browser-console error events from **167 → 85** across the route sweep.

## Fixes

**1. `[ObjectLiteral]` instance-method calls dispatch through the prototype**
Instances of an `[ObjectLiteral]` class are plain JS objects (typically `JSON.parse` results) that carry no methods of their own, so `receiver.M(...)` threw *"is not a function"* (e.g. `Mosaik.Schema.Node.TryGetSource`). Calls now emit `Type.prototype.M.call(receiver, args)`. Covers the ordinary and out/ref call paths and implicit-`this` sibling calls. Matches h5.

**2. User-defined conversion operators are materialised instead of erased**
Implicit/explicit conversion operators were dropped at conversion sites (assignment, argument, return, field/property/static initializer, explicit cast), so a source struct whose operator changes the runtime representation (e.g. `LanguageDTO`'s `Language`→code-string) leaked the raw value and later broke JSON round-tripping (`SearchRequest.Clone`). They are now invoked. Scope is deliberately limited to **in-source** types and the **Transpose runtime/BCL** (e.g. the implicit `DateTime`→`DateTimeOffset`, which fixed `startOfWeek.AddDays`); operators on referenced user libraries compiled by an older erasing compiler, and external/DOM-union types, stay erased so we don't call a non-existent method or re-enter code built for the erased form. h5 emits the identical `LanguageDTO.op_Implicit$1(...)`.

**3. Reordered-named-argument IIFE preserves `this`**
When named arguments are supplied out of order, the emitter evaluates them into a temp array inside an IIFE. It used a plain `function () { … }`, rebinding `this` to `undefined` in strict mode, so a `this`-qualified argument threw (`new SearchResultsComponent(owner: this, …, wrapResults: this._wrapResults, …)`). It is now an arrow. The same latent defect in the `record with { … }` and postfix-on-complex-operand wrappers is fixed too.

## Tests

Added to `EmitRegressionTests.cs`: object-literal prototype dispatch (emit + Node run), implicit conversion at initializer/assignment/cast, BCL `DateTime`→`DateTimeOffset` conversion, and `this` inside reordered named arguments. Whole suite: `Passed! - Failed: 0`.

## Not addressed here

`CancellationTokenSource.Dispose()` still emits `Dispose` while the runtime defines `dispose` (camelCase, matching h5's `cts.dispose()`) — a pre-existing BCL interface-method naming inconsistency that needs a runtime rebuild + package change, out of scope for this emitter-only PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCNVs1ievEHdw4VY2WYPbj)_