### PR TITLE
Block-scope C# locals with let so sibling-block same-named locals sta…

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -606,9 +606,9 @@ public class Program
 }";
             var result = new RoslynTranslator().Translate(code);
             Assert.IsTrue(result.Success, "translation should succeed");
-            // Predeclared outside a loop → `var` (matching regular locals, so it coexists with any
-            // same-named function-scoped local).
-            Assert.IsTrue(result.Javascript!.Contains("var s;"),
+            // Predeclared block-scoped with `let` (matching regular locals), so sibling-scope
+            // same-named locals stay distinct and closures capture the right binding.
+            Assert.IsTrue(result.Javascript!.Contains("let s;"),
                 "an is-pattern variable in an expression-bodied property must be predeclared\n" + result.Javascript);
         }
 
@@ -1686,6 +1686,46 @@ public class Program
         long l = 7; int i = 3; bool c = false;
         long m = c ? l : i;                                                   // int branch -> long
         System.Console.WriteLine(m);                                          // 3
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task SiblingBlockSameNameLocalsCapturedIndependently()
+        {
+            // C# block-scopes a local to its block, so same-named locals in sibling blocks are distinct
+            // and each closure captures its own. JS `var` is function-scoped, so emitting all three as
+            // `var pending` made every closure see the last value (C,C,C). Block-scoped `let` restores
+            // per-block bindings. Mirrors API.Aggregated.ActuallyTriggerDelayedTasksIfRequired (three
+            // sibling `if` blocks, each `var pending = ...` captured by a fire-and-forget task).
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static void Main()
+    {
+        var actions = new List<Func<string>>();
+        if (true) { var pending = ""A""; actions.Add(() => pending); }
+        if (true) { var pending = ""B""; actions.Add(() => pending); }
+        if (true) { var pending = ""C""; actions.Add(() => pending); }
+        foreach (var a in actions) System.Console.WriteLine(a());   // A B C
+
+        // Nested blocks reusing a name at multiple depths, each captured.
+        var deep = new List<Func<string>>();
+        { var v = ""d1""; { var w = ""d2""; { var v2 = ""d3""; deep.Add(() => v + w + v2); } } }
+        { var v = ""e1""; deep.Add(() => v); }
+        foreach (var d in deep) System.Console.WriteLine(d());      // d1d2d3  e1
+
+        // Loop body local captured per-iteration (already block-scoped).
+        var loop = new List<Func<int>>();
+        for (int i = 0; i < 3; i++) { var x = i * 10; loop.Add(() => x); }
+        foreach (var f in loop) System.Console.WriteLine(f());      // 0 10 20
+
+        // A classic for-loop variable is a single shared binding (closures see the final value).
+        var shared = new List<Func<int>>();
+        for (int i = 0; i < 3; i++) shared.Add(() => i);
+        foreach (var f in shared) System.Console.WriteLine(f());    // 3 3 3
     }
 }");
         }

--- a/Transpose/Transpose.Translator.Tests/EnumEmitModeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EnumEmitModeTests.cs
@@ -30,7 +30,7 @@ public class Program {{ public static void Main() {{ var x = Dir.TopLeft; }} }}
         {
             var js = Emit("Value");
             // Reference compiles to the raw ordinal, not Dir.TopLeft.
-            Assert.IsTrue(js.Contains("var x = 0"), "Emit.Value should inline the ordinal\n" + js);
+            Assert.IsTrue(js.Contains("let x = 0") || js.Contains("var x = 0"), "Emit.Value should inline the ordinal\n" + js);
         }
 
         [TestMethod]

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -149,7 +149,7 @@ public sealed partial class Emitter
         // out-var coexist with a same-named regular local elsewhere in the function (both flattened
         // to function scope) — a `let` predeclaration would collide with such a `var` local
         // ("Identifier 'x' has already been declared").
-        var kw = _loopDepth > 0 && _gotoContexts.Count == 0 ? "let" : "var";
+        var kw = _gotoContexts.Count > 0 ? "var" : "let";
         var blockScope = _predeclaredInScope.Count > 0 ? _predeclaredInScope.Peek() : null;
         foreach (var name in names.Distinct())
         {
@@ -331,7 +331,7 @@ public sealed partial class Emitter
         // Transpose's model and tolerates the same-name redeclarations across flattened scopes that some
         // code relies on (which `let` would reject). A goto state machine also needs `var` so a
         // local persists across `case` transitions as the loop re-enters the switch.
-        var kw = _loopDepth > 0 && _gotoContexts.Count == 0 ? "let" : "var";
+        var kw = _gotoContexts.Count > 0 ? "var" : "let";
         foreach (var variable in local.Declaration.Variables)
         {
             _w.Write($"{kw} {NameMangler.JsIdentifier(variable.Identifier.Text)}");


### PR DESCRIPTION
…y distinct

C# locals are block-scoped, so same-named locals in sibling (non-overlapping) blocks are independent bindings and a closure captures its own. The emitter declared non-loop locals with function-scoped JS var, so three sibling `if` blocks each with `var pending = ...` collapsed to ONE binding — every captured fire-and-forget task saw the last value
(API.Aggregated.ActuallyTriggerDelayedTasksIfRequired: the node-type task read the many-fields `pending`, throwing `Invalid UID128 input`). Emit non-loop locals (and predeclared out-var/pattern variables) with block-scoped `let` instead; keep `var` only for goto state machines (a local must persist across `case` re-entry) and the classic for-loop header (single shared binding). Verified against C# and JS scoping semantics (sibling/nested/loop/for + closures) and the full front-end route walk.


Claude-Session: https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF