### PR TITLE
Fix nullable-enum ToString and property-accessor [Name] emission

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -1981,5 +1981,83 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- Nullable<T>.ToString()/GetHashCode() must not pass the type as the converter fn ----
+        //
+        // The {T:ToString} / {T:GetHashCode} template placeholders (System.Nullable.toString/.getHashCode
+        // second arg) resolved to the bound type itself, so the runtime called the *type* as a function
+        // (System.Nullable.toString(icon, UIcons) → UIcons(icon)) and crashed with "Cannot read
+        // properties of undefined (reading '$initialize')" — hit rendering search results where a
+        // UIcons? icon flowed into icon.ToString(). An enum must convert through System.Enum.toString
+        // (native toString gives the number, not the name); bool/char need their own converters; every
+        // other type (and all GetHashCode) drops the arg so the runtime falls back correctly.
+
+        [TestMethod]
+        public async Task NullableToStringAndGetHashCodeMatchNative()
+        {
+            await RunTest(@"
+using System;
+[Flags] public enum Perm { None = 0, Read = 1, Write = 2, Exec = 4 }
+public enum Big : long { A = 1L, B = 5000000000L }
+public class Program
+{
+    public static void Main()
+    {
+        Perm? icon = Perm.Read;
+        Console.WriteLine(icon.ToString());                     // Read
+        Perm? flags = Perm.Read | Perm.Write;
+        Console.WriteLine(flags.ToString());                    // Read, Write
+        Console.WriteLine(flags.GetHashCode());                 // 3
+        Perm? none = null;
+        Console.WriteLine(""["" + none.ToString() + ""]"");         // []
+        Console.WriteLine(none.GetHashCode());                  // 0
+        Big? big = Big.B;
+        Console.WriteLine(big.ToString());                      // B
+        bool? b = true;
+        Console.WriteLine(b.ToString());                        // True
+        char? c = 'X';
+        Console.WriteLine(c.ToString());                        // X
+        int? i = 42;
+        Console.WriteLine(i.ToString());                        // 42
+        Console.WriteLine(i.GetHashCode());                     // 42
+        Console.WriteLine(((int)((Perm?)null).GetValueOrDefault()).ToString()); // 0 ({T:default} still works)
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- [Name] on a property ACCESSOR renames the property's JS slot ----
+        //
+        // Roslyn attaches an accessor-level attribute to the get/set method, not the property, so a
+        // property-only [Name] lookup missed it: Tesserae's ReadOnlyArray<T>.Length has its GETTER
+        // marked [Name("length")] to hit the native JS array `.length`. From a referenced (non-source,
+        // non-external) assembly the access emitted `.Length` (capital), which is undefined on a plain
+        // array — so `.Where(g => g.Values.Length > 0)` dropped every group, GetNodeTypesAndFields
+        // returned empty, and the node/field dropdown's `.Single()` threw "No element satisfies the
+        // condition". The property's JS name must fall back to its accessor's [Name].
+
+        [TestMethod]
+        public void NameOnPropertyAccessorRenamesJsSlot()
+        {
+            var code = @"
+using Transpose;
+public class Box
+{
+    public int Count { [Name(""cnt"")] get; set; }
+    public int Total { [Name(""tot"")] set; get; }
+}
+public class Program
+{
+    public static int Read(Box b) => b.Count + b.Total;
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+            Assert.IsTrue(js.Contains("b.cnt") && js.Contains("b.tot"),
+                "a property whose accessor carries [Name] must emit that JS slot for access\n" + js);
+            Assert.IsFalse(js.Contains("b.Count") || js.Contains("b.Total"),
+                "the verbatim C# property name must not leak when an accessor [Name] renames the slot\n" + js);
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -687,6 +687,11 @@ public sealed partial class Emitter
                 (map ??= new())[ps[i].Name] = TypeRef(args[i]);
                 // {T:default} in a template → the default value of the bound type argument.
                 map[ps[i].Name + ":default"] = DefaultValueLiteral(args[i]);
+                // {T:ToString} → a value→string FUNCTION for the bound type (fn arg of
+                // System.Nullable.toString). Only types whose native toString diverges from
+                // .NET get one; the rest drop the arg (see SubstituteTemplate) and fall back.
+                if (ToStringFnLiteral(args[i]) is { } tsFn)
+                    map[ps[i].Name + ":ToString"] = tsFn;
             }
         }
         if (member.ContainingType is { IsGenericType: true } ct)
@@ -694,6 +699,27 @@ public sealed partial class Emitter
         if (member is IMethodSymbol { IsGenericMethod: true } m)
             Add(m.OriginalDefinition.TypeParameters, m.TypeArguments);
         return map;
+    }
+
+    /// <summary>
+    /// The JS function that converts a value of <paramref name="t"/> to its .NET <c>ToString()</c>
+    /// form — used to resolve the <c>{T:ToString}</c> template placeholder (the <c>fn</c> argument of
+    /// <c>System.Nullable.toString</c>). Returns <c>null</c> when the value's own runtime
+    /// <c>toString()</c> already matches .NET (int, double, Int64, decimal, DateTime, structs, …);
+    /// the runtime helper then falls back to <c>a.toString()</c>. Only <c>enum</c> (native toString
+    /// gives the underlying number, not the name), <c>bool</c> ("true"/"false" vs .NET "True"/"False")
+    /// and <c>char</c> (a code-point number vs the character) need an explicit converter.
+    /// </summary>
+    private string? ToStringFnLiteral(ITypeSymbol t)
+    {
+        if (t.TypeKind == TypeKind.Enum)
+            return $"System.Enum.toStringFn({TypeRef(t)})";
+        return t.SpecialType switch
+        {
+            SpecialType.System_Boolean => "function ($v) { return System.Boolean.toString($v); }",
+            SpecialType.System_Char    => "function ($v) { return String.fromCharCode($v); }",
+            _                          => null,
+        };
     }
 
     private void EmitMethodGroup(IMethodSymbol method, ExpressionSyntax? thisTarget)
@@ -904,6 +930,19 @@ public sealed partial class Emitter
             // {param:version} — the assembly/compiler version string (used by the SystemAssembly
             // version-marker template). Resolved to the version this build was invoked with.
             if (modifier == "version") return "\"" + AssemblyVersion + "\"";
+            // {T:ToString} / {T:GetHashCode} → a value→string / value→hash FUNCTION for the bound
+            // type, the fn arg of System.Nullable.toString / .getHashCode. Only a type whose native
+            // toString diverges from .NET carries an explicit converter (in the type-arg map); every
+            // other type — and all GetHashCode — drops the arg so the runtime falls back to
+            // a.toString() / Transpose.getHashCode(a). Passing the bare type here (the old behaviour)
+            // called the type as a function and crashed with "$initialize of undefined".
+            if (modifier is "ToString" or "GetHashCode")
+            {
+                var fnKey = token + ":" + modifier;
+                if (argsByName.TryGetValue(fnKey, out var fnExpr)) return fnExpr;
+                if (typeArgs is not null && typeArgs.TryGetValue(fnKey, out var fnExpr2)) return fnExpr2;
+                return drop;
+            }
             if (token == "this") return ApplyArgModifier(modifier, receiver ?? "this");
             if (token.StartsWith("*"))
             {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -368,6 +368,8 @@ public sealed partial class Emitter
         {
             byName[definition.TypeParameters[i].Name] = TypeRef(constructed.TypeArguments[i]);
             byName[definition.TypeParameters[i].Name + ":default"] = DefaultValueLiteral(constructed.TypeArguments[i]);
+            if (ToStringFnLiteral(constructed.TypeArguments[i]) is { } tsFn)
+                byName[definition.TypeParameters[i].Name + ":ToString"] = tsFn;
         }
 
         var defType = definition.ContainingType;
@@ -378,6 +380,8 @@ public sealed partial class Emitter
             {
                 byName[defType.TypeParameters[i].Name] = TypeRef(conType.TypeArguments[i]);
                 byName[defType.TypeParameters[i].Name + ":default"] = DefaultValueLiteral(conType.TypeArguments[i]);
+                if (ToStringFnLiteral(conType.TypeArguments[i]) is { } tsFn)
+                    byName[defType.TypeParameters[i].Name + ":ToString"] = tsFn;
             }
         }
     }

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -115,6 +115,26 @@ internal static class TransposeNaming
         => GetStringAttr(symbol, NameAttr);
 
     /// <summary>
+    /// The explicit [Name] that renames a property/event's JS slot: the member's own [Name] if
+    /// present, otherwise the [Name] on one of its accessors (property get/set, event add/remove).
+    /// h5 allows <c>[Name]</c> on an accessor to rename the whole member — e.g. Tesserae's
+    /// <c>ReadOnlyArray&lt;T&gt;.Length</c> whose getter is <c>[Name("length")]</c> so the access hits
+    /// the native JS array <c>.length</c>. Roslyn attaches an accessor-level attribute to the accessor
+    /// method, not the property/event, so a member-only lookup (which happened to work for source
+    /// [External] types via the camelCase convention) silently emitted <c>.Length</c> for a referenced
+    /// non-external type and broke <c>.Where(g => g.Values.Length > 0)</c>.
+    /// </summary>
+    public static string? PropertyEffectiveName(ISymbol symbol)
+    {
+        if (GetName(symbol) is { } own) return own;
+        if (symbol is IPropertySymbol { IsIndexer: false } p)
+            return (p.GetMethod is { } g ? GetName(g) : null) ?? (p.SetMethod is { } s ? GetName(s) : null);
+        if (symbol is IEventSymbol e)
+            return (e.AddMethod is { } a ? GetName(a) : null) ?? (e.RemoveMethod is { } r ? GetName(r) : null);
+        return null;
+    }
+
+    /// <summary>
     /// The raw-JavaScript body lines of a member's <c>[Transpose.Script(...)]</c>, or null when
     /// absent. When present, these lines become the member's body verbatim and the C# body (if any)
     /// is discarded — the mechanism for hand-writing a method/accessor/operator implementation.
@@ -377,7 +397,7 @@ internal static class TransposeNaming
         // Only Transpose-compiled members (source or referenced library) get a slot suffix: an
         // external/native member (e.g. a DOM NodeListOf<T>.length hiding NodeList.length) maps to
         // a single fixed JS property, so suffixing it would reference a nonexistent property.
-        if (GetName(symbol) is null
+        if (PropertyEffectiveName(symbol) is null
             && symbol is IPropertySymbol { IsIndexer: false } or IFieldSymbol or IEventSymbol)
         {
             // Hiding suffix is only meaningful for Transpose-compiled members (external/native
@@ -437,7 +457,7 @@ internal static class TransposeNaming
     /// <summary>The base JS name of a property/field/event (before any hiding suffix).</summary>
     private static string RawMemberName(ISymbol symbol)
     {
-        if (GetName(symbol) is { } name) return name;
+        if (PropertyEffectiveName(symbol) is { } name) return name;
 
         // Enum members honour the [Enum(Emit.Name*)] casing modes on their own JS name: NameLowerCase
         // (8) lowercases, NameUpperCase (9) uppercases; Name (1) / NamePreserveCase (7) and every


### PR DESCRIPTION
Two emit bugs surfaced compiling the Curiosity front-end, both diverging from native .NET and the h5 baseline:

- Nullable<T>.ToString()/GetHashCode() passed the bound type itself as the converter fn ({T:ToString}/{T:GetHashCode} resolved to the type, ignoring the modifier), so the runtime called the type as a function and crashed with 'Cannot read properties of undefined (reading $initialize)' — e.g. a UIcons? icon flowing into icon.ToString() while rendering search hits. Resolve the placeholder to a real value->string function (enum via System.Enum.toStringFn, bool/char via their converters) and drop the arg otherwise so the runtime falls back to the value's own toString.

- [Name] on a property/event ACCESSOR (get/set/add/remove) was ignored when the member came from a referenced assembly: Roslyn attaches an accessor-level attribute to the accessor method, not the member, so a member-only lookup emitted the verbatim C# name. Tesserae's ReadOnlyArray<T>.Length has its getter marked [Name("length")] to hit the native JS array .length; from metadata it emitted .Length (undefined on an array), so .Where(g => g.Values.Length > 0) dropped every group, GetNodeTypesAndFields returned empty and the node/field dropdown's .Single() threw 'No element satisfies the condition'. Fall back to the accessor's [Name] when the member has none.

Adds regression tests for both. Full translator suite green (478 passed).


Claude-Session: https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF