### PR TITLE
Fix generic method threading and out-var hoisting in local functions

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1537,6 +1537,31 @@ public class Program
         }
 
         [TestMethod]
+        public async Task IntPlusUintPromotesToLongResult()
+        {
+            // C# binary numeric promotion: `int + uint` has no common 32-bit type, so both promote to
+            // `long` and the result is `long`. The sum must be a real Int64 at runtime — it flows into a
+            // `long`-typed variable whose later `< 0` / indexing use the Int64 helpers (.lt/.add/…). If
+            // the addition stays a plain JS number the downstream `visualIndex.lt(...)` throws
+            // `visualIndex.lt is not a function` (LogsView.ValidateVisibleRowHeights on #/manage/operate/logs).
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        int startIndex = 5;
+        for (uint i = 0; i < 3; i++)
+        {
+            var visualIndex = startIndex + i;   // int + uint => long
+            Console.WriteLine(visualIndex.GetType().Name);
+            Console.WriteLine(visualIndex < 0 || visualIndex >= 100 ? ""oob"" : ""ok "" + visualIndex);
+        }
+    }
+}");
+        }
+
+        [TestMethod]
         public void GenericMethodInTransposeNamedLibraryThreadsTypeArgs()
         {
             // A Transpose.*-named binding library that carries real implementation (NOT [assembly:External])

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1537,6 +1537,31 @@ public class Program
         }
 
         [TestMethod]
+        public void GenericMethodInTransposeNamedLibraryThreadsTypeArgs()
+        {
+            // A Transpose.*-named binding library that carries real implementation (NOT [assembly:External])
+            // must thread its generic methods' type args as leading JS parameters, so runtime uses of the
+            // type parameter in the body (IEnumerable<T>, typeof(T), …) resolve. IsTransposeCompiledSource
+            // classifies any Transpose.*-named assembly as runtime purely by name, so ThreadsTypeArgs must
+            // still thread a non-external, body-having generic method there.
+            // Regression: Transpose.Plotly.Bindings.flatten2DArrayIf1D<T> emitted `function (values)` while
+            // the body referenced `T` → `ReferenceError: T is not defined` on #/manage/operate/usage.
+            var code = @"
+using System.Collections.Generic;
+using System.Linq;
+public static class Bindings
+{
+    public static object Flatten<T>(IEnumerable<IEnumerable<T>> values) => values.First().ToArray();
+}";
+            var result = new RoslynTranslator().Translate(
+                new[] { ("App.cs", code) }, "Transpose.Plotly", null, new[] { "DEBUG" });
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+            Assert.IsTrue(js.Contains("Flatten: function (T,"),
+                "a non-external body-having generic method in a Transpose.*-named library must thread its type args\n" + js);
+        }
+
+        [TestMethod]
         public async Task ObjectLiteralInstanceMethodRunsOnPlainObject()
         {
             // The receiver is a plain object literal (no prototype), exactly like a JSON.Parse result.

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1512,6 +1512,31 @@ public class Program
         }
 
         [TestMethod]
+        public async Task ExpressionBodiedLocalFunctionHoistsOutVar()
+        {
+            // A local function with an EXPRESSION body whose expression introduces an out-var
+            // (`string F() => dict.TryGetValue(k, out var v) ? v : null`) must predeclare `var v;`
+            // in the arrow's block — the write-back `v = $ref.v` happens inside a condition IIFE but
+            // `v` is read outside it. Without the hoist the name is undeclared and strict-mode bundles
+            // throw `ReferenceError: v is not defined` (seen as `u is not defined` in the front-end's
+            // InspectChatView.CurrentUidParam). Method/lambda bodies already hoisted; local functions did not.
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        var state = new Dictionary<string, string> { { ""uid"", ""abc"" } };
+        string CurrentUidParam() => state.TryGetValue(""uid"", out var u) ? u : null;
+        string Missing() => state.TryGetValue(""nope"", out var u) ? u : ""fallback"";
+        Console.WriteLine(CurrentUidParam() ?? ""NULL"");
+        Console.WriteLine(Missing());
+    }
+}");
+        }
+
+        [TestMethod]
         public async Task ObjectLiteralInstanceMethodRunsOnPlainObject()
         {
             // The receiver is a plain object literal (no prototype), exactly like a JSON.Parse result.

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -394,19 +394,15 @@ public sealed partial class Emitter
         // External / DOM-union operators are transparent in JS and would call a non-existent method.
         if (TransposeNaming.IsExternalType(convMethod.ContainingType)) return false;
 
-        var ct = convMethod.ContainingType;
-        // In-source (this compilation's own types, e.g. LanguageDTO/UID128) — always consistent.
-        if (ct.Locations.Any(l => l.IsInSource)) return true;
-
-        // Transpose runtime / BCL types (System.*, assembly "Transpose"/"Transpose.*"): their operators
-        // are the hand-written runtime primitives this compiler emits against (e.g. the implicit
-        // DateTime→DateTimeOffset used by `DateTimeOffset x = someDate.Date`), so materialising them is
-        // consistent. A referenced USER library (Tesserae, …) compiled by an older compiler that erased
-        // conversions is NOT consistent — calling its operator can re-enter code built for the erased
-        // form (HSLColor → stack overflow) — so those stay erased unless/until the library is rebuilt.
-        var asm = ct.ContainingAssembly?.Name;
-        return asm == "Transpose"
-               || (asm is not null && asm.StartsWith("Transpose.", System.StringComparison.Ordinal));
+        // Every other user-defined operator is materialised as a real op_X call: in-source types
+        // (this compilation's own LanguageDTO/UID128), the Transpose runtime/BCL primitives (System.*,
+        // the implicit DateTime→DateTimeOffset), AND referenced user libraries. The current compiler
+        // always emits the operator method (op_Implicit/op_Explicit) into the library it defines, so a
+        // cross-assembly call resolves — e.g. Curiosity.FrontEnd calling the implicit
+        // Language→Mosaik.Schema.Optional<Language> defined in Curiosity.FrontEnd.Core (erasing it left
+        // `SaveUILanguage(l.Value, …)` passing a raw enum → `undefined.HasValue` on #/preferences).
+        // Only external/DOM operators (guarded above) stay erased.
+        return true;
     }
 
     /// <summary>Emits a call to a user-defined conversion operator (op_Implicit / op_Explicit),

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1347,13 +1347,18 @@ public sealed partial class Emitter
         // 64-bit integer arithmetic/comparison → System.Int64/UInt64 method calls. Decide on the
         // operands' DECLARED types, not the converted ones: `int >= uint` is promoted to `long` by
         // C#, but int/uint are plain JS numbers (only actual long/ulong are boxed Int64/UInt64
-        // instances with .gte/.add/… methods), so such a comparison must stay a plain operator.
+        // instances with .gte/.add/… methods), so such a comparison (bool result) stays a plain
+        // operator. An ARITHMETIC op whose RESULT is 64-bit even though both operands are narrow —
+        // `int + uint` promotes to `long` — must still produce a real Int64, or the long value flows
+        // as a plain number into a `long` variable whose later `.lt`/`.add`/… throws
+        // (`visualIndex.lt is not a function` in LogsView.ValidateVisibleRowHeights).
         var leftDeclared = _model.GetTypeInfo(binary.Left).Type ?? leftType;
         var rightDeclared = _model.GetTypeInfo(binary.Right).Type ?? rightType;
         // `long op decimal` (and vice-versa) is promoted to decimal by C#, so it must go through the
         // decimal path below — not Int64 (which would do integer division etc.). Guard against a
         // decimal operand here.
-        if ((Is64BitInteger(leftDeclared) || Is64BitInteger(rightDeclared)) && Long64Op(binary) is not null
+        if ((Is64BitInteger(leftDeclared) || Is64BitInteger(rightDeclared) || Is64BitInteger(resultType))
+            && Long64Op(binary) is not null
             && !IsDecimalType(leftDeclared) && !IsDecimalType(rightDeclared))
         {
             EmitLong64Binary(binary, leftDeclared, rightDeclared);

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -668,13 +668,18 @@ public sealed partial class Emitter
         if (def.GetAttributes().Any(a => TransposeNaming.AttrIs(a, "Transpose.IgnoreGenericAttribute"))) return false;
         // A templated method's call shape is the template itself — no separate leading type args.
         if (TransposeNaming.GetTemplate(def) is not null) return false;
-        // Source / referenced-library generic methods always thread. So do Transpose.dll BCL generic
-        // methods that have a real body (a plain C# generic method, e.g.
-        // CollectionExtensions.GetValueOrDefault / TryAdd — compiled with leading type parameters).
-        // A body-less extern (hand-written JS, incl. the DOM externs in Transpose.Core like
-        // querySelector<T>) uses its native form and must NOT thread.
+        // Source / referenced-library generic methods always thread.
         if (TransposeNaming.IsTransposeCompiledSource(method.ContainingType)) return true;
-        return method.ContainingAssembly?.Name == "Transpose" && !TransposeNaming.HasNoBody(def);
+        // Otherwise the containing type is a Transpose runtime/binding assembly (classified so by name).
+        // Its EXTERNAL types — Transpose.Core's [assembly:External] DOM bindings, whose members like
+        // Node.appendChild<T> are native JS and use their native call form — must NOT thread. A
+        // non-external type that carries a real method body threads its type args as leading JS
+        // parameters: the base "Transpose" BCL's generic methods (e.g. CollectionExtensions.TryAdd) and
+        // a Transpose.*-named library with genuine implementation (e.g. Transpose.Plotly's
+        // Bindings.flatten2DArrayIf1D<T>, which IsTransposeCompiledSource treats as runtime purely by its
+        // Transpose.* assembly name). A body-less extern (hand-written JS) uses its native form.
+        if (TransposeNaming.IsExternalType(method.ContainingType)) return false;
+        return !TransposeNaming.HasNoBody(def);
     }
 
     private void EmitOptionalDefaults(IMethodSymbol method)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -870,6 +870,11 @@ public sealed partial class Emitter
                     }
                     else if (localFn.ExpressionBody is not null)
                     {
+                        // Hoist out-var / is-pattern variables the expression introduces (e.g.
+                        // `string F() => dict.TryGetValue(k, out var v) ? v : null`) so their
+                        // write-backs and later reads resolve — an expression body has no statement
+                        // to predeclare them otherwise (matches EmitMethodBody / EmitAccessorBody).
+                        PredeclareInlineVars(localFn.ExpressionBody.Expression);
                         if (symbol?.ReturnsVoid == true) EmitExpressionStatement(localFn.ExpressionBody.Expression);
                         else { _w.Write("return "); EmitExpression(localFn.ExpressionBody.Expression); _w.WriteLine(";"); }
                     }


### PR DESCRIPTION
## Summary

This PR fixes three related bugs in the Transpose compiler affecting generic methods, binary operator type promotion, and local function expression bodies:

1. **Generic method type argument threading in Transpose.* libraries** — Non-external generic methods in `Transpose.*`-named binding libraries now correctly thread their type arguments as leading JS parameters, fixing `ReferenceError: T is not defined` when the method body references the type parameter.

2. **Out-var hoisting in expression-bodied local functions** — Expression-bodied local functions that introduce out-variables (e.g., `string F() => dict.TryGetValue(k, out var v) ? v : null`) now predeclare those variables, fixing `ReferenceError: v is not defined` in strict-mode bundles.

3. **64-bit result type detection in binary arithmetic** — Binary operations where both operands are narrow types but the result promotes to 64-bit (e.g., `int + uint` → `long`) now correctly emit Int64 method calls instead of plain JS operators, fixing `.lt is not a function` errors.

4. **User-defined operator materialization** — Simplified the logic to always materialize user-defined conversion operators except for external/DOM types, fixing cases where cross-assembly implicit conversions were incorrectly erased.

## Key Changes

- **Emitter.Members.cs** (`ThreadsTypeArgs`): Refactored to check `IsExternalType` explicitly rather than relying on assembly name alone. Non-external methods in `Transpose.*` libraries now thread type args as leading parameters, matching the behavior of source and referenced-library generics.

- **Emitter.Statements.cs** (`EmitLocalFunction`): Added `PredeclareInlineVars` call for expression-bodied local functions to hoist out-var and is-pattern variables, matching the behavior of method and accessor bodies.

- **Emitter.Expressions2.cs** (`EmitBinary`): Extended the 64-bit integer check to include the result type, not just operand types. This ensures `int + uint` (which promotes to `long`) produces a real Int64 instance.

- **Emitter.Expressions.cs** (`ShouldEmitUserConversion`): Simplified to always materialize user-defined operators except external types, removing the overly restrictive assembly-name check that was erasing cross-assembly implicit conversions.

## Tests Added

Three regression tests cover the fixed scenarios:
- `ExpressionBodiedLocalFunctionHoistsOutVar` — validates out-var hoisting in local function expressions
- `IntPlusUintPromotesToLongResult` — validates 64-bit result type detection in binary arithmetic
- `GenericMethodInTransposeNamedLibraryThreadsTypeArgs` — validates type arg threading in non-external `Transpose.*` methods

https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF