### PR TITLE
Confine clean-output-folder prune to files the project itself authored

### DIFF
--- a/Transpose/Transpose.Compiler/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler/OutputBuilder.cs
@@ -74,9 +74,10 @@ internal static class OutputBuilder
         var utf8 = new UTF8Encoding(false);
 
         // Every file this build writes, by full path. After the site is assembled, cleanOutputFolder
-        // diffs the folder against this set and prunes whatever is left over from an earlier build —
-        // so nothing the current build produced is ever deleted. All disk writes below funnel through
-        // WriteText, RecordWrite, or the resource/extract helpers, each of which records here.
+        // diffs *this project's own* previous output (a persisted manifest) against this set and prunes
+        // only what this project wrote last time but no longer writes — never a file some other project
+        // or package placed in a shared output folder. All disk writes below funnel through WriteText or
+        // the resource/extract helpers, each of which records here.
         var written = new HashSet<string>(PathComparer);
 
         void WriteText(string rel, string content)
@@ -206,10 +207,16 @@ internal static class OutputBuilder
         if (!config.HtmlDisabled)
             WriteHtml(project, config, outputDir, jsOuts, cssLinks, configuration, utf8, written);
 
-        // 5. Prune whatever the previous build left behind but this one did not re-produce.
+        // 5. Prune only files THIS project authored in an earlier build and no longer writes — read
+        //    from its own manifest — then persist the current file list as the next manifest. Files
+        //    other projects/packages/tools placed in a shared output folder are never in this project's
+        //    manifest, so they are never touched.
+        var manifestPath = ManifestPath(outputDir, project.AssemblyName);
         var removed = config.CleanOutputFolder
-            ? PruneStaleFiles(outputDir, written, config.CleanOutputFolderExclude)
+            ? PruneStaleFiles(outputDir, written, ReadManifest(manifestPath, outputDir), config.CleanOutputFolderExclude)
             : Array.Empty<string>();
+
+        WriteManifest(manifestPath, outputDir, written, utf8);
 
         return new SiteBuildResult(outputDir, removed);
     }
@@ -741,29 +748,39 @@ internal static class OutputBuilder
         OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
     /// <summary>
-    /// The "clean output folder" step: after the site is assembled, every file already in
-    /// <paramref name="outputDir"/> that this build did <em>not</em> (re)write — recorded in
-    /// <paramref name="written"/> — is a leftover from a previous build (a removed resource, a
-    /// renamed bundle, a <c>.min</c> variant no longer produced, a stale <c>index.min.html</c>) and is
-    /// deleted; directories it empties are removed too. Files matching an <paramref name="excludeGlobs"/>
-    /// pattern are kept even when stale. Unlike the legacy h5 <c>cleanOutputFolderBeforeBuild</c> —
-    /// which deleted by glob before compiling, risking loss of output when a build later failed — this
-    /// runs after a successful assembly and can only ever remove files the current build did not
-    /// produce. A delete that fails (a locked or read-only file) is skipped rather than failing the
-    /// build. Returns the files removed, for reporting.
+    /// The "clean output folder" step: prunes files THIS project authored in an <em>earlier</em> build
+    /// (recorded in <paramref name="previouslyWritten"/>, read from its own manifest) that the current
+    /// build no longer writes (not in <paramref name="written"/>) — a removed resource, a renamed
+    /// bundle, a <c>.min</c> variant no longer produced, a stale <c>index.min.html</c>. Directories it
+    /// empties are removed too. Files matching an <paramref name="excludeGlobs"/> pattern are kept even
+    /// when stale.
+    ///
+    /// Crucially, the candidate set is <em>this project's own</em> previous output, not "every file in
+    /// the folder": a site output directory is routinely shared — several entry apps compile into one
+    /// folder, and MSBuild or other tools drop assets there — and diffing against the whole folder
+    /// would delete files this project never authored. Diffing against the project's manifest confines
+    /// the prune to files it is actually responsible for. (The first build after upgrading from a
+    /// compiler with no manifest simply writes one and prunes nothing — strictly safe.)
+    ///
+    /// Unlike the legacy h5 <c>cleanOutputFolderBeforeBuild</c> — which deleted by glob before
+    /// compiling, risking loss of output when a build later failed — this runs after a successful
+    /// assembly and can only ever remove files the current build did not produce. A delete that fails
+    /// (a locked or read-only file) is skipped rather than failing the build. Returns the files
+    /// removed, for reporting.
     /// </summary>
