### PR TITLE
Update package references to latest published versions

### DIFF
--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2920" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2920" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2920" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2904" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2920" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
-        <PackageReference Include="Transpose.Core" Version="26.7.2904" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2905" />
-        <PackageReference Include="Tesserae" Version="2026.7.68442" />
+        <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
+        <PackageReference Include="Transpose.Core" Version="26.7.2920" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2921" />
+        <PackageReference Include="Tesserae" Version="2026.7.68468" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump `Transpose.BCL` 26.7.2919 → 26.7.2947 and `Transpose.Core` 26.7.2904 → 26.7.2920 across `BCL/Transpose.Core` and the `Packages/*` binding libraries
- Bump `Transpose.Newtonsoft.Json` 26.7.2905 → 26.7.2921 and the `Tesserae` reference 2026.7.68442 → 2026.7.68468 in the `dotnet new` project template
- `NUglify` stays pinned at `1.20.7` (intentional, matches the legacy compiler's minification behavior per `CLAUDE.md`); `Mono.Cecil`, `Microsoft.CodeAnalysis.CSharp`, and `MSTest` were already at their latest versions

## Test plan
- [x] `dotnet restore Transpose.slnx` — all bumped package versions resolve
- [x] `dotnet build Transpose.slnx` — toolchain projects (Translator, Compiler, Translator.Tests, Template) build clean; the BCL/Packages projects fail with a pre-existing `tps: not found` error (the `tps` CLI isn't installed globally in this environment) — reproduced identically on the unmodified branch, unrelated to this change
- Not run per request: full test suite / bootstrap

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnPnZexQJzr5LMoZjVZkh4)_