### PR TITLE
Honor the 2-arg [Template(format, nonExpandedFormat)] for non-expande…

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -2301,5 +2301,83 @@ public class Program
     }
 }", waitForOutput: "<<DONE>>");
         }
+
+        // ---- [Template] 2-arg (format, nonExpandedFormat) — the non-expanded params variant ----
+        //
+        // A 2-arg [Template] gives a second template for when the trailing `params` argument is supplied
+        // NON-expanded (a single array passed directly) rather than as individual elements. The emitter
+        // only ever used the first template. It now routes a non-expanded params call to the second:
+        //   Activator.CreateInstance(type, argsArray) → Transpose.Reflection.applyConstructor(type, …)
+        //   MethodInfo.Invoke(obj, argsArray)         → midel(this,obj).apply(null, …)
+        // while expanded (individual-element) calls keep the first template. Test source uses only
+        // System.Reflection, so native .NET is the oracle.
+
+        private const string NonExpandedParamsProgram = @"
+using System;
+using System.Reflection;
+public class Foo { public int V; public Foo(int a, int b) { V = a + b; } public int Add(int a, int b) => a + b; }
+public class Program
+{
+    public static void Main()
+    {
+        object[] ctorArgs = new object[] { 2, 3 };
+        Console.WriteLine(((Foo)Activator.CreateInstance(typeof(Foo), ctorArgs)).V); // 5  (non-expanded array)
+        Console.WriteLine(((Foo)Activator.CreateInstance(typeof(Foo), 4, 5)).V);     // 9  (expanded)
+
+        var m = typeof(Foo).GetMethod(""Add"");
+        var f = new Foo(0, 0);
+        object[] callArgs = new object[] { 10, 20 };
+        Console.WriteLine(m.Invoke(f, callArgs));   // 30 (non-expanded array)
+        Console.WriteLine(m.Invoke(f, 3, 4));       // 7  (expanded)
+        Console.WriteLine(""<<DONE>>"");
+    }
+}";
+
+        [TestMethod]
+        public async Task TemplateNonExpandedParamsVariantMatchesNative()
+        {
+            // Native oracle uses only calls that also bind in real .NET: Activator.CreateInstance has a
+            // (Type, params object[]) overload (both array and expanded forms compile), and
+            // MethodInfo.Invoke(obj, object[]) takes the array form. (The expanded Invoke(obj, a, b) is a
+            // Transpose BCL params overload with no .NET counterpart, so it is covered by the
+            // translate-only assertion below, not here.)
+            await RunTest(@"
+using System;
+using System.Reflection;
+public class Foo { public int V; public Foo(int a, int b) { V = a + b; } public int Add(int a, int b) => a + b; }
+public class Program
+{
+    public static void Main()
+    {
+        object[] ctorArgs = new object[] { 2, 3 };
+        Console.WriteLine(((Foo)Activator.CreateInstance(typeof(Foo), ctorArgs)).V); // 5  (non-expanded array)
+        Console.WriteLine(((Foo)Activator.CreateInstance(typeof(Foo), 4, 5)).V);     // 9  (expanded)
+
+        var m = typeof(Foo).GetMethod(""Add"");
+        var f = new Foo(0, 0);
+        object[] callArgs = new object[] { 10, 20 };
+        Console.WriteLine(m.Invoke(f, callArgs));   // 30 (non-expanded array)
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        [TestMethod]
+        public void TemplateNonExpandedParamsSelectsSecondTemplate()
+        {
+            var result = new RoslynTranslator().Translate(NonExpandedParamsProgram);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+            // Non-expanded (single array) → the nonExpandedFormat variant.
+            Assert.IsTrue(js.Contains("Transpose.Reflection.applyConstructor(Foo, [...ctorArgs])"),
+                "a non-expanded Activator.CreateInstance must use applyConstructor\n" + js);
+            Assert.IsTrue(js.Contains(".apply(null, [...callArgs])"),
+                "a non-expanded MethodInfo.Invoke must use .apply\n" + js);
+            // Expanded (individual elements) → the primary format.
+            Assert.IsTrue(js.Contains("Transpose.createInstance(Foo, [4, 5])"),
+                "an expanded Activator.CreateInstance must use createInstance with an array literal\n" + js);
+            Assert.IsTrue(js.Contains("midel(f, f)(3, 4)") || js.Contains(")(3, 4)"),
+                "an expanded MethodInfo.Invoke must spread the individual args\n" + js);
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -145,6 +145,16 @@ public sealed partial class Emitter
         var origin = symbol.OriginalDefinition;
         var template = TransposeNaming.GetTemplate(origin) ?? TransposeNaming.GetTemplate(symbol);
 
+        // A 2-arg [Template(format, nonExpandedFormat)]: when the trailing `params` argument is supplied
+        // as a single array passed directly (non-expanded), prefer the nonExpandedFormat variant — e.g.
+        // MethodInfo.Invoke(obj, argsArray) → midel(this,obj).apply(null, {arguments:array}) rather than
+        // the expanded midel(this,obj)({*arguments}). Individual-element (expanded) calls keep `format`.
+        if (template is not null && IsNonExpandedParamsCall(invocation.ArgumentList, symbol)
+            && (TransposeNaming.GetTemplateNonExpanded(origin) ?? TransposeNaming.GetTemplateNonExpanded(symbol)) is { } nonExpandedTemplate)
+        {
+            template = nonExpandedTemplate;
+        }
+
         // by-ref args (no template): holder objects with write-back.
         if (template is null && HasByRefArguments(invocation.ArgumentList, symbol))
         {
@@ -319,6 +329,25 @@ public sealed partial class Emitter
     }
 
     /// <summary>Captures each argument's JS, keyed by parameter name and by position.</summary>
+    /// <summary>
+    /// True when the call supplies the method's trailing <c>params</c> parameter as a SINGLE array
+    /// passed directly (non-expanded) — one positional argument per parameter, the last assignable to
+    /// the params array type — rather than as individual elements. Mirrors the spread test in
+    /// <see cref="CaptureArguments"/>; used to select the 2-arg [Template]'s nonExpandedFormat.
+    /// </summary>
+    private bool IsNonExpandedParamsCall(ArgumentListSyntax argList, IMethodSymbol method)
+    {
+        if (method.Parameters.Length == 0 || !method.Parameters[^1].IsParams) return false;
+
+        var args = argList.Arguments;
+        if (args.Count != method.Parameters.Length) return false;
+        if (args.Any(a => a.NameColon is not null)) return false;
+
+        var pi = method.Parameters.Length - 1;
+        var soleArgType = _model.GetTypeInfo(args[pi].Expression).Type;
+        return soleArgType is not null && _compilation.ClassifyConversion(soleArgType, method.Parameters[pi].Type).Exists;
+    }
+
     private (Dictionary<string, string> byName, List<string> byPos) CaptureArguments(ArgumentListSyntax argList, IMethodSymbol method)
     {
         var byName = new Dictionary<string, string>();

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -126,6 +126,21 @@ internal static class TransposeNaming
         return null;
     }
 
+    /// <summary>
+    /// The second positional argument of a 2-arg <c>[Template(format, nonExpandedFormat)]</c> — the
+    /// template to use when the method's trailing <c>params</c> argument is supplied NON-expanded (a
+    /// single array passed directly) rather than as individual elements. E.g. MethodInfo.Invoke uses
+    /// <c>midel(this,obj).apply(null, {arguments:array})</c> instead of <c>midel(this,obj)({*arguments})</c>.
+    /// Null when the attribute has fewer than two positional string arguments.
+    /// </summary>
+    public static string? GetTemplateNonExpanded(ISymbol? symbol)
+    {
+        if (symbol is null) return null;
+        var attr = symbol.GetAttributes().FirstOrDefault(a => AttrIs(a, TemplateAttr));
+        if (attr is null || attr.ConstructorArguments.Length < 2) return null;
+        return attr.ConstructorArguments[1].Value as string;
+    }
+
     /// <summary>The explicit [Name] for a member/type, or null.</summary>
     public static string? GetName(ISymbol symbol)
         => GetStringAttr(symbol, NameAttr);


### PR DESCRIPTION
…d params

The second positional argument of a 2-arg [Template] is the template to use when a method's trailing `params` argument is supplied non-expanded (a single array passed directly) rather than as individual elements. The emitter only ever used the first template.

A non-expanded params call now routes to the second template:
  Activator.CreateInstance(type, argsArray) -> Transpose.Reflection.applyConstructor(type, ...)
  MethodInfo.Invoke(obj, argsArray)         -> midel(this, obj).apply(null, ...)
while expanded (individual-element) calls keep the first template
(createInstance(...) / midel(this, obj)(...)). Non-expanded detection reuses the
same single-array-assignable test CaptureArguments uses for spread capture.

Behaviour was already correct via spread capture ([...args] / (...args)); this routes each case through the template the BCL author declared for it. Adds a run-vs-native test (Activator both forms + Invoke array form) and a template-selection assertion test.


Claude-Session: https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF