### PR TITLE
Update Transpose and Tesserae package references to latest versions

### DIFF
--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2859" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2760" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2760" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2760" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2760" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2760" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.2859" />
-        <PackageReference Include="Transpose.Core" Version="26.7.2862" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2866" />
-        <PackageReference Include="Tesserae" Version="2026.7.68399" />
+        <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+        <PackageReference Include="Transpose.Core" Version="26.7.2871" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2881" />
+        <PackageReference Include="Tesserae" Version="2026.7.68409" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump `Transpose.BCL` (26.7.2760/26.7.2859 → 26.7.2882) across `BCL/Transpose.Core`, the `Packages/*` binding libraries, and the project template
- Bump `Transpose.Core` (26.7.2771/26.7.2862 → 26.7.2871) across the `Packages/*` binding libraries and the project template
- Bump `Transpose.Newtonsoft.Json` (26.7.2866 → 26.7.2881) in the project template
- Bump `Tesserae` (2026.7.68399 → 2026.7.68409) in the project template

`Mono.Cecil`, `Microsoft.CodeAnalysis.CSharp`, `MSTest`, and the `Transpose.Build.Target` SDK were already at their latest published versions. `NUglify` is intentionally pinned to 1.20.7 (matches the legacy compiler, per `CLAUDE.md`) and was left untouched.

## Test plan
- [ ] Not built/tested per request — versions were verified against the latest available on NuGet.org

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWFiiNF7nmU7WjQDLqPpx)_