-    internal static IReadOnlyList<string> PruneStaleFiles(string outputDir, HashSet<string> written, IReadOnlyList<string> excludeGlobs)
+    internal static IReadOnlyList<string> PruneStaleFiles(
+        string outputDir, HashSet<string> written, IReadOnlyCollection<string> previouslyWritten, IReadOnlyList<string> excludeGlobs)
     {
         var removed = new List<string>();
         var fullOut = Path.GetFullPath(outputDir);
-        if (!Directory.Exists(fullOut)) return removed;
+        if (!Directory.Exists(fullOut) || previouslyWritten.Count == 0) return removed;
 
         var excludes = excludeGlobs.Where(g => !string.IsNullOrWhiteSpace(g)).Select(GlobToRegex).ToList();
 
-        foreach (var file in Directory.EnumerateFiles(fullOut, "*", SearchOption.AllDirectories))
+        foreach (var full in previouslyWritten)
         {
-            var full = Path.GetFullPath(file);
-            if (written.Contains(full)) continue;   // (re)written by this build — never a candidate
+            if (written.Contains(full)) continue;   // (re)written by this build — not stale
+            if (!File.Exists(full)) continue;        // already gone (manual delete, another build)
 
             if (excludes.Count > 0)
             {
@@ -778,6 +795,63 @@ internal static class OutputBuilder
 
         RemoveEmptyDirectories(fullOut);
         return removed;
+    }
+
+    /// <summary>
+    /// The per-project build manifest: a hidden file in the output directory listing every file the
+    /// project's last build wrote, so the next build knows exactly which files it is responsible for
+    /// pruning. Keyed by assembly name (sanitised to a safe leaf) so several projects compiling into
+    /// the same output folder each keep — and prune against — their own manifest without clobbering
+    /// one another's. The manifest is never itself recorded in <c>written</c>, so it is never a prune
+    /// candidate and never listed in the generated HTML.
+    /// </summary>
+    private static string ManifestPath(string outputDir, string assemblyName)
+    {
+        var safe = new string(assemblyName.Select(c => char.IsLetterOrDigit(c) || c is '.' or '_' or '-' ? c : '_').ToArray());
+        if (safe.Length == 0) safe = "project";
+        return Path.Combine(Path.GetFullPath(outputDir), $".tps-manifest.{safe}.json");
+    }
+
+    /// <summary>Reads the paths a previous build of this project wrote (full, normalised paths), or an
+    /// empty set when there is no manifest yet (first build, or upgrade from a manifest-less compiler)
+    /// or it can't be read — in which case nothing is pruned.</summary>
+    private static IReadOnlyCollection<string> ReadManifest(string manifestPath, string outputDir)
+    {
+        var result = new HashSet<string>(PathComparer);
+        if (!File.Exists(manifestPath)) return result;
+
+        var fullOut = Path.GetFullPath(outputDir);
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return result;
+            foreach (var e in doc.RootElement.EnumerateArray())
+            {
+                var rel = e.GetString();
+                if (string.IsNullOrEmpty(rel)) continue;
+                result.Add(Path.GetFullPath(Path.Combine(fullOut, rel.Replace('/', Path.DirectorySeparatorChar))));
+            }
+        }
+        catch { /* a corrupt/unreadable manifest simply means "prune nothing this run" */ }
+        return result;
+    }
+
+    /// <summary>Persists the files this build wrote as the next run's manifest, as output-relative,
+    /// forward-slashed paths (portable if the site folder moves). A write failure is non-fatal — the
+    /// next build just falls back to pruning nothing.</summary>
+    private static void WriteManifest(string manifestPath, string outputDir, HashSet<string> written, UTF8Encoding utf8)
+    {
+        var fullOut = Path.GetFullPath(outputDir);
+        try
+        {
+            var rels = written
+                .Select(f => Path.GetRelativePath(fullOut, f).Replace('\\', '/'))
+                .OrderBy(r => r, StringComparer.Ordinal)
+                .ToList();
+            var json = JsonSerializer.Serialize(rels, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(manifestPath, json, utf8);
+        }
+        catch { /* non-fatal: without a manifest the next build prunes nothing, which is safe */ }
     }
 
     /// <summary>Removes directories left empty by the prune, deepest first, keeping the output root.</summary>

--- a/Transpose/Transpose.Translator.Tests/CleanOutputFolderTests.cs
+++ b/Transpose/Transpose.Translator.Tests/CleanOutputFolderTests.cs
@@ -3,10 +3,13 @@ using Transpose.Compiler;
 namespace Transpose.Translator.Tests;
 
 /// <summary>
-/// Covers the "clean output folder" prune (<see cref="OutputBuilder.PruneStaleFiles"/>): after a
-/// site build, files a previous build produced but this one did not re-write are removed, the
-/// directories they empty are cleaned up, current outputs are always kept, and
-/// <c>cleanOutputFolderExclude</c> globs protect hand-placed files.
+/// Covers the "clean output folder" prune (<see cref="OutputBuilder.PruneStaleFiles"/>). The prune is
+/// manifest-based: its candidate set is the files <em>this project</em> wrote in a previous build (the
+/// persisted manifest), not "every file in the folder". So a file the current build no longer writes
+/// is removed, current outputs are always kept, directories emptied by the prune are cleaned up,
+/// <c>cleanOutputFolderExclude</c> globs protect hand-placed files, and — crucially — a file this
+/// project never authored (dropped by a sibling entry app, a package, or MSBuild into a shared output
+/// folder) is never a candidate and always survives.
 /// </summary>
 [TestClass]
 public sealed class CleanOutputFolderTests
@@ -34,33 +37,56 @@ public sealed class CleanOutputFolderTests
         return Path.GetFullPath(full);
     }
 
-    private HashSet<string> Written(params string[] fullPaths)
+    private HashSet<string> Set(params string[] fullPaths)
         => new(fullPaths, OutputBuilder.PathComparer);
 
     [TestMethod]
-    public void PrunesOnlyFilesTheBuildDidNotWrite()
+    public void PrunesOnlyFilesThePreviousBuildWroteButThisOneDidNot()
     {
-        var kept = Touch("app.js");
+        var kept     = Touch("app.js");
         var alsoKept = Touch("index.html");
-        Touch("old-app.js");            // stale — not in the written set
-        Touch("app.min.js");            // stale variant no longer produced
+        var stale    = Touch("old-app.js");     // in the previous manifest, not re-written now
+        var staleMin = Touch("app.min.js");     // variant no longer produced
 
-        var removed = OutputBuilder.PruneStaleFiles(_dir, Written(kept, alsoKept), Array.Empty<string>());
+        var written  = Set(kept, alsoKept);
+        var previous = Set(kept, alsoKept, stale, staleMin);
+
+        var removed = OutputBuilder.PruneStaleFiles(_dir, written, previous, Array.Empty<string>());
 
         Assert.IsTrue(File.Exists(kept), "current output app.js must survive");
         Assert.IsTrue(File.Exists(alsoKept), "current output index.html must survive");
-        Assert.IsFalse(File.Exists(Path.Combine(_dir, "old-app.js")), "stale file must be pruned");
-        Assert.IsFalse(File.Exists(Path.Combine(_dir, "app.min.js")), "stale variant must be pruned");
+        Assert.IsFalse(File.Exists(stale), "stale file must be pruned");
+        Assert.IsFalse(File.Exists(staleMin), "stale variant must be pruned");
         Assert.AreEqual(2, removed.Count);
+    }
+
+    [TestMethod]
+    public void FilesThisProjectNeverAuthoredAreNeverPruned()
+    {
+        // The reported bug: a shared output folder also holds assets a *sibling* project/package wrote
+        // (here msk.chatview.css). They are absent from this project's manifest, so even though the
+        // current build didn't write them they must not be touched.
+        var kept    = Touch("app.js");
+        var stale   = Touch("old-app.js");                  // this project's own stale output
+        var foreign = Touch("assets/css/msk.chatview.css"); // authored by another project — must survive
+
+        var written  = Set(kept);
+        var previous = Set(kept, stale);                    // foreign file is NOT in this project's manifest
+
+        var removed = OutputBuilder.PruneStaleFiles(_dir, written, previous, Array.Empty<string>());
+
+        Assert.IsTrue(File.Exists(foreign), "a file this project never authored must never be pruned");
+        Assert.IsFalse(File.Exists(stale), "this project's own stale output must still be pruned");
+        Assert.AreEqual(1, removed.Count);
     }
 
     [TestMethod]
     public void RemovesDirectoriesLeftEmptyByThePrune()
     {
-        var kept = Touch("app.js");
-        Touch("oldassets/old.css");     // stale, and its folder becomes empty
+        var kept  = Touch("app.js");
+        var stale = Touch("oldassets/old.css");     // stale, and its folder becomes empty
 
-        OutputBuilder.PruneStaleFiles(_dir, Written(kept), Array.Empty<string>());
+        OutputBuilder.PruneStaleFiles(_dir, Set(kept), Set(kept, stale), Array.Empty<string>());
 
         Assert.IsFalse(Directory.Exists(Path.Combine(_dir, "oldassets")), "emptied directory must be removed");
         Assert.IsTrue(Directory.Exists(_dir), "the output root itself must remain");
@@ -69,10 +95,10 @@ public sealed class CleanOutputFolderTests
     [TestMethod]
     public void KeepsNonEmptyDirectories()
     {
-        var kept = Touch("assets/app.js");
-        Touch("assets/stale.js");       // stale sibling; folder still has app.js afterwards
+        var kept  = Touch("assets/app.js");
+        var stale = Touch("assets/stale.js");       // stale sibling; folder still has app.js afterwards
 
-        OutputBuilder.PruneStaleFiles(_dir, Written(kept), Array.Empty<string>());
+        OutputBuilder.PruneStaleFiles(_dir, Set(kept), Set(kept, stale), Array.Empty<string>());
 
         Assert.IsTrue(File.Exists(kept));
         Assert.IsFalse(File.Exists(Path.Combine(_dir, "assets", "stale.js")));
@@ -82,11 +108,11 @@ public sealed class CleanOutputFolderTests
     [TestMethod]
     public void ExcludeGlobProtectsMatchingFilesByName()
     {
-        var kept = Touch("app.js");
-        Touch("keepme.txt");            // stale but protected by name
-        Touch("data.bak");              // stale but protected by *.bak
+        var kept   = Touch("app.js");
+        var txt    = Touch("keepme.txt");            // stale but protected by name
+        var bak    = Touch("data.bak");              // stale but protected by *.bak
 
-        var removed = OutputBuilder.PruneStaleFiles(_dir, Written(kept), new[] { "keepme.txt", "*.bak" });
+        var removed = OutputBuilder.PruneStaleFiles(_dir, Set(kept), Set(kept, txt, bak), new[] { "keepme.txt", "*.bak" });
 
         Assert.IsTrue(File.Exists(Path.Combine(_dir, "keepme.txt")), "exact-name exclude must protect the file");
         Assert.IsTrue(File.Exists(Path.Combine(_dir, "data.bak")), "wildcard exclude must protect the file");
@@ -96,10 +122,10 @@ public sealed class CleanOutputFolderTests
     [TestMethod]
     public void ExcludeGlobMatchesByRelativePath()
     {
-        var kept = Touch("app.js");
-        Touch("vendor/lib.js");         // stale but under a protected subtree
+        var kept  = Touch("app.js");
+        var stale = Touch("vendor/lib.js");         // stale but under a protected subtree
 
-        OutputBuilder.PruneStaleFiles(_dir, Written(kept), new[] { "vendor/*" });
+        OutputBuilder.PruneStaleFiles(_dir, Set(kept), Set(kept, stale), new[] { "vendor/*" });
 
         Assert.IsTrue(File.Exists(Path.Combine(_dir, "vendor", "lib.js")), "path-glob exclude must protect nested files");
     }
@@ -110,9 +136,23 @@ public sealed class CleanOutputFolderTests
         var a = Touch("app.js");
         var b = Touch("app.meta.js");
 
-        var removed = OutputBuilder.PruneStaleFiles(_dir, Written(a, b), Array.Empty<string>());
+        var removed = OutputBuilder.PruneStaleFiles(_dir, Set(a, b), Set(a, b), Array.Empty<string>());
 
         Assert.AreEqual(0, removed.Count);
         Assert.IsTrue(File.Exists(a) && File.Exists(b));
+    }
+
+    [TestMethod]
+    public void EmptyPreviousManifestPrunesNothing()
+    {
+        // First build after upgrading from a manifest-less compiler: no prior manifest, so nothing is a
+        // candidate even though the folder holds files the current build didn't write.
+        var kept    = Touch("app.js");
+        var unknown = Touch("mystery.js");
+
+        var removed = OutputBuilder.PruneStaleFiles(_dir, Set(kept), Set(), Array.Empty<string>());
+
+        Assert.IsTrue(File.Exists(unknown), "with no previous manifest the prune must be a no-op");
+        Assert.AreEqual(0, removed.Count);
     }
 }


### PR DESCRIPTION
The site prune (cleanOutputFolder) diffed the whole output directory against the files the current build wrote and deleted everything else. When several entry apps compile into one shared output folder (or MSBuild and packages drop assets there), that wrongly removed files the current project never authored - e.g. building the Default front-end entry app wiped the msk.*.css assets a sibling entry app had placed.

Make the prune manifest-based instead. After each successful build the project persists a hidden per-assembly manifest (.tps-manifest.<asm>.json) listing exactly the files it wrote, and the next build prunes only (previousManifest - currentlyWritten). Files the project never authored are never candidates and always survive; its own renamed/removed outputs are still cleaned up. The first build after upgrading from a manifest-less compiler simply writes a manifest and prunes nothing (strictly safe).

Updates CleanOutputFolderTests to the new signature and adds coverage for the reported case (foreign files survive) and the empty-manifest no-op.


Claude-Session: https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF