### PR TITLE
Update package dependencies to latest versions

### DIFF
--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
-        <PackageReference Include="Transpose.Core" Version="26.7.2871" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2881" />
-        <PackageReference Include="Tesserae" Version="2026.7.68409" />
+        <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+        <PackageReference Include="Transpose.Core" Version="26.7.2904" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2905" />
+        <PackageReference Include="Tesserae" Version="2026.7.68442" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps the outdated NuGet dependencies across the `dotnet new` template and the binding libraries to their latest published versions.

## Updated

| Package | From | To |
| --- | --- | --- |
| `Transpose.BCL` | 26.7.2882 | 26.7.2919 |
| `Transpose.Core` | 26.7.2871 | 26.7.2904 |
| `Transpose.Newtonsoft.Json` | 26.7.2881 | 26.7.2905 |
| `Tesserae` | 2026.7.68409 | 2026.7.68442 |

## Left unchanged

- `Mono.Cecil` (0.11.6), `Microsoft.CodeAnalysis.CSharp` (5.6.0) and `MSTest` (4.3.2) are already at their latest versions.
- `NUglify` stays pinned to 1.20.7 to match the legacy compiler, per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vjmbt1MSnq4vKMtgbG9f5D)_