### PR TITLE
Define the conditional-compilation symbol as TRANSPOSE (upper-case)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -118,8 +118,8 @@ The change is almost entirely in `using` directives:
 - `using H5.Core;` → `using Transpose.Core;`
 - Fully-qualified references `H5.Something` → `Transpose.Something`,
   `H5.Core.Something` → `Transpose.Core.Something`.
-- Conditional compilation: `#if H5` → `#if Transpose` (Transpose defines the
-  `Transpose` symbol during transpilation).
+- Conditional compilation: `#if H5` → `#if TRANSPOSE` (Transpose defines the
+  `TRANSPOSE` symbol during transpilation).
 
 Things that **do not** change (they are unqualified names or preserved tokens):
 

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -56,7 +56,7 @@ internal static class ProjectResolver
             .Select(s => s.Trim())
             .Where(s => s.Length > 0)
             .ToList();
-        if (!defines.Contains("Transpose")) defines.Add("Transpose"); // Transpose projects always compile the Transpose branch
+        if (!defines.Contains("TRANSPOSE")) defines.Add("TRANSPOSE"); // Transpose projects always compile the TRANSPOSE branch (#if TRANSPOSE)
 
         // Configuration-driven symbols the .NET SDK defines implicitly: TRACE in every configuration,
         // DEBUG in the Debug configuration. Without these, `#if DEBUG` never compiles in a `-c Debug`

--- a/Transpose/Transpose.Translator.Tests/Infrastructure/NewtonsoftJsonRunner.cs
+++ b/Transpose/Transpose.Translator.Tests/Infrastructure/NewtonsoftJsonRunner.cs
@@ -56,7 +56,7 @@ public static class NewtonsoftJsonRunner
             sources,
             PackageAssemblyName,
             extraReferencePaths: null,
-            preprocessorSymbols: new[] { "Transpose", "TRACE" },
+            preprocessorSymbols: new[] { "TRANSPOSE", "TRACE" },
             emitAssembly: true);
 
         if (result.AssemblyBytes is null || result.Javascript is null)


### PR DESCRIPTION
tps injected a mixed-case `Transpose` preprocessor symbol, so source used `#if Transpose`. Define the upper-case `TRANSPOSE` instead, so conditional compilation reads `#if TRANSPOSE`, consistent with the SDK-style all-caps symbols (DEBUG/TRACE/NETSTANDARD*). Updates the injection in ProjectResolver, the test harness symbol, and the migration doc. Consumers update their `#if Transpose` directives (and any hardcoded <DefineConstants>) to TRANSPOSE.


Claude-Session: https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF