### PR TITLE
Speed up tps builds ~64-70%, ship the compiler ReadyToRun, and fix error reporting + &lt;Import&gt; resolution

### DIFF
--- a/.claude/skills/transpose-performance/SKILL.md
+++ b/.claude/skills/transpose-performance/SKILL.md
@@ -54,19 +54,30 @@ git worktree add /tmp/tps-base <base-commit>
 BASE=/tmp/tps-base/Transpose/Transpose.Compiler/bin/Release/net10.0/tps
 ```
 
-The corpus is the **tesserae** repo (a sibling checkout): `Tesserae` is a single 263-file / ~69k-line
-project, and `Tesserae.Tests` adds a second project that depends on it — which is what exercises the
-multi-project path (`tps` compiles the dependency first, then the site build).
+The corpus is the **tesserae** repo, checked in as a submodule at `benchmarks/tesserae` so CI and a
+local run measure the same code:
+
+```bash
+git submodule update --init benchmarks/tesserae
+```
+
+`Tesserae` is a single 263-file / ~69k-line project; `Tesserae.Tests` adds a second project that depends
+on it, which is what exercises the multi-project path (`tps` compiles the dependency first, then the
+site build). A sibling checkout also works — pass `--tesserae <path>`.
 
 ## The loop
 
 ### 1. Where does this build spend its time and memory?
 
 ```bash
-cd <tesserae>
+cd benchmarks/tesserae
 rm -rf Tesserae/bin Tesserae/obj                 # clean slate — see "Cleaning" below
 $TPS --project Tesserae/Tesserae.csproj -c Debug --timing
 ```
+
+**Debug and Release are structurally different builds**, not just different optimisation flags: Debug
+emits a *metadata-only* assembly (no IL, ~18% faster) while Release emits full IL and both bundle
+variants. Measure the configuration you mean, and say which one a number came from.
 
 `--timing` prints per-phase wall time, each phase's share, **and the bytes allocated while it ran**,
 plus process totals (allocated, peak working set, gen0/1/2 counts). `--timing-json <file>` writes the
@@ -83,13 +94,29 @@ top-level phases sum to the total.
 ### 3. The full report (what to paste into a PR)
 
 ```bash
-$BENCH --tps $TPS --tesserae <tesserae> --iterations 3 --label my-change \
+$BENCH --tps $TPS --tesserae benchmarks/tesserae --iterations 3 --label my-change \
        --json artifacts/bench/my-change.json --markdown artifacts/bench/my-change.md \
        --baseline docs/perf/optimized.json
 ```
 
-`docs/perf/baseline.json` (before any of this work) and `docs/perf/optimized.json` (current) are
-checked in, so you can compare against either without rebuilding an old compiler.
+Checked-in references, so you can compare without rebuilding an old compiler:
+`docs/perf/baseline.json` (before any of this work), `docs/perf/optimized.json` (current, Debug) and
+`docs/perf/optimized-release.json` (current, Release).
+
+**Benchmark the compiler as it ships — ReadyToRun.** A plain `dotnet build` output is JIT-only and ~1 s
+per invocation slower, which will silently skew anything you conclude:
+
+```bash
+dotnet publish Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release \
+  -r linux-x64 --self-contained false -p:PublishReadyToRun=true -o artifacts/bench-tps
+$BENCH --tps artifacts/bench-tps/tps --tesserae benchmarks/tesserae --require-r2r …
+```
+
+`tps-bench` reports whether the compiler is R2R on every run; `--require-r2r` makes it a hard failure,
+and `--verify-r2r <dir>` checks a whole pack output (that is what the release pipeline gates on).
+
+Use `--env KEY=VALUE` to re-test a runtime default rather than trusting it — e.g.
+`--env DOTNET_TieredPGO=1` confirms PGO is still a loss (last measured 8.70 s vs 6.18 s with it off).
 
 `tps-bench` prints, in order: the machine (CPU model, physical/logical cores, RAM, and the SIMD/crypto
 ISAs the JIT will use), a short deterministic **CPU+memory benchmark** and the **score** it yields,
@@ -214,3 +241,17 @@ once per project. `PublishReadyToRun` halves it (measured 2.2 s → 1.1 s on a o
   (`var`, using aliases, static imports) explicitly.
 - **Don't keep a change that measures flat.** Pooling `Emitter.Capture`'s writers looked obviously right
   and moved allocation by 0.5 MB out of 312 MB. It was reverted; the finding is logged.
+
+## The CI pipelines
+
+- **`.devops/build-transpose-compiler.yml`** packs the tool. `TransposePackRidSpecificTools=true` makes
+  one `dotnet pack` produce nine ReadyToRun `Transpose.Compiler.<rid>` packages plus the outer selector
+  package, and the build then *gates* on `tps-bench --verify-r2r` over the produced `.nupkg` files, so a
+  silently-JIT-only tool cannot be published. Restore must pass the same property (it is what sets
+  `RuntimeIdentifiers`), or every inner build fails `NETSDK1047`.
+- **`.devops/benchmark-transpose-compiler.yml`** measures. It publishes the R2R compiler, benchmarks the
+  `benchmarks/tesserae` submodule in both Debug and Release against `docs/perf/optimized.json`, re-checks
+  the TieredPGO decision with `--env DOTNET_TieredPGO=1`, and publishes the reports as an artifact. It
+  runs on every compiler change and nightly, and deliberately **does not fail on a regression** — hosted
+  agents vary too much for a tight threshold to mean anything, and a build that cries wolf gets ignored.
+  Read the artifact.

--- a/.claude/skills/transpose-performance/SKILL.md
+++ b/.claude/skills/transpose-performance/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: transpose-performance
+description: >-
+  Measure and improve the Transpose compiler's build performance — wall time, allocations, GC and
+  per-phase cost — using the tps-bench harness (CPU-score-normalised, clean-slate scenarios) and
+  dotnet-trace profiles. Use this WHENEVER the task is to make `tps` faster or leaner, to find out
+  where a build spends its time or memory, to benchmark a compiler change, or to investigate a
+  build-time regression. Triggers on "why is compilation slow", "speed up tps", "profile the
+  compiler", "reduce allocations", "benchmark this change", "how long does compiling X take",
+  "parallelise the compiler", or any work touching Transpose.Bench / PhaseTimings / TODO.optimization.md.
+  Pairs with transpose-debugging (correctness of emitted JS) — every optimization here must keep the
+  emitted output byte-identical.
+---
+
+# Optimizing Transpose compilation
+
+`tps` is a plain CLI with no cache and no compile server (deliberately — see CLAUDE.md), so a build's
+cost is whatever one process does from scratch. This skill is the loop for measuring that and making
+it smaller without changing a byte of emitted JavaScript.
+
+**Read [`TODO.optimization.md`](../../../TODO.optimization.md) first.** It is the running log of every
+optimization tried, with measurements — including the ones that *did not work*, which is most of the
+value. Do not re-walk a dead end; add to it as you go.
+
+## The one thing that will mislead you
+
+The dev container is a 4-core Firecracker VM whose throughput **drifts 20–40% over minutes**. The same
+binary on the same input measured 14.1 s and 20.3 s within one session. So:
+
+- **Never** conclude anything from a single before/after pair. Use `ab.sh` (interleaves A,B,A,B…) or
+  `tps-bench --iterations 3+`.
+- **Allocation numbers are exact** (`GC.GetTotalAllocatedBytes`) while times are noisy — when a change
+  is meant to reduce garbage, believe the MB and treat the ms as corroboration.
+- **A phase's time can move for reasons unrelated to that phase.** Whichever phase touches Roslyn's
+  binder first pays the JIT warm-up for all of it: removing a pass in front of the unsupported-feature
+  scan made the scan look 3× slower while the total was flat. Compare **totals first**, phases second.
+- Kill stray build servers before measuring (`ps aux | grep VBCSCompiler`), and check `/proc/loadavg`.
+
+## Setup
+
+```bash
+cd <transpose>
+dotnet build Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release
+dotnet build Transpose/Transpose.Bench/Transpose.Bench.csproj      -c Release
+TPS=./Transpose/Transpose.Compiler/bin/Release/net10.0/tps
+BENCH=./Transpose/Transpose.Bench/bin/Release/net10.0/tps-bench
+```
+
+A baseline compiler to compare against, built from the commit you are improving on:
+
+```bash
+git worktree add /tmp/tps-base <base-commit>
+(cd /tmp/tps-base && dotnet build Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release)
+BASE=/tmp/tps-base/Transpose/Transpose.Compiler/bin/Release/net10.0/tps
+```
+
+The corpus is the **tesserae** repo (a sibling checkout): `Tesserae` is a single 263-file / ~69k-line
+project, and `Tesserae.Tests` adds a second project that depends on it — which is what exercises the
+multi-project path (`tps` compiles the dependency first, then the site build).
+
+## The loop
+
+### 1. Where does this build spend its time and memory?
+
+```bash
+cd <tesserae>
+rm -rf Tesserae/bin Tesserae/obj                 # clean slate — see "Cleaning" below
+$TPS --project Tesserae/Tesserae.csproj -c Debug --timing
+```
+
+`--timing` prints per-phase wall time, each phase's share, **and the bytes allocated while it ran**,
+plus process totals (allocated, peak working set, gen0/1/2 counts). `--timing-json <file>` writes the
+same as JSON. Sub-phases are indented (`├`) and are already counted inside their parent, so only
+top-level phases sum to the total.
+
+### 2. Is my change actually faster?
+
+```bash
+# Interleaved A/B on one project — the trustworthy quick check
+./Transpose/Transpose.Bench/ab.sh $BASE $TPS <tesserae>/Tesserae/Tesserae.csproj 4
+```
+
+### 3. The full report (what to paste into a PR)
+
+```bash
+$BENCH --tps $TPS --tesserae <tesserae> --iterations 3 --label my-change \
+       --json artifacts/bench/my-change.json --markdown artifacts/bench/my-change.md \
+       --baseline docs/perf/optimized.json
+```
+
+`docs/perf/baseline.json` (before any of this work) and `docs/perf/optimized.json` (current) are
+checked in, so you can compare against either without rebuilding an old compiler.
+
+`tps-bench` prints, in order: the machine (CPU model, physical/logical cores, RAM, and the SIMD/crypto
+ISAs the JIT will use), a short deterministic **CPU+memory benchmark** and the **score** it yields,
+then each scenario's wall time, CPU time, allocations, peak working set and phase breakdown.
+
+Every time is also reported **normalised** = `measured × score / 100`, i.e. converted to
+reference-machine milliseconds. That is what makes a number recorded in one session comparable with
+one recorded on different hardware — always quote the normalised figure when comparing across runs,
+and the raw one when describing the machine you were on.
+
+The score's reference values are **constants** calibrated on a 4-core Xeon @2.8 GHz container
+(`CpuScore.Reference`). Re-calibrate only if the workloads themselves change — never to "re-centre" a
+new machine, which would destroy the only property the score has.
+
+### 4. Where is the allocation / CPU actually going?
+
+```bash
+dotnet tool install --global dotnet-trace     # once
+
+# Allocation profile (GCAllocationTick — one sample per ~100 KB)
+dotnet-trace collect -o /tmp/alloc.nettrace --providers "Microsoft-Windows-DotNETRuntime:0x1:5" \
+  -- $TPS --project <tesserae>/Tesserae/Tesserae.csproj -c Debug -q
+dotnet-trace convert --format Speedscope /tmp/alloc.nettrace -o /tmp/alloc
+
+# CPU sampling profile
+dotnet-trace collect --format speedscope -o /tmp/cpu.nettrace \
+  --providers "Microsoft-DotNETCore-SampleProfiler:::EventLevel=Informational" \
+  -- $TPS --project <tesserae>/Tesserae/Tesserae.csproj -c Debug -q
+```
+
+The speedscope JSON is `evented` (paired `O`/`C` records per frame), not `sampled`. To rank frames,
+count ticks per frame — see [`scripts/analyze-trace.py`](scripts/analyze-trace.py):
+
+```bash
+python3 .claude/skills/transpose-performance/scripts/analyze-trace.py /tmp/alloc.speedscope.json
+```
+
+For an allocation trace, "inclusive" ≈ bytes allocated beneath a frame and the innermost managed
+frame is the allocation site. Ignore the `CPU_TIME` / `UNMANAGED_CODE_TIME` pseudo-frames.
+
+## Cleaning: what a "clean slate" means here
+
+`tps` skips a referenced project whose package DLL is up to date (`ProjectResolver.IsPackageUpToDate`),
+so a second run measures a *different, much cheaper* build. Before every timed clean run, delete
+`bin` and `obj` **of the project and of every project it references transitively**. `tps-bench` and
+`ab.sh` both do this; if you time by hand, do it too, or you will report an incremental build as a
+full one. Benchmark the incremental path deliberately instead, with a `:warm` scenario.
+
+## The correctness gate — non-negotiable
+
+A compiler optimization that changes output is a bug, not an optimization. Before claiming any win:
+
+1. **Test suite**: `dotnet test Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj -c Release`
+   — 499 tests, ~3.5 min, must stay green.
+2. **Byte-compare the whole emitted site** against the baseline compiler, for `Tesserae.Tests` (which
+   covers both the package build and the site build):
+   ```bash
+   cd <tesserae>
+   rm -rf Tesserae/bin Tesserae/obj Tesserae.Tests/bin Tesserae.Tests/obj
+   $BASE --project Tesserae.Tests/Tesserae.Tests.csproj -c Debug -q
+   cp -r Tesserae.Tests/bin/Debug/netstandard2.0/tps /tmp/out-base
+   rm -rf Tesserae/bin Tesserae/obj Tesserae.Tests/bin Tesserae.Tests/obj
+   $TPS  --project Tesserae.Tests/Tesserae.Tests.csproj -c Debug -q
+   cp -r Tesserae.Tests/bin/Debug/netstandard2.0/tps /tmp/out-new
+   diff -r /tmp/out-base /tmp/out-new
+   ```
+   Output is byte-reproducible as of the enumerator-naming fix, so `diff -r` should be silent. If you
+   are comparing against a compiler older than that fix, normalise `$e<hex>` names first
+   (see [`scripts/compare-site.sh`](scripts/compare-site.sh)).
+3. **Touching `UnsupportedFeatureScanner`**: also diff the diagnostics of a file exercising every rule
+   (pointers, `unsafe`, `checked`, `nint`, P/Invoke, `System.IO`/`System.Threading` types, a using
+   alias and a static import) — see the scanner section of `TODO.optimization.md`.
+
+## What the cost structure actually looks like
+
+Measured on the reference box for a clean `Tesserae` build (after the current round of optimization —
+re-measure, do not trust these as current):
+
+| phase | share | notes |
+|---|--:|---|
+| `bind + emit .NET assembly` | ~43% | Roslyn binding every method body + IL codegen |
+| `scan unsupported features` | ~22% | the *first* Roslyn consumer, so it absorbs JIT warm-up |
+| `emit JavaScript` | ~21% | the largest single allocator |
+| `embed resources into DLL (Cecil)` | ~7% | Mono.Cecil re-serialises the assembly |
+| `build compilation (parse + references)` | ~5% | parallel |
+
+Two structural facts worth internalising before optimizing anything:
+
+- **A build binds the project roughly twice**: once inside `Compilation.Emit` (for IL) and once through
+  the `SemanticModel` (for the JS emitter). Roslyn's internal bound trees are not reachable from the
+  public API, so these cannot be merged — the only way to remove one is to stop producing IL
+  (`--metadata-only-assembly`, opt-in).
+- **The unsupported-feature scan and the JS emitter share one `TreeModel`**, so a member the scan binds
+  is already bound when the emitter reaches it. This is why the scan looks expensive but is nearly
+  free: removing its `var` resolution moved ~0.8 s into the JS emit and left the total flat.
+
+### Per-invocation fixed cost
+
+A **one-file** project takes ~2.2 s and allocates 5 MB. That is almost entirely JIT of Roslyn plus
+importing `Transpose.dll`'s metadata, and every project in a solution pays it, since the SDK runs `tps`
+once per project. `PublishReadyToRun` halves it (measured 2.2 s → 1.1 s on a one-file project, and
+~1 s off any build) but needs RID-specific tool packaging. This is the largest untaken opportunity.
+
+## Rules of thumb learned here
+
+- **Runtime configuration beat every code change.** `TieredPGO=false` alone was ~25–30%; Server GC ~15%.
+  Check `Transpose.Compiler.csproj` + `runtimeconfig.template.json` before writing code.
+- **Parallelising two already-parallel phases makes things worse** on a 4-core box — both the scan/emit
+  overlap and the JS-emit/assembly-emit overlap were measured *slower*. Re-test on many-core hardware
+  before assuming otherwise; the code is deliberately sequential there.
+- **Cache the expensive pure functions of a symbol.** The naming layer (`TransposeNaming`) recomputed a
+  member's JS name once per *reference*; caching `MemberJsName`, `JsBaseName` and
+  `ImplementedInterfaceMember` cut JS emit 2.3×. Key caches on the symbol **as passed**, never on
+  `OriginalDefinition`, or you change answers.
+- **`GetAttributes().FirstOrDefault(a => AttrIs(a, name))` is not free**: the closure and the boxed
+  `ImmutableArray` enumerator made attribute lookup the single largest allocation site in the build.
+  Plain loops (`TransposeNaming.FindAttr`/`HasAttr`/`AnyInSource`) instead. Same for `.OfType<T>()` over
+  `GetMembers()`.
+- **Screen syntactically before asking the semantic model.** Binding an identifier binds its whole
+  enclosing member. The scanner's per-identifier filter (identifier text vs. a precomputed name set) cut
+  it from 2.7 s to 0.7 s — but only do this when the filter is provably *sound*, and handle the escapes
+  (`var`, using aliases, static imports) explicitly.
+- **Don't keep a change that measures flat.** Pooling `Emitter.Capture`'s writers looked obviously right
+  and moved allocation by 0.5 MB out of 312 MB. It was reverted; the finding is logged.

--- a/.claude/skills/transpose-performance/scripts/analyze-trace.py
+++ b/.claude/skills/transpose-performance/scripts/analyze-trace.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Rank the hot frames in a speedscope file produced by `dotnet-trace convert`.
+
+dotnet-trace emits `evented` speedscope profiles (paired open/close records per frame), which the
+speedscope UI understands but which cannot be summed by hand. This reconstructs each sample's stack
+and reports two rankings:
+
+  * allocation/CPU SITES  — the innermost managed frame of each sample (where the cost is incurred)
+  * INCLUSIVE             — every frame a sample passed through (where the cost is attributable)
+
+For an allocation trace (`--providers Microsoft-Windows-DotNETRuntime:0x1:5`) each sample is one
+GCAllocationTick, i.e. ~100 KB allocated, so counts convert directly to megabytes. For a CPU trace
+(SampleProfiler) the counts are samples, so read them as relative shares.
+
+Usage:
+    analyze-trace.py <file.speedscope.json> [--top N] [--filter SUBSTRING]
+"""
+
+import argparse
+import collections
+import json
+import sys
+
+# Pseudo-frames dotnet-trace inserts that carry no attribution of their own.
+PSEUDO = {"CPU_TIME", "UNMANAGED_CODE_TIME", "(Non-Activities)", "Threads"}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("path", help="the .speedscope.json produced by `dotnet-trace convert`")
+    ap.add_argument("--top", type=int, default=30, help="how many frames to list per ranking")
+    ap.add_argument("--filter", default=None,
+                    help="only show inclusive frames whose name contains this substring "
+                         "(e.g. Transpose.Translator)")
+    args = ap.parse_args()
+
+    with open(args.path) as fh:
+        doc = json.load(fh)
+
+    names = [f["name"] for f in doc["shared"]["frames"]]
+    sites = collections.Counter()
+    inclusive = collections.Counter()
+    total = 0
+
+    for profile in doc["profiles"]:
+        stack: list[int] = []
+        previous = None
+        for event in profile.get("events", ()):
+            if event["type"] == "O":
+                stack.append(event["frame"])
+                previous = "O"
+            else:
+                # A close immediately after an open means `stack` is a complete sample.
+                if previous == "O" and stack:
+                    total += 1
+                    real = [f for f in stack if names[f] not in PSEUDO]
+                    if real:
+                        sites[real[-1]] += 1
+                        for frame in set(real):
+                            inclusive[frame] += 1
+                if stack:
+                    stack.pop()
+                previous = "C"
+
+    if total == 0:
+        print("No samples found — is this an `evented` speedscope file from dotnet-trace?", file=sys.stderr)
+        return 1
+
+    print(f"{total} samples  (~{total * 100 / 1024:.0f} MB if this is an allocation trace)\n")
+
+    def show(counter: collections.Counter, title: str, name_filter: str | None = None) -> None:
+        print(f"== {title} ==")
+        shown = 0
+        for frame, count in counter.most_common():
+            if name_filter and name_filter not in names[frame]:
+                continue
+            print(f"{count * 100 / total:6.2f}%  {count * 100 / 1024:8.1f}MB  {names[frame][:130]}")
+            shown += 1
+            if shown >= args.top:
+                break
+        print()
+
+    show(sites, "SITES (innermost managed frame)")
+    show(inclusive, "INCLUSIVE (cost beneath the frame)", args.filter)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/transpose-performance/scripts/compare-site.sh
+++ b/.claude/skills/transpose-performance/scripts/compare-site.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Byte-compare two emitted site trees — the correctness gate for any compiler optimization.
+#
+# `$e<hex>` enumerator temporaries are normalised away so a comparison against a compiler older than
+# the reproducible-naming fix still works (they used to be derived from a reference hash code and so
+# differed on every run). Everything else must match exactly.
+#
+#   compare-site.sh <dir-A> <dir-B>
+set -uo pipefail
+
+A=${1:?usage: compare-site.sh <dir-A> <dir-B>}
+B=${2:?}
+fail=0
+
+norm() { sed -E 's/\$e[0-9a-f]+/$eN/g' "$1"; }
+
+if ! diff <(cd "$A" && find . -type f | sort) <(cd "$B" && find . -type f | sort); then
+  echo "FILE SET DIFFERS"
+  fail=1
+fi
+
+while read -r f; do
+  if [ ! -f "$B/$f" ]; then continue; fi          # already reported by the file-set diff
+  norm "$A/$f" > /tmp/.cmp-a 2>/dev/null || cp "$A/$f" /tmp/.cmp-a
+  norm "$B/$f" > /tmp/.cmp-b 2>/dev/null || cp "$B/$f" /tmp/.cmp-b
+  if ! cmp -s /tmp/.cmp-a /tmp/.cmp-b; then
+    echo "DIFFERS: $f"
+    diff /tmp/.cmp-a /tmp/.cmp-b | head -12
+    fail=1
+  fi
+done < <(cd "$A" && find . -type f | sort)
+
+rm -f /tmp/.cmp-a /tmp/.cmp-b
+[ $fail -eq 0 ] && echo "SITE OUTPUT IDENTICAL"
+exit $fail

--- a/.devops/benchmark-transpose-compiler.yml
+++ b/.devops/benchmark-transpose-compiler.yml
@@ -1,0 +1,139 @@
+# Compiler performance benchmark.
+#
+# Compiles a real project — the tesserae submodule under benchmarks/tesserae, 263 files / ~69k lines,
+# plus a second project that depends on it — with the ReadyToRun-published compiler, and records
+# wall time, CPU time, allocations, peak working set and the per-phase breakdown.
+#
+# Two things make the numbers usable despite hosted agents being wildly inconsistent:
+#
+#   * tps-bench scores the agent with a short deterministic CPU+memory benchmark and reports every
+#     timing *normalised* by that score, i.e. converted to reference-machine milliseconds. A run on a
+#     fast agent and a run on a slow one are then directly comparable.
+#   * It compares against docs/perf/optimized.json, the recorded state of the compiler, and prints the
+#     deltas.
+#
+# It deliberately does NOT fail on a regression. Hosted agents differ enough — different CPU SKUs,
+# noisy neighbours — that a threshold tight enough to catch a real 10% regression would fire on noise
+# constantly, and a build that cries wolf gets ignored. The report is published as an artifact and
+# printed in the log; read it. If you want a gate, gate on a large threshold and on several
+# consecutive runs, not one.
+
+variables:
+  compiler: '$(Build.SourcesDirectory)/Transpose/Transpose.Compiler/Transpose.Compiler.csproj'
+  bench: '$(Build.SourcesDirectory)/Transpose/Transpose.Bench/Transpose.Bench.csproj'
+  corpus: '$(Build.SourcesDirectory)/benchmarks/tesserae'
+  buildConfiguration: 'Release'
+  # The agent's own RID. Publishing for it (rather than a portable publish) is what makes the measured
+  # compiler the ReadyToRun one users actually get.
+  benchRid: 'linux-x64'
+  publishDir: '$(Build.SourcesDirectory)/artifacts/bench-tps'
+  reportDir: '$(Build.ArtifactStagingDirectory)/benchmark'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+# Every compiler change gets a measurement, and a nightly run tracks drift in the runtime/SDK even
+# when nothing in the repo changed.
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - Transpose/Transpose.Compiler/*
+    - Transpose/Transpose.Translator/*
+    - Transpose/Transpose.Bench/*
+    - .devops/benchmark-transpose-compiler.yml
+
+pr: none
+
+schedules:
+- cron: "0 3 * * *"
+  displayName: 'Nightly performance run'
+  branches:
+    include:
+    - master
+  always: true
+
+steps:
+# The corpus is a submodule, so it has to be fetched explicitly.
+- checkout: self
+  submodules: true
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 10.0 SDK'
+  inputs:
+    packageType: sdk
+    version: 10.x
+    includePreviewVersions: false
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- script: |
+    set -euo pipefail
+    test -f "$(corpus)/Tesserae/Tesserae.csproj" \
+      || { echo "benchmarks/tesserae is empty — the submodule was not checked out"; exit 1; }
+    echo "corpus commit: $(git -C "$(corpus)" rev-parse --short HEAD)"
+  displayName: 'check the benchmark corpus is present'
+
+# Publish the compiler exactly as it ships: RID-specific and ReadyToRun. Benchmarking a plain
+# `dotnet build` output would understate the shipped compiler by ~1 s per invocation.
+- script: |
+    set -euo pipefail
+    dotnet publish "$(compiler)" -c $(buildConfiguration) -r $(benchRid) --self-contained false \
+      -p:PublishReadyToRun=true -o "$(publishDir)"
+  displayName: 'publish the compiler (ReadyToRun, $(benchRid))'
+
+- task: DotNetCoreCLI@2
+  displayName: 'build bench'
+  inputs:
+    command: 'build'
+    projects: '$(bench)'
+    arguments: '-c $(buildConfiguration)'
+
+# --require-r2r: if the publish above silently lost ReadyToRun, the numbers would be measuring a
+# different compiler than the one that ships, so stop rather than record a misleading result.
+# Debug is the configuration a developer waits on, and since Debug emits a metadata-only assembly
+# while Release emits full IL, the two are structurally different builds — both are worth recording.
+- script: |
+    set -euo pipefail
+    BENCH="$(Build.SourcesDirectory)/Transpose/Transpose.Bench/bin/$(buildConfiguration)/net10.0/tps-bench.dll"
+    mkdir -p "$(reportDir)"
+
+    for cfg in Debug Release; do
+      echo "=============== $cfg ==============="
+      dotnet "$BENCH" \
+        --tps "$(publishDir)/tps" \
+        --tesserae "$(corpus)" \
+        --configuration "$cfg" \
+        --iterations 3 --warmups 1 \
+        --require-r2r \
+        --label "$cfg-$(Build.SourceVersion)" \
+        --baseline "$(Build.SourcesDirectory)/docs/perf/optimized.json" \
+        --json "$(reportDir)/benchmark-$cfg.json" \
+        --markdown "$(reportDir)/benchmark-$cfg.md"
+    done
+  displayName: 'benchmark the compiler (Debug + Release)'
+
+# Re-validate a runtime default rather than trusting it forever. TieredPGO is turned OFF in
+# Transpose.Compiler.csproj because instrumented tier-0 code costs a short-lived compiler far more than
+# the better tier-1 code ever repays (~25-30% measured). That trade depends on the runtime's PGO
+# implementation, so this step measures with PGO forced back ON: if that ever becomes the faster
+# column, the csproj should change. Informational — one scenario, so it stays cheap.
+- script: |
+    set -euo pipefail
+    BENCH="$(Build.SourcesDirectory)/Transpose/Transpose.Bench/bin/$(buildConfiguration)/net10.0/tps-bench.dll"
+    dotnet "$BENCH" \
+      --tps "$(publishDir)/tps" \
+      --scenario "tesserae=$(corpus)/Tesserae/Tesserae.csproj" \
+      --iterations 3 --warmups 1 --no-cpu-bench \
+      --env DOTNET_TieredPGO=1 \
+      --label "tieredpgo-on" \
+      --json "$(reportDir)/tieredpgo-on.json"
+  displayName: 're-check that TieredPGO=off is still the faster default'
+  continueOnError: true
+
+- task: PublishPipelineArtifact@1
+  displayName: 'publish the benchmark report'
+  inputs:
+    targetPath: '$(reportDir)'
+    artifact: 'benchmark'

--- a/.devops/build-transpose-compiler.yml
+++ b/.devops/build-transpose-compiler.yml
@@ -1,10 +1,23 @@
 variables:
   compiler: '$(Build.SourcesDirectory)/Transpose/Transpose.Compiler/Transpose.Compiler.csproj'
+  bench: '$(Build.SourcesDirectory)/Transpose/Transpose.Bench/Transpose.Bench.csproj'
   buildConfiguration: 'Release'
   targetVersion: yy.M.$(build.buildId)
 
+# ReadyToRun-compiling the tool is worth ~1 s off *every* `tps` invocation (a one-file project goes
+# 2.2 s -> 1.1 s; a clean Tesserae build -11%), and the SDK runs tps once per project, so it multiplies
+# across a solution. R2R is native code, so it needs RID-specific tool packages: the csproj's
+# TransposePackRidSpecificTools property turns on RuntimeIdentifiers + PublishReadyToRun, and a single
+# `dotnet pack` then produces one Transpose.Compiler.<rid> package per RID plus the small outer
+# Transpose.Compiler package that maps RIDs to them. `dotnet tool install Transpose.Compiler` keeps
+# working unchanged and resolves the right one automatically.
+#
+# Pool is ubuntu-latest: that host was verified end-to-end to cross-compile R2R for all nine RIDs
+# (win/linux/osx x x64/arm64/x86/musl) from a single pack. Any host should manage it — crossgen2 targets
+# a RID rather than the host — but this is the configuration with evidence behind it. The verify step
+# below fails the build if R2R is ever silently lost, whatever the agent.
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'ubuntu-latest'
 
 trigger:
   branches:
@@ -14,6 +27,7 @@ trigger:
     include:
     - Transpose/Transpose.Compiler/*
     - Transpose/Transpose.Translator/*
+    - Transpose/Transpose.Bench/*
     - .devops/build-transpose-compiler.yml
 
 pr: none
@@ -36,6 +50,7 @@ steps:
   displayName: 'Create CalVer Version'
   inputs:
     targetType: 'inline'
+    pwsh: true
     script: |
       $dottedDate = (Get-Date).ToString("yy.M")
       $buildID = $($env:BUILD_BUILDID)
@@ -44,11 +59,15 @@ steps:
       Write-Host "##vso[task.setvariable variable=targetVersion;]$newTargetVersion"
       Write-Host "Updated targetVersion to '$newTargetVersion'"
 
+# Restore has to see the same property as the pack: TransposePackRidSpecificTools sets
+# RuntimeIdentifiers, and without it in the restore the per-RID assets are missing and every inner
+# build fails with NETSDK1047.
 - task: DotNetCoreCLI@2
-  displayName: 'restore nuget compiler'
+  displayName: 'restore nuget compiler (all RIDs)'
   inputs:
     command: 'restore'
     projects: '$(compiler)'
+    arguments: '-p:TransposePackRidSpecificTools=true'
 
 - task: DotNetCoreCLI@2
   displayName: 'build compiler'
@@ -57,14 +76,35 @@ steps:
     projects: '$(compiler)'
     arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)'
 
+# One pack produces the outer selector package plus one ReadyToRun package per RID (~15 MB each).
 - task: DotNetCoreCLI@2
-  displayName: 'pack nuget compiler'
+  displayName: 'pack nuget compiler (ReadyToRun, per RID)'
   inputs:
     command: 'pack'
     configuration: '$(buildConfiguration)'
     packagesToPack: '$(compiler)'
     versioningScheme: 'off'
-    buildProperties: 'Version="$(targetVersion)";AllowUnsafeBlocks="True";LangVersion="latest"'
+    buildProperties: 'Version="$(targetVersion)";AllowUnsafeBlocks="True";LangVersion="latest";TransposePackRidSpecificTools="true"'
+
+- task: DotNetCoreCLI@2
+  displayName: 'build bench (for the ReadyToRun gate)'
+  inputs:
+    command: 'build'
+    projects: '$(bench)'
+    arguments: '-c $(buildConfiguration)'
+
+# Gate: refuse to publish a tool that is not actually precompiled. R2R is easy to lose silently (a
+# restore missing the property, a RID-agnostic pack) and the only symptom would be that everyone's
+# builds quietly get ~1 s slower per project. `tps-bench --verify-r2r` opens each produced .nupkg and
+# checks the PE ManagedNativeHeader of the assemblies inside, so it validates exactly what is about to
+# be pushed rather than whatever is in the build tree. It also expects the outer selector package to
+# have no implementation, and fails if there is nothing to verify at all.
+# Exit 2 = a package is IL-only; exit 1 = nothing verified.
+- script: |
+    set -euo pipefail
+    dotnet "$(Build.SourcesDirectory)/Transpose/Transpose.Bench/bin/$(buildConfiguration)/net10.0/tps-bench.dll" \
+      --verify-r2r "$(Build.ArtifactStagingDirectory)"
+  displayName: 'verify the packed tool is ReadyToRun'
 
 - task: NuGetCommand@2
   displayName: 'push nuget'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "benchmarks/tesserae"]
+	path = benchmarks/tesserae
+	url = https://github.com/curiosity-ai/tesserae.git
+	branch = master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ Transpose/                     # The compiler toolchain
 │   ├── OutputBuilder.cs       #   site build (runtime + bundle + resources + index.html) + stale-output prune
 │   ├── ResourceEmbedder.cs    #   embeds JS + resources into the package DLL (Mono.Cecil)
 │   └── TransposeJson.cs       #   reads tps.json (output/fileName/html/resources/reflection)
+├── Transpose.Bench/           # Benchmark harness. AssemblyName + tool command: `tps-bench`
+│   ├── MachineInfo.cs         #   CPU model / cores / RAM / SIMD-ISA detection
+│   ├── CpuScore.cs            #   short deterministic CPU+memory benchmark -> normalisation score
+│   ├── Scenario.cs            #   clean-slate `tps` runs (wipes bin/obj of the project closure)
+│   ├── Report.cs              #   console / Markdown / JSON output + --baseline comparison
+│   └── ab.sh                  #   interleaved A/B of two tps binaries on one project
 ├── Transpose.Build.Target/    # MSBuild SDK (package id Transpose.Build.Target) that invokes `tps`
 ├── Transpose.Template/        # `dotnet new` template (package id Transpose.Template)
 └── Transpose.Translator.Tests/# MSTest suite; transpiles snippets and diffs vs native .NET via Playwright
@@ -151,7 +157,25 @@ plain CLI, by design.
 
 `--out/-o`, `--site-dir`, `--configuration/-c`, `--emit-package`, `--separate-assemblies`,
 `--with-runtime`, `--reference/-r <dll>` (extra assemblies not in the NuGet cache),
-`--define/-D <SYM>`, `--assembly-version <v>`, `--project/-p`, `--max-errors`, `--quiet/-q`.
+`--define/-D <SYM>`, `--assembly-version <v>`, `--project/-p`, `--max-errors`, `--quiet/-q`,
+`--timing` (per-phase time + allocations), `--timing-json <file>`, `--metadata-only-assembly`.
+
+## Performance
+
+A clean build's cost, and how to measure it, is documented in **`TODO.optimization.md`** (the running
+log of what has been tried, including what did not work) and the **`transpose-performance`** skill.
+The short version:
+
+- `tps --timing` prints a per-phase breakdown with the bytes allocated in each phase, plus GC and
+  peak-working-set totals. `--timing-json` writes the same machine-readably.
+- `tps-bench` (`Transpose/Transpose.Bench`) reports the machine (CPU/cores/RAM/ISAs), scores it with a
+  short deterministic CPU+memory benchmark, then times clean-slate builds and normalises every timing
+  by that score so results from different machines are comparable. `ab.sh` interleaves two compilers.
+- The compiler's runtime configuration is load-bearing: `<TieredPGO>false</TieredPGO>` and Server GC
+  in `Transpose.Compiler.csproj` (plus `runtimeconfig.template.json`) are together worth ~40% of a
+  build. Do not "tidy them away".
+- Any change here must keep the emitted site **byte-identical** — output is reproducible, so
+  `diff -r` against a baseline compiler is the gate. The 499-test suite is the other gate.
 
 ## Known remaining work (compilation-related)
 
@@ -202,6 +226,10 @@ Claude Code; read the `SKILL.md` directly in other contexts):
 - **`transpose-runtime-and-bcl`** — rebuild the runtime (`--build-runtime`), add/modify BCL APIs
   (extern+`[Template]`+`Resources/*.js` vs. real C# in a non-external class + a `tps.json` bundle
   entry), and add/run regression tests in `EmitRegressionTests.cs`.
+- **`transpose-performance`** — measure and improve *build* performance: the `tps-bench` harness
+  (CPU-score-normalised, clean-slate scenarios), `--timing`, dotnet-trace allocation/CPU profiles, and
+  the correctness gate that keeps emitted output byte-identical. Captures the measurement traps on this
+  hardware (the host drifts 20–40%, so never trust a single run) and the cost structure of a build.
 
 ## Conventions when editing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Transpose/                     # The compiler toolchain
 │   ├── MachineInfo.cs         #   CPU model / cores / RAM / SIMD-ISA detection
 │   ├── CpuScore.cs            #   short deterministic CPU+memory benchmark -> normalisation score
 │   ├── Scenario.cs            #   clean-slate `tps` runs (wipes bin/obj of the project closure)
+│   ├── R2RCheck.cs            #   is this tps (or .nupkg) ReadyToRun-compiled?
 │   ├── Report.cs              #   console / Markdown / JSON output + --baseline comparison
 │   └── ab.sh                  #   interleaved A/B of two tps binaries on one project
 ├── Transpose.Build.Target/    # MSBuild SDK (package id Transpose.Build.Target) that invokes `tps`
@@ -66,6 +67,10 @@ Packages/                      # Additional binding libraries (all [assembly: Ex
 ├── Transpose.P2/              #   package Transpose.P2
 ├── Transpose.HttpClient/      #   package Transpose.HttpClient
 └── Transpose.Placeholders/    #   placeholder attributes (package Transpose.Placeholders)
+
+benchmarks/tesserae/           # git submodule: the benchmark corpus (see Performance below)
+docs/perf/                     # recorded tps-bench reports (baseline + current)
+.devops/                       # Azure DevOps pipelines (one per package, plus the benchmark)
 
 docs/, logo/, lib/, External-less # docs, transpose.png/svg, misc
 ```
@@ -176,6 +181,19 @@ The short version:
   build. Do not "tidy them away".
 - Any change here must keep the emitted site **byte-identical** — output is reproducible, so
   `diff -r` against a baseline compiler is the gate. The 499-test suite is the other gate.
+- The benchmark corpus is the **tesserae** submodule at `benchmarks/tesserae`
+  (`git submodule update --init benchmarks/tesserae`). Recorded reports live in `docs/perf/`.
+- **Debug and Release are structurally different builds.** Debug emits a *metadata-only* assembly
+  (full metadata, `throw null` bodies — ~18% faster, and sound because a Transpose assembly binds
+  against the stand-in BCL and can never execute); Release emits full IL. Consequently the SDK
+  **refuses to package a Debug build**: `GeneratePackageOnBuild` is forced off and `dotnet pack -c Debug`
+  fails with TPS1001. Pack Release.
+- **The published tool is ReadyToRun.** `TransposePackRidSpecificTools=true` makes one `dotnet pack`
+  produce a ReadyToRun `Transpose.Compiler.<rid>` package per RID plus the outer selector package;
+  `dotnet tool install Transpose.Compiler` resolves the right one. That is worth ~1 s off *every*
+  invocation, and `.devops/build-transpose-compiler.yml` gates on `tps-bench --verify-r2r` so it cannot
+  be lost silently. Benchmark an R2R publish, not a `dotnet build` output, or you understate the
+  shipped compiler.
 
 ## Known remaining work (compilation-related)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,12 +158,22 @@ items, transpiles, and writes the site (runtime + bundle + resources + `index.ht
 DLL (`--emit-package`). **There is no compilation server and no cache** — the new compiler is a
 plain CLI, by design.
 
+Because there is no MSBuild evaluation, `ProjectXml` does the one bit of evaluation that changes
+which files compile: it follows `<Import Project="…"/>` transitively and flattens the result, so a
+**shared project**'s `.projitems` (where its `<Compile>` items live) is picked up. Each item is
+expanded against the directory of the file that *declared* it for `$(MSBuildThisFileDirectory)`, and
+against the project directory for a plain relative path — MSBuild's two rules. Any other `$(…)`
+property is not guessed at: such an import or item is skipped, which is why SDK-internal imports
+(`$(MSBuildToolsPath)…`) never get followed. Conditions are not evaluated anywhere in the resolver.
+
 ### `tps` CLI options (selected)
 
 `--out/-o`, `--site-dir`, `--configuration/-c`, `--emit-package`, `--separate-assemblies`,
 `--with-runtime`, `--reference/-r <dll>` (extra assemblies not in the NuGet cache),
-`--define/-D <SYM>`, `--assembly-version <v>`, `--project/-p`, `--max-errors`, `--quiet/-q`,
-`--timing` (per-phase time + allocations), `--timing-json <file>`, `--metadata-only-assembly`.
+`--define/-D <SYM>`, `--assembly-version <v>`, `--project/-p`, `--quiet/-q`,
+`--timing` (per-phase time + allocations), `--timing-json <file>`,
+`--metadata-only-assembly` / `--no-metadata-only-assembly`,
+`--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line).
 
 ## Performance
 
@@ -224,6 +234,8 @@ The short version:
   `HtmlGenerator`. **Source maps** for the emitted bundle are still remaining.
 - **Reference resolution beyond the NuGet cache** — `<Reference HintPath>` and `tps.json`
   `references`/`referencesPath` (partially covered by `--reference`).
+- **MSBuild evaluation** stays deliberately shallow: `<Import>` is followed (see above) but
+  conditions, arbitrary properties, `Directory.Build.props` and item metadata are not evaluated.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 
 Caching and the compilation server are intentionally **out of scope**.

--- a/TODO.optimization.md
+++ b/TODO.optimization.md
@@ -251,6 +251,16 @@ recycling them looked obviously right. Measured allocation was **unchanged**: 31
 `Capture`'s large inclusive cost is the emission work beneath it, not the writer itself. Reverted
 rather than carry the complexity.
 
+### Caching `ISymbol.ToDisplayString()` for the emitter's literal comparisons — **rejected (no effect)**
+
+A fair amount of the emitter's dispatch is `type.ToDisplayString() == "System.DateTime"`-style, and
+`ToDisplayString` formats a fresh string every call — including in `IsTaskType` (per await),
+`ShouldWrapParams` (per `params` call) and the DateTime/TimeSpan arithmetic check (per binary
+expression). Routing all 17 such sites through a per-symbol cache measured **flat**: 272.3–274.1 MB vs
+273.8 MB, no time change. The paths turn out to be guarded by earlier returns often enough that they
+were never hot, and once the naming layer was cached (§3) nothing else asked for these strings in bulk.
+Reverted rather than carry an unbounded per-symbol dictionary for no measured benefit.
+
 ### `gcConcurrent=0` with Server GC — **rejected**
 
 13.8 s vs 11.7 s with background GC on.
@@ -261,6 +271,40 @@ Fastest single setting for a big project (9.7 s) but 2.3× slower on a one-file 
 2.11 s). A compiler must not punish small projects to reward large ones.
 
 ---
+
+## The runtime build (`--build-runtime`) — instrumented, not yet optimized
+
+Building the base library (`BCL/Transpose.BCL`, 527 files) into `Transpose.dll` + `tps.js` is the
+heaviest single operation in the repo, and until now it reported no phases at all. It is now
+instrumented; measured on the reference box:
+
+| phase | ms | share | alloc |
+|---|--:|--:|--:|
+| resolve project | 154 | 1.1% | 64 MB |
+| build compilation (parse, self-contained BCL) | 892 | 6.4% | 87 MB |
+| **bind + diagnostics** | **4 768** | **34.4%** | **1 383 MB** |
+| emit JavaScript (ClassPath) | 1 910 | 13.8% | 103 MB |
+| write ClassPath files | 58 | 0.4% | 1 MB |
+| assemble runtime bundles (tps.js) | 29 | 0.2% | 25 MB |
+| minify runtime bundles | 1 195 | 8.6% | 192 MB |
+| **bind + emit runtime assembly (with bundles)** | **4 836** | **34.9%** | **1 911 MB** |
+| total | 13 842 | | **3 767 MB** |
+
+It binds the BCL **three times**: `GetDiagnostics`, then again through the emitter's semantic models,
+then a third time inside the final `Emit`. The two visible binds alone are 3.3 GB of the 3.8 GB.
+
+The main `BuildAssembly` path collapsed two of its binds, but the same fix is not a drop-in here:
+
+- The diagnostics **gate the JS emit**, and the assembly emit must come *last* (it takes the assembled
+  `tps.js`/`tps.meta.js` bundles as manifest resources), so its diagnostics arrive too late to gate.
+- Swapping `Compilation.GetDiagnostics()` for per-tree `SemanticModel.GetDiagnostics()` on a
+  `TreeModel` shared with the emitter *would* prepay the emitter's bind (the trick that works in the
+  main path), but a self-contained-BCL compilation is exactly where compilation-level diagnostics like
+  `CS0518 predefined type not defined` matter, and those are not guaranteed to come out of a per-tree
+  pass. Needs a careful diagnostics diff on a deliberately-broken BCL before it can be trusted.
+
+Left alone deliberately: this is a maintainer-only operation (producing the `Transpose.BCL` package),
+not something a user's build runs, so the risk/benefit is much worse than on the project path.
 
 ## Ideas not yet tried
 
@@ -289,15 +333,15 @@ Roughly in expected-value order.
 - **`MetadataImportOptions.All`** makes Roslyn import every non-public member of every reference
   (`Transpose.dll` is large). It is required for overload numbering to match, but its cost has never
   been isolated — worth measuring before assuming it is unavoidable.
-- **`ISymbol.ToDisplayString()` comparisons against string literals** remain in the emitter
-  (`IsTaskType` and friends in `Emitter.cs`, ~11 sites in `Emitter.Expressions2.cs`). Each formats a
-  fresh fully-qualified string. Resolving the target types once from the compilation and comparing with
-  `SymbolEqualityComparer` would remove them from hot paths. Smaller now that the naming layer is
-  cached, but still real.
-- **Remaining allocation sites** after the current round (from a fresh trace, ~557 MB total):
-  `ImmutableArray.CreateRange` 36 MB, `StringBuilder.ExpandByABlock` 30 MB, `StringBuilder.ToString`
-  23 MB, `SyntaxNode.ChildNodes()` 11 MB. Most are inside Roslyn, reached through `GetMembers()` /
-  `AllInterfaces` / syntax walks — reducing them means making fewer such calls, not micro-tuning.
+- **Remaining allocation sites.** A fresh trace of the current compiler totals ~519 MB (down from
+  669 MB at the start) and shows **no dominant site left in Transpose's own code** — `TransposeNaming`
+  has disappeared from the profile entirely (it was 164 MB / 24% inclusive). What is left is spread
+  thinly through Roslyn's data structures: `StringBuilder.ExpandByABlock` 30 MB,
+  `StringBuilder.ToString` 24 MB, bare array allocation 16 MB, `ImmutableArray.CreateRange` 12 MB,
+  `ImmutableArray.Builder.ToArray` 11 MB, `SyntaxNode.ChildNodes()` 11 MB, `MethodSymbol.AsMember`
+  11 MB. Reducing these means making *fewer* Roslyn calls (fewer `GetMembers()` / `AllInterfaces`
+  walks, fewer syntax re-walks), not micro-tuning — and each is now worth only ~2% of allocation, so
+  measure before investing.
 - **`TransposeAssemblies.RuntimeJs` uses `Assembly.LoadFrom`** on the stand-in BCL just to read an
   embedded resource. Not on the hot path (only `--with-runtime`), but a `PEReader` read — as
   `NoBodyMethodTokens` already does — would avoid loading a fake corlib into the compiler process.

--- a/TODO.optimization.md
+++ b/TODO.optimization.md
@@ -16,42 +16,58 @@ Clean-slate builds of the tesserae corpus, `-c Debug`, medians of 3, CPU-score-n
 
 | scenario | before | after | delta | alloc delta |
 |---|--:|--:|--:|--:|
-| `tesserae` — 263 files / ~69k LOC → package DLL | 15.82 s | **7.23 s** | **−54.3%** | −36.9% |
-| `tesserae+tests` — multi-project: dependency + site build | 23.16 s | **8.64 s** | **−62.7%** | −41.5% |
-| `tesserae+tests-warm` — dependency already up to date | 9.03 s | **4.23 s** | **−53.1%** | −46.4% |
+| `tesserae` — 263 files / ~69k LOC → package DLL | 15.82 s | **5.71 s** | **−63.9%** | −44.4% |
+| `tesserae+tests` — multi-project: dependency + site build | 23.16 s | **6.80 s** | **−70.6%** | −48.9% |
+| `tesserae+tests-warm` — dependency already up to date | 9.03 s | **3.21 s** | **−64.4%** | −55.0% |
 
-Baseline commit `79fcfc1`. The recorded reports are checked in as `docs/perf/baseline.json` and
-`docs/perf/optimized.json` (plus `optimized.md`), so a later change can be compared against either
+"After" is the compiler as it now ships: a ReadyToRun publish, `-c Debug` (which emits a metadata-only
+assembly). The equivalent Release figures — full IL, and both minified and formatted bundles — are
+8.34 s / 9.35 s / 3.73 s; Release is the slower configuration by design.
+
+Baseline commit `79fcfc1`. The recorded reports are checked in so a later change can be compared
 without rebuilding an old compiler:
 
+| file | what it is |
+|---|---|
+| `docs/perf/baseline.json` | before any of this work (JIT compiler, full-IL Debug) |
+| `docs/perf/optimized.json` | current, ReadyToRun publish, Debug — the default comparison target |
+| `docs/perf/optimized-release.json` | current, ReadyToRun publish, Release |
+
 ```bash
-tps-bench --tps <tps> --tesserae <tesserae> --iterations 3 --baseline docs/perf/optimized.json
+tps-bench --tps <tps> --tesserae benchmarks/tesserae --iterations 3 --baseline docs/perf/optimized.json
 ```
+
+The corpus is a submodule (`benchmarks/tesserae`), so `git submodule update --init` before benchmarking.
 
 Emitted output is **byte-identical** to the pre-optimization compiler across all of it (verified with
 `compare-site.sh` over the whole `Tesserae.Tests` site), and the 499-test suite stays green.
 
-### Phase split now, for `tesserae`
+### Phase split now, for `tesserae` (Debug, ReadyToRun compiler)
 
 | phase | ms | share | alloc |
 |---|--:|--:|--:|
-| resolve project | 47 | 0.6% | 15 MB |
-| build compilation (parse + references) | 396 | 5.0% | 29 MB |
-| scan unsupported features | 1 823 | 23.1% | 57 MB |
-| bind + emit .NET assembly | 3 258 | 41.3% | 199 MB |
-| emit JavaScript | 1 689 | 21.4% | 274 MB |
-| collect package resources (minify) | 49 | 0.6% | 40 MB |
-| embed resources into DLL (Mono.Cecil) | 633 | 8.0% | 71 MB |
+| resolve project | 37 | 0.6% | 15 MB |
+| build compilation (parse + references) | 287 | 4.9% | 29 MB |
+| scan unsupported features | 1 264 | 21.6% | 57 MB |
+| bind + emit .NET assembly (metadata only) | 1 139 | 19.5% | 57 MB |
+| emit JavaScript | 1 898 | 32.5% | 279 MB |
+| body diagnostics (semantic models) | 899 | 15.4% | 75 MB |
+| collect package resources (minify) | 60 | 1.0% | 40 MB |
+| embed resources into DLL (Mono.Cecil) | 257 | 4.4% | 52 MB |
 
-Two structural facts that bound everything below:
+Two structural facts that bounded everything, and where they now stand:
 
-1. **A build binds the whole project about twice** — once inside `Compilation.Emit` (to produce IL) and
-   once through the `SemanticModel` (to drive the JS emitter). Roslyn's internal bound trees are not
-   reachable from the public API, so the two cannot be merged. The only way to remove one is to stop
-   producing IL at all (see `--metadata-only-assembly` below).
-2. **Every `tps` invocation has a ~2.2 s floor.** A *one-file* project takes 2.2 s and allocates 5 MB;
-   that is JIT of Roslyn plus importing `Transpose.dll`'s metadata. The SDK runs `tps` once per
-   project, so a solution pays it per project.
+1. **A build used to bind the whole project about twice** — once inside `Compilation.Emit` (to produce
+   IL) and once through the `SemanticModel` (to drive the JS emitter). Roslyn's internal bound trees
+   are not reachable from the public API, so the two cannot be merged; the only way to remove one is to
+   stop producing IL, which is what the metadata-only Debug emit does (§12). What is left is one bind,
+   shared between the scan, the JS emit, and the body-diagnostics pass.
+2. **Every `tps` invocation had a ~2.2 s floor** — a *one-file* project took 2.2 s while allocating only
+   5 MB, essentially all JIT of Roslyn — and the SDK runs `tps` once per project. ReadyToRun packaging
+   (§13) halves that floor.
+
+In Release (full IL, both bundle variants) the assembly emit is back to ~3.3 s and minification adds its
+own cost, which is why Release measures 8.34 s against Debug's 5.71 s.
 
 ---
 
@@ -207,26 +223,65 @@ is also what makes the `diff -r` correctness gate usable.
 
 ---
 
-## Available but not enabled: `--metadata-only-assembly` — a further ~18%
+### 12. Metadata-only assembly in Debug — ~18%
 
-`<TransposeMetadataOnlyAssembly>true</TransposeMetadataOnlyAssembly>` or `--metadata-only-assembly`
-emits the project's .NET assembly as metadata only (full metadata **including private members**,
-`throw null` method bodies) instead of compiling IL. Method-body diagnostics then come from the
-semantic models, which the scan and the JS emit have already populated, so that pass reads cached bound
-trees instead of binding again.
+`Compilation.Emit` with `metadataOnly: true, includePrivateMembers: true` produces full metadata with
+`throw null` method bodies instead of compiling IL. Method-body diagnostics then come from the semantic
+models, which the scan and the JS emit have already populated, so that pass reads cached bound trees
+instead of binding again — 0.8 s where the body codegen it replaces cost 2.1 s.
 
-Measured on `tesserae`: **8.3 s → 6.8 s (−18%)**, `bind + emit .NET assembly` 3.4 s → 1.3 s (the
-replacement diagnostics pass costs 0.8 s), total allocation 687 MB → 603 MB, and the DLL roughly halves
-(1.58 MB → 0.81 MB). Emitted JavaScript is byte-identical, and body errors (CS0103 / CS0029 / CS1503)
-are still reported — verified on a purpose-built broken project.
+Measured on `tesserae`: **8.3 s → 6.8 s (−18%)**, `bind + emit .NET assembly` 3.4 s → 1.3 s, total
+allocation 687 MB → 603 MB, DLL roughly halved. Emitted JavaScript byte-identical; body errors
+(CS0103 / CS0029 / CS1503) still reported, verified on a purpose-built broken project.
 
-**Off by default because it changes what a published package contains, and that is a maintainer
-decision.** The argument for turning it on: a Transpose-compiled assembly can never execute. It binds
-against `Transpose.dll`, a stand-in BCL with no implementations, so no .NET host can load it and no
-ordinary .NET project can reference it. Its only jobs are being *bound against* by another Transpose
-project and carrying the compiled JS as embedded resources — both need metadata alone, so the IL is
-already dead weight. Note it implies no debug information (Roslyn rejects an embedded PDB when there
-are no bodies to describe).
+**Default: on for Debug, off for Release.** It is sound because a Transpose-compiled assembly can never
+execute — it binds against `Transpose.dll`, a stand-in BCL with no implementations, so no .NET host can
+load it and no ordinary .NET project can reference it; its only jobs are being *bound against* by
+another Transpose project and carrying the compiled JS as embedded resources, and both need metadata
+alone. But Release is what `dotnet pack` publishes, so Release keeps real IL, and the SDK makes a Debug
+package impossible: `GeneratePackageOnBuild` is forced off for Debug and `dotnet pack -c Debug` fails
+with TPS1001. (`<TransposeMetadataOnlyAssembly>` / `--metadata-only-assembly` /
+`--no-metadata-only-assembly` override the default.) It implies no debug information — Roslyn rejects
+an embedded PDB when there are no bodies to describe.
+
+The pack guard hooks `BeforeTargets="GenerateNuspec"`, not `"Pack"`: GenerateNuspec is a *dependency* of
+Pack and is what writes the .nupkg, so a Pack hook fires after the package is already on disk. That was
+observed, not theorised.
+
+### 13. ReadyToRun tool packaging — ~1 s off every invocation
+
+A `tps` run has a fixed floor — a one-file project takes 2.2 s and allocates 5 MB, essentially all of
+it JIT-compiling Roslyn — and the SDK invokes tps once per project, so a solution pays it per project.
+Publishing the tool ReadyToRun precompiles that away: **2.2 s → 1.1 s** on a one-file project, and on
+`tesserae` the installed R2R tool measured 5.84–6.51 s against 6.72–7.18 s for the JIT build (~18%).
+
+R2R is native code, so it requires RID-specific tool packages. `TransposePackRidSpecificTools=true`
+(in `Transpose.Compiler.csproj`) sets `RuntimeIdentifiers` + `PublishReadyToRun`, and one `dotnet pack`
+then produces nine `Transpose.Compiler.<rid>` packages plus a 2 KB outer `Transpose.Compiler` package
+whose `DotnetToolSettings.xml` maps each RID to its package. `dotnet tool install Transpose.Compiler`
+resolves the right one with no change for users — verified end to end locally, including that the
+installed payload is R2R.
+
+Things that cost time to work out, recorded so they do not have to be again:
+
+- Use **`RuntimeIdentifiers`**, not `ToolPackageRuntimeIdentifiers`. The SDK derives the tool-package
+  RID list from either, but only `RuntimeIdentifiers` also makes *restore* fetch the per-RID assets;
+  with the other one every inner build fails `NETSDK1047`. The pipeline's restore step must pass the
+  property too.
+- A list-valued property cannot be passed as `-p:X=a;b;c` on the command line (MSBuild parses the
+  semicolons as argument separators, and escaping them makes it one RID literal). It has to live in the
+  csproj, gated by a plain boolean property.
+- With RID-specific packages the outer package contains **no implementation**, so a platform absent
+  from the RID list cannot run the tool at all. Hence the deliberately broad list (win/linux/osx ×
+  x64/arm64, plus win-x86 and musl for Alpine containers) — an extra RID costs one ~15 MB package per
+  release, a missing one breaks somebody.
+- Cross-OS and cross-architecture R2R works: a single pack on Linux produced verified-R2R payloads for
+  win-x64, win-arm64, osx-arm64 and the rest. The compiler pipeline runs on `ubuntu-latest` because
+  that is the host this was verified on.
+- `tps-bench --verify-r2r <dir>` opens each produced `.nupkg` and checks the PE ManagedNativeHeader of
+  the assemblies inside, so the pipeline gates on what it is about to push rather than on the build
+  tree (which contains both the pre-publish IL copy and the R2R publish copy of every RID).
+  `--require-r2r` does the same for a single compiler before benchmarking it.
 
 ---
 
@@ -310,13 +365,6 @@ not something a user's build runs, so the risk/benefit is much worse than on the
 
 Roughly in expected-value order.
 
-- **Ship `tps` ReadyToRun — the largest untaken win.** Measured: a one-file project 2.2 s → **1.1 s**,
-  and `tesserae` 8.4–9.4 s → **7.3–7.9 s** (~11%), i.e. ~1 s off *every* invocation. The csproj already
-  sets `PublishReadyToRun`, so it only needs a RID-specific publish:
-  `dotnet publish -c Release -r linux-x64 --self-contained false -p:PublishReadyToRun=true`.
-  The blocker is packaging: `Transpose.Compiler` ships as a portable dotnet tool, so capturing this
-  means RID-specific tool packages and per-platform CI. Since the SDK invokes `tps` once per project,
-  the saving multiplies across a solution.
 - **Replace the Mono.Cecil resource embed with Roslyn `manifestResources`** (0.6 s + 71 MB, and Cecil
   re-serialises the whole assembly). `BuildRuntimePackage` already does this. The obstacle is ordering:
   the resources include the compiled JS, available only *after* the JS emit, while the assembly is

--- a/TODO.optimization.md
+++ b/TODO.optimization.md
@@ -1,0 +1,255 @@
+# TODO.optimization.md — Transpose compiler performance
+
+Running log of compiler performance work: what was measured, what was tried, what worked, and — just
+as important — **what did not**, so a future session does not re-walk a dead end.
+
+Read this together with the **`transpose-performance`** skill (`.claude/skills/transpose-performance/`),
+which describes the workflow and the measurement traps on this hardware.
+
+---
+
+## How to measure (short version)
+
+```bash
+# 1. Build the compiler and the benchmark harness
+dotnet build Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release
+dotnet build Transpose/Transpose.Bench/Transpose.Bench.csproj      -c Release
+
+# 2. Full report: machine info + CPU score + clean-slate compiler scenarios
+./Transpose/Transpose.Bench/bin/Release/net10.0/tps-bench \
+    --tps ./Transpose/Transpose.Compiler/bin/Release/net10.0/tps \
+    --tesserae /home/user/tesserae \
+    --iterations 3 --label my-change \
+    --json artifacts/bench/my-change.json --baseline artifacts/bench/baseline.json
+
+# 3. Quick A/B of two compiler binaries, interleaved (the only trustworthy way on a noisy host)
+./Transpose/Transpose.Bench/ab.sh <tps-A> <tps-B> /home/user/tesserae/Tesserae/Tesserae.csproj 4
+
+# 4. Per-phase timing + per-phase allocations for one build
+tps --project <proj.csproj> -c Debug --timing
+```
+
+### ⚠ The measurement trap on this hardware
+
+The dev container is a 4-core Firecracker VM whose throughput **drifts by 20–40% over minutes**. A
+single before/after pair is worthless — we recorded the *same binary and the same input* at 14.1 s and
+20.3 s within one session. Rules:
+
+- Never conclude anything from one run. Use `ab.sh` (interleaves A,B,A,B…) or `tps-bench --iterations 3+`.
+- A phase can also change time for a reason that has nothing to do with that phase: **whichever phase
+  touches Roslyn's binder first pays the JIT warm-up for it**. That is why "scan unsupported features"
+  appeared to grow from 0.68 s to 2.0 s when the `GetDiagnostics` pass in front of it was removed — the
+  scan did not get slower, it inherited the warm-up bill. Compare *totals*, and only then read phases.
+
+---
+
+## Baseline (before any of this work)
+
+Commit `79fcfc1`, `-c Debug`, 4-core Xeon @2.8 GHz container, CPU score ≈ 92, medians of 3:
+
+| scenario | wall | alloc | peak WS |
+|---|--:|--:|--:|
+| `tesserae` (263 files / ~69k LOC → package DLL) | **17.1 s** | 1 086 MB | 389 MB |
+| `tesserae+tests` (multi-project: dependency + site build) | **25.1 s** | 1 623 MB | 511 MB |
+| `tesserae+tests-warm` (dependency up to date) | **9.8 s** | 529 MB | 256 MB |
+
+Phase split for `tesserae`:
+
+| phase | ms | share | alloc |
+|---|--:|--:|--:|
+| resolve project | 39 | 0.2% | 15 MB |
+| build compilation (parse + references) | 1 011 | 5.9% | 28 MB |
+| bind + diagnostics (`GetDiagnostics`) | 4 397 | 25.7% | 144 MB |
+| scan unsupported features | 2 661 | 15.6% | 150 MB |
+| emit .NET assembly (`Compilation.Emit`) | 4 251 | 24.9% | 207 MB |
+| emit JavaScript | 3 706 | 21.7% | **430 MB** |
+| collect package resources (minify) | 104 | 0.6% | 40 MB |
+| embed resources into DLL (Mono.Cecil) | 927 | 5.4% | 71 MB |
+
+Headline observation: a build binds the whole project **more than once** (GetDiagnostics, then Emit,
+then the scanner's per-identifier queries, then the JS emitter's), and JS emit is by far the biggest
+allocator.
+
+---
+
+## What worked
+
+Ordered by size of win. All were verified to leave the emitted site **byte-identical** (see
+"Correctness gate" below) and to keep the 499-test suite green.
+
+### 1. Runtime configuration: `TieredPGO=off` — ~25–30%
+
+`Transpose.Compiler.csproj` → `<TieredPGO>false</TieredPGO>`.
+
+Tiered PGO instruments tier-0 code to collect a profile. Roslyn's binder is exactly the deeply
+polymorphic code that instrumentation taxes hardest, and a compile is over in seconds — long before
+the better tier-1 code the profile would buy can pay that tax back. Measured (interleaved, Server GC
+on for both): **14.1–14.6 s → 10.3 s** on `tesserae`, and **neutral** (2.11 s vs 2.13 s) on a
+one-file project, so there is no small-project regression.
+
+Related knobs measured at the same time:
+
+| setting | `tesserae` | one-file project | verdict |
+|---|--:|--:|---|
+| default | 14.1–14.6 s | 2.11 s | — |
+| `TieredPGO=0` | **10.3 s** | 2.13 s | **adopted** |
+| `TC_CallCountingDelayMs=0` | 11.9–12.1 s | 2.17 s | adopted (stacks with the above → 9.2 s) |
+| `TC_QuickJitForLoops=0` | 13.1–13.6 s | — | not worth it on its own |
+| `TieredCompilation=0` (no tiering at all) | 9.7–10.0 s | **4.85 s (2.3× worse)** | **rejected** — cripples small projects |
+
+`CallCountingDelayMs` has no MSBuild property, so it is set through
+`Transpose.Compiler/runtimeconfig.template.json`.
+
+### 2. Runtime configuration: Server GC — ~15%
+
+`<ServerGarbageCollection>true</ServerGarbageCollection>`. A build produces ~900 MB of short-lived
+garbage inside several `Parallel.ForEach` phases; on Workstation GC every collection serialises on one
+heap and stalls all workers. Interleaved measurement: **15.1–17.3 s → 12.2–12.9 s**. Peak working set
+rises ~390 MB → ~490 MB, and .NET's DATAS keeps the heap count adaptive so a trivial project does not
+pay a many-heap memory penalty.
+
+Rejected variant: `gcConcurrent=0` alongside Server GC — measurably *worse* (13.8 s vs 11.7 s).
+
+### 3. `UnsupportedFeatureScanner`: screen identifiers by text before binding — −2.0 s, −124 MB
+
+`VisitIdentifierName` fires on nearly every identifier in the source and used to call
+`GetSymbolInfo` on each one, which binds the whole enclosing member. It now first checks the
+identifier's *text* against a set precomputed once per compilation: the simple names of every type in
+a denied namespace (`System.IO`, `System.Net.Sockets`, `System.Threading`) that the scanner would
+actually reject, plus `nint`/`nuint`/`var`.
+
+This is **sound, not heuristic** — an identifier can only bind to a denied type if its text is that
+type's name. The three ways around that are each handled explicitly:
+
+- `var` is in the set, so an inferred local whose type is never written out is still caught.
+- `using MyFile = System.IO.File;` — the alias name is added to the file's name set when the directive
+  is visited, so the *usage site* is still reported (reporting the directive instead would have
+  rejected an unused import, which the scanner never did).
+- `using static System.IO.File;` — same, with the imported type's member names.
+
+Also prefiltered: `CheckDllImport` (screen the written attribute name before binding) and
+`VisitIsPatternExpression` (only a *string-literal* constant pattern can be the span-pattern form).
+
+Result: **2 661 ms → 684 ms**, allocations 150 MB → 27 MB. Diagnostics were diffed against the old
+compiler on a purpose-built file exercising every rule: same set of rejected constructs, minus five
+*duplicate* reports at the same site (the old code reported both `File` and `ReadAllText` in
+`File.ReadAllText(...)`, and separately flagged the `var` on the same line).
+
+### 4. Take diagnostics from `Compilation.Emit` instead of a separate `GetDiagnostics()` — ~0.7 s, −75 MB
+
+`Emit`'s result already carries every declaration and method-body diagnostic. When an assembly is
+being emitted (every real project build) the standalone `GetDiagnostics()` pass is now skipped.
+
+**This is much less of a win than the phase table suggests** and the reason is worth recording:
+`GetDiagnostics` and `Emit` were not doing the same work twice, they were *sharing* it. `Emit` runs on
+`compilation.WithOptions(…DynamicallyLinkedLibrary)`, and the preceding `GetDiagnostics` on the
+original compilation warmed the reference manager and the JIT for the binder. Removing it made `Emit`
+alone go 4.25 s → ~6.5 s, so the net was ~0.7 s, not the 4.3 s the table implies. Source-only builds
+(the test suite, `--out`) keep the `GetDiagnostics` path. On a *failed* emit we fall back to a full
+`GetDiagnostics`, because `Emit` stops before compiling method bodies when declarations already have
+errors and would otherwise report a subset.
+
+### 5. Parallel parsing — −0.6 s
+
+`CompilationBuilder.Build` parsed 263 files sequentially. Now `Parallel.For` into a pre-sized array so
+tree order (and therefore bundle order) is preserved. **1 011 ms → ~450 ms.**
+
+### 6. Parallel type collection — −0.25 s
+
+`Emitter.CollectTypes` walked every tree sequentially calling `GetDeclaredSymbol`. Now per-tree in
+parallel, merged in tree order, with the dedupe (partial types) applied after the merge.
+**345 ms → ~80 ms.**
+
+### 7. One shared semantic-model cache for the scan *and* the emit — ~5% of JS emit
+
+A `SemanticModel` retains the bound form of every member it is asked about. Previously the scanner
+built throw-away models, and `Emitter.Clone()` built a **fresh `TreeModel` per type** (483 of them).
+Now a single `TreeModel` (backed by a `ConcurrentDictionary`) is created in `RoslynTranslator` and
+passed to both the scan and every emitter clone, so a member the scan bound is already bound when the
+emitter reaches it. JS emit 2 543 → ~2 300 ms, allocations 446 → 432 MB.
+
+Smaller than hoped, and the reason is instructive: Roslyn caches at *member* granularity, so two
+types in the same file were never sharing bound bodies anyway — only the (cheap) tree-level model
+object was duplicated. The real saving comes from the scan/emit overlap, not from the clones.
+
+### 8. Deterministic output (correctness, found while verifying)
+
+`EmitEnumeratorInit` named its enumerator temp from `forEach.GetHashCode()` — a *reference* hash, so
+the emitted bundle differed byte-for-byte on every compile of unchanged sources. Now derived from
+`forEach.SpanStart`, which is stable and unique within a file (all the uniqueness the name needs,
+since it is local to one JS function). Confirmed: two consecutive clean builds now produce an
+identical `app.js`.
+
+---
+
+## What did not work
+
+### Running the unsupported-feature scan concurrently with the assembly emit — **rejected**
+
+Both phases are already internally parallel (`Parallel.ForEach` / Roslyn's concurrent build) and
+saturate all 4 cores, so overlapping them just made them contend: the scan went 0.68 s → 2.2 s and the
+emit 4.25 s → 8.3 s, for a **worse** total (14.5 s vs 14.4 s sequential). Worth re-testing on a
+many-core machine, where there is idle capacity to absorb it — the code was left sequential and the
+`Task.Run` removed.
+
+### `gcConcurrent=0` with Server GC — **rejected**
+
+13.8 s vs 11.7 s with concurrent (background) GC on. See table above.
+
+### `TieredCompilation=0` — **rejected**
+
+Fastest option for a big project (9.7 s) but 2.3× slower on a one-file project (4.85 s vs 2.11 s).
+A compiler must not punish small projects to reward large ones.
+
+---
+
+## Ideas not yet tried
+
+Roughly in expected-value order.
+
+- **Replace the Mono.Cecil resource embed with Roslyn `manifestResources`** (0.6–0.9 s + 71 MB, and the
+  DLL is currently written twice). `BuildRuntimePackage` already does this. The obstacle is ordering:
+  the resources include the compiled JS, which is only available *after* the JS emit, while the
+  assembly is emitted *before* it (that emit is what produces the diagnostics gating the JS emit).
+  Sketched way out: start `Emit` on a worker with lazy `ResourceDescription` providers that block on
+  the JS-emit task, so the two overlap and Cecil disappears. Needs care — Roslyn calls the provider
+  synchronously during metadata writing, so a mis-ordering deadlocks.
+- **`metadataOnly` assembly emit.** The package DLL is only ever *bound against* (by `tps`), never
+  executed, so a ref-assembly-with-private-members would do and would skip method-body codegen
+  entirely. But it also skips method-body *diagnostics*, so `GetDiagnostics` comes back: measured
+  trade is roughly break-even, and it changes what a published NuGet package contains (method bodies
+  become `throw null`). **Do not do this silently** — it needs a product decision.
+- **Drop the embedded PDB** from the package emit (`DebugInformationFormat.Embedded` is hardcoded even
+  though Tesserae sets `DebugType=None`). Not yet measured in isolation.
+- **JS emit allocation reduction** — still the largest allocator at ~430 MB for `tesserae`. Suspects:
+  `ISymbol.ToDisplayString()` on hot paths (it formats a fresh string every call and several
+  comparisons are done against the *formatted* name), LINQ in the emitter walkers, one `JsWriter` +
+  `StringBuilder` per type, and `TypeRef`/`MemberJsName` recomputation. A `ToDisplayString` result
+  cache keyed on symbol is the obvious first move.
+- **`IsTaskType` and friends compare `ToDisplayString()` against string literals.** Replacing those
+  with `SymbolEqualityComparer` against symbols resolved once from the compilation would remove a
+  large number of string formats from the hottest emitter paths.
+- **Reflection metadata build** (~450–650 ms inside JS emit) is sequential; it is a per-type map and
+  should parallelise like the type bodies do.
+- **`MetadataImportOptions.All`** makes Roslyn import every non-public member of every reference. It is
+  required for overload numbering to match, but the cost has never been measured — worth quantifying
+  before assuming it is unavoidable.
+- **Re-test phase overlap on a many-core machine.** All the "parallelising made it worse" results above
+  are 4-core results.
+
+---
+
+## Correctness gate for any change here
+
+1. `dotnet test Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj -c Release`
+   — 499 tests, ~3.5 min, must stay green.
+2. Byte-compare the whole emitted site against the pre-change compiler:
+   ```bash
+   git worktree add /tmp/tps-base <base-commit>
+   (cd /tmp/tps-base && dotnet build Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release)
+   # build Tesserae.Tests with each compiler into /tmp/out-base and /tmp/out-new, then
+   diff -r /tmp/out-base /tmp/out-new
+   ```
+3. For anything touching `UnsupportedFeatureScanner`, diff the diagnostics of a file that exercises
+   every rule (pointers, `unsafe`, `checked`, `nint`, P/Invoke, `System.IO`/`System.Threading` types,
+   an alias import and a static import) against the pre-change compiler.

--- a/TODO.optimization.md
+++ b/TODO.optimization.md
@@ -3,203 +3,262 @@
 Running log of compiler performance work: what was measured, what was tried, what worked, and — just
 as important — **what did not**, so a future session does not re-walk a dead end.
 
-Read this together with the **`transpose-performance`** skill (`.claude/skills/transpose-performance/`),
-which describes the workflow and the measurement traps on this hardware.
+The workflow, the measurement traps, and the correctness gate live in the
+**`transpose-performance`** skill (`.claude/skills/transpose-performance/`). Read that for *how*;
+read this for *what has already been done*.
 
 ---
 
-## How to measure (short version)
+## Where things stand
+
+Clean-slate builds of the tesserae corpus, `-c Debug`, medians of 3, CPU-score-normalised
+(`tps-bench`, 4-core Xeon @2.80 GHz container, score ≈ 92):
+
+| scenario | before | after | delta | alloc delta |
+|---|--:|--:|--:|--:|
+| `tesserae` — 263 files / ~69k LOC → package DLL | 15.82 s | **7.23 s** | **−54.3%** | −36.9% |
+| `tesserae+tests` — multi-project: dependency + site build | 23.16 s | **8.64 s** | **−62.7%** | −41.5% |
+| `tesserae+tests-warm` — dependency already up to date | 9.03 s | **4.23 s** | **−53.1%** | −46.4% |
+
+Baseline commit `79fcfc1`. The recorded reports are checked in as `docs/perf/baseline.json` and
+`docs/perf/optimized.json` (plus `optimized.md`), so a later change can be compared against either
+without rebuilding an old compiler:
 
 ```bash
-# 1. Build the compiler and the benchmark harness
-dotnet build Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release
-dotnet build Transpose/Transpose.Bench/Transpose.Bench.csproj      -c Release
-
-# 2. Full report: machine info + CPU score + clean-slate compiler scenarios
-./Transpose/Transpose.Bench/bin/Release/net10.0/tps-bench \
-    --tps ./Transpose/Transpose.Compiler/bin/Release/net10.0/tps \
-    --tesserae /home/user/tesserae \
-    --iterations 3 --label my-change \
-    --json artifacts/bench/my-change.json --baseline artifacts/bench/baseline.json
-
-# 3. Quick A/B of two compiler binaries, interleaved (the only trustworthy way on a noisy host)
-./Transpose/Transpose.Bench/ab.sh <tps-A> <tps-B> /home/user/tesserae/Tesserae/Tesserae.csproj 4
-
-# 4. Per-phase timing + per-phase allocations for one build
-tps --project <proj.csproj> -c Debug --timing
+tps-bench --tps <tps> --tesserae <tesserae> --iterations 3 --baseline docs/perf/optimized.json
 ```
 
-### ⚠ The measurement trap on this hardware
+Emitted output is **byte-identical** to the pre-optimization compiler across all of it (verified with
+`compare-site.sh` over the whole `Tesserae.Tests` site), and the 499-test suite stays green.
 
-The dev container is a 4-core Firecracker VM whose throughput **drifts by 20–40% over minutes**. A
-single before/after pair is worthless — we recorded the *same binary and the same input* at 14.1 s and
-20.3 s within one session. Rules:
-
-- Never conclude anything from one run. Use `ab.sh` (interleaves A,B,A,B…) or `tps-bench --iterations 3+`.
-- A phase can also change time for a reason that has nothing to do with that phase: **whichever phase
-  touches Roslyn's binder first pays the JIT warm-up for it**. That is why "scan unsupported features"
-  appeared to grow from 0.68 s to 2.0 s when the `GetDiagnostics` pass in front of it was removed — the
-  scan did not get slower, it inherited the warm-up bill. Compare *totals*, and only then read phases.
-
----
-
-## Baseline (before any of this work)
-
-Commit `79fcfc1`, `-c Debug`, 4-core Xeon @2.8 GHz container, CPU score ≈ 92, medians of 3:
-
-| scenario | wall | alloc | peak WS |
-|---|--:|--:|--:|
-| `tesserae` (263 files / ~69k LOC → package DLL) | **17.1 s** | 1 086 MB | 389 MB |
-| `tesserae+tests` (multi-project: dependency + site build) | **25.1 s** | 1 623 MB | 511 MB |
-| `tesserae+tests-warm` (dependency up to date) | **9.8 s** | 529 MB | 256 MB |
-
-Phase split for `tesserae`:
+### Phase split now, for `tesserae`
 
 | phase | ms | share | alloc |
 |---|--:|--:|--:|
-| resolve project | 39 | 0.2% | 15 MB |
-| build compilation (parse + references) | 1 011 | 5.9% | 28 MB |
-| bind + diagnostics (`GetDiagnostics`) | 4 397 | 25.7% | 144 MB |
-| scan unsupported features | 2 661 | 15.6% | 150 MB |
-| emit .NET assembly (`Compilation.Emit`) | 4 251 | 24.9% | 207 MB |
-| emit JavaScript | 3 706 | 21.7% | **430 MB** |
-| collect package resources (minify) | 104 | 0.6% | 40 MB |
-| embed resources into DLL (Mono.Cecil) | 927 | 5.4% | 71 MB |
+| resolve project | 47 | 0.6% | 15 MB |
+| build compilation (parse + references) | 396 | 5.0% | 29 MB |
+| scan unsupported features | 1 823 | 23.1% | 57 MB |
+| bind + emit .NET assembly | 3 258 | 41.3% | 199 MB |
+| emit JavaScript | 1 689 | 21.4% | 274 MB |
+| collect package resources (minify) | 49 | 0.6% | 40 MB |
+| embed resources into DLL (Mono.Cecil) | 633 | 8.0% | 71 MB |
 
-Headline observation: a build binds the whole project **more than once** (GetDiagnostics, then Emit,
-then the scanner's per-identifier queries, then the JS emitter's), and JS emit is by far the biggest
-allocator.
+Two structural facts that bound everything below:
+
+1. **A build binds the whole project about twice** — once inside `Compilation.Emit` (to produce IL) and
+   once through the `SemanticModel` (to drive the JS emitter). Roslyn's internal bound trees are not
+   reachable from the public API, so the two cannot be merged. The only way to remove one is to stop
+   producing IL at all (see `--metadata-only-assembly` below).
+2. **Every `tps` invocation has a ~2.2 s floor.** A *one-file* project takes 2.2 s and allocates 5 MB;
+   that is JIT of Roslyn plus importing `Transpose.dll`'s metadata. The SDK runs `tps` once per
+   project, so a solution pays it per project.
 
 ---
 
 ## What worked
 
-Ordered by size of win. All were verified to leave the emitted site **byte-identical** (see
-"Correctness gate" below) and to keep the 499-test suite green.
+Ordered by size. Every one was verified against the correctness gate in the skill.
 
 ### 1. Runtime configuration: `TieredPGO=off` — ~25–30%
 
 `Transpose.Compiler.csproj` → `<TieredPGO>false</TieredPGO>`.
 
 Tiered PGO instruments tier-0 code to collect a profile. Roslyn's binder is exactly the deeply
-polymorphic code that instrumentation taxes hardest, and a compile is over in seconds — long before
-the better tier-1 code the profile would buy can pay that tax back. Measured (interleaved, Server GC
-on for both): **14.1–14.6 s → 10.3 s** on `tesserae`, and **neutral** (2.11 s vs 2.13 s) on a
-one-file project, so there is no small-project regression.
+polymorphic code instrumentation taxes hardest, and a compile is over in seconds — long before the
+better tier-1 code the profile would buy can pay that tax back. Measured interleaved, Server GC on for
+both: **14.1–14.6 s → 10.3 s** on `tesserae`, and **neutral** on a one-file project (2.13 s vs 2.11 s),
+so small projects do not regress.
 
-Related knobs measured at the same time:
+Everything measured in this area:
 
 | setting | `tesserae` | one-file project | verdict |
 |---|--:|--:|---|
 | default | 14.1–14.6 s | 2.11 s | — |
 | `TieredPGO=0` | **10.3 s** | 2.13 s | **adopted** |
-| `TC_CallCountingDelayMs=0` | 11.9–12.1 s | 2.17 s | adopted (stacks with the above → 9.2 s) |
-| `TC_QuickJitForLoops=0` | 13.1–13.6 s | — | not worth it on its own |
-| `TieredCompilation=0` (no tiering at all) | 9.7–10.0 s | **4.85 s (2.3× worse)** | **rejected** — cripples small projects |
+| `TC_CallCountingDelayMs=0` | 11.9–12.1 s | 2.17 s | **adopted** (stacks with the above → 9.2 s) |
+| `TC_QuickJitForLoops=0` | 13.1–13.6 s | — | rejected — not worth it alone |
+| `TieredCompilation=0` (no tiering) | 9.7–10.0 s | **4.85 s (2.3× worse)** | **rejected** — cripples small projects |
 
-`CallCountingDelayMs` has no MSBuild property, so it is set through
+`CallCountingDelayMs` has no MSBuild property, so it is set via
 `Transpose.Compiler/runtimeconfig.template.json`.
 
 ### 2. Runtime configuration: Server GC — ~15%
 
-`<ServerGarbageCollection>true</ServerGarbageCollection>`. A build produces ~900 MB of short-lived
+`<ServerGarbageCollection>true</ServerGarbageCollection>`. A build makes ~700–900 MB of short-lived
 garbage inside several `Parallel.ForEach` phases; on Workstation GC every collection serialises on one
-heap and stalls all workers. Interleaved measurement: **15.1–17.3 s → 12.2–12.9 s**. Peak working set
-rises ~390 MB → ~490 MB, and .NET's DATAS keeps the heap count adaptive so a trivial project does not
-pay a many-heap memory penalty.
+heap and stalls all workers. Interleaved: **15.1–17.3 s → 12.2–12.9 s**. Peak working set rises
+~390 MB → ~490 MB; .NET's DATAS keeps the heap count adaptive, so a trivial project does not pay a
+many-heap memory penalty.
 
 Rejected variant: `gcConcurrent=0` alongside Server GC — measurably *worse* (13.8 s vs 11.7 s).
 
-### 3. `UnsupportedFeatureScanner`: screen identifiers by text before binding — −2.0 s, −124 MB
+### 3. `TransposeNaming`: cache the naming layer — JS emit 2.3× faster
 
-`VisitIdentifierName` fires on nearly every identifier in the source and used to call
-`GetSymbolInfo` on each one, which binds the whole enclosing member. It now first checks the
-identifier's *text* against a set precomputed once per compilation: the simple names of every type in
-a denied namespace (`System.IO`, `System.Net.Sockets`, `System.Threading`) that the scanner would
-actually reject, plus `nint`/`nuint`/`var`.
+An allocation profile put a quarter of the build's entire allocation inside `TransposeNaming`.
+Resolving a member's JavaScript name is an expensive graph walk and it was redone once per *reference*
+in the source. Now cached per symbol:
 
-This is **sound, not heuristic** — an identifier can only bind to a denied type if its text is that
-type's name. The three ways around that are each handled explicitly:
+- `MemberJsName` — for a property/field it walks `AllInterfaces` and every interface's members to decide
+  whether the member must yield its plain JS slot.
+- `JsBaseName` — `OverloadGroup` calls it for every candidate method in every base type, to group
+  overloads by their final JS name.
+- `ImplementedInterfaceMember` — O(interfaces × their members) with a
+  `FindImplementationForInterfaceMember` call each, walked once per level of the override chain.
+
+Caches are keyed on the symbol **as passed**, never on `OriginalDefinition`: a constructed generic's
+member is a distinct symbol, and caching it separately cannot change an answer while normalising could.
+
+Result: `emit JavaScript` **3 706 ms / 430 MB → 1 775 ms / 275 MB**.
+
+### 4. `UnsupportedFeatureScanner`: screen identifiers by text before binding — 2 661 ms → 684 ms
+
+`VisitIdentifierName` fires on nearly every identifier in the source and used to call `GetSymbolInfo`
+on each, which binds the whole enclosing member. It now first checks the identifier's *text* against a
+set precomputed once per compilation: the simple names of every type in a denied namespace
+(`System.IO`, `System.Net.Sockets`, `System.Threading`) that the scanner would actually reject, plus
+`nint`/`nuint`/`var`.
+
+**Sound, not heuristic** — an identifier can only bind to a denied type if its text is that type's
+name. The three escapes are handled explicitly:
 
 - `var` is in the set, so an inferred local whose type is never written out is still caught.
-- `using MyFile = System.IO.File;` — the alias name is added to the file's name set when the directive
-  is visited, so the *usage site* is still reported (reporting the directive instead would have
-  rejected an unused import, which the scanner never did).
+- `using MyFile = System.IO.File;` — the alias name joins the file's name set when the directive is
+  visited, so the *usage site* is still reported. (Reporting the directive itself would have rejected
+  an *unused* import, which the scanner never did.)
 - `using static System.IO.File;` — same, with the imported type's member names.
 
 Also prefiltered: `CheckDllImport` (screen the written attribute name before binding) and
 `VisitIsPatternExpression` (only a *string-literal* constant pattern can be the span-pattern form).
 
-Result: **2 661 ms → 684 ms**, allocations 150 MB → 27 MB. Diagnostics were diffed against the old
-compiler on a purpose-built file exercising every rule: same set of rejected constructs, minus five
-*duplicate* reports at the same site (the old code reported both `File` and `ReadAllText` in
-`File.ReadAllText(...)`, and separately flagged the `var` on the same line).
+Allocation 150 MB → 27 MB. Diagnostics were diffed against the old compiler on a file exercising every
+rule: the same set of rejected constructs, minus five *duplicate* reports at the same site (the old
+code reported both `File` and `ReadAllText` in `File.ReadAllText(...)`, and separately flagged the
+`var` on the same line).
 
-### 4. Take diagnostics from `Compilation.Emit` instead of a separate `GetDiagnostics()` — ~0.7 s, −75 MB
+### 5. Allocation-free attribute and location lookups — −42 MB
 
-`Emit`'s result already carries every declaration and method-body diagnostic. When an assembly is
-being emitted (every real project build) the standalone `GetDiagnostics()` pass is now skipped.
+`GetAttributes().FirstOrDefault(a => AttrIs(a, name))` allocates a closure (it captures `name`) and
+boxes the `ImmutableArray` enumerator on *every* call — it was the single largest allocation site in
+the build. Now `TransposeNaming.FindAttr`/`HasAttr`, plain loops. Same treatment for
+`Locations.Any(l => l.IsInSource)` (`AnyInSource`) and the `GetMembers().OfType<IMethodSymbol>()` walks
+in the overload collection.
 
-**This is much less of a win than the phase table suggests** and the reason is worth recording:
-`GetDiagnostics` and `Emit` were not doing the same work twice, they were *sharing* it. `Emit` runs on
-`compilation.WithOptions(…DynamicallyLinkedLibrary)`, and the preceding `GetDiagnostics` on the
-original compilation warmed the reference manager and the JIT for the binder. Removing it made `Emit`
-alone go 4.25 s → ~6.5 s, so the net was ~0.7 s, not the 4.3 s the table implies. Source-only builds
-(the test suite, `--out`) keep the `GetDiagnostics` path. On a *failed* emit we fall back to a full
-`GetDiagnostics`, because `Emit` stops before compiling method bodies when declarations already have
-errors and would otherwise report a subset.
-
-### 5. Parallel parsing — −0.6 s
-
-`CompilationBuilder.Build` parsed 263 files sequentially. Now `Parallel.For` into a pre-sized array so
-tree order (and therefore bundle order) is preserved. **1 011 ms → ~450 ms.**
-
-### 6. Parallel type collection — −0.25 s
-
-`Emitter.CollectTypes` walked every tree sequentially calling `GetDeclaredSymbol`. Now per-tree in
-parallel, merged in tree order, with the dedupe (partial types) applied after the merge.
-**345 ms → ~80 ms.**
-
-### 7. One shared semantic-model cache for the scan *and* the emit — ~5% of JS emit
+### 6. One shared semantic-model cache for the scan *and* the emit
 
 A `SemanticModel` retains the bound form of every member it is asked about. Previously the scanner
-built throw-away models, and `Emitter.Clone()` built a **fresh `TreeModel` per type** (483 of them).
-Now a single `TreeModel` (backed by a `ConcurrentDictionary`) is created in `RoslynTranslator` and
-passed to both the scan and every emitter clone, so a member the scan bound is already bound when the
-emitter reaches it. JS emit 2 543 → ~2 300 ms, allocations 446 → 432 MB.
+built throw-away models and `Emitter.Clone()` built a **fresh `TreeModel` per type** (483 of them). Now
+a single `TreeModel` (a `ConcurrentDictionary`, created in `RoslynTranslator`) is shared by the scan and
+every emitter clone.
 
-Smaller than hoped, and the reason is instructive: Roslyn caches at *member* granularity, so two
-types in the same file were never sharing bound bodies anyway — only the (cheap) tree-level model
-object was duplicated. The real saving comes from the scan/emit overlap, not from the clones.
+**Proof that it works**: temporarily dropping `var` from the scanner's name set moved ~780 ms *out* of
+the scan and ~465 ms *into* the JS emit, leaving the total flat (8.43–8.53 s vs 8.28–8.83 s). The
+scan's binds are prepaid emitter work, not extra work — which is why the scan looks expensive in the
+phase table and yet costs nothing.
 
-### 8. Deterministic output (correctness, found while verifying)
+Sharing between emitter *clones* specifically was smaller than hoped, and the reason is worth knowing:
+Roslyn caches at *member* granularity, so two types in the same file never shared bound bodies anyway —
+only the (cheap) tree-level model object was duplicated.
 
-`EmitEnumeratorInit` named its enumerator temp from `forEach.GetHashCode()` — a *reference* hash, so
-the emitted bundle differed byte-for-byte on every compile of unchanged sources. Now derived from
-`forEach.SpanStart`, which is stable and unique within a file (all the uniqueness the name needs,
-since it is local to one JS function). Confirmed: two consecutive clean builds now produce an
-identical `app.js`.
+### 7. Take diagnostics from `Compilation.Emit` instead of a separate `GetDiagnostics()` — ~0.7 s, −75 MB
+
+`Emit`'s result already carries every declaration and method-body diagnostic. When an assembly is being
+emitted (every real project build) the standalone `GetDiagnostics()` pass is skipped.
+
+**Much less of a win than the phase table implies**, and the reason matters: the two were not doing the
+same work twice, they were *sharing* it. `Emit` runs on `compilation.WithOptions(…Library)`, and the
+preceding `GetDiagnostics` on the original compilation warmed the reference manager and the JIT for the
+binder. Removing it made `Emit` alone go 4.25 s → ~6.5 s, so the net was ~0.7 s, not 4.3 s.
+
+Source-only builds (the test suite, `--out`) keep the `GetDiagnostics` path. A *failed* emit falls back
+to a full `GetDiagnostics`, because `Emit` stops before compiling method bodies when declarations
+already have errors and would otherwise report a subset. That fallback now dedupes on `(Id, Location)`
+— `Diagnostic` has reference equality, so errors found by both passes were printed twice.
+
+### 8. Parallel parsing (−0.6 s) and parallel type collection (−0.25 s)
+
+`CompilationBuilder.Build` parsed 263 files sequentially (**1 011 ms → ~410 ms**); `Emitter.CollectTypes`
+walked every tree sequentially calling `GetDeclaredSymbol` (**345 ms → ~77 ms**). Both fan out per file
+into a pre-sized array and merge in input order, so tree order — and therefore bundle order — is
+unchanged. The partial-type dedupe happens after the merge.
+
+### 9. Honour the project's `DebugType`
+
+The assembly emit hardcoded an embedded PDB even for a project that declares `DebugType=None`
+(Tesserae does). Now read from the csproj (`DebugType`/`DebugSymbols`), defaulting to on so a project
+that says nothing keeps what it always got. ~5% off the emit phase and ~12% off the DLL size for
+projects that opt out.
+
+### 10. Write the package DLL once, not twice
+
+`WritePackage` wrote the emitted assembly to disk and then had Mono.Cecil read it straight back to add
+the resources and rewrite it. Cecil now reads the assembly from memory and writes the final file
+directly. A package DLL with the JS, CSS and fonts embedded is tens of megabytes (Tesserae's is
+~15 MB), so this halves the file I/O — though it measured **flat on this box**, where everything was in
+the page cache. Kept because it is simpler and strictly less work; expect it to matter on real disks
+and in CI.
+
+### 11. Reproducible output (a correctness fix found while verifying)
+
+`EmitEnumeratorInit` named its enumerator temporary from `forEach.GetHashCode()` — a *reference* hash,
+so an unchanged project emitted a byte-different bundle on every build. Now derived from
+`forEach.SpanStart`, which is stable and unique within a file (all the uniqueness the name needs, since
+it is local to one JS function). Two consecutive clean builds now produce an identical `app.js`, which
+is also what makes the `diff -r` correctness gate usable.
+
+---
+
+## Available but not enabled: `--metadata-only-assembly` — a further ~18%
+
+`<TransposeMetadataOnlyAssembly>true</TransposeMetadataOnlyAssembly>` or `--metadata-only-assembly`
+emits the project's .NET assembly as metadata only (full metadata **including private members**,
+`throw null` method bodies) instead of compiling IL. Method-body diagnostics then come from the
+semantic models, which the scan and the JS emit have already populated, so that pass reads cached bound
+trees instead of binding again.
+
+Measured on `tesserae`: **8.3 s → 6.8 s (−18%)**, `bind + emit .NET assembly` 3.4 s → 1.3 s (the
+replacement diagnostics pass costs 0.8 s), total allocation 687 MB → 603 MB, and the DLL roughly halves
+(1.58 MB → 0.81 MB). Emitted JavaScript is byte-identical, and body errors (CS0103 / CS0029 / CS1503)
+are still reported — verified on a purpose-built broken project.
+
+**Off by default because it changes what a published package contains, and that is a maintainer
+decision.** The argument for turning it on: a Transpose-compiled assembly can never execute. It binds
+against `Transpose.dll`, a stand-in BCL with no implementations, so no .NET host can load it and no
+ordinary .NET project can reference it. Its only jobs are being *bound against* by another Transpose
+project and carrying the compiled JS as embedded resources — both need metadata alone, so the IL is
+already dead weight. Note it implies no debug information (Roslyn rejects an embedded PDB when there
+are no bodies to describe).
 
 ---
 
 ## What did not work
 
-### Running the unsupported-feature scan concurrently with the assembly emit — **rejected**
+### Overlapping two already-parallel phases — **rejected, twice**
 
-Both phases are already internally parallel (`Parallel.ForEach` / Roslyn's concurrent build) and
-saturate all 4 cores, so overlapping them just made them contend: the scan went 0.68 s → 2.2 s and the
-emit 4.25 s → 8.3 s, for a **worse** total (14.5 s vs 14.4 s sequential). Worth re-testing on a
-many-core machine, where there is idle capacity to absorb it — the code was left sequential and the
-`Task.Run` removed.
+Both attempts made things *worse* on this 4-core box, because each phase already saturates all cores
+and they simply contend:
+
+- **scan ∥ assembly emit**: scan 0.68 s → 2.2 s, emit 4.25 s → 8.3 s, total 14.4 s → 14.5 s.
+- **JS emit ∥ assembly emit** (retested after all the other wins, in case the picture had changed):
+  JS emit 1.6 s → 2.5–2.9 s, assembly emit 3.4 s → 5.1–5.6 s, total 8.2–8.7 s → 8.6–9.0 s.
+
+The code is deliberately sequential there. Worth re-testing on many-core hardware, where there is idle
+capacity to absorb it — but do not assume; measure.
+
+### Pooling `Emitter.Capture`'s writers — **rejected (no effect)**
+
+The emitter captures sub-fragments into a throw-away `JsWriter` (and `StringBuilder`) constantly, so
+recycling them looked obviously right. Measured allocation was **unchanged**: 312.4 MB vs 312.9 MB.
+`Capture`'s large inclusive cost is the emission work beneath it, not the writer itself. Reverted
+rather than carry the complexity.
 
 ### `gcConcurrent=0` with Server GC — **rejected**
 
-13.8 s vs 11.7 s with concurrent (background) GC on. See table above.
+13.8 s vs 11.7 s with background GC on.
 
 ### `TieredCompilation=0` — **rejected**
 
-Fastest option for a big project (9.7 s) but 2.3× slower on a one-file project (4.85 s vs 2.11 s).
-A compiler must not punish small projects to reward large ones.
+Fastest single setting for a big project (9.7 s) but 2.3× slower on a one-file project (4.85 s vs
+2.11 s). A compiler must not punish small projects to reward large ones.
 
 ---
 
@@ -207,49 +266,45 @@ A compiler must not punish small projects to reward large ones.
 
 Roughly in expected-value order.
 
-- **Replace the Mono.Cecil resource embed with Roslyn `manifestResources`** (0.6–0.9 s + 71 MB, and the
-  DLL is currently written twice). `BuildRuntimePackage` already does this. The obstacle is ordering:
-  the resources include the compiled JS, which is only available *after* the JS emit, while the
-  assembly is emitted *before* it (that emit is what produces the diagnostics gating the JS emit).
-  Sketched way out: start `Emit` on a worker with lazy `ResourceDescription` providers that block on
-  the JS-emit task, so the two overlap and Cecil disappears. Needs care — Roslyn calls the provider
-  synchronously during metadata writing, so a mis-ordering deadlocks.
-- **`metadataOnly` assembly emit.** The package DLL is only ever *bound against* (by `tps`), never
-  executed, so a ref-assembly-with-private-members would do and would skip method-body codegen
-  entirely. But it also skips method-body *diagnostics*, so `GetDiagnostics` comes back: measured
-  trade is roughly break-even, and it changes what a published NuGet package contains (method bodies
-  become `throw null`). **Do not do this silently** — it needs a product decision.
-- **Drop the embedded PDB** from the package emit (`DebugInformationFormat.Embedded` is hardcoded even
-  though Tesserae sets `DebugType=None`). Not yet measured in isolation.
-- **JS emit allocation reduction** — still the largest allocator at ~430 MB for `tesserae`. Suspects:
-  `ISymbol.ToDisplayString()` on hot paths (it formats a fresh string every call and several
-  comparisons are done against the *formatted* name), LINQ in the emitter walkers, one `JsWriter` +
-  `StringBuilder` per type, and `TypeRef`/`MemberJsName` recomputation. A `ToDisplayString` result
-  cache keyed on symbol is the obvious first move.
-- **`IsTaskType` and friends compare `ToDisplayString()` against string literals.** Replacing those
-  with `SymbolEqualityComparer` against symbols resolved once from the compilation would remove a
-  large number of string formats from the hottest emitter paths.
-- **Reflection metadata build** (~450–650 ms inside JS emit) is sequential; it is a per-type map and
-  should parallelise like the type bodies do.
-- **`MetadataImportOptions.All`** makes Roslyn import every non-public member of every reference. It is
-  required for overload numbering to match, but the cost has never been measured — worth quantifying
-  before assuming it is unavoidable.
-- **Re-test phase overlap on a many-core machine.** All the "parallelising made it worse" results above
-  are 4-core results.
-
----
-
-## Correctness gate for any change here
-
-1. `dotnet test Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj -c Release`
-   — 499 tests, ~3.5 min, must stay green.
-2. Byte-compare the whole emitted site against the pre-change compiler:
-   ```bash
-   git worktree add /tmp/tps-base <base-commit>
-   (cd /tmp/tps-base && dotnet build Transpose/Transpose.Compiler/Transpose.Compiler.csproj -c Release)
-   # build Tesserae.Tests with each compiler into /tmp/out-base and /tmp/out-new, then
-   diff -r /tmp/out-base /tmp/out-new
-   ```
-3. For anything touching `UnsupportedFeatureScanner`, diff the diagnostics of a file that exercises
-   every rule (pointers, `unsafe`, `checked`, `nint`, P/Invoke, `System.IO`/`System.Threading` types,
-   an alias import and a static import) against the pre-change compiler.
+- **Ship `tps` ReadyToRun — the largest untaken win.** Measured: a one-file project 2.2 s → **1.1 s**,
+  and `tesserae` 8.4–9.4 s → **7.3–7.9 s** (~11%), i.e. ~1 s off *every* invocation. The csproj already
+  sets `PublishReadyToRun`, so it only needs a RID-specific publish:
+  `dotnet publish -c Release -r linux-x64 --self-contained false -p:PublishReadyToRun=true`.
+  The blocker is packaging: `Transpose.Compiler` ships as a portable dotnet tool, so capturing this
+  means RID-specific tool packages and per-platform CI. Since the SDK invokes `tps` once per project,
+  the saving multiplies across a solution.
+- **Replace the Mono.Cecil resource embed with Roslyn `manifestResources`** (0.6 s + 71 MB, and Cecil
+  re-serialises the whole assembly). `BuildRuntimePackage` already does this. The obstacle is ordering:
+  the resources include the compiled JS, available only *after* the JS emit, while the assembly is
+  emitted *before* it (that emit is what produces the diagnostics gating the JS emit). Sketched way out:
+  start `Emit` on a worker with lazy `ResourceDescription` providers that block on the JS-emit task.
+  Needs care — Roslyn calls the provider synchronously during metadata writing, so a mis-ordering
+  deadlocks — and the overlap results above suggest the parallelism itself will not pay on 4 cores;
+  the win would be dropping Cecil, not the overlap.
+- **Reflection metadata build** (~400 ms inside JS emit) is sequential and would parallelise like the
+  type bodies do — *but* `BuildMetadataBlock` assigns namespace indices into a shared `_nsCache` in
+  visit order, and those indices are baked into the emitted JSON. Parallelising it would change the
+  `$n` array and therefore the output, so it needs a deterministic pre-pass over namespaces first.
+  Deferred: 5% for a real risk to byte-identical output.
+- **`MetadataImportOptions.All`** makes Roslyn import every non-public member of every reference
+  (`Transpose.dll` is large). It is required for overload numbering to match, but its cost has never
+  been isolated — worth measuring before assuming it is unavoidable.
+- **`ISymbol.ToDisplayString()` comparisons against string literals** remain in the emitter
+  (`IsTaskType` and friends in `Emitter.cs`, ~11 sites in `Emitter.Expressions2.cs`). Each formats a
+  fresh fully-qualified string. Resolving the target types once from the compilation and comparing with
+  `SymbolEqualityComparer` would remove them from hot paths. Smaller now that the naming layer is
+  cached, but still real.
+- **Remaining allocation sites** after the current round (from a fresh trace, ~557 MB total):
+  `ImmutableArray.CreateRange` 36 MB, `StringBuilder.ExpandByABlock` 30 MB, `StringBuilder.ToString`
+  23 MB, `SyntaxNode.ChildNodes()` 11 MB. Most are inside Roslyn, reached through `GetMembers()` /
+  `AllInterfaces` / syntax walks — reducing them means making fewer such calls, not micro-tuning.
+- **`TransposeAssemblies.RuntimeJs` uses `Assembly.LoadFrom`** on the stand-in BCL just to read an
+  embedded resource. Not on the hot path (only `--with-runtime`), but a `PEReader` read — as
+  `NoBodyMethodTokens` already does — would avoid loading a fake corlib into the compiler process.
+- **`HasNoBody` looks up a method's metadata token in `NoBodyMethodTokens`, which is built from
+  `Transpose.dll` only** — but it is called for methods from *any* referenced assembly, and metadata
+  tokens are only meaningful within their own module. This is a latent correctness bug (a spurious
+  token match changes an emitted name), not a performance one, and it is why changing what a
+  referenced package DLL contains can shift emitted output. Worth fixing on its own merits.
+- **Re-test every "parallelising made it worse" result on many-core hardware.** All of them are 4-core
+  results.

--- a/Transpose.slnx
+++ b/Transpose.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/Transpose/">
+    <Project Path="Transpose/Transpose.Bench/Transpose.Bench.csproj" />
     <Project Path="Transpose/Transpose.Build.Target/Transpose.Build.Target.csproj" />
     <Project Path="Transpose/Transpose.Compiler/Transpose.Compiler.csproj" />
     <Project Path="Transpose/Transpose.Template/Transpose.Template.csproj" />

--- a/Transpose/Transpose.Bench/CpuScore.cs
+++ b/Transpose/Transpose.Bench/CpuScore.cs
@@ -1,0 +1,262 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Transpose.Bench;
+
+/// <summary>
+/// A short, deterministic CPU + memory benchmark whose only purpose is to make compiler timings
+/// comparable across machines. The compiler's cost is dominated by four things — pointer-chasing
+/// through Roslyn's symbol graph, hash-table lookups on string keys, allocating and copying short
+/// strings, and single-threaded scalar work — so the score is built from micro-workloads that
+/// mirror exactly those, not from a generic FLOPS number. A machine that scores 2× here really does
+/// compile roughly 2× faster, which is what lets a normalised timing be compared to another run.
+///
+/// Every workload is deterministic (a fixed-seed xorshift, never <see cref="Random"/> or the clock)
+/// so the score is stable run to run, and each is calibrated against a reference measurement so a
+/// score of 100 means "as fast as the reference machine". The total budget is ~2 s.
+/// </summary>
+internal static class CpuScore
+{
+    /// <summary>One micro-workload's result: how long it took, and the score it earns
+    /// (reference ÷ measured × 100, so higher is faster).</summary>
+    internal readonly record struct Workload(string Name, string Measures, double Ms, double ReferenceMs)
+    {
+        public double Score => ReferenceMs / Ms * 100.0;
+    }
+
+    /// <summary>
+    /// The reference machine's per-workload milliseconds. Calibrated on a 4-core / 4-thread
+    /// Intel Xeon @ 2.80 GHz x64 Linux container (AVX-512 capable, 16 GB, .NET 10, workstation GC),
+    /// so that box scores ~100 and every other machine's score is its speed relative to it.
+    ///
+    /// These are deliberately constants: a self-calibrating baseline would always report 100 and
+    /// destroy the only thing the score is for — comparing a timing taken on one machine with a
+    /// timing taken on another. Re-calibrate (and say so in TODO.optimization.md) only if the
+    /// workloads themselves change, never to "re-centre" a new machine.
+    ///
+    /// Caveat worth knowing when reading a report: <c>pointer-chase</c> is pure dependent-load
+    /// memory latency and is the one workload a virtualised or noisy host can perturb by ~1.5×
+    /// even with best-of-5. Its weight in the geometric mean is 1/6, so that shows up as roughly
+    /// ±7% on the score; the other five are stable to about ±3%.
+    /// </summary>
+    private static readonly (string name, string measures, double ms)[] Reference =
+    {
+        ("pointer-chase",  "memory latency (Roslyn symbol-graph walks)",   85.0),
+        ("dictionary",     "hashing + probing (symbol/name tables)",       68.0),
+        ("string-churn",   "allocation + GC throughput (JS emit)",         62.0),
+        ("scalar-int",     "scalar ALU + branch prediction",               69.0),
+        ("sort",           "cache-friendly compare/swap (type ordering)",  74.0),
+        ("memcpy",         "memory bandwidth (StringBuilder growth)",      62.0),
+    };
+
+    internal sealed record Result(double Score, IReadOnlyList<Workload> Workloads, double TotalMs)
+    {
+        public string Describe()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"CPU benchmark  →  score {Score:F1}  (100 = reference machine; higher is faster)");
+            foreach (var w in Workloads)
+                sb.AppendLine($"  {w.Name,-14} {w.Ms,7:F1} ms  (ref {w.ReferenceMs,5:F0} ms)  score {w.Score,6:F1}   {w.Measures}");
+            sb.AppendLine($"  {"total",-14} {TotalMs,7:F1} ms");
+            return sb.ToString();
+        }
+    }
+
+    // Workload sizes. Fixed (never time-boxed) so every machine performs exactly the same amount of
+    // work — that is what makes the resulting score comparable at all. Chosen so each workload runs
+    // for roughly 100 ms on the reference machine, keeping the whole benchmark near 2 s.
+    private const int ChaseSlots = 1 << 22;         // 4M slots = 16 MB, past L2/L3 on most CPUs
+    private const int ChaseSteps = 1_000_000;
+    private const int DictOps = 900_000;
+    private const int StringOps = 1_200_000;
+    private const int ScalarIters = 12_000_000;
+    private const int SortItems = 900_000;
+    /// <summary>Repetitions per workload; the fastest one is kept.</summary>
+    private const int Repetitions = 5;
+
+    private const int CopyBytes = 1 << 21;          // 2 MB
+    private const int CopyReps = 420;
+
+    public static Result Run()
+    {
+        // Warm the JIT so the first measured workload is not paying for tier-0 code.
+        PointerChase(BuildChaseTable(1 << 14), 100_000);
+        DictionaryChurn(20_000);
+        StringChurn(20_000);
+        ScalarInt(2_000_000);
+        SortWorkload(BuildRandomInts(20_000));
+        MemCopy(new byte[1 << 16], new byte[1 << 16], 20);
+
+        var total = Stopwatch.StartNew();
+        var results = new List<Workload>();
+
+        // Input data is built outside the timed region: a workload should measure the operation it
+        // is named for, not the cost of generating its input.
+        var chaseTable = BuildChaseTable(ChaseSlots);
+        results.Add(Measure(0, () => PointerChase(chaseTable, ChaseSteps)));
+        results.Add(Measure(1, () => DictionaryChurn(DictOps)));
+        results.Add(Measure(2, () => StringChurn(StringOps)));
+        results.Add(Measure(3, () => ScalarInt(ScalarIters)));
+        var sortSource = BuildRandomInts(SortItems);
+        results.Add(Measure(4, () => SortWorkload(sortSource)));
+        var copySrc = new byte[CopyBytes];
+        var copyDst = new byte[CopyBytes];
+        for (var i = 0; i < CopyBytes; i++) copySrc[i] = (byte)i;
+        results.Add(Measure(5, () => MemCopy(copySrc, copyDst, CopyReps)));
+
+        total.Stop();
+
+        // Geometric mean: one pathological workload (e.g. a machine with an odd cache hierarchy)
+        // then moves the score proportionally instead of dominating it, as an arithmetic mean would.
+        var logSum = 0.0;
+        foreach (var r in results) logSum += Math.Log(r.Score);
+        var score = Math.Exp(logSum / results.Count);
+
+        return new Result(score, results, total.Elapsed.TotalMilliseconds);
+    }
+
+    private static Workload Measure(int index, Func<long> body)
+    {
+        var (name, measures, refMs) = Reference[index];
+        // Best-of-N: the minimum is the least noisy estimator of a machine's real capability
+        // (interference from another process only ever makes a run slower). Five repetitions rather
+        // than three because on a shared/virtualised host the memory-latency workload in particular
+        // can be perturbed by a factor of two, and that noise would otherwise leak into the score.
+        var best = double.MaxValue;
+        long sink = 0;
+        for (var i = 0; i < Repetitions; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            sink += body();
+            sw.Stop();
+            best = Math.Min(best, sw.Elapsed.TotalMilliseconds);
+        }
+        Consume(sink);
+        return new Workload(name, measures, Math.Max(best, 0.001), refMs);
+    }
+
+    /// <summary>Keeps a computed value observably live so the JIT cannot delete the workload.</summary>
+    private static long _sink;
+    private static void Consume(long v) => System.Threading.Volatile.Write(ref _sink, v);
+
+    /// <summary>Deterministic xorshift64* — the same sequence on every machine and architecture.</summary>
+    private static ulong Next(ref ulong s)
+    {
+        s ^= s >> 12; s ^= s << 25; s ^= s >> 27;
+        return s * 0x2545F4914F6CDD1DUL;
+    }
+
+    /// <summary>A random permutation of [0, slots): following it produces a dependent-load chain.</summary>
+    private static int[] BuildChaseTable(int slots)
+    {
+        var next = new int[slots];
+        for (var i = 0; i < slots; i++) next[i] = i;
+        // Fisher–Yates with the fixed-seed PRNG → the same permutation on every machine.
+        var s = 0x9E3779B97F4A7C15UL;
+        for (var i = slots - 1; i > 0; i--)
+        {
+            var j = (int)(Next(ref s) % (ulong)(i + 1));
+            (next[i], next[j]) = (next[j], next[i]);
+        }
+        return next;
+    }
+
+    /// <summary>Dependent-load chase through a permutation of a large array: each read's address
+    /// depends on the previous read, so the loop cannot be prefetched and measures raw memory
+    /// latency — the single best proxy for walking Roslyn's symbol and syntax graphs.</summary>
+    private static long PointerChase(int[] next, int steps)
+    {
+        var p = 0;
+        for (var i = 0; i < steps; i++) p = next[p];
+        return p;
+    }
+
+    /// <summary>String-keyed dictionary insert + lookup churn: hashing, probing and equality on
+    /// short strings, which is what Roslyn's name lookups and the emitter's mangling caches do
+    /// constantly.</summary>
+    private static long DictionaryChurn(int n)
+    {
+        var d = new Dictionary<string, int>(StringComparer.Ordinal);
+        var keys = new string[Math.Min(n, 4096)];
+        for (var i = 0; i < keys.Length; i++) keys[i] = "Tesserae.Components.Symbol_" + i;
+        for (var i = 0; i < n; i++)
+        {
+            var k = keys[i % keys.Length];
+            d[k] = i;
+        }
+        long hits = 0;
+        var s = 0x243F6A8885A308D3UL;
+        for (var i = 0; i < n; i++)
+        {
+            var k = keys[(int)(Next(ref s) % (ulong)keys.Length)];
+            if (d.TryGetValue(k, out var v)) hits += v & 1;
+        }
+        return hits;
+    }
+
+    /// <summary>Short-string allocation, concatenation and StringBuilder growth — a direct stand-in
+    /// for the JS emitter, whose cost is almost entirely producing small strings and appending
+    /// them. Exercises the allocator and gen0 GC throughput.</summary>
+    private static long StringChurn(int n)
+    {
+        var sb = new StringBuilder(1 << 16);
+        long len = 0;
+        for (var i = 0; i < n; i++)
+        {
+            var name = "Tesserae$" + i.ToString() + "$" + (i & 31).ToString();
+            sb.Append(name);
+            sb.Append(" = function (a, b) { return a + b; };\n");
+            if (sb.Length > 1 << 18) { len += sb.Length; sb.Clear(); }
+        }
+        return len + sb.Length;
+    }
+
+    /// <summary>Scalar integer arithmetic with an unpredictable branch: measures ALU throughput and
+    /// branch-prediction quality, which govern the tight syntax-walk loops.</summary>
+    private static long ScalarInt(int iterations)
+    {
+        var s = 0xDEADBEEFCAFEBABEUL;
+        long acc = 0;
+        for (var i = 0; i < iterations; i++)
+        {
+            var v = Next(ref s);
+            // A genuinely unpredictable branch (50/50 on a PRNG bit).
+            if ((v & 1) != 0) acc += (long)(v >> 33);
+            else acc -= (long)(v & 0xFFFF);
+        }
+        return acc;
+    }
+
+    private static int[] BuildRandomInts(int n)
+    {
+        var a = new int[n];
+        var s = 0x13198A2E03707344UL;
+        for (var i = 0; i < n; i++) a[i] = (int)(Next(ref s) & 0x7FFFFFFF);
+        return a;
+    }
+
+    /// <summary>Sorting a large int array: compare/swap over a cache-resident-then-spilling working
+    /// set, mirroring the emitter's dependency-depth ordering of types. The source array is copied
+    /// each rep so every repetition sorts the same unsorted input (sorting an already-sorted array
+    /// is a different, much cheaper operation).</summary>
+    private static long SortWorkload(int[] source)
+    {
+        var a = new int[source.Length];
+        Array.Copy(source, a, source.Length);
+        Array.Sort(a);
+        return a[0] + a[a.Length / 2] + a[^1];
+    }
+
+    /// <summary>Bulk block copy: measures sustained memory bandwidth, which is what bounds
+    /// StringBuilder growth and writing multi-megabyte JS bundles.</summary>
+    private static long MemCopy(byte[] src, byte[] dst, int reps)
+    {
+        long sum = 0;
+        for (var r = 0; r < reps; r++)
+        {
+            Buffer.BlockCopy(src, 0, dst, 0, src.Length);
+            sum += dst[r % src.Length];
+        }
+        return sum;
+    }
+}

--- a/Transpose/Transpose.Bench/Fmt.cs
+++ b/Transpose/Transpose.Bench/Fmt.cs
@@ -1,0 +1,26 @@
+namespace Transpose.Bench;
+
+/// <summary>Small formatting helpers shared by the report writers.</summary>
+internal static class Fmt
+{
+    public static string Gb(long bytes) => $"{bytes / (1024.0 * 1024 * 1024):N1} GB";
+    public static string Mb(long bytes) => $"{bytes / (1024.0 * 1024):N1} MB";
+    public static string Mb(double bytes) => $"{bytes / (1024.0 * 1024):N1} MB";
+
+    /// <summary>Median of a sample. Used instead of the mean for the headline number: a single
+    /// scheduling hiccup in one iteration should not move the reported figure.</summary>
+    public static double Median(IReadOnlyList<double> values)
+    {
+        if (values.Count == 0) return 0;
+        var sorted = values.OrderBy(v => v).ToArray();
+        var mid = sorted.Length / 2;
+        return sorted.Length % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0;
+    }
+
+    public static double StdDev(IReadOnlyList<double> values)
+    {
+        if (values.Count < 2) return 0;
+        var mean = values.Average();
+        return Math.Sqrt(values.Sum(v => (v - mean) * (v - mean)) / (values.Count - 1));
+    }
+}

--- a/Transpose/Transpose.Bench/MachineInfo.cs
+++ b/Transpose/Transpose.Bench/MachineInfo.cs
@@ -1,0 +1,215 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using System.Text;
+
+namespace Transpose.Bench;
+
+/// <summary>
+/// Describes the machine a benchmark ran on. Compiler timings are meaningless without it: the same
+/// build can take 8 s or 40 s depending on core count and memory bandwidth, so every report leads
+/// with the CPU model, core/thread counts, RAM, and the SIMD/crypto instruction sets available (the
+/// JIT's vector width in particular changes how fast Roslyn's own hot loops run).
+/// </summary>
+internal sealed record MachineInfo(
+    string CpuModel,
+    int PhysicalCores,
+    int LogicalCores,
+    double MaxMhz,
+    long TotalRamBytes,
+    long AvailableRamBytes,
+    string Os,
+    string Architecture,
+    string Runtime,
+    string GcMode,
+    IReadOnlyList<string> Capabilities)
+{
+    public static MachineInfo Collect()
+    {
+        var (model, physical, mhz) = ReadCpuDetails();
+        var (totalRam, availRam) = ReadMemory();
+
+        return new MachineInfo(
+            CpuModel: model,
+            PhysicalCores: physical,
+            LogicalCores: Environment.ProcessorCount,
+            MaxMhz: mhz,
+            TotalRamBytes: totalRam,
+            AvailableRamBytes: availRam,
+            Os: RuntimeInformation.OSDescription.Trim(),
+            Architecture: RuntimeInformation.ProcessArchitecture.ToString(),
+            Runtime: RuntimeInformation.FrameworkDescription,
+            GcMode: (System.Runtime.GCSettings.IsServerGC ? "Server" : "Workstation")
+                    + (System.Runtime.GCSettings.LatencyMode == System.Runtime.GCLatencyMode.SustainedLowLatency ? ", SustainedLowLatency" : "")
+                    + (GCSettings_Concurrent() ? ", concurrent" : ", non-concurrent"),
+            Capabilities: DetectCapabilities());
+    }
+
+    private static bool GCSettings_Concurrent()
+    {
+        // There is no public API for "is background GC enabled"; the config switch is the closest
+        // observable. Absent config it defaults to on.
+        var v = AppContext.GetData("System.GC.Concurrent")?.ToString();
+        return v is null || !string.Equals(v, "false", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>CPU model string, physical core count and peak clock. Read from
+    /// <c>/proc/cpuinfo</c> + <c>/sys</c> on Linux (the only place the model name is exposed without
+    /// P/Invoke); other platforms fall back to what the runtime reports.</summary>
+    private static (string model, int physicalCores, double maxMhz) ReadCpuDetails()
+    {
+        var model = RuntimeInformation.ProcessArchitecture.ToString() + " CPU";
+        var physical = Environment.ProcessorCount;
+        double mhz = 0;
+
+        if (OperatingSystem.IsLinux())
+        {
+            try
+            {
+                var lines = File.ReadAllLines("/proc/cpuinfo");
+                var coreIds = new HashSet<string>();
+                string? physicalId = null;
+                foreach (var line in lines)
+                {
+                    var idx = line.IndexOf(':');
+                    if (idx < 0) continue;
+                    var key = line.AsSpan(0, idx).Trim().ToString();
+                    var value = line.AsSpan(idx + 1).Trim().ToString();
+                    switch (key)
+                    {
+                        case "model name" or "Model" or "Hardware" or "cpu model":
+                            if (value.Length > 0) model = value;
+                            break;
+                        case "physical id":
+                            physicalId = value;
+                            break;
+                        case "core id":
+                            coreIds.Add((physicalId ?? "0") + "/" + value);
+                            break;
+                        case "cpu MHz":
+                            if (double.TryParse(value, CultureInfo.InvariantCulture, out var m)) mhz = Math.Max(mhz, m);
+                            break;
+                    }
+                }
+                if (coreIds.Count > 0) physical = coreIds.Count;
+            }
+            catch { /* best effort */ }
+
+            // The advertised maximum turbo frequency, when the kernel exposes it — a better
+            // normalisation input than the momentary "cpu MHz" above.
+            foreach (var f in new[] { "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq" })
+            {
+                try
+                {
+                    if (File.Exists(f) && double.TryParse(File.ReadAllText(f).Trim(), CultureInfo.InvariantCulture, out var khz))
+                        mhz = Math.Max(mhz, khz / 1000.0);
+                }
+                catch { /* best effort */ }
+            }
+        }
+
+        return (model, physical, mhz);
+    }
+
+    /// <summary>Total and currently-available RAM. Inside a container the cgroup limit is what
+    /// actually applies, so prefer the runtime's view (which honours it) and cross-check
+    /// <c>/proc/meminfo</c>.</summary>
+    private static (long total, long available) ReadMemory()
+    {
+        var info = GC.GetGCMemoryInfo();
+        long total = info.TotalAvailableMemoryBytes;
+        long available = 0;
+
+        if (OperatingSystem.IsLinux())
+        {
+            try
+            {
+                foreach (var line in File.ReadLines("/proc/meminfo"))
+                {
+                    var parts = line.Split(':', 2);
+                    if (parts.Length != 2) continue;
+                    var kbText = parts[1].Replace("kB", "").Trim();
+                    if (!long.TryParse(kbText, CultureInfo.InvariantCulture, out var kb)) continue;
+                    if (parts[0] == "MemTotal" && total <= 0) total = kb * 1024;
+                    else if (parts[0] == "MemAvailable") available = kb * 1024;
+                }
+            }
+            catch { /* best effort */ }
+        }
+        return (total, available);
+    }
+
+    /// <summary>The instruction-set extensions the JIT will actually use in this process. Reported
+    /// because they gate how fast Roslyn's (and the emitter's) string/span work runs — the same
+    /// binary is materially faster on a machine where AVX-512 or SVE is enabled.</summary>
+    private static List<string> DetectCapabilities()
+    {
+        var caps = new List<string>();
+
+        void Add(string name, bool supported) { if (supported) caps.Add(name); }
+
+        Add($"Vector<T>={System.Numerics.Vector<byte>.Count * 8}bit", true);
+        Add("Vector64.HwAccel", Vector64.IsHardwareAccelerated);
+        Add("Vector128.HwAccel", Vector128.IsHardwareAccelerated);
+        Add("Vector256.HwAccel", Vector256.IsHardwareAccelerated);
+        Add("Vector512.HwAccel", Vector512.IsHardwareAccelerated);
+
+        var arch = RuntimeInformation.ProcessArchitecture;
+        if (arch is System.Runtime.InteropServices.Architecture.X86 or System.Runtime.InteropServices.Architecture.X64)
+        {
+            Add("SSE2", Sse2.IsSupported);
+            Add("SSE3", Sse3.IsSupported);
+            Add("SSSE3", Ssse3.IsSupported);
+            Add("SSE4.1", Sse41.IsSupported);
+            Add("SSE4.2", Sse42.IsSupported);
+            Add("AVX", Avx.IsSupported);
+            Add("AVX2", Avx2.IsSupported);
+            Add("AVX512F", Avx512F.IsSupported);
+            Add("AVX512BW", Avx512BW.IsSupported);
+            Add("AVX512VBMI", Avx512Vbmi.IsSupported);
+            Add("AVX10v1", Avx10v1.IsSupported);
+            Add("AVX-VNNI", AvxVnni.IsSupported);
+            Add("FMA", Fma.IsSupported);
+            Add("BMI1", Bmi1.IsSupported);
+            Add("BMI2", Bmi2.IsSupported);
+            Add("LZCNT", Lzcnt.IsSupported);
+            Add("POPCNT", Popcnt.IsSupported);
+            Add("AES", System.Runtime.Intrinsics.X86.Aes.IsSupported);
+            Add("PCLMULQDQ", Pclmulqdq.IsSupported);
+        }
+        else if (arch is System.Runtime.InteropServices.Architecture.Arm64 or System.Runtime.InteropServices.Architecture.Arm)
+        {
+            Add("AdvSIMD", AdvSimd.IsSupported);
+            Add("AdvSIMD.Arm64", AdvSimd.Arm64.IsSupported);
+            Add("CRC32", Crc32.IsSupported);
+            Add("AES", System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+            Add("SHA1", Sha1.IsSupported);
+            Add("SHA256", Sha256.IsSupported);
+            Add("Dp", Dp.IsSupported);
+            Add("Rdm", Rdm.IsSupported);
+#pragma warning disable SYSLIB5003 // Sve is experimental; reporting its availability is exactly the point
+            Add("SVE", Sve.IsSupported);
+#pragma warning restore SYSLIB5003
+        }
+
+        return caps;
+    }
+
+    public string Describe()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Machine");
+        sb.AppendLine($"  CPU:          {CpuModel}");
+        sb.AppendLine($"  Cores:        {PhysicalCores} physical / {LogicalCores} logical"
+            + (MaxMhz > 0 ? $"  @ {MaxMhz / 1000.0:F2} GHz max" : ""));
+        sb.AppendLine($"  RAM:          {Fmt.Gb(TotalRamBytes)} total"
+            + (AvailableRamBytes > 0 ? $", {Fmt.Gb(AvailableRamBytes)} available" : ""));
+        sb.AppendLine($"  OS:           {Os} ({Architecture})");
+        sb.AppendLine($"  Runtime:      {Runtime}");
+        sb.AppendLine($"  GC:           {GcMode}");
+        sb.AppendLine($"  CPU features: {string.Join(", ", Capabilities)}");
+        return sb.ToString();
+    }
+}

--- a/Transpose/Transpose.Bench/Program.cs
+++ b/Transpose/Transpose.Bench/Program.cs
@@ -1,0 +1,229 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Transpose.Bench;
+
+/// <summary>
+/// <c>tps-bench</c> — the benchmark harness for the Transpose compiler.
+///
+/// It answers "did that change make the compiler faster?" in a way that survives being run on a
+/// different machine, or a noisy one:
+///
+///  1. Print the machine (CPU model, cores, RAM, SIMD/crypto ISAs) — timings without it are
+///     uninterpretable.
+///  2. Run a short deterministic CPU + memory benchmark and derive a <b>score</b> (100 = the
+///     reference machine). Every compiler timing is then also reported <i>normalised</i>
+///     (measured × score ÷ 100), which is what makes two machines' numbers comparable.
+///  3. Run the compiler over real projects, from a genuinely clean slate (wiping the project's and
+///     its dependencies' bin/obj, because <c>tps</c> otherwise skips up-to-date dependencies), and
+///     report wall time, CPU time, allocations, peak working set, GC counts, and the compiler's own
+///     per-phase breakdown.
+///
+/// Usage:
+///   tps-bench --tps &lt;path-to-tps&gt; [--scenario name=project.csproj[:clean|:warm]] …
+///             [--iterations N] [--warmups N] [--configuration Debug|Release]
+///             [--json out.json] [--markdown out.md] [--baseline prev.json] [--no-cpu-bench]
+///
+/// With no <c>--scenario</c>, the two standard scenarios are used if the sibling <c>tesserae</c>
+/// checkout is found: the single-project build (Tesserae) and the multi-project build
+/// (Tesserae.Tests, which also builds its Tesserae dependency).
+/// </summary>
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        if (args.Contains("-h") || args.Contains("--help")) { ShowHelp(); return 0; }
+
+        var tps = "tps";
+        var configuration = "Debug";
+        var iterations = 3;
+        var warmups = 1;
+        string? jsonOut = null, markdownOut = null, baselineIn = null, label = null;
+        var runCpuBench = true;
+        var verbose = false;
+        var scenarioArgs = new List<string>();
+        string? tesseraeRoot = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--tps": tps = args[++i]; break;
+                case "--configuration" or "-c": configuration = args[++i]; break;
+                case "--iterations" or "-n": iterations = int.Parse(args[++i]); break;
+                case "--warmups": warmups = int.Parse(args[++i]); break;
+                case "--scenario" or "-s": scenarioArgs.Add(args[++i]); break;
+                case "--tesserae": tesseraeRoot = args[++i]; break;
+                case "--json": jsonOut = args[++i]; break;
+                case "--markdown": markdownOut = args[++i]; break;
+                case "--baseline": baselineIn = args[++i]; break;
+                case "--label": label = args[++i]; break;
+                case "--no-cpu-bench": runCpuBench = false; break;
+                case "--verbose" or "-v": verbose = true; break;
+                default:
+                    Console.Error.WriteLine($"Unexpected argument: {args[i]}");
+                    return 1;
+            }
+        }
+
+        var machine = MachineInfo.Collect();
+        Console.WriteLine(machine.Describe());
+
+        CpuScore.Result? cpu = null;
+        if (runCpuBench)
+        {
+            Console.WriteLine("Running CPU benchmark (fixed work, best-of-3 per workload) …");
+            cpu = CpuScore.Run();
+            Console.WriteLine(cpu.Describe());
+        }
+        var score = cpu?.Score ?? 100.0;
+
+        var scenarios = scenarioArgs.Count > 0
+            ? scenarioArgs.Select(a => ParseScenario(a, configuration)).ToList()
+            : DefaultScenarios(tesseraeRoot, configuration);
+
+        if (scenarios.Count == 0)
+        {
+            Console.Error.WriteLine(
+                "No scenarios. Pass --scenario name=project.csproj[:clean|:warm], or --tesserae <repo-root> "
+                + "so the default Tesserae scenarios can be located.");
+            return 1;
+        }
+
+        var resolvedTps = ResolveTps(tps);
+        if (resolvedTps is null)
+        {
+            Console.Error.WriteLine($"Could not find the tps compiler at '{tps}'. Pass --tps <path>.");
+            return 1;
+        }
+        Console.WriteLine($"Compiler: {resolvedTps}");
+        Console.WriteLine($"Config:   {configuration}   iterations: {iterations} (+{warmups} warm-up)\n");
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "tps-bench");
+        var runner = new ScenarioRunner(resolvedTps, tempDir, verbose);
+
+        var results = new List<ScenarioResult>();
+        foreach (var s in scenarios)
+        {
+            Console.WriteLine($"Scenario {s.Name}  ({(s.Clean ? "clean slate" : "warm/incremental")}) — {Path.GetFileName(s.CsprojPath)}");
+            results.Add(runner.Run(s, warmups, iterations));
+            Console.WriteLine();
+        }
+
+        var report = new Report(label ?? "current", machine, cpu, configuration, iterations, results);
+        Console.WriteLine(report.Describe(score));
+
+        Baseline? baseline = baselineIn is not null ? Baseline.Load(baselineIn) : null;
+        if (baseline is not null) Console.WriteLine(report.CompareTo(baseline, score));
+
+        if (jsonOut is not null) { report.WriteJson(jsonOut, score); Console.WriteLine($"Wrote {jsonOut}"); }
+        if (markdownOut is not null) { report.WriteMarkdown(markdownOut, score, baseline); Console.WriteLine($"Wrote {markdownOut}"); }
+
+        return results.All(r => r.Succeeded) ? 0 : 1;
+    }
+
+    /// <summary>Parses <c>name=path.csproj[:clean|:warm]</c>. Clean is the default — an incremental
+    /// build measures a different (much cheaper) code path and must be asked for explicitly.</summary>
+    private static Scenario ParseScenario(string arg, string configuration)
+    {
+        var eq = arg.IndexOf('=');
+        var name = eq > 0 ? arg[..eq] : Path.GetFileNameWithoutExtension(arg);
+        var rest = eq > 0 ? arg[(eq + 1)..] : arg;
+        var clean = true;
+        string? note = null;
+        if (rest.EndsWith(":warm", StringComparison.OrdinalIgnoreCase))
+        {
+            clean = false; rest = rest[..^5];
+            note = "outputs left in place — measures the incremental path";
+        }
+        else if (rest.EndsWith(":clean", StringComparison.OrdinalIgnoreCase))
+        {
+            rest = rest[..^6];
+        }
+        return new Scenario(name, Path.GetFullPath(rest), clean, configuration, note);
+    }
+
+    /// <summary>The two standard scenarios: a single project, and a multi-project build where the
+    /// root project's dependency must be compiled first. Located relative to this repository (the
+    /// <c>tesserae</c> checkout is normally a sibling of <c>transpose</c>).</summary>
+    private static List<Scenario> DefaultScenarios(string? tesseraeRoot, string configuration)
+    {
+        var roots = new List<string>();
+        if (tesseraeRoot is not null) roots.Add(tesseraeRoot);
+        var here = AppContext.BaseDirectory;
+        for (var d = new DirectoryInfo(here); d is not null; d = d.Parent)
+        {
+            roots.Add(Path.Combine(d.FullName, "tesserae"));
+            roots.Add(Path.Combine(d.FullName, "..", "tesserae"));
+        }
+        roots.Add(Path.Combine(Directory.GetCurrentDirectory(), "..", "tesserae"));
+
+        foreach (var root in roots)
+        {
+            var lib = Path.Combine(root, "Tesserae", "Tesserae.csproj");
+            var tests = Path.Combine(root, "Tesserae.Tests", "Tesserae.Tests.csproj");
+            if (!File.Exists(lib)) continue;
+            var list = new List<Scenario>
+            {
+                new("tesserae", Path.GetFullPath(lib), true, configuration,
+                    "single project, ~69k LOC / 263 files → package DLL with embedded JS"),
+            };
+            if (File.Exists(tests))
+            {
+                list.Add(new("tesserae+tests", Path.GetFullPath(tests), true, configuration,
+                    "multi-project: builds the Tesserae dependency, then the site build"));
+                list.Add(new("tesserae+tests-warm", Path.GetFullPath(tests), false, configuration,
+                    "incremental: dependency already up to date, only the site project recompiles"));
+            }
+            return list;
+        }
+        return new List<Scenario>();
+    }
+
+    private static string? ResolveTps(string tps)
+    {
+        if (File.Exists(tps)) return Path.GetFullPath(tps);
+        if (Directory.Exists(tps))
+        {
+            var candidate = Path.Combine(tps, OperatingSystem.IsWindows() ? "tps.exe" : "tps");
+            if (File.Exists(candidate)) return Path.GetFullPath(candidate);
+        }
+        // Bare command name: let the OS resolve it from PATH, but verify it exists first so the
+        // failure is a clear message rather than a Win32Exception mid-run.
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
+        foreach (var dir in pathVar.Split(Path.PathSeparator))
+        {
+            if (dir.Length == 0) continue;
+            var candidate = Path.Combine(dir, tps);
+            if (File.Exists(candidate)) return candidate;
+            if (OperatingSystem.IsWindows() && File.Exists(candidate + ".exe")) return candidate + ".exe";
+        }
+        return null;
+    }
+
+    private static void ShowHelp() => Console.WriteLine("""
+        tps-bench — Transpose compiler benchmark harness
+
+        Prints the machine's CPU/RAM/ISA details, scores it with a short deterministic CPU+memory
+        benchmark, then times `tps` builds from a clean slate and reports wall time, CPU time,
+        allocations, peak working set and the compiler's per-phase breakdown — both raw and
+        normalised by the CPU score, so results from different machines are comparable.
+
+        Usage:
+          tps-bench --tps <path-to-tps> [options]
+
+        Options:
+          --tps <path>              The tps compiler to measure (file, directory, or PATH command).
+          -s, --scenario <spec>     name=project.csproj[:clean|:warm]  (repeatable; clean is default)
+          --tesserae <repo-root>    Locate the default Tesserae scenarios explicitly.
+          -c, --configuration <c>   Build configuration passed to tps (default Debug).
+          -n, --iterations <N>      Measured iterations per scenario (default 3).
+          --warmups <N>             Discarded iterations before measuring (default 1).
+          --label <name>            Name this run in the report (e.g. a commit or "baseline").
+          --json <file>             Write the full result as JSON (use as a --baseline later).
+          --markdown <file>         Write a Markdown summary table.
+          --baseline <file>         Compare against a previous --json run and print the deltas.
+          --no-cpu-bench            Skip the CPU benchmark (score assumed 100).
+          -v, --verbose             Echo the compiler's output for each run.
+        """);
+}

--- a/Transpose/Transpose.Bench/Program.cs
+++ b/Transpose/Transpose.Bench/Program.cs
@@ -34,6 +34,21 @@ public static class Program
     {
         if (args.Contains("-h") || args.Contains("--help")) { ShowHelp(); return 0; }
 
+        // Standalone verification mode: no benchmarking, just answer "is every tps payload under this
+        // directory ReadyToRun-compiled?" and set the exit code. A release pipeline runs this over its
+        // publish/pack output, where there is one payload per RID and none of them can be executed on
+        // the build agent.
+        var verifyIndex = Array.IndexOf(args, "--verify-r2r");
+        if (verifyIndex >= 0)
+        {
+            if (verifyIndex + 1 >= args.Length)
+            {
+                Console.Error.WriteLine("--verify-r2r needs a directory to search for tps payloads.");
+                return 1;
+            }
+            return VerifyR2R(args[verifyIndex + 1]);
+        }
+
         var tps = "tps";
         var configuration = "Debug";
         var iterations = 3;
@@ -41,7 +56,9 @@ public static class Program
         string? jsonOut = null, markdownOut = null, baselineIn = null, label = null;
         var runCpuBench = true;
         var verbose = false;
+        var requireR2R = false;
         var scenarioArgs = new List<string>();
+        var envOverrides = new List<(string key, string value)>();
         string? tesseraeRoot = null;
 
         for (var i = 0; i < args.Length; i++)
@@ -59,6 +76,19 @@ public static class Program
                 case "--baseline": baselineIn = args[++i]; break;
                 case "--label": label = args[++i]; break;
                 case "--no-cpu-bench": runCpuBench = false; break;
+                case "--require-r2r": requireR2R = true; break;
+                case "--env":
+                {
+                    var spec = args[++i];
+                    var eq = spec.IndexOf('=');
+                    if (eq <= 0)
+                    {
+                        Console.Error.WriteLine($"--env expects KEY=VALUE, got '{spec}'.");
+                        return 1;
+                    }
+                    envOverrides.Add((spec[..eq], spec[(eq + 1)..]));
+                    break;
+                }
                 case "--verbose" or "-v": verbose = true; break;
                 default:
                     Console.Error.WriteLine($"Unexpected argument: {args[i]}");
@@ -96,11 +126,25 @@ public static class Program
             Console.Error.WriteLine($"Could not find the tps compiler at '{tps}'. Pass --tps <path>.");
             return 1;
         }
+        // Report (and optionally enforce) whether the compiler is ReadyToRun. A JIT-only build pays
+        // ~1 s of extra JIT per invocation, so a timing is not interpretable without knowing which it
+        // was — and a release pipeline wants to fail rather than ship a silently-slower tool.
+        var r2r = R2RCheck.Inspect(resolvedTps);
         Console.WriteLine($"Compiler: {resolvedTps}");
+        Console.WriteLine($"          {r2r.Describe()}");
+        if (requireR2R && !r2r.IsReadyToRun)
+        {
+            Console.Error.WriteLine($"\n--require-r2r: the compiler at {resolvedTps} is not ReadyToRun-compiled.");
+            Console.Error.WriteLine("Publish it with a RID and -p:PublishReadyToRun=true, or pack with "
+                                  + "-p:TransposePackRidSpecificTools=true.");
+            return 2;
+        }
         Console.WriteLine($"Config:   {configuration}   iterations: {iterations} (+{warmups} warm-up)\n");
 
         var tempDir = Path.Combine(Path.GetTempPath(), "tps-bench");
-        var runner = new ScenarioRunner(resolvedTps, tempDir, verbose);
+        if (envOverrides.Count > 0)
+            Console.WriteLine("Env:      " + string.Join(", ", envOverrides.Select(e => $"{e.key}={e.value}")));
+        var runner = new ScenarioRunner(resolvedTps, tempDir, verbose, envOverrides);
 
         var results = new List<ScenarioResult>();
         foreach (var s in scenarios)
@@ -120,6 +164,68 @@ public static class Program
         if (markdownOut is not null) { report.WriteMarkdown(markdownOut, score, baseline); Console.WriteLine($"Wrote {markdownOut}"); }
 
         return results.All(r => r.Succeeded) ? 0 : 1;
+    }
+
+    /// <summary>Verifies every tps payload under <paramref name="root"/> is ReadyToRun-compiled,
+    /// printing one line each. Exit 0 when all are, 2 when any is not, 1 when none were found —
+    /// "found nothing" must fail, or a mistyped path would silently pass a release.</summary>
+    private static int VerifyR2R(string root)
+    {
+        var full = Path.GetFullPath(root);
+        Console.WriteLine($"Verifying ReadyToRun under {full}");
+
+        // Packages first: if the directory holds .nupkg files it is a pack output, and verifying what
+        // is about to be pushed beats verifying whatever the build tree happens to contain.
+        var packages = R2RCheck.InspectPackages(full);
+        if (packages.Count > 0)
+        {
+            var badPackages = 0;
+            foreach (var p in packages)
+            {
+                Console.WriteLine($"  [{(p.IsAcceptable ? "ok  " : "FAIL")}] {Path.GetFileName(p.PackagePath)}: {p.Describe()}");
+                if (!p.IsAcceptable) badPackages++;
+            }
+            var implementations = packages.Count(p => p.Kind == R2RCheck.PackageKind.ToolImplementation);
+            Console.WriteLine($"\n{implementations - badPackages}/{implementations} implementation package(s) ReadyToRun-compiled"
+                            + $" ({packages.Count} package(s) inspected).");
+            if (implementations == 0)
+            {
+                Console.Error.WriteLine("No tool implementation package found — nothing was verified. A RID-agnostic "
+                                      + "pack cannot be ReadyToRun; pack with -p:TransposePackRidSpecificTools=true.");
+                return 1;
+            }
+            if (badPackages > 0)
+            {
+                Console.Error.WriteLine("Not every package is ReadyToRun. Make sure restore ran with the same "
+                                      + "-p:TransposePackRidSpecificTools=true as the pack.");
+                return 2;
+            }
+            return 0;
+        }
+
+        var results = R2RCheck.InspectAll(full);
+        if (results.Count == 0)
+        {
+            Console.Error.WriteLine("No tps payload (tps.dll) or .nupkg found — nothing was verified.");
+            return 1;
+        }
+
+        var bad = 0;
+        foreach (var r in results)
+        {
+            var relative = Path.GetRelativePath(full, r.Directory);
+            Console.WriteLine($"  [{(r.IsReadyToRun ? "ok  " : "FAIL")}] {relative}: {r.Describe()}");
+            if (!r.IsReadyToRun) bad++;
+        }
+        Console.WriteLine($"\n{results.Count - bad}/{results.Count} payload(s) ReadyToRun-compiled.");
+        if (bad > 0)
+        {
+            Console.Error.WriteLine("Not every payload is ReadyToRun. Pack with "
+                                  + "-p:TransposePackRidSpecificTools=true (which sets RuntimeIdentifiers "
+                                  + "and PublishReadyToRun), and make sure restore ran with the same property.");
+            return 2;
+        }
+        return 0;
     }
 
     /// <summary>Parses <c>name=path.csproj[:clean|:warm]</c>. Clean is the default — an incremental
@@ -224,6 +330,16 @@ public static class Program
           --markdown <file>         Write a Markdown summary table.
           --baseline <file>         Compare against a previous --json run and print the deltas.
           --no-cpu-bench            Skip the CPU benchmark (score assumed 100).
+          --require-r2r             Fail (exit 2) unless the compiler is ReadyToRun-compiled. For a
+                                    release pipeline: R2R is worth ~1 s per invocation and is easy to
+                                    lose silently.
+          --verify-r2r <dir>        Verify-only mode (no benchmarking). If <dir> holds .nupkg files,
+                                    verifies the payload inside each — exactly what a pipeline is about
+                                    to push; otherwise verifies every tps payload found beneath it.
+                                    Exit 2 if any is not ReadyToRun, 1 if there was nothing to verify.
+          --env KEY=VALUE           Set an environment variable for each compiler process (repeatable).
+                                    Use it to re-test a runtime default, e.g.
+                                    --env DOTNET_TieredPGO=1 to confirm PGO is still a loss.
           -v, --verbose             Echo the compiler's output for each run.
         """);
 }

--- a/Transpose/Transpose.Bench/R2RCheck.cs
+++ b/Transpose/Transpose.Bench/R2RCheck.cs
@@ -1,0 +1,224 @@
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace Transpose.Bench;
+
+/// <summary>
+/// Reports whether a <c>tps</c> installation is ReadyToRun-compiled.
+///
+/// This matters twice over. It belongs in every benchmark report, because a JIT-only and an R2R build
+/// of the same commit differ by ~1 s per invocation (the fixed cost of JIT-compiling Roslyn) — a
+/// timing without that context can be off by 15-20% for reasons that have nothing to do with the
+/// compiler's code. And it is the check a release pipeline needs: R2R is easy to lose silently (a
+/// missing <c>-p:PublishReadyToRun=true</c>, a RID-agnostic publish) and the only symptom is that
+/// everyone's builds are quietly slower.
+///
+/// Detection is the PE ManagedNativeHeader directory: a ReadyToRun image carries one, plain IL does
+/// not. Native files (the apphost) have no metadata at all and are reported separately.
+/// </summary>
+internal static class R2RCheck
+{
+    /// <summary>The assemblies whose compilation state actually drives startup cost: the compiler
+    /// itself, the translator, and Roslyn (by far the largest JIT bill).</summary>
+    private static readonly string[] Significant =
+    {
+        "tps.dll", "Transpose.Translator.dll",
+        "Microsoft.CodeAnalysis.dll", "Microsoft.CodeAnalysis.CSharp.dll",
+    };
+
+    internal sealed record Result(
+        string Directory,
+        int ReadyToRunCount,
+        int IlOnlyCount,
+        IReadOnlyList<string> SignificantIlOnly,
+        IReadOnlyList<string> SignificantMissing)
+    {
+        /// <summary>True when every assembly that matters for startup is ReadyToRun. False also when
+        /// one of them is simply absent — a `tps` resolved from PATH may be a shim whose payload lives
+        /// elsewhere, and "cannot tell" must never read as "verified".</summary>
+        public bool IsReadyToRun => ReadyToRunCount > 0 && SignificantIlOnly.Count == 0 && SignificantMissing.Count == 0;
+
+        public string Describe()
+        {
+            var sb = new StringBuilder();
+            if (IsReadyToRun)
+            {
+                sb.Append($"ReadyToRun: yes — {ReadyToRunCount} assembly(ies) precompiled");
+                if (IlOnlyCount > 0) sb.Append($", {IlOnlyCount} left as IL");
+            }
+            else if (SignificantMissing.Count > 0 && ReadyToRunCount == 0 && IlOnlyCount == 0)
+            {
+                sb.Append("ReadyToRun: unknown — no managed assemblies found next to the tps executable "
+                        + "(a PATH shim? point --tps at the published payload to check)");
+            }
+            else
+            {
+                sb.Append($"ReadyToRun: NO — {IlOnlyCount} assembly(ies) are IL-only");
+                if (SignificantIlOnly.Count > 0) sb.Append($" (including {string.Join(", ", SignificantIlOnly)})");
+                if (SignificantMissing.Count > 0) sb.Append($"; not found: {string.Join(", ", SignificantMissing)}");
+                sb.Append(". Expect ~1 s of extra JIT per invocation.");
+            }
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>Inspects the directory holding <paramref name="tpsPath"/>, following a dotnet-tool
+    /// shim to the real payload first.</summary>
+    public static Result Inspect(string tpsPath)
+    {
+        var dir = Path.GetDirectoryName(ResolvePayload(tpsPath)) ?? ".";
+        var r2r = 0;
+        var il = 0;
+        var significantIl = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in SafeEnumerate(dir))
+        {
+            var name = Path.GetFileName(file);
+            bool? isR2R = Classify(file);
+            if (isR2R is null) continue;              // native or unreadable — not a managed assembly
+            seen.Add(name);
+            if (isR2R.Value) r2r++;
+            else
+            {
+                il++;
+                if (Significant.Contains(name, StringComparer.OrdinalIgnoreCase)) significantIl.Add(name);
+            }
+        }
+
+        var missing = Significant.Where(s => !seen.Contains(s)).ToArray();
+        return new Result(dir, r2r, il, significantIl, missing);
+    }
+
+    /// <summary>
+    /// Verifies every <c>tps</c> payload under <paramref name="root"/> — one per RID for a multi-RID
+    /// tool pack, each identified by the <c>tps.dll</c> sitting in it. Returns the per-payload results;
+    /// an empty list means nothing was found, which a caller must treat as a failure rather than a
+    /// pass.
+    ///
+    /// A RID-specific build leaves two copies of each payload in the build tree: the intermediate
+    /// build output (plain IL) and the <c>publish</c> subfolder next to it (ReadyToRun, and the one
+    /// that gets packed). Only the latter is meaningful, so a directory that has a <c>publish</c> child
+    /// with its own payload is skipped — otherwise every RID would report a spurious failure.
+    /// </summary>
+    public static IReadOnlyList<Result> InspectAll(string root)
+    {
+        var results = new List<Result>();
+        try
+        {
+            foreach (var dll in Directory.EnumerateFiles(root, "tps.dll", SearchOption.AllDirectories)
+                                         .OrderBy(p => p, StringComparer.Ordinal))
+            {
+                var dir = Path.GetDirectoryName(dll)!;
+                if (File.Exists(Path.Combine(dir, "publish", "tps.dll"))) continue;  // superseded
+                results.Add(Inspect(dll));
+            }
+        }
+        catch { /* unreadable root — reported as "nothing found" by the empty list */ }
+        return results;
+    }
+
+    /// <summary>What a single .nupkg turned out to be.</summary>
+    internal enum PackageKind { ToolImplementation, Selector, NotATool }
+
+    /// <summary>The verdict for one .nupkg: its kind, and (for an implementation package) whether its
+    /// payload is ReadyToRun.</summary>
+    internal sealed record PackageResult(string PackagePath, PackageKind Kind, Result? Payload)
+    {
+        /// <summary>A selector package legitimately carries no implementation, so it passes. Anything
+        /// that is not a tool package at all is not this check's business and also passes.</summary>
+        public bool IsAcceptable => Kind != PackageKind.ToolImplementation || (Payload?.IsReadyToRun ?? false);
+
+        public string Describe() => Kind switch
+        {
+            PackageKind.Selector => "RID selector package (no implementation, as expected)",
+            PackageKind.NotATool => "not a dotnet-tool package — skipped",
+            _ => Payload!.Describe(),
+        };
+    }
+
+    /// <summary>
+    /// Verifies the payload inside every <c>.nupkg</c> in <paramref name="directory"/> — i.e. exactly
+    /// what a pipeline is about to push, rather than whatever happens to be in the build tree.
+    ///
+    /// A multi-RID tool pack produces one implementation package per RID plus a tiny outer selector
+    /// package that maps RIDs to those; the selector has no payload and must not be treated as a
+    /// failure.
+    /// </summary>
+    public static IReadOnlyList<PackageResult> InspectPackages(string directory)
+    {
+        var results = new List<PackageResult>();
+        string[] packages;
+        try { packages = Directory.GetFiles(directory, "*.nupkg", SearchOption.TopDirectoryOnly); }
+        catch { return results; }
+
+        foreach (var pkg in packages.OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var temp = Path.Combine(Path.GetTempPath(), "tps-r2r-verify", Path.GetFileNameWithoutExtension(pkg));
+            try
+            {
+                if (Directory.Exists(temp)) Directory.Delete(temp, recursive: true);
+                System.IO.Compression.ZipFile.ExtractToDirectory(pkg, temp);
+
+                var isTool = Directory.EnumerateFiles(temp, "DotnetToolSettings.xml", SearchOption.AllDirectories).Any();
+                var payloadDll = Directory.EnumerateFiles(temp, "tps.dll", SearchOption.AllDirectories).FirstOrDefault();
+
+                var kind = payloadDll is not null ? PackageKind.ToolImplementation
+                         : isTool ? PackageKind.Selector
+                         : PackageKind.NotATool;
+                results.Add(new PackageResult(pkg, kind, payloadDll is null ? null : Inspect(payloadDll)));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  warning: could not inspect {Path.GetFileName(pkg)}: {ex.Message}");
+                results.Add(new PackageResult(pkg, PackageKind.NotATool, null));
+            }
+            finally
+            {
+                try { if (Directory.Exists(temp)) Directory.Delete(temp, recursive: true); } catch { }
+            }
+        }
+        return results;
+    }
+
+    /// <summary>
+    /// The real executable behind <paramref name="tpsPath"/>. A globally-installed dotnet tool puts a
+    /// shim in <c>~/.dotnet/tools</c> — on Unix a symlink into
+    /// <c>~/.dotnet/tools/.store/&lt;id&gt;/&lt;version&gt;/…/tools/&lt;tfm&gt;/&lt;rid&gt;/</c> — and the
+    /// assemblies live next to the target, not next to the shim. Following it is what lets this check
+    /// answer the question for a tool as actually installed, rather than only for a publish folder.
+    /// Falls back to the given path when it is not a link (a Windows shim is a real executable, and a
+    /// publish folder needs no resolution).
+    /// </summary>
+    private static string ResolvePayload(string tpsPath)
+    {
+        var full = Path.GetFullPath(tpsPath);
+        try
+        {
+            // ResolveLinkTarget(returnFinalTarget: true) walks a whole chain of links.
+            if (File.ResolveLinkTarget(full, returnFinalTarget: true) is { } target)
+                return target.FullName;
+        }
+        catch { /* not a link, or unreadable — use the path as given */ }
+        return full;
+    }
+
+    private static IEnumerable<string> SafeEnumerate(string dir)
+    {
+        try { return Directory.EnumerateFiles(dir, "*.dll", SearchOption.TopDirectoryOnly); }
+        catch { return Array.Empty<string>(); }
+    }
+
+    /// <summary>True = ReadyToRun, false = IL only, null = not a managed assembly.</summary>
+    private static bool? Classify(string path)
+    {
+        try
+        {
+            using var fs = File.OpenRead(path);
+            using var pe = new PEReader(fs);
+            if (!pe.HasMetadata) return null;
+            return pe.PEHeaders.CorHeader?.ManagedNativeHeaderDirectory.Size > 0;
+        }
+        catch { return null; }
+    }
+}

--- a/Transpose/Transpose.Bench/Report.cs
+++ b/Transpose/Transpose.Bench/Report.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Transpose.Bench;
+
+/// <summary>
+/// Formats a benchmark run for humans (console + Markdown) and for machines (JSON, so a later run
+/// can diff against it with <c>--baseline</c>).
+///
+/// Every timing appears twice: as measured, and <b>normalised</b> — multiplied by the machine's CPU
+/// score ÷ 100. A slow machine's 30 s build and a fast machine's 12 s build normalise to the same
+/// number, which is the only way a result recorded in one session can be compared to another.
+/// </summary>
+internal sealed record Report(
+    string Label,
+    MachineInfo Machine,
+    CpuScore.Result? Cpu,
+    string Configuration,
+    int Iterations,
+    IReadOnlyList<ScenarioResult> Results)
+{
+    /// <summary>Scales a measured duration to reference-machine time. A machine that scores 200
+    /// (twice the reference) has its 5 s build reported as a normalised 10 s, so the normalised
+    /// number is machine-independent and directly comparable across sessions.</summary>
+    public static double Normalise(double ms, double score) => ms * score / 100.0;
+
+    public string Describe(double score)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Results");
+        sb.AppendLine($"  (normalised = measured × score/100, i.e. reference-machine milliseconds; score {score:F1})");
+        sb.AppendLine();
+        sb.AppendLine($"  {"scenario",-22} {"wall (median)",14} {"normalised",12} {"±stddev",9} {"cpu-time",10} {"alloc",10} {"peak WS",10}");
+        sb.AppendLine($"  {new string('-', 22)} {new string('-', 14)} {new string('-', 12)} {new string('-', 9)} {new string('-', 10)} {new string('-', 10)} {new string('-', 10)}");
+        foreach (var r in Results)
+        {
+            if (!r.Succeeded) { sb.AppendLine($"  {r.Scenario.Name,-22} FAILED"); continue; }
+            sb.AppendLine($"  {r.Scenario.Name,-22} {r.MedianWallMs / 1000,11:F2} s  {Normalise(r.MedianWallMs, score) / 1000,9:F2} s  "
+                + $"{r.StdDevMs / 1000,7:F2} s  {r.MedianCpuMs / 1000,8:F2} s  {Fmt.Mb(r.MedianAllocBytes),10} {Fmt.Mb(r.MedianPeakWsBytes),10}");
+        }
+        sb.AppendLine();
+
+        foreach (var r in Results)
+        {
+            if (!r.Succeeded) continue;
+            var phases = r.MedianPhases();
+            if (phases.Count == 0) continue;
+            sb.AppendLine($"  {r.Scenario.Name} — phase breakdown (median across {r.Iterations.Count} run(s))");
+            // Sub-phases are indented in their name and already counted inside their parent.
+            var topLevel = phases.Where(p => !p.name.StartsWith(' ')).ToList();
+            var total = topLevel.Sum(p => p.ms);
+            foreach (var (name, ms, bytes) in phases)
+            {
+                var isSub = name.StartsWith(' ');
+                var share = isSub || total <= 0 ? "" : $"{ms * 100.0 / total,5:F1}%";
+                sb.AppendLine($"      {ms,8:N0} ms  {share,6}  {Fmt.Mb(bytes),10}  {name}");
+            }
+            sb.AppendLine($"      {total,8:N0} ms  {"",6}  {Fmt.Mb(topLevel.Sum(p => p.bytes)),10}  (sum of top-level phases)");
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    public string CompareTo(Baseline baseline, double score)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Comparison vs baseline '{baseline.Label}' (recorded on {baseline.CpuModel}, score {baseline.Score:F1})");
+        sb.AppendLine($"  {"scenario",-22} {"baseline",12} {"current",12} {"delta",12} {"alloc delta",14}");
+        sb.AppendLine($"  {new string('-', 22)} {new string('-', 12)} {new string('-', 12)} {new string('-', 12)} {new string('-', 14)}");
+        foreach (var r in Results)
+        {
+            if (!r.Succeeded) continue;
+            var bs = baseline.Scenarios.FirstOrDefault(s => s.Name == r.Scenario.Name);
+            if (bs is null) { sb.AppendLine($"  {r.Scenario.Name,-22} (not in baseline)"); continue; }
+            var cur = Normalise(r.MedianWallMs, score);
+            var pct = bs.NormalisedWallMs > 0 ? (cur - bs.NormalisedWallMs) / bs.NormalisedWallMs * 100 : 0;
+            var allocPct = bs.AllocBytes > 0 ? (r.MedianAllocBytes - bs.AllocBytes) / bs.AllocBytes * 100 : 0;
+            sb.AppendLine($"  {r.Scenario.Name,-22} {bs.NormalisedWallMs / 1000,9:F2} s  {cur / 1000,9:F2} s  "
+                + $"{pct,+10:F1}%  {allocPct,+12:F1}%");
+        }
+        sb.AppendLine("  (negative = faster / less allocation than the baseline)");
+        return sb.ToString();
+    }
+
+    public void WriteJson(string path, double score)
+    {
+        var dto = new BaselineDto
+        {
+            Label = Label,
+            Score = score,
+            CpuModel = Machine.CpuModel,
+            LogicalCores = Machine.LogicalCores,
+            PhysicalCores = Machine.PhysicalCores,
+            TotalRamBytes = Machine.TotalRamBytes,
+            Os = Machine.Os,
+            Runtime = Machine.Runtime,
+            Capabilities = Machine.Capabilities.ToList(),
+            Configuration = Configuration,
+            Iterations = Iterations,
+            CpuWorkloads = Cpu?.Workloads.Select(w => new WorkloadDto { Name = w.Name, Ms = w.Ms, ReferenceMs = w.ReferenceMs, Score = w.Score }).ToList(),
+            Scenarios = Results.Where(r => r.Succeeded).Select(r => new ScenarioDto
+            {
+                Name = r.Scenario.Name,
+                Project = r.Scenario.CsprojPath,
+                Clean = r.Scenario.Clean,
+                WallMs = r.MedianWallMs,
+                MinWallMs = r.MinWallMs,
+                StdDevMs = r.StdDevMs,
+                NormalisedWallMs = Normalise(r.MedianWallMs, score),
+                CpuMs = r.MedianCpuMs,
+                AllocBytes = r.MedianAllocBytes,
+                PeakWorkingSetBytes = r.MedianPeakWsBytes,
+                Phases = r.MedianPhases().Select(p => new PhaseDto { Name = p.name, Ms = p.ms, Bytes = p.bytes }).ToList(),
+            }).ToList(),
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        File.WriteAllText(path, JsonSerializer.Serialize(dto, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    public void WriteMarkdown(string path, double score, Baseline? baseline)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Transpose compiler benchmark — {Label}");
+        sb.AppendLine();
+        sb.AppendLine($"- **CPU**: {Machine.CpuModel} — {Machine.PhysicalCores} physical / {Machine.LogicalCores} logical cores");
+        sb.AppendLine($"- **RAM**: {Fmt.Gb(Machine.TotalRamBytes)}");
+        sb.AppendLine($"- **OS / runtime**: {Machine.Os} · {Machine.Runtime} ({Machine.Architecture})");
+        sb.AppendLine($"- **CPU features**: `{string.Join(" ", Machine.Capabilities)}`");
+        sb.AppendLine($"- **CPU score**: **{score:F1}** (100 = reference machine; normalised times are `measured × score/100`)");
+        sb.AppendLine($"- **Configuration**: {Configuration}, {Iterations} measured iteration(s) per scenario");
+        sb.AppendLine();
+        sb.AppendLine("| scenario | wall (median) | normalised | ±stddev | cpu-time | alloc | peak WS |");
+        sb.AppendLine("|---|--:|--:|--:|--:|--:|--:|");
+        foreach (var r in Results.Where(r => r.Succeeded))
+            sb.AppendLine($"| `{r.Scenario.Name}` | {r.MedianWallMs / 1000:F2} s | {Normalise(r.MedianWallMs, score) / 1000:F2} s "
+                + $"| {r.StdDevMs / 1000:F2} s | {r.MedianCpuMs / 1000:F2} s | {Fmt.Mb(r.MedianAllocBytes)} | {Fmt.Mb(r.MedianPeakWsBytes)} |");
+        sb.AppendLine();
+
+        foreach (var r in Results.Where(r => r.Succeeded))
+        {
+            var phases = r.MedianPhases();
+            if (phases.Count == 0) continue;
+            var total = phases.Where(p => !p.name.StartsWith(' ')).Sum(p => p.ms);
+            sb.AppendLine($"## `{r.Scenario.Name}` phase breakdown");
+            sb.AppendLine();
+            sb.AppendLine("| phase | ms | share | alloc |");
+            sb.AppendLine("|---|--:|--:|--:|");
+            foreach (var (name, ms, bytes) in phases)
+            {
+                var share = name.StartsWith(' ') || total <= 0 ? "" : $"{ms * 100.0 / total:F1}%";
+                sb.AppendLine($"| {name.Replace("├", "&boxvr;").Replace("└", "&boxur;")} | {ms:N0} | {share} | {Fmt.Mb(bytes)} |");
+            }
+            sb.AppendLine();
+        }
+
+        if (baseline is not null) sb.AppendLine("```\n" + CompareTo(baseline, score) + "```");
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        File.WriteAllText(path, sb.ToString());
+    }
+}
+
+// ---- JSON shapes (also the --baseline input format) ------------------------------------------
+
+internal sealed class BaselineDto
+{
+    public string Label { get; set; } = "";
+    public double Score { get; set; }
+    public string CpuModel { get; set; } = "";
+    public int LogicalCores { get; set; }
+    public int PhysicalCores { get; set; }
+    public long TotalRamBytes { get; set; }
+    public string Os { get; set; } = "";
+    public string Runtime { get; set; } = "";
+    public List<string>? Capabilities { get; set; }
+    public string Configuration { get; set; } = "";
+    public int Iterations { get; set; }
+    public List<WorkloadDto>? CpuWorkloads { get; set; }
+    public List<ScenarioDto> Scenarios { get; set; } = new();
+}
+
+internal sealed class WorkloadDto
+{
+    public string Name { get; set; } = "";
+    public double Ms { get; set; }
+    public double ReferenceMs { get; set; }
+    public double Score { get; set; }
+}
+
+internal sealed class ScenarioDto
+{
+    public string Name { get; set; } = "";
+    public string Project { get; set; } = "";
+    public bool Clean { get; set; }
+    public double WallMs { get; set; }
+    public double MinWallMs { get; set; }
+    public double StdDevMs { get; set; }
+    public double NormalisedWallMs { get; set; }
+    public double CpuMs { get; set; }
+    public double AllocBytes { get; set; }
+    public double PeakWorkingSetBytes { get; set; }
+    public List<PhaseDto> Phases { get; set; } = new();
+}
+
+internal sealed class PhaseDto
+{
+    public string Name { get; set; } = "";
+    public double Ms { get; set; }
+    public double Bytes { get; set; }
+}
+
+/// <summary>A previously recorded run, loaded from <c>--json</c> output for comparison.</summary>
+internal sealed record Baseline(string Label, double Score, string CpuModel, IReadOnlyList<ScenarioDto> Scenarios)
+{
+    public static Baseline? Load(string path)
+    {
+        try
+        {
+            var dto = JsonSerializer.Deserialize<BaselineDto>(File.ReadAllText(path),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (dto is null) return null;
+            return new Baseline(dto.Label, dto.Score, dto.CpuModel, dto.Scenarios);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Could not read baseline '{path}': {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/Transpose/Transpose.Bench/Scenario.cs
+++ b/Transpose/Transpose.Bench/Scenario.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Transpose.Bench;
+
+/// <summary>
+/// One thing to measure: run <c>tps</c> on a project, optionally after wiping every build output it
+/// and its project references produce ("clean slate"). Cleaning matters because <c>tps</c> skips a
+/// referenced project whose package DLL is already up to date — without a wipe the second iteration
+/// would measure a different, much cheaper build than the first.
+/// </summary>
+internal sealed record Scenario(string Name, string CsprojPath, bool Clean, string Configuration, string? Note)
+{
+    /// <summary>The <c>bin</c>/<c>obj</c> directories to wipe before a clean run: this project's and
+    /// those of every project it references, transitively (a stale dependency DLL is exactly what
+    /// makes a build incremental).</summary>
+    public IReadOnlyList<string> OutputDirsToClean()
+    {
+        var dirs = new List<string>();
+        foreach (var proj in ProjectClosure(CsprojPath))
+        {
+            var dir = Path.GetDirectoryName(proj)!;
+            dirs.Add(Path.Combine(dir, "bin"));
+            dirs.Add(Path.Combine(dir, "obj"));
+        }
+        return dirs;
+    }
+
+    /// <summary>The project and all its transitive <c>ProjectReference</c>s.</summary>
+    public static IReadOnlyList<string> ProjectClosure(string csproj)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var order = new List<string>();
+        void Walk(string p)
+        {
+            p = Path.GetFullPath(p);
+            if (!File.Exists(p) || !seen.Add(p)) return;
+            order.Add(p);
+            var dir = Path.GetDirectoryName(p)!;
+            XDocument doc;
+            try { doc = XDocument.Load(p); } catch { return; }
+            foreach (var pr in doc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+            {
+                var include = pr.Attribute("Include")?.Value;
+                if (!string.IsNullOrWhiteSpace(include))
+                    Walk(Path.Combine(dir, include!.Replace('\\', '/')));
+            }
+        }
+        Walk(csproj);
+        return order;
+    }
+}
+
+/// <summary>The measurements from a single <c>tps</c> invocation.</summary>
+internal sealed record Iteration(
+    double WallMs,
+    long CompilerReportedMs,
+    long TotalAllocatedBytes,
+    long PeakWorkingSetBytes,
+    long ProcessorTimeMs,
+    int Gen0, int Gen1, int Gen2,
+    IReadOnlyList<PhaseSample> Phases,
+    bool Succeeded,
+    string Output);
+
+internal sealed record PhaseSample(string Name, long Ms, long Bytes, int Count);
+
+/// <summary>Everything measured for one scenario across its iterations.</summary>
+internal sealed record ScenarioResult(Scenario Scenario, IReadOnlyList<Iteration> Iterations)
+{
+    public bool Succeeded => Iterations.Count > 0 && Iterations.All(i => i.Succeeded);
+    public IReadOnlyList<double> WallMsSamples => Iterations.Select(i => i.WallMs).ToArray();
+    public double MedianWallMs => Fmt.Median(WallMsSamples);
+    public double MinWallMs => Iterations.Count == 0 ? 0 : Iterations.Min(i => i.WallMs);
+    public double StdDevMs => Fmt.StdDev(WallMsSamples);
+    public double MedianAllocBytes => Fmt.Median(Iterations.Select(i => (double)i.TotalAllocatedBytes).ToArray());
+    public double MedianPeakWsBytes => Fmt.Median(Iterations.Select(i => (double)i.PeakWorkingSetBytes).ToArray());
+    public double MedianCpuMs => Fmt.Median(Iterations.Select(i => (double)i.ProcessorTimeMs).ToArray());
+
+    /// <summary>Per-phase medians across iterations, in the order the compiler reported them.</summary>
+    public IReadOnlyList<(string name, double ms, double bytes)> MedianPhases()
+    {
+        var order = new List<string>();
+        var byName = new Dictionary<string, List<(double ms, double bytes)>>();
+        foreach (var it in Iterations)
+            foreach (var p in it.Phases)
+            {
+                if (!byName.TryGetValue(p.Name, out var list)) { byName[p.Name] = list = new(); order.Add(p.Name); }
+                list.Add((p.Ms, p.Bytes));
+            }
+        return order
+            .Select(n => (n,
+                Fmt.Median(byName[n].Select(x => x.ms).ToArray()),
+                Fmt.Median(byName[n].Select(x => x.bytes).ToArray())))
+            .ToArray();
+    }
+}
+
+internal sealed class ScenarioRunner
+{
+    private readonly string _tps;
+    private readonly string _tempDir;
+    private readonly bool _verbose;
+
+    public ScenarioRunner(string tpsPath, string tempDir, bool verbose)
+    {
+        _tps = tpsPath;
+        _tempDir = tempDir;
+        _verbose = verbose;
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public ScenarioResult Run(Scenario scenario, int warmups, int iterations)
+    {
+        for (var i = 0; i < warmups; i++)
+        {
+            Console.Write($"  {scenario.Name}: warm-up {i + 1}/{warmups} … ");
+            var w = RunOnce(scenario);
+            Console.WriteLine(w.Succeeded ? $"{w.WallMs / 1000:F2} s (discarded)" : "FAILED");
+            if (!w.Succeeded) { Console.WriteLine(Indent(w.Output)); return new ScenarioResult(scenario, new[] { w }); }
+        }
+
+        var samples = new List<Iteration>();
+        for (var i = 0; i < iterations; i++)
+        {
+            Console.Write($"  {scenario.Name}: run {i + 1}/{iterations} … ");
+            var it = RunOnce(scenario);
+            samples.Add(it);
+            Console.WriteLine(it.Succeeded
+                ? $"{it.WallMs / 1000:F2} s   {Fmt.Mb(it.TotalAllocatedBytes)} alloc   peak {Fmt.Mb(it.PeakWorkingSetBytes)}"
+                : "FAILED");
+            if (!it.Succeeded) { Console.WriteLine(Indent(it.Output)); break; }
+        }
+        return new ScenarioResult(scenario, samples);
+    }
+
+    private static string Indent(string text) =>
+        string.Join('\n', text.Split('\n').TakeLast(30).Select(l => "      " + l));
+
+    private Iteration RunOnce(Scenario scenario)
+    {
+        if (scenario.Clean)
+            foreach (var dir in scenario.OutputDirsToClean())
+                if (Directory.Exists(dir))
+                    try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+
+        var statsPath = Path.Combine(_tempDir, $"stats-{Guid.NewGuid():N}.json");
+
+        var psi = new ProcessStartInfo(_tps)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("--project");
+        psi.ArgumentList.Add(scenario.CsprojPath);
+        psi.ArgumentList.Add("--configuration");
+        psi.ArgumentList.Add(scenario.Configuration);
+        psi.ArgumentList.Add("--timing-json");
+        psi.ArgumentList.Add(statsPath);
+
+        var sw = Stopwatch.StartNew();
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEndAsync();
+        var stderr = proc.StandardError.ReadToEndAsync();
+        proc.WaitForExit();
+        sw.Stop();
+
+        var output = stdout.Result + stderr.Result;
+        if (_verbose) Console.WriteLine();
+        if (_verbose) Console.WriteLine(Indent(output));
+
+        var stats = ReadStats(statsPath);
+        try { if (File.Exists(statsPath)) File.Delete(statsPath); } catch { /* best effort */ }
+
+        return new Iteration(
+            WallMs: sw.Elapsed.TotalMilliseconds,
+            CompilerReportedMs: stats?.WallClockMs ?? 0,
+            TotalAllocatedBytes: stats?.TotalAllocatedBytes ?? 0,
+            PeakWorkingSetBytes: stats?.PeakWorkingSetBytes ?? 0,
+            ProcessorTimeMs: stats?.ProcessorTimeMs ?? 0,
+            Gen0: stats?.Gen0 ?? 0, Gen1: stats?.Gen1 ?? 0, Gen2: stats?.Gen2 ?? 0,
+            Phases: stats?.Phases?.Select(p => new PhaseSample(p.Name, p.Ms, p.Bytes, p.Count)).ToArray()
+                    ?? Array.Empty<PhaseSample>(),
+            Succeeded: proc.ExitCode == 0,
+            Output: output);
+    }
+
+    private sealed record StatsDump(
+        long WallClockMs, long TotalAllocatedBytes, long PeakWorkingSetBytes,
+        int Gen0, int Gen1, int Gen2, long ProcessorTimeMs, List<PhaseDump>? Phases);
+    private sealed record PhaseDump(string Name, long Ms, long Bytes, int Count);
+
+    private static StatsDump? ReadStats(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            return JsonSerializer.Deserialize<StatsDump>(File.ReadAllText(path),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch { return null; }
+    }
+}

--- a/Transpose/Transpose.Bench/Scenario.cs
+++ b/Transpose/Transpose.Bench/Scenario.cs
@@ -102,12 +102,20 @@ internal sealed class ScenarioRunner
     private readonly string _tps;
     private readonly string _tempDir;
     private readonly bool _verbose;
+    private readonly IReadOnlyList<(string key, string value)> _env;
 
-    public ScenarioRunner(string tpsPath, string tempDir, bool verbose)
+    /// <param name="env">Extra environment variables for each compiler process. The compiler's runtime
+    /// configuration is load-bearing (TieredPGO off and Server GC are together worth ~40% of a build),
+    /// and those are exactly the settings a DOTNET_* variable can override — so being able to set them
+    /// per run is what makes "is that still the right default on this runtime?" a measurable question
+    /// rather than a belief.</param>
+    public ScenarioRunner(string tpsPath, string tempDir, bool verbose,
+                          IReadOnlyList<(string key, string value)>? env = null)
     {
         _tps = tpsPath;
         _tempDir = tempDir;
         _verbose = verbose;
+        _env = env ?? Array.Empty<(string, string)>();
         Directory.CreateDirectory(_tempDir);
     }
 
@@ -159,6 +167,7 @@ internal sealed class ScenarioRunner
         psi.ArgumentList.Add(scenario.Configuration);
         psi.ArgumentList.Add("--timing-json");
         psi.ArgumentList.Add(statsPath);
+        foreach (var (key, value) in _env) psi.Environment[key] = value;
 
         var sw = Stopwatch.StartNew();
         using var proc = Process.Start(psi)!;

--- a/Transpose/Transpose.Bench/Transpose.Bench.csproj
+++ b/Transpose/Transpose.Bench/Transpose.Bench.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Transpose.Bench</RootNamespace>
+    <AssemblyName>tps-bench</AssemblyName>
+    <StartupObject>Transpose.Bench.Program</StartupObject>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!-- Packable as a dotnet tool so the benchmark can be run the same way on any machine
+         (install Transpose.Bench globally, then run `tps-bench`), which is what makes the
+         CPU-score normalisation useful: results from different machines become comparable. -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>tps-bench</ToolCommandName>
+    <PackageId>Transpose.Bench</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Curiosity GmbH</Authors>
+    <Company>Curiosity GmbH</Company>
+    <Description>Transpose — compiler performance benchmark harness (CPU-score-normalised).</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/curiosity-ai/transpose</PackageProjectUrl>
+  </PropertyGroup>
+
+</Project>

--- a/Transpose/Transpose.Bench/ab.sh
+++ b/Transpose/Transpose.Bench/ab.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Interleaved A/B timing of two `tps` binaries on one project.
+#
+# The benchmark host is a shared VM whose throughput drifts by tens of percent over minutes, so
+# measuring A for a while and then B is worthless — the drift swamps the effect. This alternates
+# A,B,A,B,… so both see the same conditions, and reports each one's median.
+#
+#   ab.sh <tps-A> <tps-B> <project.csproj> [rounds] [configuration]
+set -uo pipefail
+
+A=${1:?usage: ab.sh <tps-A> <tps-B> <project.csproj> [rounds] [config]}
+B=${2:?}
+PROJ=${3:?}
+ROUNDS=${4:-3}
+CFG=${5:-Debug}
+PROJDIR=$(dirname "$PROJ")
+
+# Wipe the project's and its project references' outputs: tps skips an up-to-date dependency, so
+# without this the second round would measure a different build.
+clean() {
+  rm -rf "$PROJDIR/bin" "$PROJDIR/obj"
+  grep -o 'ProjectReference Include="[^"]*"' "$PROJ" 2>/dev/null | sed 's/.*Include="//; s/"$//' | tr '\\' '/' | while read -r ref; do
+    d=$(dirname "$PROJDIR/$ref"); rm -rf "$d/bin" "$d/obj"
+  done
+}
+
+run() { # <tps> -> prints wall ms
+  clean
+  local t0 t1
+  t0=$(date +%s%N)
+  "$1" --project "$PROJ" -c "$CFG" -q >/dev/null 2>&1
+  t1=$(date +%s%N)
+  echo $(( (t1 - t0) / 1000000 ))
+}
+
+declare -a AT BT
+for i in $(seq 1 "$ROUNDS"); do
+  a=$(run "$A"); AT+=("$a")
+  b=$(run "$B"); BT+=("$b")
+  printf 'round %d:  A %6d ms   B %6d ms   (B/A %.3f)\n' "$i" "$a" "$b" "$(echo "scale=4; $b/$a" | bc)"
+done
+
+median() { printf '%s\n' "$@" | sort -n | awk '{v[NR]=$1} END{print (NR%2)?v[(NR+1)/2]:int((v[NR/2]+v[NR/2+1])/2)}'; }
+MA=$(median "${AT[@]}"); MB=$(median "${BT[@]}")
+printf '\nmedian:   A %6d ms   B %6d ms   ->  B is %.1f%% %s\n' \
+  "$MA" "$MB" "$(echo "scale=4; d=($MB-$MA)*100/$MA; if (d<0) -d else d" | bc)" \
+  "$( [ "$MB" -lt "$MA" ] && echo faster || echo slower )"

--- a/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
+++ b/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
@@ -486,5 +486,33 @@
     <Message Importance="high" Text="... Transpose compilation finished!" />
   </Target>
 
+  <!--
+    A Debug build must never become a NuGet package.
+
+    In Debug, tps emits the project's .NET assembly as *metadata only* (real metadata, `throw null`
+    method bodies) because that is measurably faster and nothing consumes a Debug assembly except the
+    developer's own build. That assembly is fine to bind against and carries the compiled JavaScript
+    as embedded resources, but it must not be published: a consumer restoring it would get a package
+    whose IL is gone. Release keeps full IL and is the configuration to pack.
+
+    So: silently turn off GeneratePackageOnBuild for Debug (this file is imported after the project
+    body, so it wins over a project that sets it), and fail loudly if someone explicitly asks to pack
+    a Debug build. Set TransposeAllowDebugPackaging=true to override — only sensible together with
+    TransposeMetadataOnlyAssembly=false, which restores full IL in Debug.
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug' And '$(TransposeAllowDebugPackaging)' != 'true'">
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <!-- Hooked before GenerateNuspec, not before Pack: GenerateNuspec is a *dependency* of Pack and is
+       what actually writes the .nupkg, so a BeforeTargets="Pack" hook fires too late — the package is
+       already on disk by then (observed). Pack is listed as well so the guard still fires for any
+       flow that reaches Pack without GenerateNuspec. -->
+  <Target Name="_TransposeBlockDebugPackaging" BeforeTargets="GenerateNuspec;Pack"
+          Condition="'$(Configuration)' == 'Debug' And '$(TransposeAllowDebugPackaging)' != 'true'">
+    <Error Code="TPS1001"
+           Text="Refusing to pack a Debug build of $(MSBuildProjectName). In Debug, Transpose emits a metadata-only assembly (no method bodies), which must not be published. Pack the Release configuration instead: dotnet pack -c Release. To override, set TransposeAllowDebugPackaging=true (and TransposeMetadataOnlyAssembly=false so the assembly carries real IL)." />
+  </Target>
+
   <Import Project="$(CustomAfterTranspose)" Condition="'$(CustomAfterTranspose)' != '' And Exists('$(CustomAfterTranspose)')" />
 </Project>

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -510,7 +510,6 @@ public static class Program
         var mainJsName = config?.ExplicitFileName ?? project.AssemblyName + ".js";
         var dllPath = ProjectResolver.OutputDll(project.CsprojPath, configuration)!;
         Directory.CreateDirectory(Path.GetDirectoryName(dllPath)!);
-        File.WriteAllBytes(dllPath, result.AssemblyBytes!);
 
         var items = PhaseTimings.Measure("collect package resources (minify + read files)", () => config is not null
             ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables)
@@ -520,8 +519,9 @@ public static class Program
         // makes it resolve that assembly. Seed the resolver with the reference directories so those
         // types are found (the referenced DLLs live in the NuGet cache / sibling bin folders, not
         // next to this DLL).
+        // Writes the DLL — the emitted assembly plus the embedded resources — in one pass.
         PhaseTimings.Measure("embed resources into DLL (Cecil)",
-            () => ResourceEmbedder.Embed(dllPath, items, project.ReferencePaths));
+            () => ResourceEmbedder.Embed(dllPath, result.AssemblyBytes!, items, project.ReferencePaths));
         return (dllPath, items);
     }
 

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -33,6 +33,8 @@ public static class Program
         var extraReferences = new List<string>();
         var extraDefines = new List<string>();
         string? assemblyVersion = null;
+        // Overrides the project's <TransposeMetadataOnlyAssembly>; see ResolvedProject for what it does.
+        var metadataOnlyAssembly = false;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -51,6 +53,7 @@ public static class Program
                 case "--define" or "-D": extraDefines.Add(args[++i]); break;
                 case "--timing": PhaseTimings.Enabled = true; break;
                 case "--timing-json": _timingJsonPath = args[++i]; PhaseTimings.Enabled = true; break;
+                case "--metadata-only-assembly": metadataOnlyAssembly = true; break;
                 case "--assembly-version": assemblyVersion = args[++i]; break;
                 case "--project" or "-p": projectArg = args[++i]; break;
                 default:
@@ -160,7 +163,7 @@ public static class Program
         // separate-assembly / package mode this project binds against its dependencies' built DLLs
         // and extracts their embedded JS, so each must be compiled — in dependency order — before
         // this one. Up-to-date packages are skipped.
-        if (separateAssemblies && !EnsureReferencedProjectsBuilt(csproj, configuration, maxErrors))
+        if (separateAssemblies && !EnsureReferencedProjectsBuilt(csproj, configuration, maxErrors, metadataOnlyAssembly))
         {
             Console.Error.WriteLine("\nFAILED building referenced projects.");
             return 1;
@@ -184,7 +187,9 @@ public static class Program
                 reflectionEnabled,
                 metadataTarget,
                 emitAssembly: emitPackage || isSiteBuild,
-                assemblyVersion: assemblyVersion);
+                assemblyVersion: assemblyVersion,
+                emitDebugInformation: project.EmitDebugInformation,
+                metadataOnlyAssembly: metadataOnlyAssembly || project.MetadataOnlyAssembly);
         }
         catch (Exception ex)
         {
@@ -441,7 +446,7 @@ public static class Program
     /// which builds project references (each producing a DLL with its JS embedded) before the
     /// project that consumes them.
     /// </summary>
-    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors)
+    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors, bool metadataOnlyAssembly)
     {
         foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
         {
@@ -452,7 +457,7 @@ public static class Program
                 continue;
             }
             Console.WriteLine($"  building dependency: {name}");
-            if (!BuildPackage(dep, configuration, maxErrors))
+            if (!BuildPackage(dep, configuration, maxErrors, metadataOnlyAssembly))
             {
                 Console.Error.WriteLine($"  dependency build FAILED: {name}");
                 return false;
@@ -464,7 +469,7 @@ public static class Program
     /// <summary>Compiles one project into its Transpose package DLL (the .NET assembly with the compiled JS
     /// and tps.json resources embedded). Its own project references are consumed as their built DLLs,
     /// so they must already have been built (this is called in dependency order).</summary>
-    private static bool BuildPackage(string csproj, string configuration, int maxErrors)
+    private static bool BuildPackage(string csproj, string configuration, int maxErrors, bool metadataOnlyAssembly)
     {
         ResolvedProject project;
         try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
@@ -480,7 +485,9 @@ public static class Program
                 project.Sources, project.AssemblyName, project.ReferencePaths,
                 project.DefineConstants, project.LanguageVersion,
                 reflectionEnabled, metadataTarget, emitAssembly: true,
-                assemblyVersion: ProjectResolver.ReadAssemblyVersion(csproj));
+                assemblyVersion: ProjectResolver.ReadAssemblyVersion(csproj),
+                emitDebugInformation: project.EmitDebugInformation,
+                metadataOnlyAssembly: metadataOnlyAssembly || project.MetadataOnlyAssembly);
         }
         catch (Exception ex) { Console.Error.WriteLine($"    translator threw: {ex.Message}"); return false; }
 
@@ -596,6 +603,13 @@ public static class Program
               --site-dir <dir>      Output directory for the assembled site
               --with-runtime        Prepend the tps.js runtime + shim to the output
               --max-errors <n>      Max individual errors to print (default 40)
+              --metadata-only-assembly
+                                    Emit the .NET assembly as metadata only (full metadata including
+                                    private members, `throw null` bodies) instead of real IL. A
+                                    Transpose assembly is only ever bound against — it cannot execute,
+                                    since it binds to the stand-in BCL — so this skips a second full
+                                    bind of every method body (~18% off a large build). Equivalent to
+                                    <TransposeMetadataOnlyAssembly>true</TransposeMetadataOnlyAssembly>.
               --timing              Print a per-phase timing/allocation breakdown of the build
               --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON
               -q, --quiet           Suppress warning output

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -50,6 +50,7 @@ public static class Program
                 case "--reference" or "-r": extraReferences.Add(args[++i]); break;
                 case "--define" or "-D": extraDefines.Add(args[++i]); break;
                 case "--timing": PhaseTimings.Enabled = true; break;
+                case "--timing-json": _timingJsonPath = args[++i]; PhaseTimings.Enabled = true; break;
                 case "--assembly-version": assemblyVersion = args[++i]; break;
                 case "--project" or "-p": projectArg = args[++i]; break;
                 default:
@@ -104,7 +105,8 @@ public static class Program
         ResolvedProject project;
         try
         {
-            project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies);
+            project = PhaseTimings.Measure("resolve project (csproj + globs + references)",
+                () => ProjectResolver.Resolve(csproj, configuration, separateAssemblies));
         }
         catch (Exception ex)
         {
@@ -190,8 +192,9 @@ public static class Program
             return 2;
         }
 
-        sw.Stop();
-
+        // The stopwatch keeps running: writing the package (minifying the embedded JS, the Cecil
+        // resource embed) and assembling the site are a real part of a build's cost, and the
+        // reported total should include them rather than stopping at the translator's last phase.
         if (!result.Success)
         {
             ReportDiagnostics(result.Diagnostics, maxErrors);
@@ -345,24 +348,78 @@ public static class Program
     }
 
     /// <summary>Prints the per-phase timing breakdown gathered when <c>--timing</c> (or
-    /// <c>TRANSPOSE_TIMING=1</c>) is set. Shows each phase's total time and its share of the sum,
-    /// so a build's hotspots (binding, JS emit, minification) are visible at a glance.</summary>
+    /// <c>TRANSPOSE_TIMING=1</c>) is set. Shows each phase's total time, its share of the sum, and
+    /// the bytes allocated while it ran, so a build's hotspots (binding, JS emit, minification) and
+    /// its garbage producers are visible at a glance. With <c>--timing-json</c> the same numbers —
+    /// plus process-wide GC/memory totals — are written as JSON for a benchmark harness to consume.</summary>
     private static void PrintTimings(long wallClockMs)
     {
         if (!PhaseTimings.Enabled) return;
         var phases = PhaseTimings.Snapshot();
         if (phases.Count == 0) return;
-        long sum = 0;
-        foreach (var p in phases) sum += p.ms;
+        // Sub-phases are named with a leading indent ("  ├ …") and are already counted inside their
+        // parent, so only top-level phases contribute to the total.
+        long sum = 0, sumBytes = 0;
+        foreach (var p in phases)
+        {
+            if (p.phase.StartsWith(" ", StringComparison.Ordinal)) continue;
+            sum += p.ms; sumBytes += p.bytes;
+        }
         var denom = sum == 0 ? 1 : sum;
         Console.WriteLine("\n  timing breakdown:");
-        foreach (var (phase, ms, count) in phases)
+        foreach (var (phase, ms, bytes, count) in phases)
         {
             var share = ms * 100.0 / denom;
             var times = count > 1 ? $" ×{count}" : "";
-            Console.WriteLine($"    {ms,7:N0} ms  {share,5:F1}%  {phase}{times}");
+            Console.WriteLine($"    {ms,7:N0} ms  {share,5:F1}%  {Mb(bytes),9} alloc  {phase}{times}");
         }
-        Console.WriteLine($"    {sum,7:N0} ms          measured phases (wall clock {wallClockMs:N0} ms)");
+        Console.WriteLine($"    {sum,7:N0} ms          {Mb(sumBytes),9} alloc  measured phases (wall clock {wallClockMs:N0} ms)");
+        Console.WriteLine($"    total allocated {Mb(GC.GetTotalAllocatedBytes(precise: true))}, "
+            + $"peak working set {Mb(Process.GetCurrentProcess().PeakWorkingSet64)}, "
+            + $"GC {GC.CollectionCount(0)}/{GC.CollectionCount(1)}/{GC.CollectionCount(2)} (gen0/1/2)");
+
+        if (_timingJsonPath is not null) WriteTimingJson(_timingJsonPath, wallClockMs, phases);
+    }
+
+    private static string Mb(long bytes) => $"{bytes / (1024.0 * 1024.0):N1} MB";
+
+    /// <summary>Path passed to <c>--timing-json</c>: where the machine-readable build-stats dump goes.
+    /// The benchmark harness (<c>tps-bench</c>) reads this instead of scraping console output.</summary>
+    private static string? _timingJsonPath;
+
+    private static void WriteTimingJson(string path, long wallClockMs,
+        IReadOnlyList<(string phase, long ms, long bytes, int count)> phases)
+    {
+        var proc = Process.GetCurrentProcess();
+        var sb = new System.Text.StringBuilder();
+        sb.Append("{\n");
+        sb.Append($"  \"wallClockMs\": {wallClockMs},\n");
+        sb.Append($"  \"totalAllocatedBytes\": {GC.GetTotalAllocatedBytes(precise: true)},\n");
+        sb.Append($"  \"peakWorkingSetBytes\": {proc.PeakWorkingSet64},\n");
+        sb.Append($"  \"gen0\": {GC.CollectionCount(0)}, \"gen1\": {GC.CollectionCount(1)}, \"gen2\": {GC.CollectionCount(2)},\n");
+        sb.Append($"  \"processorTimeMs\": {(long)proc.TotalProcessorTime.TotalMilliseconds},\n");
+        sb.Append("  \"phases\": [\n");
+        for (var i = 0; i < phases.Count; i++)
+        {
+            var (phase, ms, bytes, count) = phases[i];
+            sb.Append($"    {{ \"name\": {JsonString(phase)}, \"ms\": {ms}, \"bytes\": {bytes}, \"count\": {count} }}");
+            sb.Append(i == phases.Count - 1 ? "\n" : ",\n");
+        }
+        sb.Append("  ]\n}\n");
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+            File.WriteAllText(path, sb.ToString());
+        }
+        catch (Exception ex) { Console.Error.WriteLine($"  warning: could not write --timing-json: {ex.Message}"); }
+    }
+
+    private static string JsonString(string s)
+    {
+        var sb = new System.Text.StringBuilder("\"");
+        foreach (var c in s)
+            sb.Append(c switch { '"' => "\\\"", '\\' => "\\\\", '\n' => "\\n", '\r' => "\\r", '\t' => "\\t", _ => c.ToString() });
+        return sb.Append('"').ToString();
     }
 
     private static (bool reflectionEnabled, MetadataTarget target) ReflectionSettings(TransposeJson? tpscfg)
@@ -448,15 +505,16 @@ public static class Program
         Directory.CreateDirectory(Path.GetDirectoryName(dllPath)!);
         File.WriteAllBytes(dllPath, result.AssemblyBytes!);
 
-        var items = config is not null
+        var items = PhaseTimings.Measure("collect package resources (minify + read files)", () => config is not null
             ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables)
-            : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) };
+            : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) });
         // Cecil re-serializes the assembly's metadata when embedding the resources; encoding a
         // parameter's default value whose type lives in a referenced assembly (e.g. a Tesserae enum)
         // makes it resolve that assembly. Seed the resolver with the reference directories so those
         // types are found (the referenced DLLs live in the NuGet cache / sibling bin folders, not
         // next to this DLL).
-        ResourceEmbedder.Embed(dllPath, items, project.ReferencePaths);
+        PhaseTimings.Measure("embed resources into DLL (Cecil)",
+            () => ResourceEmbedder.Embed(dllPath, items, project.ReferencePaths));
         return (dllPath, items);
     }
 
@@ -538,7 +596,8 @@ public static class Program
               --site-dir <dir>      Output directory for the assembled site
               --with-runtime        Prepend the tps.js runtime + shim to the output
               --max-errors <n>      Max individual errors to print (default 40)
-              --timing              Print a per-phase timing breakdown of the build
+              --timing              Print a per-phase timing/allocation breakdown of the build
+              --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON
               -q, --quiet           Suppress warning output
               -h, --help            Show this help
             """);

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -289,6 +289,8 @@ public static class Program
 
         // Write the ClassPath per-class files + reflection metadata under Resources/.generated/.
         var genRoot = Path.Combine(project.ProjectDir, "Resources", ".generated");
+        PhaseTimings.Measure("write ClassPath files", () =>
+        {
         if (Directory.Exists(genRoot)) Directory.Delete(genRoot, recursive: true);
         Directory.CreateDirectory(genRoot);
         // Group types that share a ClassPath file (same simple name across generic arities, e.g.
@@ -302,6 +304,7 @@ public static class Program
         }
         if (result.ClassPath.MetaBlock is not null)
             File.WriteAllText(Path.Combine(genRoot, project.AssemblyName + ".meta.js"), result.ClassPath.MetaBlock);
+        });
         Console.WriteLine($"  emitted:    {result.ClassPath.Files.Count} ClassPath file(s) into Resources/.generated");
         if (result.ClassPath.Skipped.Count > 0)
         {
@@ -313,8 +316,11 @@ public static class Program
         // pre-minified variant of each next to it. Embedding the .min.js in the runtime package
         // means a referencing build never re-minifies the (large) runtime — it just picks the
         // variant its configuration wants, exactly as it does for the formatted/minified pair.
-        var bundles = RuntimeAssembler.Assemble(project.ProjectDir);
-        var minBundles = new List<(string name, byte[] bytes)>();
+        var bundles = PhaseTimings.Measure("assemble runtime bundles (tps.js)",
+            () => RuntimeAssembler.Assemble(project.ProjectDir));
+        var minBundles = PhaseTimings.Measure("minify runtime bundles", () =>
+        {
+        var mins = new List<(string name, byte[] bytes)>();
         foreach (var (name, bytes) in bundles)
         {
             var minName = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && !name.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
@@ -322,8 +328,10 @@ public static class Program
                 : null;
             if (minName is null) continue;
             var minText = JsMinifier.Minify(System.Text.Encoding.UTF8.GetString(bytes), name, project.MinifyLocalVariables);
-            minBundles.Add((minName, System.Text.Encoding.UTF8.GetBytes(minText)));
+            mins.Add((minName, System.Text.Encoding.UTF8.GetBytes(minText)));
         }
+        return mins;
+        });
         bundles = bundles.Concat(minBundles).ToList();
         // Write the assembly to bin/<config>/<tfm>/, matching the SDK's output path so `dotnet pack`
         // finds it (the Transpose.Build.Target SDK forces netstandard2.0, so that is the effective tfm).

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -26,7 +26,8 @@ public static class Program
         var configuration = "Debug";
         var withRuntime = false;
         var quiet = false;
-        var maxErrors = 40;
+        // 0 = print every error. A cap loses information the user needs, so it is opt-in.
+        var maxErrors = 0;
         var emitPackage = false;
         var separateAssemblies = false;
         var buildRuntime = false;
@@ -49,7 +50,7 @@ public static class Program
                 case "--separate-assemblies": separateAssemblies = true; break;
                 case "--with-runtime": withRuntime = true; break;
                 case "--quiet" or "-q": quiet = true; break;
-                case "--max-errors": maxErrors = int.Parse(args[++i]); break;
+                case "--max-errors": maxErrors = Math.Max(0, int.Parse(args[++i])); break;
                 case "--reference" or "-r": extraReferences.Add(args[++i]); break;
                 case "--define" or "-D": extraDefines.Add(args[++i]); break;
                 case "--timing": PhaseTimings.Enabled = true; break;
@@ -163,7 +164,7 @@ public static class Program
             string.Equals(Path.GetFileNameWithoutExtension(p), "Transpose", StringComparison.OrdinalIgnoreCase));
         if (buildRuntime
             || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && !referencesTransposeBcl))
-            return BuildRuntime(project, configuration, sw, outPath);
+            return BuildRuntime(project, configuration, sw, outPath, maxErrors);
 
         // Reflection settings come from the project's tps.json (target inline vs a .meta.js file).
         var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
@@ -275,7 +276,7 @@ public static class Program
     /// those with the hand-written Resources/*.js primitives into tps.js (and the reflection block
     /// into tps.meta.js) per the project's tps.json, and embeds both into Transpose.dll.
     /// </summary>
-    private static int BuildRuntime(ResolvedProject project, string configuration, Stopwatch sw, string? outPath)
+    private static int BuildRuntime(ResolvedProject project, string configuration, Stopwatch sw, string? outPath, int maxErrors)
     {
         var cfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
         var reflectionEnabled = !(cfg?.ReflectionDisabled ?? false);
@@ -291,7 +292,7 @@ public static class Program
 
         if (!result.Success)
         {
-            ReportDiagnostics(result.Diagnostics, 40);
+            ReportDiagnostics(result.Diagnostics, maxErrors);
             Console.Error.WriteLine($"\nFAILED building runtime in {sw.ElapsedMilliseconds} ms.");
             return 1;
         }
@@ -575,9 +576,31 @@ public static class Program
         return null;
     }
 
+    /// <summary>
+    /// Prints the build's diagnostics. **Every** error is printed by default: a truncated list makes a
+    /// broken build take several compile cycles to fix, and the caller has no way to know whether the
+    /// errors it cannot see are the same problem or a different one. <paramref name="maxErrors"/> caps
+    /// the list only when a caller explicitly asked for a cap (<c>--max-errors</c>).
+    ///
+    /// Ordering comes from <see cref="OrderErrorsForReport"/>.
+    /// </summary>
+    /// <summary>
+    /// The errors to report, in the order to report them: by file, then line, then column — the order
+    /// you would fix them in — rather than by the phase that produced them (the unsupported-feature
+    /// scan runs before Roslyn's diagnostics, and its parallel per-file walk has no inherent order).
+    /// Nothing is filtered out here; truncation, if any, is the caller's decision.
+    /// </summary>
+    internal static List<Diagnostic> OrderErrorsForReport(IReadOnlyList<Diagnostic> diagnostics)
+        => diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)
+            .OrderBy(d => d.Location.SourceTree?.FilePath ?? "", StringComparer.OrdinalIgnoreCase)
+            .ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Line)
+            .ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Character)
+            .ThenBy(d => d.Id, StringComparer.Ordinal)
+            .ToList();
+
     private static void ReportDiagnostics(IReadOnlyList<Diagnostic> diagnostics, int maxErrors)
     {
-        var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+        var errors = OrderErrorsForReport(diagnostics);
         var warnings = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToList();
 
         if (errors.Count > 0)
@@ -586,10 +609,11 @@ public static class Program
             var byId = errors.GroupBy(d => d.Id).OrderByDescending(g => g.Count());
             Console.Error.WriteLine("  by id: " + string.Join(", ", byId.Select(g => $"{g.Key}×{g.Count()}")));
             Console.Error.WriteLine();
-            foreach (var d in errors.Take(maxErrors))
+            var shown = maxErrors > 0 ? errors.Take(maxErrors) : errors;
+            foreach (var d in shown)
                 Console.Error.WriteLine("  " + Format(d));
-            if (errors.Count > maxErrors)
-                Console.Error.WriteLine($"  … and {errors.Count - maxErrors} more.");
+            if (maxErrors > 0 && errors.Count > maxErrors)
+                Console.Error.WriteLine($"  … and {errors.Count - maxErrors} more (raise or drop --max-errors to see them).");
         }
 
         if (warnings.Count > 0)
@@ -623,7 +647,9 @@ public static class Program
                                     embedded JS) instead of recompiling their source into the bundle.
               --site-dir <dir>      Output directory for the assembled site
               --with-runtime        Prepend the tps.js runtime + shim to the output
-              --max-errors <n>      Max individual errors to print (default 40)
+              --max-errors <n>      Cap how many individual errors are printed. By default there is
+                                    no cap — every error is reported, ordered by file and line. Pass 0
+                                    to restore that explicitly.
               --metadata-only-assembly, --no-metadata-only-assembly
                                     Force the .NET assembly to be metadata only (full metadata
                                     including private members, `throw null` bodies) or real IL. A

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -33,8 +33,9 @@ public static class Program
         var extraReferences = new List<string>();
         var extraDefines = new List<string>();
         string? assemblyVersion = null;
-        // Overrides the project's <TransposeMetadataOnlyAssembly>; see ResolvedProject for what it does.
-        var metadataOnlyAssembly = false;
+        // Overrides the project's <TransposeMetadataOnlyAssembly>, which in turn overrides the
+        // per-configuration default. Null = nothing on the command line expressed a preference.
+        bool? metadataOnlyAssembly = null;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -54,6 +55,7 @@ public static class Program
                 case "--timing": PhaseTimings.Enabled = true; break;
                 case "--timing-json": _timingJsonPath = args[++i]; PhaseTimings.Enabled = true; break;
                 case "--metadata-only-assembly": metadataOnlyAssembly = true; break;
+                case "--no-metadata-only-assembly": metadataOnlyAssembly = false; break;
                 case "--assembly-version": assemblyVersion = args[++i]; break;
                 case "--project" or "-p": projectArg = args[++i]; break;
                 default:
@@ -137,6 +139,13 @@ public static class Program
         Console.WriteLine($"  config:     {configuration}");
         Console.WriteLine($"  lang:       {project.LanguageVersion}");
 
+        // Command line beats the csproj property, which beats the per-configuration default. Printed,
+        // because "why is my DLL half the size in Debug?" should be answerable from the build log.
+        var metadataOnly = metadataOnlyAssembly
+                           ?? project.MetadataOnlyAssembly
+                           ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration);
+        Console.WriteLine($"  assembly:   {(metadataOnly ? "metadata only (throw-null bodies, not packable)" : "full IL")}");
+
         // The project's tps.json drives runtime-package detection and reflection settings. A
         // tps.<Configuration>.json overlay (e.g. tps.Release.json) is merged on top when present.
         var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
@@ -189,7 +198,7 @@ public static class Program
                 emitAssembly: emitPackage || isSiteBuild,
                 assemblyVersion: assemblyVersion,
                 emitDebugInformation: project.EmitDebugInformation,
-                metadataOnlyAssembly: metadataOnlyAssembly || project.MetadataOnlyAssembly);
+                metadataOnlyAssembly: metadataOnly);
         }
         catch (Exception ex)
         {
@@ -454,7 +463,7 @@ public static class Program
     /// which builds project references (each producing a DLL with its JS embedded) before the
     /// project that consumes them.
     /// </summary>
-    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors, bool metadataOnlyAssembly)
+    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors, bool? metadataOnlyAssembly)
     {
         foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
         {
@@ -477,7 +486,7 @@ public static class Program
     /// <summary>Compiles one project into its Transpose package DLL (the .NET assembly with the compiled JS
     /// and tps.json resources embedded). Its own project references are consumed as their built DLLs,
     /// so they must already have been built (this is called in dependency order).</summary>
-    private static bool BuildPackage(string csproj, string configuration, int maxErrors, bool metadataOnlyAssembly)
+    private static bool BuildPackage(string csproj, string configuration, int maxErrors, bool? metadataOnlyAssembly)
     {
         ResolvedProject project;
         try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
@@ -495,7 +504,11 @@ public static class Program
                 reflectionEnabled, metadataTarget, emitAssembly: true,
                 assemblyVersion: ProjectResolver.ReadAssemblyVersion(csproj),
                 emitDebugInformation: project.EmitDebugInformation,
-                metadataOnlyAssembly: metadataOnlyAssembly || project.MetadataOnlyAssembly);
+                // Each dependency reads its own csproj property, but a command-line override applies
+                // to the whole invocation.
+                metadataOnlyAssembly: metadataOnlyAssembly
+                                      ?? project.MetadataOnlyAssembly
+                                      ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration));
         }
         catch (Exception ex) { Console.Error.WriteLine($"    translator threw: {ex.Message}"); return false; }
 
@@ -611,13 +624,16 @@ public static class Program
               --site-dir <dir>      Output directory for the assembled site
               --with-runtime        Prepend the tps.js runtime + shim to the output
               --max-errors <n>      Max individual errors to print (default 40)
-              --metadata-only-assembly
-                                    Emit the .NET assembly as metadata only (full metadata including
-                                    private members, `throw null` bodies) instead of real IL. A
+              --metadata-only-assembly, --no-metadata-only-assembly
+                                    Force the .NET assembly to be metadata only (full metadata
+                                    including private members, `throw null` bodies) or real IL. A
                                     Transpose assembly is only ever bound against — it cannot execute,
-                                    since it binds to the stand-in BCL — so this skips a second full
-                                    bind of every method body (~18% off a large build). Equivalent to
-                                    <TransposeMetadataOnlyAssembly>true</TransposeMetadataOnlyAssembly>.
+                                    since it binds to the stand-in BCL — so metadata-only skips a
+                                    second full bind of every method body (~18% off a large build).
+                                    Default: metadata only for Debug, real IL for Release. A project
+                                    can pin it with <TransposeMetadataOnlyAssembly>. The Transpose SDK
+                                    refuses to pack a Debug build, so a metadata-only assembly cannot
+                                    reach a NuGet feed.
               --timing              Print a per-phase timing/allocation breakdown of the build
               --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON
               -q, --quiet           Suppress warning output

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -31,20 +31,35 @@ internal sealed class ResolvedProject
     public bool MinifyLocalVariables { get; init; }
 
     /// <summary>
-    /// The csproj <c>&lt;TransposeMetadataOnlyAssembly&gt;</c> property (default false): emit the
-    /// project's .NET assembly as metadata only — full type/member metadata including private members,
-    /// but <c>throw null</c> method bodies — instead of compiling real IL.
+    /// The csproj <c>&lt;TransposeMetadataOnlyAssembly&gt;</c> property: emit the project's .NET assembly
+    /// as metadata only — full type/member metadata including private members, but <c>throw null</c>
+    /// method bodies — instead of compiling real IL. Null when the project says nothing, in which case
+    /// the configuration decides (see <see cref="MetadataOnlyAssemblyDefault"/>).
     ///
-    /// It is opt-in because it changes what a published package contains, but the reasoning behind
-    /// offering it is that a Transpose-compiled assembly can never execute anyway: it binds against
+    /// Skipping the IL codegen removes the second full bind of every method body from the build:
+    /// measured ~18% off a clean Tesserae build (8.3 s → 6.8 s), roughly halves the DLL, and produces
+    /// byte-identical JavaScript. Implies no debug information (Roslyn rejects an embedded PDB when
+    /// there are no bodies to describe).
+    ///
+    /// It is sound because a Transpose-compiled assembly can never execute: it binds against
     /// <c>Transpose.dll</c>, a stand-in BCL with no implementations, so no .NET host can load it. Its
     /// only jobs are to be *bound against* by another Transpose project and to carry the compiled JS
-    /// as embedded resources — both of which need metadata alone. Skipping the IL codegen removes the
-    /// second full bind of every method body from the build: measured at ~18% off a clean Tesserae
-    /// build (8.3 s → 6.8 s) and roughly halves the DLL, with byte-identical JavaScript output.
-    /// Implies no debug information (Roslyn rejects an embedded PDB with no bodies to describe).
+    /// as embedded resources — both of which need metadata alone.
     /// </summary>
-    public bool MetadataOnlyAssembly { get; init; }
+    public bool? MetadataOnlyAssembly { get; init; }
+
+    /// <summary>
+    /// Whether to emit a metadata-only assembly for <paramref name="configuration"/> when the project
+    /// expresses no preference: yes for Debug, no for Release.
+    ///
+    /// Debug is the inner-loop configuration — its output is consumed by the developer's own build and
+    /// by `dotnet serve`, never shipped — so it takes the faster path. Release is what
+    /// <c>dotnet pack</c> turns into a NuGet package, so it keeps real IL, and the Transpose SDK
+    /// additionally refuses to package a Debug build at all (see Sdk.targets) so a metadata-only
+    /// assembly cannot reach a feed by accident.
+    /// </summary>
+    public static bool MetadataOnlyAssemblyDefault(string configuration)
+        => string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Whether the emitted .NET assembly carries debug information, from the csproj's
     /// <c>&lt;DebugType&gt;</c> (<c>None</c> — or <c>DebugSymbols=false</c> — turns it off). Producing an
@@ -122,7 +137,7 @@ internal static class ProjectResolver
             DefineConstants = defines,
             LanguageVersion = lang,
             MinifyLocalVariables = string.Equals(Property(doc, "MinifyLocalVariables")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
-            MetadataOnlyAssembly = string.Equals(Property(doc, "TransposeMetadataOnlyAssembly")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
+            MetadataOnlyAssembly = ParseBool(Property(doc, "TransposeMetadataOnlyAssembly")),
             EmitDebugInformation = !string.Equals(Property(doc, "DebugType")?.Trim(), "none", StringComparison.OrdinalIgnoreCase)
                                    && !string.Equals(Property(doc, "DebugSymbols")?.Trim(), "false", StringComparison.OrdinalIgnoreCase),
             ProjectDirs = projectDirs,
@@ -328,6 +343,17 @@ internal static class ProjectResolver
         }
 
         return true;
+    }
+
+    /// <summary>Parses an MSBuild boolean property, returning null when it is absent or empty so a
+    /// caller can tell "the project did not say" from "the project said false".</summary>
+    private static bool? ParseBool(string? value)
+    {
+        value = value?.Trim();
+        if (string.IsNullOrEmpty(value)) return null;
+        if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)) return true;
+        if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)) return false;
+        return null;
     }
 
     /// <summary>The built output DLL path of a referenced project: bin/&lt;config&gt;/&lt;tfm&gt;/&lt;asm&gt;.dll.</summary>

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -30,6 +30,30 @@ internal sealed class ResolvedProject
     /// legacy compiler's safe minifier profile that keeps local names.</summary>
     public bool MinifyLocalVariables { get; init; }
 
+    /// <summary>
+    /// The csproj <c>&lt;TransposeMetadataOnlyAssembly&gt;</c> property (default false): emit the
+    /// project's .NET assembly as metadata only — full type/member metadata including private members,
+    /// but <c>throw null</c> method bodies — instead of compiling real IL.
+    ///
+    /// It is opt-in because it changes what a published package contains, but the reasoning behind
+    /// offering it is that a Transpose-compiled assembly can never execute anyway: it binds against
+    /// <c>Transpose.dll</c>, a stand-in BCL with no implementations, so no .NET host can load it. Its
+    /// only jobs are to be *bound against* by another Transpose project and to carry the compiled JS
+    /// as embedded resources — both of which need metadata alone. Skipping the IL codegen removes the
+    /// second full bind of every method body from the build: measured at ~18% off a clean Tesserae
+    /// build (8.3 s → 6.8 s) and roughly halves the DLL, with byte-identical JavaScript output.
+    /// Implies no debug information (Roslyn rejects an embedded PDB with no bodies to describe).
+    /// </summary>
+    public bool MetadataOnlyAssembly { get; init; }
+
+    /// <summary>Whether the emitted .NET assembly carries debug information, from the csproj's
+    /// <c>&lt;DebugType&gt;</c> (<c>None</c> — or <c>DebugSymbols=false</c> — turns it off). Producing an
+    /// embedded PDB is real work and adds ~12% to the assembly's size, and a Transpose project's DLL
+    /// exists to be *bound against* by other Transpose projects — nobody steps through its IL — so a
+    /// project that says it wants no symbols should not pay for them. Defaults to true, so a project
+    /// that says nothing keeps the debug information it has always got.</summary>
+    public bool EmitDebugInformation { get; init; } = true;
+
     /// <summary>Directories of every project in the closure — the root first, then the
     /// referenced projects it pulls in (each may contribute tps.json resources).</summary>
     public required List<string> ProjectDirs { get; init; }
@@ -98,6 +122,9 @@ internal static class ProjectResolver
             DefineConstants = defines,
             LanguageVersion = lang,
             MinifyLocalVariables = string.Equals(Property(doc, "MinifyLocalVariables")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
+            MetadataOnlyAssembly = string.Equals(Property(doc, "TransposeMetadataOnlyAssembly")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
+            EmitDebugInformation = !string.Equals(Property(doc, "DebugType")?.Trim(), "none", StringComparison.OrdinalIgnoreCase)
+                                   && !string.Equals(Property(doc, "DebugSymbols")?.Trim(), "false", StringComparison.OrdinalIgnoreCase),
             ProjectDirs = projectDirs,
             ReferencedProjectDlls = projectDlls,
         };

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -4,10 +4,12 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace Transpose.Compiler;
 
 /// <summary>
-/// Minimal resolver for an Transpose project: gathers the C# sources (the SDK's default glob),
-/// and resolves the package references — transitively — to their assemblies in the NuGet
-/// global-packages cache. Transpose projects reference Transpose.dll as their whole BCL plus a few Transpose.*
-/// packages (Transpose.Core, Transpose.Newtonsoft.Json), all of which live in the cache once restored.
+/// Minimal resolver for an Transpose project: gathers the C# sources (the SDK's default glob, explicit
+/// <c>&lt;Compile&gt;</c> items, and anything the project <c>&lt;Import&gt;</c>s — see
+/// <see cref="ProjectXml"/>), and resolves the package references — transitively — to their assemblies
+/// in the NuGet global-packages cache. Transpose projects reference Transpose.dll as their whole BCL plus a
+/// few Transpose.* packages (Transpose.Core, Transpose.Newtonsoft.Json), all of which live in the cache
+/// once restored.
 /// </summary>
 internal sealed class ResolvedProject
 {
@@ -84,13 +86,15 @@ internal static class ProjectResolver
     {
         csprojPath = Path.GetFullPath(csprojPath);
         var projectDir = Path.GetDirectoryName(csprojPath)!;
-        var doc = XDocument.Load(csprojPath);
+        // Loads the csproj *and everything it <Import>s* — a shared project's .projitems is where its
+        // <Compile> items live, so ignoring imports silently dropped that source. See ProjectXml.
+        var doc = ProjectXml.Load(csprojPath);
 
-        var assemblyName = Property(doc, "AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
+        var assemblyName = doc.Property("AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
 
         var targetFramework = EffectiveTargetFramework(doc);
 
-        var defines = (Property(doc, "DefineConstants") ?? "")
+        var defines = (doc.Property("DefineConstants") ?? "")
             .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
             .Select(s => s.Trim())
             .Where(s => s.Length > 0)
@@ -112,7 +116,7 @@ internal static class ProjectResolver
         foreach (var fx in FrameworkDefines(targetFramework))
             if (!defines.Contains(fx)) defines.Add(fx);
 
-        var lang = ParseLangVersion(Property(doc, "LangVersion"));
+        var lang = ParseLangVersion(doc.Property("LangVersion"));
 
         // Default (bundle) mode: translate the whole closure of source projects into one JS
         // output. Separate-assembly mode: compile only this project's own sources and reference
@@ -136,10 +140,10 @@ internal static class ProjectResolver
             ReferencePaths = references.Values.ToList(),
             DefineConstants = defines,
             LanguageVersion = lang,
-            MinifyLocalVariables = string.Equals(Property(doc, "MinifyLocalVariables")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
-            MetadataOnlyAssembly = ParseBool(Property(doc, "TransposeMetadataOnlyAssembly")),
-            EmitDebugInformation = !string.Equals(Property(doc, "DebugType")?.Trim(), "none", StringComparison.OrdinalIgnoreCase)
-                                   && !string.Equals(Property(doc, "DebugSymbols")?.Trim(), "false", StringComparison.OrdinalIgnoreCase),
+            MinifyLocalVariables = string.Equals(doc.Property("MinifyLocalVariables")?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
+            MetadataOnlyAssembly = ParseBool(doc.Property("TransposeMetadataOnlyAssembly")),
+            EmitDebugInformation = !string.Equals(doc.Property("DebugType")?.Trim(), "none", StringComparison.OrdinalIgnoreCase)
+                                   && !string.Equals(doc.Property("DebugSymbols")?.Trim(), "false", StringComparison.OrdinalIgnoreCase),
             ProjectDirs = projectDirs,
             ReferencedProjectDlls = projectDlls,
         };
@@ -152,10 +156,10 @@ internal static class ProjectResolver
     /// This is what makes binding libraries such as Transpose.Core (which mark the whole assembly
     /// <c>[assembly: External]</c>) compile: every type is external and its extern members are JS bindings.
     /// </summary>
-    private static string? SynthesizeAssemblyAttributes(XDocument doc)
+    private static string? SynthesizeAssemblyAttributes(ProjectXml doc)
     {
         var lines = new List<string>();
-        foreach (var e in doc.Descendants().Where(e => e.Name.LocalName == "AssemblyAttribute"))
+        foreach (var (e, _) in doc.Elements("AssemblyAttribute"))
         {
             var name = e.Attribute("Include")?.Value?.Trim();
             if (string.IsNullOrWhiteSpace(name)) continue;
@@ -203,7 +207,7 @@ internal static class ProjectResolver
         csprojPath = Path.GetFullPath(csprojPath);
         if (!visited.Add(csprojPath) || !File.Exists(csprojPath)) return;
 
-        var doc = XDocument.Load(csprojPath);
+        var doc = ProjectXml.Load(csprojPath);
         var projectDir = Path.GetDirectoryName(csprojPath)!;
 
         // In separate mode only the root contributes source + tps.json resources; a referenced
@@ -218,7 +222,7 @@ internal static class ProjectResolver
         foreach (var (name, path) in ResolvePackageReferenceDlls(doc, roots))
             references.TryAdd(name, path);
 
-        foreach (var pr in doc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+        foreach (var (pr, _) in doc.Elements("ProjectReference"))
         {
             var include = pr.Attribute("Include")?.Value;
             if (string.IsNullOrWhiteSpace(include)) continue;
@@ -234,13 +238,12 @@ internal static class ProjectResolver
                     references[Path.GetFileNameWithoutExtension(dll)] = dll;
                     if (!projectDlls.Contains(dll)) projectDlls.Add(dll);
                 }
-                if (visited.Add(refPath) && File.Exists(refPath))
+                if (visited.Add(refPath) && ProjectXml.TryLoad(refPath) is { } refDoc)
                 {
-                    var refDoc = XDocument.Load(refPath);
                     var refDir = Path.GetDirectoryName(refPath)!;
                     foreach (var (name, path) in ResolvePackageReferenceDlls(refDoc, roots))
                         references.TryAdd(name, path);
-                    foreach (var nested in refDoc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+                    foreach (var (nested, _) in refDoc.Elements("ProjectReference"))
                     {
                         var ninc = nested.Attribute("Include")?.Value;
                         if (string.IsNullOrWhiteSpace(ninc)) continue;
@@ -277,8 +280,9 @@ internal static class ProjectResolver
             csproj = Path.GetFullPath(csproj);
             if (!visited.Add(csproj) || !File.Exists(csproj)) return;
             var dir = Path.GetDirectoryName(csproj)!;
-            var doc = XDocument.Load(csproj);
-            foreach (var pr in doc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+            var doc = ProjectXml.TryLoad(csproj);
+            if (doc is null) return;
+            foreach (var (pr, _) in doc.Elements("ProjectReference"))
             {
                 var include = pr.Attribute("Include")?.Value;
                 if (string.IsNullOrWhiteSpace(include)) continue;
@@ -302,10 +306,9 @@ internal static class ProjectResolver
     /// </summary>
     public static bool IsPackable(string csprojPath)
     {
-        if (!File.Exists(csprojPath)) return false;
-        var doc = XDocument.Load(csprojPath);
+        if (ProjectXml.TryLoad(csprojPath) is not { } doc) return false;
         static bool IsTrue(string? v) => string.Equals(v?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
-        return IsTrue(Property(doc, "GeneratePackageOnBuild")) || IsTrue(Property(doc, "IsPackable"));
+        return IsTrue(doc.Property("GeneratePackageOnBuild")) || IsTrue(doc.Property("IsPackable"));
     }
 
     /// <summary>
@@ -332,9 +335,18 @@ internal static class ProjectResolver
             if (File.GetLastWriteTimeUtc(src) > dllTime) return false;
         }
 
+        if (ProjectXml.TryLoad(csprojPath) is not { } doc) return false;
+
+        // Imported files (a shared project's .projitems) and the sources they contribute live outside
+        // this project's directory, so the glob above never sees them. Without this, editing shared
+        // source left the package "up to date" and the change simply did not reach the output.
+        foreach (var imported in doc.ImportedFiles)
+            if (File.GetLastWriteTimeUtc(imported) > dllTime) return false;
+        foreach (var (path, _) in ResolveSources(doc, dir))
+            if (File.Exists(path) && File.GetLastWriteTimeUtc(path) > dllTime) return false;
+
         // A dependency rebuilt more recently invalidates this project too.
-        var doc = XDocument.Load(csprojPath);
-        foreach (var pr in doc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+        foreach (var (pr, _) in doc.Elements("ProjectReference"))
         {
             var include = pr.Attribute("Include")?.Value;
             if (string.IsNullOrWhiteSpace(include)) continue;
@@ -359,17 +371,16 @@ internal static class ProjectResolver
     /// <summary>The built output DLL path of a referenced project: bin/&lt;config&gt;/&lt;tfm&gt;/&lt;asm&gt;.dll.</summary>
     private static string? ProjectOutputDll(string csprojPath, string configuration)
     {
-        if (!File.Exists(csprojPath)) return null;
-        var doc = XDocument.Load(csprojPath);
+        if (ProjectXml.TryLoad(csprojPath) is not { } doc) return null;
         var dir = Path.GetDirectoryName(csprojPath)!;
-        var asm = Property(doc, "AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
+        var asm = doc.Property("AssemblyName") ?? Path.GetFileNameWithoutExtension(csprojPath);
         var tfm = EffectiveTargetFramework(doc);
         var binBase = Path.Combine(dir, "bin", configuration, tfm);
         var dll = Path.Combine(binBase, asm + ".dll");
         return dll;
     }
 
-    private static List<(string path, string text)> ResolveSources(XDocument doc, string projectDir)
+    private static List<(string path, string text)> ResolveSources(ProjectXml doc, string projectDir)
     {
         // The set of compiled files, in a deterministic order (glob first, then explicit includes),
         // deduplicated by full path (case-insensitive).
@@ -383,7 +394,7 @@ internal static class ProjectResolver
 
         // SDK default glob: every .cs under the project directory, minus the build output — unless the
         // project opts out with <EnableDefaultCompileItems>false</EnableDefaultCompileItems>.
-        if (!IsFalse(Property(doc, "EnableDefaultCompileItems")))
+        if (!IsFalse(doc.Property("EnableDefaultCompileItems")))
         {
             foreach (var f in Directory.EnumerateFiles(projectDir, "*.cs", SearchOption.AllDirectories))
                 if (!IsUnderBuildOutput(f, projectDir)) AddFile(f);
@@ -393,20 +404,29 @@ internal static class ProjectResolver
         // *outside* the project directory (e.g. shared source linked in via ..\..\Shared\*.cs). MSBuild
         // resolves these; tps reads the csproj raw, so it must expand them itself. Link/LinkBase only
         // affect IDE/output layout, not which file is compiled, so they are ignored here.
-        foreach (var inc in doc.Descendants().Where(e => e.Name.LocalName == "Compile")
-                     .Select(e => e.Attribute("Include")?.Value)
-                     .Where(v => !string.IsNullOrWhiteSpace(v)))
+        //
+        // Items from an <Import>ed file (a shared project's .projitems) come through here too, which is
+        // the whole point of the flattened view: such a file writes its includes as
+        // $(MSBuildThisFileDirectory)Foo.cs, so each item is expanded against the directory of the file
+        // that *declared* it, while a plain relative path still resolves against the project directory
+        // exactly as MSBuild does.
+        foreach (var (element, declaringDir) in doc.Elements("Compile"))
         {
-            foreach (var f in ExpandInclude(projectDir, inc!))
+            var inc = element.Attribute("Include")?.Value;
+            if (string.IsNullOrWhiteSpace(inc)) continue;
+            foreach (var f in ExpandInclude(projectDir, declaringDir, inc!))
                 if (!IsUnderBuildOutput(f, projectDir)) AddFile(f);
         }
 
-        // Honour explicit <Compile Remove="..."/> (glob or exact, relative to the project dir).
-        var removed = doc.Descendants().Where(e => e.Name.LocalName == "Compile")
-            .Select(e => e.Attribute("Remove")?.Value)
-            .Where(v => !string.IsNullOrWhiteSpace(v))
-            .Select(v => NormalizeGlob(projectDir, v!))
-            .ToList();
+        // Honour explicit <Compile Remove="..."/> (glob or exact), with the same two-directory rule.
+        var removed = new List<string>();
+        foreach (var (element, declaringDir) in doc.Elements("Compile"))
+        {
+            var rem = element.Attribute("Remove")?.Value;
+            if (string.IsNullOrWhiteSpace(rem)) continue;
+            if (SubstituteThisFileDirectory(rem!, declaringDir) is { } pattern)
+                removed.Add(NormalizeGlob(projectDir, pattern));
+        }
 
         var result = new List<(string, string)>();
         foreach (var full in files)
@@ -417,13 +437,16 @@ internal static class ProjectResolver
         return result;
     }
 
-    /// <summary>Expands a <c>&lt;Compile Include&gt;</c> pattern (relative to the project directory)
-    /// into concrete .cs files. Handles a single file, a same-directory glob (<c>*.cs</c>), and a
-    /// recursive glob (<c>**\*.cs</c>), and resolves patterns that reach outside the project directory
-    /// (shared source linked in via <c>..\..\Shared\...</c>).</summary>
-    private static IEnumerable<string> ExpandInclude(string projectDir, string pattern)
+    /// <summary>Expands a <c>&lt;Compile Include&gt;</c> pattern into concrete .cs files. Handles a
+    /// single file, a same-directory glob (<c>*.cs</c>), and a recursive glob (<c>**\*.cs</c>), and
+    /// resolves patterns that reach outside the project directory (shared source linked in via
+    /// <c>..\..\Shared\...</c>). <paramref name="declaringDir"/> is the directory of the file the item
+    /// was written in, which is what <c>$(MSBuildThisFileDirectory)</c> means; everything relative is
+    /// still resolved against <paramref name="projectDir"/>, as MSBuild does. A pattern containing a
+    /// property this resolver cannot expand yields nothing rather than a guess.</summary>
+    private static IEnumerable<string> ExpandInclude(string projectDir, string declaringDir, string rawPattern)
     {
-        pattern = pattern.Replace('\\', '/');
+        if (SubstituteThisFileDirectory(rawPattern, declaringDir) is not { } pattern) yield break;
         if (!pattern.Contains('*'))
         {
             var single = Path.GetFullPath(Path.Combine(projectDir, pattern));
@@ -454,6 +477,20 @@ internal static class ProjectResolver
             || rel.Contains("/obj/") || rel.Contains("/bin/");
     }
 
+    /// <summary>Expands <c>$(MSBuildThisFileDirectory)</c> (and the project-directory equivalent) in an
+    /// item specification, returning null when some other unexpandable <c>$(…)</c> remains — see
+    /// <see cref="ProjectXml.ResolvePath"/> for why guessing is worse than skipping.</summary>
+    private static string? SubstituteThisFileDirectory(string spec, string declaringDir)
+    {
+        var value = spec.Replace('\\', '/').Trim();
+        var dirWithSlash = declaringDir.Replace('\\', '/').TrimEnd('/') + "/";
+        value = value
+            .Replace("$(MSBuildThisFileDirectory)", dirWithSlash, StringComparison.OrdinalIgnoreCase)
+            .Replace("$(MSBuildProjectDirectory)/", dirWithSlash, StringComparison.OrdinalIgnoreCase)
+            .Replace("$(MSBuildProjectDirectory)", dirWithSlash, StringComparison.OrdinalIgnoreCase);
+        return value.Contains("$(", StringComparison.Ordinal) ? null : value;
+    }
+
     private static string NormalizeGlob(string projectDir, string pattern)
         => Path.GetFullPath(Path.Combine(projectDir, pattern.Replace('\\', '/'))).Replace('\\', '/');
 
@@ -469,12 +506,12 @@ internal static class ProjectResolver
 
     // ---- reference resolution (NuGet global-packages cache) -----------------
 
-    private static IEnumerable<(string name, string path)> ResolvePackageReferenceDlls(XDocument doc, List<string> roots)
+    private static IEnumerable<(string name, string path)> ResolvePackageReferenceDlls(ProjectXml doc, List<string> roots)
     {
         var resolved = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); // asmName → dll path
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);             // pkgId@version
 
-        foreach (var pr in doc.Descendants().Where(e => e.Name.LocalName == "PackageReference"))
+        foreach (var (pr, _) in doc.Elements("PackageReference"))
         {
             var id = pr.Attribute("Include")?.Value ?? pr.Attribute("Update")?.Value;
             var version = pr.Attribute("Version")?.Value ?? pr.Element(pr.Name.Namespace + "Version")?.Value;
@@ -546,14 +583,11 @@ internal static class ProjectResolver
         yield return "/root/.nuget/packages";
     }
 
-    private static string? Property(XDocument doc, string name)
-        => doc.Descendants().FirstOrDefault(e => e.Name.LocalName == name)?.Value;
-
     /// <summary>The project's <c>&lt;AssemblyVersion&gt;</c> (falling back to <c>&lt;Version&gt;</c>),
     /// emitted into the bundle as <c>Transpose.assemblyVersion(...)</c>. Null when neither is set.</summary>
     public static string? ReadAssemblyVersion(string csprojPath)
     {
-        try { var doc = XDocument.Load(csprojPath); return Property(doc, "AssemblyVersion") ?? Property(doc, "Version"); }
+        try { var doc = ProjectXml.Load(csprojPath); return doc.Property("AssemblyVersion") ?? doc.Property("Version"); }
         catch { return null; }
     }
 
@@ -568,15 +602,13 @@ internal static class ProjectResolver
     /// <c>netstandard2.0</c>. Honour that here, otherwise tps writes the DLL under the declared tfm
     /// and <c>dotnet pack</c> fails with NU5026 (<c>&lt;Assembly&gt;.dll</c> not found).
     /// </summary>
-    private static string EffectiveTargetFramework(XDocument doc)
+    private static string EffectiveTargetFramework(ProjectXml doc)
     {
-        var sdk = doc.Root?.Attribute("Sdk")?.Value
-                  ?? doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "Sdk")?.Attribute("Name")?.Value
-                  ?? "";
+        var sdk = doc.SdkName ?? "";
         if (sdk.StartsWith("Transpose.Build.Target", StringComparison.OrdinalIgnoreCase))
             return "netstandard2.0";
-        return Property(doc, "TargetFramework")
-               ?? Property(doc, "TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim()
+        return doc.Property("TargetFramework")
+               ?? doc.Property("TargetFrameworks")?.Split(';', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim()
                ?? "netstandard2.0";
     }
 

--- a/Transpose/Transpose.Compiler/ProjectXml.cs
+++ b/Transpose/Transpose.Compiler/ProjectXml.cs
@@ -1,0 +1,155 @@
+using System.Xml.Linq;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// A project file together with every file it pulls in via <c>&lt;Import Project="…"/&gt;</c>, flattened
+/// into one queryable view.
+///
+/// <c>tps</c> reads the csproj as raw XML rather than evaluating it with MSBuild, so an
+/// <c>&lt;Import&gt;</c> used to be invisible — and that is how **shared projects** work: a
+/// <c>.shproj</c>'s companion <c>.projitems</c> holds the <c>&lt;Compile&gt;</c> items and every
+/// consuming project imports it. Without following imports, all of that source silently vanished from
+/// the compilation and the build failed with "type or namespace not found" for code that plainly
+/// exists.
+///
+/// Each element is kept alongside the directory of the file that *declared* it, because the two
+/// directories mean different things in MSBuild and a <c>.projitems</c> depends on both:
+///
+///   * <c>$(MSBuildThisFileDirectory)</c> is the declaring file's own directory (with a trailing
+///     separator). A <c>.projitems</c> always writes its includes this way — that is what makes the
+///     same file work from consumers in different folders.
+///   * a plain relative <c>Include</c> is resolved against the *project* directory, wherever it was
+///     written.
+///
+/// MSBuild conditions are not evaluated (nor are they anywhere else in this resolver), so an import is
+/// followed whenever its path resolves to a file that exists. That is also what keeps SDK-internal
+/// imports out: they are written in terms of properties like <c>$(MSBuildToolsPath)</c> that this
+/// resolver cannot expand, so they simply do not resolve.
+/// </summary>
+internal sealed class ProjectXml
+{
+    /// <summary>Guards against a cycle that <see cref="_visited"/> would not catch (a file importing
+    /// itself through different relative spellings) and against pathological nesting.</summary>
+    private const int MaxImportDepth = 32;
+
+    /// <summary>Every element of the project and its imports, paired with the directory of the file
+    /// that declared it. Project-own elements come first, so a first-match property lookup gives the
+    /// project precedence over what it imports.</summary>
+    private readonly List<(XElement element, string declaringDir)> _elements = new();
+
+    private readonly HashSet<string> _visited = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The project file this view is rooted at.</summary>
+    public string ProjectPath { get; }
+
+    /// <summary>The project's directory — the base for relative item includes.</summary>
+    public string ProjectDir { get; }
+
+    /// <summary>Absolute paths of the imported files that were actually found and read. Callers that
+    /// do up-to-date checks need these: a change to a <c>.projitems</c> (or to the files it lists) has
+    /// to invalidate the build just as a change to the csproj does.</summary>
+    public IReadOnlyList<string> ImportedFiles { get; }
+
+    private ProjectXml(string projectPath)
+    {
+        ProjectPath = Path.GetFullPath(projectPath);
+        ProjectDir = Path.GetDirectoryName(ProjectPath)!;
+        var imported = new List<string>();
+        Add(ProjectPath, depth: 0, imported);
+        ImportedFiles = imported;
+    }
+
+    /// <summary>Loads <paramref name="projectPath"/> and its transitive imports. Returns null when the
+    /// file does not exist or is not readable XML — callers already treat a missing project as
+    /// "nothing to contribute".</summary>
+    public static ProjectXml? TryLoad(string projectPath)
+    {
+        if (!File.Exists(projectPath)) return null;
+        try { return new ProjectXml(projectPath); }
+        catch { return null; }
+    }
+
+    /// <summary>Loads <paramref name="projectPath"/>, throwing if it cannot be read — for the root
+    /// project, where an unreadable csproj is a hard error the user must see.</summary>
+    public static ProjectXml Load(string projectPath) => new(projectPath);
+
+    private void Add(string file, int depth, List<string> imported)
+    {
+        file = Path.GetFullPath(file);
+        if (depth > MaxImportDepth || !_visited.Add(file) || !File.Exists(file)) return;
+
+        XDocument doc;
+        try { doc = XDocument.Load(file); }
+        catch { return; }   // an unreadable import must not fail the whole resolve
+        if (depth > 0) imported.Add(file);
+
+        if (depth == 0)
+            SdkName = doc.Root?.Attribute("Sdk")?.Value
+                      ?? doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "Sdk")?.Attribute("Name")?.Value;
+
+        var dir = Path.GetDirectoryName(file)!;
+        foreach (var element in doc.Descendants())
+            _elements.Add((element, dir));
+
+        // Depth-first, in document order, so imported elements land after the importing file's own.
+        foreach (var import in doc.Descendants().Where(e => e.Name.LocalName == "Import"))
+        {
+            var spec = import.Attribute("Project")?.Value;
+            if (string.IsNullOrWhiteSpace(spec)) continue;
+            var resolved = ResolvePath(spec!, dir, dir);
+            if (resolved is not null) Add(resolved, depth + 1, imported);
+        }
+    }
+
+    /// <summary>Every element with the given local name, each with the directory of its declaring
+    /// file.</summary>
+    public IEnumerable<(XElement element, string declaringDir)> Elements(string localName)
+        => _elements.Where(e => e.element.Name.LocalName == localName);
+
+    /// <summary>The project's <c>Sdk</c> attribute (or a nested <c>&lt;Sdk Name="…"/&gt;</c>) — read from
+    /// the project itself, never from an import, since the SDK is a property of the project.</summary>
+    public string? SdkName { get; private set; }
+
+    /// <summary>The first value found for a property, searching the project before its imports —
+    /// mirroring the previous single-document behaviour, extended across imports.</summary>
+    public string? Property(string name)
+        => _elements.FirstOrDefault(e => e.element.Name.LocalName == name).element?.Value;
+
+    /// <summary>
+    /// Resolves an MSBuild path expression to an absolute path, or null when it cannot be resolved
+    /// (an unexpandable property, or a file that is not there).
+    ///
+    /// <paramref name="declaringDir"/> is what <c>$(MSBuildThisFileDirectory)</c> expands to;
+    /// <paramref name="baseDir"/> is what a relative path is resolved against. For an
+    /// <c>&lt;Import&gt;</c> both are the declaring file's directory; for an item include the base is
+    /// the project directory.
+    /// </summary>
+    public static string? ResolvePath(string spec, string declaringDir, string baseDir)
+    {
+        var expanded = ExpandThisFileDirectory(spec, declaringDir);
+        if (expanded is null) return null;
+        var full = Path.GetFullPath(Path.Combine(baseDir, expanded));
+        return File.Exists(full) ? full : null;
+    }
+
+    /// <summary>
+    /// Expands the two <c>$(MSBuildThisFile…)</c> forms a <c>.projitems</c> uses, and gives up (null)
+    /// on any other <c>$(…)</c> property: guessing at a property this resolver never evaluated would
+    /// silently compile the wrong set of files, whereas skipping is visible and safe.
+    /// <c>$(MSBuildThisFileDirectory)</c> keeps MSBuild's trailing separator, so
+    /// <c>$(MSBuildThisFileDirectory)Foo.cs</c> concatenates correctly.
+    /// </summary>
+    private static string? ExpandThisFileDirectory(string spec, string declaringDir)
+    {
+        var value = spec.Replace('\\', '/').Trim();
+        var dirWithSlash = declaringDir.Replace('\\', '/').TrimEnd('/') + "/";
+
+        value = value
+            .Replace("$(MSBuildThisFileDirectory)", dirWithSlash, StringComparison.OrdinalIgnoreCase)
+            .Replace("$(MSBuildProjectDirectory)/", dirWithSlash, StringComparison.OrdinalIgnoreCase)
+            .Replace("$(MSBuildProjectDirectory)", dirWithSlash, StringComparison.OrdinalIgnoreCase);
+
+        return value.Contains("$(", StringComparison.Ordinal) ? null : value;
+    }
+}

--- a/Transpose/Transpose.Compiler/ResourceEmbedder.cs
+++ b/Transpose/Transpose.Compiler/ResourceEmbedder.cs
@@ -32,7 +32,15 @@ internal static class ResourceEmbedder
         catch { return false; }
     }
 
-    public static void Embed(string assemblyPath, IReadOnlyList<EmbeddedItem> items, IEnumerable<string>? referencePaths = null)
+    /// <summary>
+    /// Writes <paramref name="assemblyBytes"/> to <paramref name="assemblyPath"/> with
+    /// <paramref name="items"/> embedded as private manifest resources.
+    ///
+    /// The freshly-emitted assembly is handed over in memory rather than written first and re-read:
+    /// with the JS, CSS and fonts embedded, a package DLL runs to tens of megabytes, and writing it
+    /// once and then reading it straight back only to rewrite it was pure I/O.
+    /// </summary>
+    public static void Embed(string assemblyPath, byte[] assemblyBytes, IReadOnlyList<EmbeddedItem> items, IEnumerable<string>? referencePaths = null)
     {
         // Cecil resolves referenced assemblies when it re-serializes metadata on Write() — e.g. to
         // determine the underlying type of a parameter's default value whose type is a referenced
@@ -44,8 +52,8 @@ internal static class ResourceEmbedder
             foreach (var dir in referencePaths.Select(p => Path.GetDirectoryName(Path.GetFullPath(p))!).Distinct())
                 resolver.AddSearchDirectory(dir);
 
-        // Read → modify → write back the assembly in place (ReadWrite so we can overwrite it).
-        using var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadWrite = true, AssemblyResolver = resolver });
+        using var source = new MemoryStream(assemblyBytes, writable: false);
+        using var asm = AssemblyDefinition.ReadAssembly(source, new ReaderParameters { AssemblyResolver = resolver });
         var resources = asm.MainModule.Resources;
 
         void Replace(string name, byte[] bytes)
@@ -71,6 +79,6 @@ internal static class ResourceEmbedder
         var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
         Replace(ManifestName, Utf8NoBom.GetBytes(json));
 
-        asm.Write();
+        asm.Write(assemblyPath);
     }
 }

--- a/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
+++ b/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
@@ -46,6 +46,40 @@
     <PackageProjectUrl>https://github.com/curiosity-ai/transpose</PackageProjectUrl>
   </PropertyGroup>
 
+  <!--
+    ReadyToRun tool packaging (CI only; see .devops/build-transpose-compiler.yml).
+
+    A `tps` run has a ~2.2 s floor on a one-file project, essentially all of it JIT-compiling Roslyn,
+    and the SDK invokes tps once per project. Publishing the tool ReadyToRun precompiles that to
+    native code: measured 2.2 s -> 1.1 s on a one-file project and ~1 s off every build (-11% on
+    Tesserae). See TODO.optimization.md.
+
+    R2R is native code, so it requires RID-specific packages. Setting ToolPackageRuntimeIdentifiers
+    makes `dotnet pack` produce one `Transpose.Compiler.<rid>` package per RID plus the outer
+    `Transpose.Compiler` package that selects between them, and `dotnet tool install
+    Transpose.Compiler` then resolves the right one automatically — no change for users.
+
+    The catch, and the reason the RID list below is broad: with RID-specific packages the outer
+    package contains NO implementation, so a platform that is not in this list cannot run the tool at
+    all. Adding a RID costs one more ~15 MB package per release; omitting one that somebody uses
+    breaks them. Hence: every platform .NET itself ships a runtime pack for that anyone plausibly
+    builds on, musl (Alpine containers) included.
+
+    Gated behind a property so the ordinary `dotnet build` / `dotnet pack` dev loop stays a plain,
+    fast, RID-agnostic build. Without it, `dotnet pack` produces exactly the portable package it
+    always did.
+  -->
+  <PropertyGroup Condition="'$(TransposePackRidSpecificTools)' == 'true'">
+    <!-- RuntimeIdentifiers, not ToolPackageRuntimeIdentifiers: the SDK derives the tool-package RID
+         list from either, but only RuntimeIdentifiers also makes *restore* fetch the per-RID assets.
+         With ToolPackageRuntimeIdentifiers alone every inner build fails with NETSDK1047. -->
+    <RuntimeIdentifiers>win-x64;win-arm64;win-x86;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <!-- Composite R2R would be faster still but bloats each package considerably and cannot be
+         cross-compiled as reliably; plain R2R already captures the JIT win. -->
+    <PublishReadyToRunComposite>false</PublishReadyToRunComposite>
+  </PropertyGroup>
+
   <ItemGroup>
     <Using Include="Transpose.Translator" />
   </ItemGroup>

--- a/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
+++ b/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
@@ -13,6 +13,25 @@
     <InvariantTimezone>true</InvariantTimezone>
     <PublishReadyToRun>true</PublishReadyToRun>
 
+    <!-- Runtime tuning for a short-lived, allocation-heavy, highly parallel batch process. Both of
+         these were measured with tps-bench on a real project (Tesserae, 263 files / ~69k LOC); see
+         TODO.optimization.md for the numbers.
+
+         Server GC: a build allocates ~900 MB of short-lived garbage across several Parallel.ForEach
+         phases. Workstation GC serialises those collections on one heap and stalls every worker;
+         per-core heaps cut ~15% off the wall clock. .NET's DATAS keeps the heap count adaptive, so a
+         one-file project does not pay a many-heap memory penalty for this.
+
+         TieredPGO off: this is the single largest runtime-level win (~25-30%). PGO instruments
+         tier-0 code to profile it, and Roslyn's binder is exactly the deeply polymorphic code that
+         instrumentation costs the most on — but a compile finishes in seconds, so the better tier-1
+         code the profile would eventually buy never gets to pay that cost back. Measured neutral on
+         a trivial project and a large win on a real one. Tiered compilation itself stays ON: turning
+         it off entirely is ~25% faster on a big project but more than 2× slower on a small one. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <TieredPGO>false</TieredPGO>
+
 
     <!-- Packable as a dotnet global/local tool: `tps` is the compiler command the
          Transpose.Build.Target SDK invokes. -->

--- a/Transpose/Transpose.Compiler/runtimeconfig.template.json
+++ b/Transpose/Transpose.Compiler/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "System.Runtime.TieredCompilation.CallCountingDelayMs": 0
+  }
+}

--- a/Transpose/Transpose.Translator.Tests/ProjectImportTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ProjectImportTests.cs
@@ -1,0 +1,245 @@
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers <c>&lt;Import Project="…"/&gt;</c> resolution — the mechanism **shared projects** rely on: a
+/// <c>.shproj</c>'s companion <c>.projitems</c> holds the <c>&lt;Compile&gt;</c> items and every
+/// consuming project imports it. <c>tps</c> reads the csproj as raw XML rather than evaluating it with
+/// MSBuild, so before <see cref="ProjectXml"/> an import was invisible and all of that source silently
+/// vanished from the compilation (the build failed with "type or namespace not found" for code that
+/// plainly existed).
+///
+/// The two directory rules a <c>.projitems</c> depends on are what these tests pin down:
+/// <c>$(MSBuildThisFileDirectory)</c> means the *declaring* file's directory, while a plain relative
+/// include is resolved against the *project* directory.
+/// </summary>
+[TestClass]
+public sealed class ProjectImportTests
+{
+    private string _root = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-import-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string Write(string rel, string content)
+    {
+        var full = Path.Combine(_root, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    /// <summary>A project that opts out of the default glob, so the only sources are the ones the
+    /// import contributes — which makes a missed import unmissable in the assertion.</summary>
+    private const string AppCsprojTemplate = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>netstandard2.0</TargetFramework>
+            <AssemblyName>app</AssemblyName>
+            <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+          </PropertyGroup>
+        {IMPORTS}
+        </Project>
+        """;
+
+    private string WriteApp(params string[] imports)
+        => Write("App/App.csproj", AppCsprojTemplate.Replace("{IMPORTS}",
+            string.Join("\n", imports.Select(i => "  " + i))));
+
+    private static IReadOnlyList<string> SourceNames(string csproj)
+        => ProjectResolver.Resolve(csproj).Sources
+            .Select(s => Path.GetFileName(s.path))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+    [TestMethod]
+    public void ProjItemsCompileItemsAreImported()
+    {
+        // $(MSBuildThisFileDirectory) — the form every real .projitems uses — must resolve against the
+        // .projitems' own folder, including for a nested path.
+        Write("Shared/Shared.projitems", """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <PropertyGroup><HasSharedItems>true</HasSharedItems></PropertyGroup>
+              <ItemGroup>
+                <Compile Include="$(MSBuildThisFileDirectory)Greeter.cs" />
+                <Compile Include="$(MSBuildThisFileDirectory)Nested\Helper.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+        Write("Shared/Greeter.cs", "namespace Sh { public static class Greeter { } }");
+        Write("Shared/Nested/Helper.cs", "namespace Sh { public static class Helper { } }");
+        var csproj = WriteApp("""<Import Project="..\Shared\Shared.projitems" Label="Shared" />""");
+
+        CollectionAssert.AreEqual(new[] { "Greeter.cs", "Helper.cs" }, SourceNames(csproj).ToArray());
+    }
+
+    [TestMethod]
+    public void ImportsAreFollowedTransitively()
+    {
+        Write("Deep/Deep.projitems", """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ItemGroup><Compile Include="$(MSBuildThisFileDirectory)Deep.cs" /></ItemGroup>
+            </Project>
+            """);
+        Write("Deep/Deep.cs", "namespace Sh { public static class Deep { } }");
+        Write("Shared/Shared.projitems", """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ItemGroup><Compile Include="$(MSBuildThisFileDirectory)Greeter.cs" /></ItemGroup>
+              <Import Project="$(MSBuildThisFileDirectory)..\Deep\Deep.projitems" />
+            </Project>
+            """);
+        Write("Shared/Greeter.cs", "namespace Sh { public static class Greeter { } }");
+        var csproj = WriteApp("""<Import Project="..\Shared\Shared.projitems" />""");
+
+        CollectionAssert.AreEqual(new[] { "Deep.cs", "Greeter.cs" }, SourceNames(csproj).ToArray());
+    }
+
+    [TestMethod]
+    public void RelativeIncludeInAnImportResolvesAgainstTheProjectDirectory()
+    {
+        // MSBuild resolves a *relative* item include against the project being built, not the file that
+        // declared it. That asymmetry with $(MSBuildThisFileDirectory) is exactly why .projitems files
+        // are written the way they are, so both halves need pinning down.
+        Write("Shared/Shared.projitems", """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ItemGroup><Compile Include="Local.cs" /></ItemGroup>
+            </Project>
+            """);
+        Write("App/Local.cs", "public static class Local { }");
+        Write("Shared/Local.cs", "public static class WrongLocal { }");
+        var csproj = WriteApp("""<Import Project="..\Shared\Shared.projitems" />""");
+
+        var resolved = ProjectResolver.Resolve(csproj).Sources.Single().path.Replace('\\', '/');
+        StringAssert.Contains(resolved, "/App/Local.cs");
+    }
+
+    [TestMethod]
+    public void CompileRemoveInAnImportIsHonoured()
+    {
+        Write("Shared/Shared.projitems", """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ItemGroup>
+                <Compile Include="$(MSBuildThisFileDirectory)Keep.cs" />
+                <Compile Include="$(MSBuildThisFileDirectory)Drop.cs" />
+                <Compile Remove="$(MSBuildThisFileDirectory)Drop.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+        Write("Shared/Keep.cs", "public static class Keep { }");
+        Write("Shared/Drop.cs", "public static class Drop { }");
+        var csproj = WriteApp("""<Import Project="..\Shared\Shared.projitems" />""");
+
+        CollectionAssert.AreEqual(new[] { "Keep.cs" }, SourceNames(csproj).ToArray());
+    }
+
+    [TestMethod]
+    public void UnresolvableAndMissingImportsAreSkippedWithoutFailing()
+    {
+        // A conditioned import whose file is absent, and an import written in terms of a property this
+        // resolver never evaluates, must both be ignored rather than throw — an SDK-internal import
+        // (`$(MSBuildToolsPath)…`) is exactly the second case, and every project has those.
+        Write("Shared/Shared.projitems", """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ItemGroup><Compile Include="$(MSBuildThisFileDirectory)Greeter.cs" /></ItemGroup>
+            </Project>
+            """);
+        Write("Shared/Greeter.cs", "namespace Sh { public static class Greeter { } }");
+        var csproj = WriteApp(
+            """<Import Project="..\Shared\Shared.projitems" />""",
+            """<Import Project="..\NotThere\Nope.projitems" Condition="false" />""",
+            """<Import Project="$(SomePropertyWeCannotExpand)Other.props" />""");
+
+        CollectionAssert.AreEqual(new[] { "Greeter.cs" }, SourceNames(csproj).ToArray());
+    }
+
+    [TestMethod]
+    public void PropertiesAndPackageReferencesComeThroughImports()
+    {
+        // Sources are not the only thing an import can carry: a shared .props commonly sets properties
+        // and package references, and the flattened view has to surface those too. The project's own
+        // value wins over an imported one.
+        Write("Shared/Common.props", """
+            <Project>
+              <PropertyGroup>
+                <AssemblyName>from-import</AssemblyName>
+                <DefineConstants>FROM_IMPORT</DefineConstants>
+              </PropertyGroup>
+            </Project>
+            """);
+        var csproj = Write("App/App.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>netstandard2.0</TargetFramework>
+                <AssemblyName>from-project</AssemblyName>
+                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+              </PropertyGroup>
+              <Import Project="..\Shared\Common.props" />
+            </Project>
+            """);
+
+        var resolved = ProjectResolver.Resolve(csproj);
+        Assert.AreEqual("from-project", resolved.AssemblyName, "the project's own property must win");
+        Assert.IsTrue(resolved.DefineConstants.Contains("FROM_IMPORT"),
+            "a define declared only in an imported file must still reach the compilation");
+    }
+}
+
+/// <summary>
+/// Covers error reporting: a failing build must surface **every** error, not a truncated prefix. The
+/// compiler used to stop at 40, which made a broken project take several compile cycles to fix and
+/// left the user unable to tell whether the errors they could not see were the same problem or a
+/// different one.
+/// </summary>
+[TestClass]
+public sealed class ErrorReportingTests
+{
+    /// <summary>Compiles two files with a known number of body errors each and returns the diagnostics
+    /// the translator produced. B.cs is passed first so the ordering assertion has something to do.</summary>
+    private static IReadOnlyList<Microsoft.CodeAnalysis.Diagnostic> Errors(int perFile)
+    {
+        string Body(string cls) => "public class " + cls + " {\n" + string.Concat(
+            Enumerable.Range(0, perFile).Select(i => $"    public int M{i}() {{ return Missing{i}(); }}\n")) + "}\n";
+
+        var result = new Transpose.Translator.RoslynTranslator().Translate(
+            new[] { ("B.cs", Body("B")), ("A.cs", Body("A")) }, "ErrTest");
+        return result.Errors.ToList();
+    }
+
+    [TestMethod]
+    public void EveryErrorIsReported()
+    {
+        // 60 per file = 120 total: comfortably past the 40-error cap the compiler used to apply.
+        const int perFile = 60;
+        var errors = Program.OrderErrorsForReport(Errors(perFile));
+        Assert.AreEqual(perFile * 2, errors.Count(d => d.Id == "CS0103"),
+            "every error from both files must survive to the report");
+    }
+
+    [TestMethod]
+    public void ErrorsAreOrderedByFileThenPosition()
+    {
+        var errors = Program.OrderErrorsForReport(Errors(5));
+
+        var files = errors.Select(d => Path.GetFileName(d.Location.SourceTree?.FilePath ?? "")).ToList();
+        CollectionAssert.AreEqual(files.OrderBy(f => f, StringComparer.OrdinalIgnoreCase).ToArray(), files.ToArray(),
+            "files must be grouped and ordered — A.cs before B.cs even though B.cs was compiled first");
+
+        foreach (var group in errors.GroupBy(d => d.Location.SourceTree?.FilePath))
+        {
+            var lines = group.Select(d => d.Location.GetLineSpan().StartLinePosition.Line).ToList();
+            CollectionAssert.AreEqual(lines.OrderBy(l => l).ToArray(), lines.ToArray(),
+                "within a file, errors must ascend by line");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
+++ b/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
@@ -31,11 +31,20 @@ public static class CompilationBuilder
         // Give each source text an explicit encoding: emitting the assembly with embedded debug
         // information (as the package build does) requires it — Roslyn otherwise reports CS8055
         // ("Cannot emit debug information for a source text without encoding").
-        var trees = sources
-            .Select(s => CSharpSyntaxTree.ParseText(
-                Microsoft.CodeAnalysis.Text.SourceText.From(s.text, System.Text.Encoding.UTF8),
-                parseOptions, path: s.path))
-            .ToList();
+        //
+        // Parsing is embarrassingly parallel (each file is independent) and a real project has
+        // hundreds of files, so fan it out. The result must keep the input order: the emitted JS is
+        // ordered by declaration, and reordering the trees would reorder the bundle for no reason.
+        var sourceList = sources as IList<(string path, string text)> ?? sources.ToList();
+        var treeArray = new SyntaxTree[sourceList.Count];
+        Parallel.For(0, sourceList.Count, i =>
+        {
+            var (path, text) = sourceList[i];
+            treeArray[i] = CSharpSyntaxTree.ParseText(
+                Microsoft.CodeAnalysis.Text.SourceText.From(text, System.Text.Encoding.UTF8),
+                parseOptions, path: path);
+        });
+        var trees = treeArray;
 
         // Nullable reference types only exist from C# 8; enabling the annotations context
         // under an earlier language version (e.g. a project pinned to 7.2) is a hard error.

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -81,7 +81,9 @@ public sealed class RoslynTranslator
         bool reflectionEnabled = true,
         MetadataTarget metadataTarget = MetadataTarget.Inline,
         bool emitAssembly = true,
-        string? assemblyVersion = null)
+        string? assemblyVersion = null,
+        bool emitDebugInformation = true,
+        bool metadataOnlyAssembly = false)
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -129,10 +131,17 @@ public sealed class RoslynTranslator
             // Include private members so a referencing project sees the full member set — the
             // overload numbering (e.g. $ctorN) must match what this assembly emits for itself,
             // and that numbering counts private overloads too.
+            // Debug information is embedded in the PE (there is no separate .pdb alongside a tps
+            // output) unless the project asked for none — see ResolvedProject.EmitDebugInformation.
+            // Roslyn rejects an embedded PDB alongside a metadata-only emit (there are no bodies to
+            // describe), so the metadata-only mode implies no debug information.
+            var debugFormat = emitDebugInformation && !metadataOnlyAssembly
+                ? Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded
+                : default;
             var emit = PhaseTimings.Measure("bind + emit .NET assembly", () => asmCompilation.Emit(ms, options: new Microsoft.CodeAnalysis.Emit.EmitOptions(
-                metadataOnly: false,
+                metadataOnly: metadataOnlyAssembly,
                 includePrivateMembers: true,
-                debugInformationFormat: Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded)));
+                debugInformationFormat: debugFormat)));
 
             roslynErrors = emit.Diagnostics
                 .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
@@ -147,8 +156,13 @@ public sealed class RoslynTranslator
                 var full = PhaseTimings.Measure("bind + diagnostics (error path)", () => compilation.GetDiagnostics()
                     .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
                     .ToList());
+                // Diagnostic has reference equality, so the same error reported by both passes has to
+                // be matched on what identifies it to a user — its id and location — or the list would
+                // show every error twice.
+                var already = new HashSet<(string, Location)>();
+                foreach (var d in roslynErrors) already.Add((d.Id, d.Location));
                 foreach (var d in full)
-                    if (!roslynErrors.Contains(d)) roslynErrors.Add(d);
+                    if (already.Add((d.Id, d.Location))) roslynErrors.Add(d);
             }
             else
             {
@@ -167,6 +181,8 @@ public sealed class RoslynTranslator
         if (diagnostics.Count > 0 && diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
             return new AssemblyBuildResult(null, null, null, diagnostics);
 
+        string? js = null, metadataJs = null;
+        TranslationException? emitterFailure = null;
         try
         {
             var emitter = new Emitter(compilation, assemblyName, models)
@@ -176,14 +192,49 @@ public sealed class RoslynTranslator
                 AssemblyVersion = string.IsNullOrWhiteSpace(assemblyVersion) ? "1.0.0.0" : assemblyVersion!,
             };
             CompileProgress.Report("emitting JavaScript");
-            var js = PhaseTimings.Measure("emit JavaScript", () => emitter.Emit());
-            return new AssemblyBuildResult(js, emitter.MetadataScript, assemblyBytes, diagnostics);
+            js = PhaseTimings.Measure("emit JavaScript", () => emitter.Emit());
+            metadataJs = emitter.MetadataScript;
         }
         catch (TranslationException ex)
         {
-            diagnostics.Add(Diagnostics.Create(Diagnostics.Unsupported, ex.Location, ex.Message));
+            emitterFailure = ex;
+        }
+
+        // A metadata-only assembly emit never compiled the method bodies, so their diagnostics have
+        // to come from somewhere else. They come from the semantic models — which the scan and the JS
+        // emit have already populated, so this pass mostly reads cached bound trees rather than
+        // binding again, and is an order of magnitude cheaper than the body codegen it replaced.
+        // (It runs after the JS emit for exactly that reason; on the error path that means a broken
+        // project does the JS emit first, which is why an emitter failure is held rather than thrown.)
+        if (emitAssembly && metadataOnlyAssembly)
+        {
+            var bodyErrors = PhaseTimings.Measure("body diagnostics (semantic models)", () =>
+            {
+                var found = new System.Collections.Concurrent.ConcurrentBag<Diagnostic>();
+                Parallel.ForEach(compilation.SyntaxTrees, tree =>
+                {
+                    foreach (var d in models.SemanticModelFor(tree).GetDiagnostics())
+                        if (d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
+                            found.Add(d);
+                });
+                return found.ToList();
+            });
+            if (bodyErrors.Count > 0)
+            {
+                // Real compile errors explain an emitter failure far better than the emitter's own
+                // "unsupported construct" would, so they are reported instead of it.
+                diagnostics.AddRange(bodyErrors);
+                return new AssemblyBuildResult(null, null, null, diagnostics);
+            }
+        }
+
+        if (emitterFailure is not null)
+        {
+            diagnostics.Add(Diagnostics.Create(Diagnostics.Unsupported, emitterFailure.Location, emitterFailure.Message));
             return new AssemblyBuildResult(null, null, null, diagnostics);
         }
+
+        return new AssemblyBuildResult(js, metadataJs, assemblyBytes, diagnostics);
     }
 
     /// <summary>

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -91,53 +91,85 @@ public sealed class RoslynTranslator
                 preprocessorSymbols: preprocessorSymbols));
 
         var diagnostics = new List<Diagnostic>();
-        CompileProgress.Report("binding + analyzing");
-        var roslynErrors = PhaseTimings.Measure("bind + diagnostics", () => compilation.GetDiagnostics()
-            .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
-            .ToList());
 
-        // Run the unsupported-feature scanner even when Roslyn reported errors: an unsupported
-        // construct (e.g. an [InlineArray] whose attribute the BCL keeps internal) can surface a
-        // Roslyn error first, and we still want the clear "… not supported" message to be reported
-        // alongside it. Scanning a compilation with errors is safe — the scanner tolerates missing
-        // symbols — but guard against an unexpected throw so the Roslyn errors are never lost.
-        IReadOnlyList<Diagnostic> unsupported;
+        // One semantic-model cache for the whole build, shared by the unsupported-feature scan and
+        // the JS emitter. A SemanticModel retains the bound form of each member it is asked about, so
+        // a member the scan binds (to resolve the inferred type behind a `var`, say) is already bound
+        // when the emitter gets to it — the two passes bind the project once between them instead of
+        // once each.
+        var models = new TreeModel(compilation);
+
+        // The scan runs before the assembly emit deliberately: it is the cheaper of the two and its
+        // diagnostics are the ones a user most wants to see first. It runs even when Roslyn reported
+        // errors — an unsupported construct (e.g. an [InlineArray] whose attribute the BCL keeps
+        // internal) can surface a Roslyn error first, and the clear "… not supported" message should
+        // still appear alongside it. Scanning a compilation with errors is safe (the scanner tolerates
+        // missing symbols), but an unexpected throw must never lose the Roslyn errors.
         CompileProgress.Report("scanning for unsupported features");
-        try { unsupported = PhaseTimings.Measure("scan unsupported features", () => UnsupportedFeatureScanner.Scan(compilation)); }
-        catch { unsupported = new List<Diagnostic>(); }
-        diagnostics.AddRange(unsupported);
-        diagnostics.AddRange(roslynErrors);
-        if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-            return new AssemblyBuildResult(null, null, null, diagnostics);
+        IReadOnlyList<Diagnostic> unsupported;
+        try { unsupported = PhaseTimings.Measure("scan unsupported features", () => UnsupportedFeatureScanner.Scan(compilation, models)); }
+        catch { unsupported = System.Array.Empty<Diagnostic>(); }
 
-        // Emit the real .NET assembly (as a library) so referencing projects can bind to its
-        // types. Emitted before translation so an emit failure is reported like any other error.
+        // Binding the whole compilation is the single most expensive thing a build does, and
+        // Compilation.Emit already does it — its result carries every declaration and method-body
+        // diagnostic GetDiagnostics would have produced. So when an assembly is being emitted we take
+        // the diagnostics from the emit and never bind twice; only a source-only build (the test
+        // suite, `--out`) needs a standalone GetDiagnostics pass.
+
+        CompileProgress.Report("binding + analyzing");
+
         byte[]? assemblyBytes = null;
+        List<Diagnostic> roslynErrors;
+
         if (emitAssembly)
         {
             var asmCompilation = compilation.WithOptions(
                 compilation.Options.WithOutputKind(OutputKind.DynamicallyLinkedLibrary));
             using var ms = new MemoryStream();
-            CompileProgress.Report("emitting .NET assembly");
             // Include private members so a referencing project sees the full member set — the
             // overload numbering (e.g. $ctorN) must match what this assembly emits for itself,
             // and that numbering counts private overloads too.
-            var emit = PhaseTimings.Measure("emit .NET assembly", () => asmCompilation.Emit(ms, options: new Microsoft.CodeAnalysis.Emit.EmitOptions(
+            var emit = PhaseTimings.Measure("bind + emit .NET assembly", () => asmCompilation.Emit(ms, options: new Microsoft.CodeAnalysis.Emit.EmitOptions(
                 metadataOnly: false,
                 includePrivateMembers: true,
                 debugInformationFormat: Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded)));
+
+            roslynErrors = emit.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
+                .ToList();
+
+            // A failed emit stops before compiling method bodies when the *declarations* already have
+            // errors, so its diagnostic list can be a subset of the full picture. Only on that (rare,
+            // already-failing) path do we pay for a full GetDiagnostics, so the reported error list is
+            // as complete as it always was.
             if (!emit.Success)
             {
-                diagnostics.AddRange(emit.Diagnostics
-                    .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id)));
-                return new AssemblyBuildResult(null, null, null, diagnostics);
+                var full = PhaseTimings.Measure("bind + diagnostics (error path)", () => compilation.GetDiagnostics()
+                    .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
+                    .ToList());
+                foreach (var d in full)
+                    if (!roslynErrors.Contains(d)) roslynErrors.Add(d);
             }
-            assemblyBytes = ms.ToArray();
+            else
+            {
+                assemblyBytes = ms.ToArray();
+            }
         }
+        else
+        {
+            roslynErrors = PhaseTimings.Measure("bind + diagnostics", () => compilation.GetDiagnostics()
+                .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
+                .ToList());
+        }
+
+        diagnostics.AddRange(unsupported);
+        diagnostics.AddRange(roslynErrors);
+        if (diagnostics.Count > 0 && diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            return new AssemblyBuildResult(null, null, null, diagnostics);
 
         try
         {
-            var emitter = new Emitter(compilation, assemblyName)
+            var emitter = new Emitter(compilation, assemblyName, models)
             {
                 ReflectionEnabled = reflectionEnabled,
                 MetadataTarget = metadataTarget,

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -251,13 +251,22 @@ public sealed class RoslynTranslator
         LanguageVersion languageVersion = LanguageVersion.Latest,
         bool reflectionEnabled = true)
     {
-        var compilation = CompilationBuilder.Build(
-            sources, assemblyName, languageVersion,
-            preprocessorSymbols: preprocessorSymbols, selfContainedBcl: true);
+        CompileProgress.Report("parsing the base library");
+        var compilation = PhaseTimings.Measure("build compilation (parse, self-contained BCL)", () =>
+            CompilationBuilder.Build(
+                sources, assemblyName, languageVersion,
+                preprocessorSymbols: preprocessorSymbols, selfContainedBcl: true));
 
+        // Note for anyone optimizing this path: it binds the BCL three times over — here, again
+        // through the emitter's semantic models, and a third time inside EmitAssembly below. The main
+        // BuildAssembly path collapsed two of its binds (see the comments there); the same is possible
+        // here but has not been done, because this build's diagnostics gate the JS emit and the
+        // assembly emit happens last (it needs the assembled bundles as manifest resources).
         var diagnostics = new List<Diagnostic>();
-        diagnostics.AddRange(compilation.GetDiagnostics()
-            .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id)));
+        CompileProgress.Report("binding + analyzing the base library");
+        diagnostics.AddRange(PhaseTimings.Measure("bind + diagnostics", () => compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
+            .ToList()));
         if (diagnostics.Count > 0)
             return new RuntimePackageResult(null, null, diagnostics);
 
@@ -269,7 +278,8 @@ public sealed class RoslynTranslator
             compilation.Options.WithOutputKind(OutputKind.DynamicallyLinkedLibrary));
 
         var emitter = new Emitter(compilation, assemblyName) { ReflectionEnabled = reflectionEnabled };
-        var classPath = emitter.EmitClassPath();
+        CompileProgress.Report("emitting per-class JavaScript");
+        var classPath = PhaseTimings.Measure("emit JavaScript (ClassPath)", emitter.EmitClassPath);
 
         // Emit the assembly with the runtime JS bundles embedded as manifest resources, through
         // Roslyn — see RuntimePackageResult.EmitAssembly for why this must not be a Mono.Cecil
@@ -281,8 +291,9 @@ public sealed class RoslynTranslator
                 .Select(r => new ResourceDescription(r.name, () => new MemoryStream(r.bytes), isPublic: false))
                 .ToList();
             using var ms = new MemoryStream();
-            var emit = asmCompilation.Emit(ms, manifestResources: descriptions,
-                options: new Microsoft.CodeAnalysis.Emit.EmitOptions(metadataOnly: false, includePrivateMembers: true));
+            var emit = PhaseTimings.Measure("bind + emit runtime assembly (with bundles)", () =>
+                asmCompilation.Emit(ms, manifestResources: descriptions,
+                    options: new Microsoft.CodeAnalysis.Emit.EmitOptions(metadataOnly: false, includePrivateMembers: true)));
             if (!emit.Success)
             {
                 var errors = string.Join("\n", emit.Diagnostics

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -547,10 +547,13 @@ public sealed partial class Emitter
     /// </summary>
     private string EmitEnumeratorInit(CommonForEachStatementSyntax forEach, ExpressionSyntax source)
     {
-        // Zero-pad to 8 hex digits before slicing: a small hashcode (< 0x1000) formats to fewer
-        // than 4 hex chars, so an unpadded Substring(0, 4) threw ArgumentOutOfRangeException on
-        // certain foreach nodes.
-        var enumVar = "$e" + ((uint)forEach.GetHashCode()).ToString("x8").Substring(0, 4);
+        // Name the enumerator from the statement's source position, not from SyntaxNode.GetHashCode():
+        // a node's hash code is reference-based, so it varies between runs and made the emitted bundle
+        // differ byte-for-byte on every compile of unchanged sources. The span start is stable and is
+        // unique within a file, which is all the uniqueness this needs — the variable is local to one
+        // JS function, and two foreach statements in the same function always start at different
+        // offsets (nested ones included).
+        var enumVar = "$e" + forEach.SpanStart.ToString("x4");
         var getEnum = _model.GetForEachStatementInfo(forEach).GetEnumeratorMethod;
         var ext = getEnum is { IsExtensionMethod: true } ? (getEnum.ReducedFrom ?? getEnum) : null;
         _w.Write($"var {enumVar} = TransposeR.getEnumerator(");

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -60,19 +60,29 @@ public sealed partial class Emitter
     /// script (a full Transpose.assembly wrapper) produced by the last <see cref="Emit"/>; else null.</summary>
     public string? MetadataScript { get; private set; }
 
-    public Emitter(CSharpCompilation compilation, string assemblyName = CompilationBuilder.DefaultAssemblyName)
+    /// <param name="models">A semantic-model cache to reuse. Passing the one the
+    /// unsupported-feature scan already populated means every member that scan bound is bound
+    /// once for the whole build instead of twice.</param>
+    internal Emitter(CSharpCompilation compilation, string assemblyName, TreeModel? models)
     {
         _compilation = compilation;
         _assemblyName = assemblyName;
-        _model = new TreeModel(compilation);
+        _model = models ?? new TreeModel(compilation);
     }
 
-    private Emitter(CSharpCompilation compilation, string assemblyName, NameMangler names)
+    public Emitter(CSharpCompilation compilation, string assemblyName = CompilationBuilder.DefaultAssemblyName)
+        : this(compilation, assemblyName, null)
+    {
+    }
+
+    private Emitter(CSharpCompilation compilation, string assemblyName, NameMangler names, TreeModel model)
     {
         _compilation = compilation;
         _assemblyName = assemblyName;
         _names = names;
-        _model = new TreeModel(compilation);
+        // Share the parent's semantic-model cache rather than building a fresh one per type: see
+        // TreeModel for why that is the single biggest lever on JS-emit time.
+        _model = model;
         _w.Indent();
     }
 
@@ -81,7 +91,7 @@ public sealed partial class Emitter
         _w.WriteLine("/**");
         _w.WriteLine(" * Transpose.Translator generated output.");
         _w.WriteLine(" */");
-        var types = CollectTypes();
+        var types = PhaseTimings.Measure("  ├ collect + order types", CollectTypes);
 
         // Reflection metadata: either woven into this assembly function (inline target) or
         // collected into a standalone metadata script (file target), never both.
@@ -113,23 +123,27 @@ public sealed partial class Emitter
             // (a crash) instead of a reported error.
             try
             {
-                Parallel.ForEach(types, type =>
-                {
-                    results[type] = EmitOnlyType(this, type);
-                    var count = Interlocked.Increment(ref done);
-                    CompileProgress.ReportStep("emitting JavaScript", count, types.Count);
-                });
+                PhaseTimings.Measure("  ├ emit type bodies (parallel)", () =>
+                    Parallel.ForEach(types, type =>
+                    {
+                        results[type] = EmitOnlyType(this, type);
+                        var count = Interlocked.Increment(ref done);
+                        CompileProgress.ReportStep("emitting JavaScript", count, types.Count);
+                    }));
             }
             catch (AggregateException ex) when (ex.Flatten().InnerExceptions.OfType<TranslationException>().FirstOrDefault() is { } te)
             {
                 throw te;
             }
 
-            foreach(var type in types)
+            PhaseTimings.Measure("  ├ concatenate type bodies", () =>
             {
-                _w.Write(results[type]);
-                _w.WriteLine();
-            }
+                foreach (var type in types)
+                {
+                    _w.Write(results[type]);
+                    _w.WriteLine();
+                }
+            });
 
             // [Transpose.Ready] static methods: schedule each via Transpose.ready so it runs on
             // page load (or immediately when the assembly is loaded on demand, e.g. a lazily
@@ -143,11 +157,11 @@ public sealed partial class Emitter
             //    CompileProgress.ReportStep("emitting JavaScript", ++done, types.Count);
             //}
 
-            if (inlineMeta) EmitReflectionMetadata(types);
+            if (inlineMeta) PhaseTimings.Measure("  ├ reflection metadata (inline)", () => EmitReflectionMetadata(types));
         });
         _w.WriteLine(");");
 
-        MetadataScript = fileMeta ? BuildMetadataFile(types) : null;
+        MetadataScript = fileMeta ? PhaseTimings.Measure("  └ reflection metadata (file)", () => BuildMetadataFile(types)) : null;
         return _w.ToString();
     }
 
@@ -160,7 +174,7 @@ public sealed partial class Emitter
 
     private Emitter Clone()
     {
-        return new Emitter(_compilation, _assemblyName, _names);
+        return new Emitter(_compilation, _assemblyName, _names, _model);
     }
 
     /// <summary>The result of an <c>outputBy: ClassPath</c> emission: one bare
@@ -236,15 +250,19 @@ public sealed partial class Emitter
 
     private List<INamedTypeSymbol> CollectTypes()
     {
-        var declared = new List<INamedTypeSymbol>();
-        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-        foreach (var tree in _compilation.SyntaxTrees)
+        // Resolve each file's declared types in parallel — every tree is independent and a project
+        // has hundreds of them — then merge in tree order so the emitted bundle's type order stays
+        // exactly what a sequential walk produced.
+        var trees = _compilation.SyntaxTrees as IList<SyntaxTree> ?? _compilation.SyntaxTrees.ToList();
+        var perTree = new List<INamedTypeSymbol>[trees.Count];
+        Parallel.For(0, trees.Count, i =>
         {
-            var model = _compilation.GetSemanticModel(tree);
+            var tree = trees[i];
+            var model = _model.SemanticModelFor(tree);
+            var found = new List<INamedTypeSymbol>();
             foreach (var node in tree.GetRoot().DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
             {
-                if (model.GetDeclaredSymbol(node) is INamedTypeSymbol sym && seen.Add(sym))
+                if (model.GetDeclaredSymbol(node) is INamedTypeSymbol sym)
                 {
                     // External types ([External] on the type/assembly, or [Scope]/[GlobalMethods]
                     // bindings) have no emitted body: they are native JS (DOM, browser globals) or
@@ -253,10 +271,18 @@ public sealed partial class Emitter
                     // the real definition ("already defined") — so an [assembly: External] binding
                     // library such as Transpose.Core contributes no runtime defines, matching h5.core.
                     if (TransposeNaming.IsExternalType(sym)) continue;
-                    declared.Add(sym);
+                    found.Add(sym);
                 }
             }
-        }
+            perTree[i] = found;
+        });
+
+        // Dedupe across trees (a partial type is declared in several) preserving first-seen order.
+        var declared = new List<INamedTypeSymbol>();
+        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var found in perTree)
+            foreach (var sym in found)
+                if (seen.Add(sym)) declared.Add(sym);
 
         // Emit each type after every source type it depends on (base class + implemented/
         // extended interfaces), so the runtime's Transpose.define never sees an undefined reference

--- a/Transpose/Transpose.Translator/Emit/TreeModel.cs
+++ b/Transpose/Transpose.Translator/Emit/TreeModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -10,25 +11,32 @@ namespace Transpose.Translator;
 /// <see cref="SemanticModel"/> for the node being asked about. A Roslyn semantic model is
 /// bound to a single syntax tree, but a <c>partial</c> type's members span several files
 /// (trees); routing each query by the node's own tree keeps multi-file projects working.
-/// Models are cached per tree.
+///
+/// One <see cref="TreeModel"/> is shared by every <see cref="Emitter"/> clone, i.e. across the whole
+/// parallel per-type emit, and that sharing is the point: a Roslyn <see cref="SemanticModel"/>
+/// caches the bound form of each member it is asked about, so all the types declared in one file —
+/// and every later query about the same member — reuse a single bind instead of paying for a fresh
+/// one per type. A <see cref="SemanticModel"/> is safe for concurrent readers (Roslyn's IDE layer
+/// relies on that), so the only thing needing care here is the tree→model map itself, hence the
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+///
+/// The trade is memory: bound bodies stay reachable for the whole emit rather than being collected
+/// per type. For the projects this compiler targets that is a few hundred MB at most, and it buys
+/// back far more time than it costs.
 /// </summary>
 internal sealed class TreeModel
 {
     private readonly Compilation _compilation;
-    private readonly Dictionary<SyntaxTree, SemanticModel> _cache = new();
+    private readonly ConcurrentDictionary<SyntaxTree, SemanticModel> _cache = new();
 
     public TreeModel(Compilation compilation) => _compilation = compilation;
 
-    private SemanticModel For(SyntaxNode node)
-    {
-        var tree = node.SyntaxTree;
-        if (!_cache.TryGetValue(tree, out var model))
-        {
-            model = _compilation.GetSemanticModel(tree);
-            _cache[tree] = model;
-        }
-        return model;
-    }
+    private SemanticModel For(SyntaxNode node) => SemanticModelFor(node.SyntaxTree);
+
+    /// <summary>The cached model for a whole tree — for callers that already know the tree (e.g. the
+    /// per-file type collection) and so can skip going through a node.</summary>
+    public SemanticModel SemanticModelFor(SyntaxTree tree)
+        => _cache.GetOrAdd(tree, static (t, compilation) => compilation.GetSemanticModel(t), _compilation);
 
     public TypeInfo GetTypeInfo(SyntaxNode node) => For(node).GetTypeInfo(node);
     public SymbolInfo GetSymbolInfo(SyntaxNode node) => For(node).GetSymbolInfo(node);

--- a/Transpose/Transpose.Translator/Support/PhaseTimings.cs
+++ b/Transpose/Transpose.Translator/Support/PhaseTimings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Transpose.Translator;
 
@@ -10,51 +11,81 @@ namespace Transpose.Translator;
 /// <see cref="Measure{T}"/> records the wall-clock time of each named phase so the compiler can
 /// print a breakdown of where a build spends its time. Phases with the same name accumulate, so a
 /// per-file loop reports one total per phase rather than one line per file.
+///
+/// A phase also records how many bytes the CLR allocated while it ran
+/// (<see cref="GC.GetTotalAllocatedBytes(bool)"/> — process-wide, so a phase that fans out over
+/// worker threads still has their allocations attributed to it). Allocation is the compiler's
+/// dominant scaling cost, and knowing *which* phase produces the garbage is what makes it
+/// actionable. Nested or concurrent phases would double-count those bytes, so only the outermost
+/// running scope is charged; an inner one records time alone.
 /// </summary>
 public static class PhaseTimings
 {
     private static readonly object _gate = new();
     private static readonly List<string> _order = new();
-    private static readonly Dictionary<string, (long ms, int count)> _phases = new();
+    private static readonly Dictionary<string, Entry> _phases = new();
+
+    /// <summary>Number of <see cref="Measure{T}"/> scopes currently running. Allocation deltas are
+    /// attributed only by the scope that sees a transition from 0, so nested/overlapping phases do
+    /// not charge the same bytes twice.</summary>
+    private static int _depth;
+
+    private struct Entry
+    {
+        public long Ms;
+        public long Bytes;
+        public int Count;
+    }
 
     /// <summary>When false, <see cref="Measure{T}"/> and <see cref="Record"/> are no-ops
     /// beyond running the action itself.</summary>
     public static bool Enabled { get; set; }
         = string.Equals(Environment.GetEnvironmentVariable("TRANSPOSE_TIMING"), "1", StringComparison.Ordinal);
 
-    /// <summary>Runs <paramref name="action"/>, and — when enabled — attributes its elapsed time to
-    /// the named phase (accumulating across calls with the same name).</summary>
+    /// <summary>Runs <paramref name="action"/>, and — when enabled — attributes its elapsed time
+    /// (plus, for an outermost scope, the bytes allocated while it ran) to the named phase,
+    /// accumulating across calls with the same name.</summary>
     public static T Measure<T>(string phase, Func<T> action)
     {
         if (!Enabled) return action();
+        var outermost = Interlocked.Increment(ref _depth) == 1;
+        var bytes0 = outermost ? GC.GetTotalAllocatedBytes(precise: false) : 0;
         var sw = Stopwatch.StartNew();
         try { return action(); }
-        finally { sw.Stop(); Record(phase, sw.ElapsedMilliseconds); }
+        finally
+        {
+            sw.Stop();
+            var bytes = outermost ? GC.GetTotalAllocatedBytes(precise: false) - bytes0 : 0;
+            Interlocked.Decrement(ref _depth);
+            Record(phase, sw.ElapsedMilliseconds, bytes);
+        }
     }
 
     /// <inheritdoc cref="Measure{T}"/>
     public static void Measure(string phase, Action action) =>
         Measure<object?>(phase, () => { action(); return null; });
 
-    /// <summary>Adds <paramref name="ms"/> to the named phase's running total.</summary>
-    public static void Record(string phase, long ms)
+    /// <summary>Adds <paramref name="ms"/> (and <paramref name="bytes"/> allocated) to the named
+    /// phase's running total.</summary>
+    public static void Record(string phase, long ms, long bytes = 0)
     {
         if (!Enabled) return;
         lock (_gate)
         {
             if (_phases.TryGetValue(phase, out var cur))
-                _phases[phase] = (cur.ms + ms, cur.count + 1);
-            else { _phases[phase] = (ms, 1); _order.Add(phase); }
+                _phases[phase] = new Entry { Ms = cur.Ms + ms, Bytes = cur.Bytes + bytes, Count = cur.Count + 1 };
+            else { _phases[phase] = new Entry { Ms = ms, Bytes = bytes, Count = 1 }; _order.Add(phase); }
         }
     }
 
-    /// <summary>The recorded phases in first-seen order: name, total milliseconds, and call count.</summary>
-    public static IReadOnlyList<(string phase, long ms, int count)> Snapshot()
+    /// <summary>The recorded phases in first-seen order: name, total milliseconds, bytes allocated
+    /// while the phase ran, and call count.</summary>
+    public static IReadOnlyList<(string phase, long ms, long bytes, int count)> Snapshot()
     {
         lock (_gate)
         {
-            var list = new List<(string, long, int)>(_order.Count);
-            foreach (var p in _order) { var v = _phases[p]; list.Add((p, v.ms, v.count)); }
+            var list = new List<(string, long, long, int)>(_order.Count);
+            foreach (var p in _order) { var v = _phases[p]; list.Add((p, v.Ms, v.Bytes, v.Count)); }
             return list;
         }
     }
@@ -62,6 +93,6 @@ public static class PhaseTimings
     /// <summary>Clears all recorded phases (used between independent builds in one process).</summary>
     public static void Reset()
     {
-        lock (_gate) { _order.Clear(); _phases.Clear(); }
+        lock (_gate) { _order.Clear(); _phases.Clear(); _depth = 0; }
     }
 }

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -27,6 +28,37 @@ internal static class TransposeNaming
     /// namespaces against the constant by offset instead, allocating nothing on the (dominant)
     /// non-matching path.</summary>
     public static bool AttrIs(AttributeData a, string fullName) => IsFullyQualified(a.AttributeClass, fullName);
+
+    /// <summary>
+    /// The first attribute on <paramref name="symbol"/> matching <paramref name="fullName"/>, or null.
+    ///
+    /// Deliberately a plain loop rather than <c>GetAttributes().FirstOrDefault(a =&gt; AttrIs(a, name))</c>:
+    /// that form allocates a closure (it captures <paramref name="fullName"/>) and boxes the
+    /// <see cref="ImmutableArray{T}"/>'s enumerator on *every* call, and these lookups run for
+    /// essentially every symbol the emitter touches — they were the single largest allocation site in
+    /// a build (~42 MB on a 69k-line project) before this became allocation-free.
+    /// </summary>
+    internal static AttributeData? FindAttr(ISymbol? symbol, string fullName)
+    {
+        if (symbol is null) return null;
+        foreach (var a in symbol.GetAttributes())
+            if (AttrIs(a, fullName)) return a;
+        return null;
+    }
+
+    /// <summary>Whether <paramref name="symbol"/> carries <paramref name="fullName"/>. Allocation-free,
+    /// for the same reason as <see cref="FindAttr"/>.</summary>
+    internal static bool HasAttr(ISymbol? symbol, string fullName) => FindAttr(symbol, fullName) is not null;
+
+    /// <summary>Whether any of <paramref name="locations"/> is in source. Allocation-free replacement
+    /// for <c>Locations.Any(l =&gt; l.IsInSource)</c>, which boxes the ImmutableArray enumerator on a
+    /// path the emitter takes for every symbol it names.</summary>
+    internal static bool AnyInSource(ImmutableArray<Location> locations)
+    {
+        foreach (var l in locations)
+            if (l.IsInSource) return true;
+        return false;
+    }
 
     /// <summary>True if <paramref name="cls"/>'s fully-qualified name equals <paramref name="dotted"/>
     /// (namespaces + type name, e.g. "Transpose.NameAttribute"). Walks name then containing namespaces
@@ -69,8 +101,8 @@ internal static class TransposeNaming
     public static string? ScopePrefix(ITypeSymbol? type)
     {
         if (type is null) return null;
-        var scope = type.GetAttributes().FirstOrDefault(a => AttrIs(a, ScopeAttr));
-        var global = type.GetAttributes().Any(a => AttrIs(a, GlobalMethodsAttr));
+        var scope = FindAttr(type, ScopeAttr);
+        var global = HasAttr(type, GlobalMethodsAttr);
         if (scope is null && !global) return null;
         return (scope?.ConstructorArguments.FirstOrDefault().Value as string) ?? "";
     }
@@ -83,7 +115,7 @@ internal static class TransposeNaming
     /// </summary>
     public static int EnumEmitMode(ITypeSymbol enumType)
     {
-        var a = enumType.GetAttributes().FirstOrDefault(x => AttrIs(x, EnumAttr));
+        var a = FindAttr(enumType, EnumAttr);
         if (a is null || a.ConstructorArguments.Length == 0) return 7;
         return a.ConstructorArguments[0].Value is int m ? m : 7;
     }
@@ -119,7 +151,7 @@ internal static class TransposeNaming
     public static string? GetTemplateFn(ISymbol? symbol)
     {
         if (symbol is null) return null;
-        var attr = symbol.GetAttributes().FirstOrDefault(a => AttrIs(a, TemplateAttr));
+        var attr = FindAttr(symbol, TemplateAttr);
         if (attr is null) return null;
         foreach (var na in attr.NamedArguments)
             if (na.Key == "Fn") return na.Value.Value as string;
@@ -136,7 +168,7 @@ internal static class TransposeNaming
     public static string? GetTemplateNonExpanded(ISymbol? symbol)
     {
         if (symbol is null) return null;
-        var attr = symbol.GetAttributes().FirstOrDefault(a => AttrIs(a, TemplateAttr));
+        var attr = FindAttr(symbol, TemplateAttr);
         if (attr is null || attr.ConstructorArguments.Length < 2) return null;
         return attr.ConstructorArguments[1].Value as string;
     }
@@ -172,7 +204,7 @@ internal static class TransposeNaming
     /// </summary>
     public static string[]? GetScriptBody(ISymbol symbol)
     {
-        var a = symbol.GetAttributes().FirstOrDefault(x => AttrIs(x, ScriptAttr));
+        var a = FindAttr(symbol, ScriptAttr);
         if (a is null || a.ConstructorArguments.Length == 0) return null;
         var arg = a.ConstructorArguments[0];
         if (arg.Kind == TypedConstantKind.Array)
@@ -199,7 +231,7 @@ internal static class TransposeNaming
         if (type is null) return null;
         var outer = type;
         while (outer.ContainingType is { } ct) outer = ct;
-        var a = outer.GetAttributes().FirstOrDefault(x => AttrIs(x, NamespaceAttr));
+        var a = FindAttr(outer, NamespaceAttr);
         if (a is null || a.ConstructorArguments.Length == 0) return null;
         var arg = a.ConstructorArguments[0].Value;
         // [Namespace(false)] suppresses; [Namespace(true)] is the default (no override).
@@ -218,7 +250,7 @@ internal static class TransposeNaming
     /// </summary>
     public static bool? ReflectableOverride(ISymbol symbol)
     {
-        var a = symbol.GetAttributes().FirstOrDefault(x => AttrIs(x, ReflectableAttr));
+        var a = FindAttr(symbol, ReflectableAttr);
         if (a is null) return null;
         if (a.ConstructorArguments.Length > 0 && a.ConstructorArguments[0].Value is bool b) return b;
         return true;
@@ -242,7 +274,7 @@ internal static class TransposeNaming
         // types are native JS objects, so their indexer is bracket access. Real Transpose runtime
         // collection classes (List<T>, Dictionary<,>, …) are not external and keep getItem/setItem.
         if (indexer.ContainingType is not { TypeKind: TypeKind.Class } ct || !IsExternalType(ct)) return false;
-        if (indexer.ContainingType.GetAttributes().Any(a => AttrIs(a, AccessorsIndexerAttr))) return false;
+        if (HasAttr(indexer.ContainingType, AccessorsIndexerAttr)) return false;
         if (GetName(indexer) is not null) return false;
         if (GetTemplate(indexer.GetMethod?.OriginalDefinition) is not null) return false;
         if (GetTemplate(indexer.SetMethod?.OriginalDefinition) is not null) return false;
@@ -307,7 +339,7 @@ internal static class TransposeNaming
         // with the hand-written primitives and with how user code calls the referenced BCL.
         if (IsTransposeRuntimeAssembly(type.ContainingAssembly)) return false;
         if (IsExternalType(type)) return false;
-        if (type.Locations.Any(l => l.IsInSource)) return true;
+        if (AnyInSource(type.Locations)) return true;
         return true; // referenced user library (compiled with --emit-package)
     }
 
@@ -350,7 +382,7 @@ internal static class TransposeNaming
     {
         for (var t = type; t is not null; t = t.ContainingType)
         {
-            if (t.GetAttributes().Any(a => AttrIs(a, ExternalAttr)))
+            if (HasAttr(t, ExternalAttr))
                 return true;
         }
         // Assembly-level [assembly: External] (how binding libraries such as Transpose.Core mark
@@ -360,24 +392,22 @@ internal static class TransposeNaming
 
     /// <summary>True if the assembly carries <c>[assembly: Transpose.External]</c>.</summary>
     public static bool AssemblyHasExternalAttribute(IAssemblySymbol? asm)
-        => asm is not null && asm.GetAttributes().Any(a => AttrIs(a, ExternalAttr));
+        => HasAttr(asm, ExternalAttr);
 
     public static bool IsExternal(ISymbol symbol)
     {
         for (var s = symbol; s is not null; s = s.ContainingType)
         {
-            if (s.GetAttributes().Any(a => AttrIs(a, ExternalAttr)))
+            if (HasAttr(s, ExternalAttr))
                 return true;
         }
         // Types defined in the Transpose assembly (not in user source) are external BCL.
-        return !symbol.Locations.Any(l => l.IsInSource);
+        return !AnyInSource(symbol.Locations);
     }
 
     private static string? GetStringAttr(ISymbol? symbol, string attrName)
     {
-        if (symbol is null) return null;
-        var attr = symbol.GetAttributes()
-            .FirstOrDefault(a => AttrIs(a, attrName));
+        var attr = FindAttr(symbol, attrName);
         if (attr is null || attr.ConstructorArguments.Length == 0) return null;
         return attr.ConstructorArguments[0].Value as string;
     }
@@ -388,6 +418,26 @@ internal static class TransposeNaming
     /// keep their C# name, with the entry point mapped to "main").
     /// </summary>
     public static string MemberJsName(ISymbol symbol)
+        => _memberCache.TryGetValue(symbol, out var cached) ? cached : _memberCache[symbol] = MemberJsNameCore(symbol);
+
+    /// <summary>
+    /// Resolved JS member names, cached per symbol.
+    ///
+    /// <see cref="MemberJsNameCore"/> is a pure function of the symbol but a genuinely expensive one:
+    /// for a property/field it walks <c>AllInterfaces</c> and every interface's members to decide
+    /// whether the member must yield its plain slot, and for a method it can build and sort the whole
+    /// overload group. The emitter asks for the same member's name once per *reference* in the source,
+    /// so on a real project this recomputation dominated allocation (~164 MB on a 69k-line project).
+    /// Methods keep their own cache inside <see cref="MethodJsName"/> (keyed on the original
+    /// definition, and populated a group at a time); this one covers every symbol kind.
+    ///
+    /// Keyed on the symbol exactly as passed, not on its original definition: a constructed generic's
+    /// member is a distinct symbol and caching it separately cannot change an answer, whereas
+    /// normalising here would.
+    /// </summary>
+    private static readonly ConcurrentDictionary<ISymbol, string> _memberCache = new(SymbolEqualityComparer.Default);
+
+    private static string MemberJsNameCore(ISymbol symbol)
     {
         // An explicit interface implementation is named by the interface-qualified mangled
         // name Transpose uses (e.g. IMyInterface.Method → Namespace$IMyInterface$method), so it
@@ -508,7 +558,7 @@ internal static class TransposeNaming
         // NOT short-circuit here even when in source (self-building the BCL): its members bind to
         // native JS names via [Convention]/casing — e.g. String.Length ([External] +
         // [Convention(CamelCase)]) must emit `length` to hit the native JS string property.
-        if (symbol.Locations.Any(l => l.IsInSource) && !IsExternalType(symbol.ContainingType))
+        if (AnyInSource(symbol.Locations) && !IsExternalType(symbol.ContainingType))
             return symbol.Name;
 
         // Property / field / event: camelCase under an [External] type or a
@@ -733,8 +783,18 @@ internal static class TransposeNaming
     /// object-override runtime names, an explicit [Name], an inherited [Name] (from an
     /// overridden base or implemented interface member), the implemented interface member's
     /// own name, then the convention-derived name.
+    ///
+    /// Cached per method: <see cref="OverloadGroup"/> calls this for every candidate method in every
+    /// base type in order to group overloads by their final JS name, and it recurses into interface
+    /// members, so the same method's base name was being derived many times over.
     /// </summary>
+    private static readonly ConcurrentDictionary<IMethodSymbol, string> _baseNameCache = new(SymbolEqualityComparer.Default);
+
     private static string JsBaseName(IMethodSymbol method)
+        => _baseNameCache.TryGetValue(method, out var cached) ? cached : _baseNameCache[method] = JsBaseNameCore(method);
+
+    /// <inheritdoc cref="JsBaseName"/>
+    private static string JsBaseNameCore(IMethodSymbol method)
     {
         if (IsObjectToString(method)) return "toString";
         if (IsObjectGetHashCode(method)) return "getHashCode";
@@ -777,7 +837,7 @@ internal static class TransposeNaming
     /// </summary>
     public static bool HasNoBody(IMethodSymbol method)
     {
-        if (method.Locations.Any(l => l.IsInSource))
+        if (AnyInSource(method.Locations))
         {
             // Self-building the BCL (--build-runtime): the runtime types are in source, but their
             // `extern` members are hand-written-JS backed exactly as when referenced from metadata,
@@ -799,8 +859,23 @@ internal static class TransposeNaming
         return null;
     }
 
-    /// <summary>The interface member this method implements (implicitly), or null.</summary>
+    /// <summary>
+    /// Resolved implicit interface members, cached per method. <see cref="ImplementedInterfaceMemberCore"/>
+    /// is O(interfaces x their members) with a <c>FindImplementationForInterfaceMember</c> call for each,
+    /// walked once per level of the override chain — and it is reached from <see cref="JsBaseName"/>,
+    /// which <see cref="OverloadGroup"/> calls for every candidate in every base type. Caching it turns
+    /// a repeatedly-recomputed graph walk into one lookup. A null result is cached too (as the absent
+    /// value of the nullable), since "implements nothing" is the common answer.
+    /// </summary>
+    private static readonly ConcurrentDictionary<IMethodSymbol, IMethodSymbol?> _implementedIfaceCache = new(SymbolEqualityComparer.Default);
+
     private static IMethodSymbol? ImplementedInterfaceMember(IMethodSymbol method)
+        => _implementedIfaceCache.TryGetValue(method, out var cached)
+            ? cached
+            : _implementedIfaceCache[method] = ImplementedInterfaceMemberCore(method);
+
+    /// <summary>The interface member this method implements (implicitly), or null.</summary>
+    private static IMethodSymbol? ImplementedInterfaceMemberCore(IMethodSymbol method)
     {
         // Walk the override chain: an override implements whatever interface member its overridden
         // base declared as the implementation. Roslyn's FindImplementationForInterfaceMember resolves
@@ -816,8 +891,9 @@ internal static class TransposeNaming
             if (type is null) continue;
             foreach (var iface in type.AllInterfaces)
             {
-                foreach (var member in iface.GetMembers().OfType<IMethodSymbol>())
+                foreach (var ifaceMember in iface.GetMembers())
                 {
+                    if (ifaceMember is not IMethodSymbol member) continue;
                     if (type.FindImplementationForInterfaceMember(member) is IMethodSymbol impl
                         && SymbolEqualityComparer.Default.Equals(impl.OriginalDefinition, m.OriginalDefinition))
                         return member.OriginalDefinition;
@@ -882,8 +958,9 @@ internal static class TransposeNaming
         if (type is null) return false;
         foreach (var iface in type.AllInterfaces)
         {
-            foreach (var member in iface.GetMembers().OfType<IMethodSymbol>())
+            foreach (var ifaceMember in iface.GetMembers())
             {
+                if (ifaceMember is not IMethodSymbol member) continue;
                 if (type.FindImplementationForInterfaceMember(member) is IMethodSymbol im
                     && SymbolEqualityComparer.Default.Equals(im.OriginalDefinition, method.OriginalDefinition))
                     return true;
@@ -906,8 +983,9 @@ internal static class TransposeNaming
         var seen = new System.Collections.Generic.HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         for (var t = method.ContainingType; t is not null; t = t.BaseType)
         {
-            foreach (var candidate in t.GetMembers().OfType<IMethodSymbol>())
+            foreach (var typeMember in t.GetMembers())
             {
+                if (typeMember is not IMethodSymbol candidate) continue;
                 var c = candidate.OriginalDefinition;
                 if (c.MethodKind != kind || c.IsStatic != isStatic) continue;
                 if (c.ExplicitInterfaceImplementations.Length > 0) continue;
@@ -996,7 +1074,7 @@ internal static class TransposeNaming
     /// <summary>A [Convention] applied directly to a member (e.g. KeyValuePair.Key).</summary>
     private static Notation? MemberConventionNotation(ISymbol symbol)
     {
-        var a = symbol.GetAttributes().FirstOrDefault(x => AttrIs(x, ConventionAttr));
+        var a = FindAttr(symbol, ConventionAttr);
         if (a is null) return null;
         var notation = a.ConstructorArguments.Length > 0 && a.ConstructorArguments[0].Value is int cn
             ? cn
@@ -1010,8 +1088,9 @@ internal static class TransposeNaming
         AttributeData? best = null;
         var bestPriority = int.MinValue;
         var bestSpecific = -1;
-        foreach (var a in type.GetAttributes().Where(a => AttrIs(a, ConventionAttr)))
+        foreach (var a in type.GetAttributes())
         {
+            if (!AttrIs(a, ConventionAttr)) continue;
             var member = NamedInt(a, "Member", ConvAll);
             if (member != ConvAll && (member & memberKindFlag) == 0) continue;
             var priority = NamedInt(a, "Priority", 0);
@@ -1063,8 +1142,7 @@ internal static class TransposeNaming
     public static string? GlobalTargetName(IMethodSymbol? method)
     {
         if (method is null) return null;
-        var a = method.OriginalDefinition.GetAttributes()
-            .FirstOrDefault(x => AttrIs(x, "Transpose.GlobalTargetAttribute"));
+        var a = FindAttr(method.OriginalDefinition, "Transpose.GlobalTargetAttribute");
         return a?.ConstructorArguments.Length > 0 ? a.ConstructorArguments[0].Value as string : null;
     }
 

--- a/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
+++ b/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
@@ -94,6 +94,8 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
             // `var` binds to the inferred type, which may itself be denied even when that type's name
             // appears nowhere in the file (`var s = Factory.OpenFile();`). It is the one identifier
             // text that can name any type at all, so it always gets a semantic query.
+            // Measured: including it moves ~0.8s from the JS emit into the scan and leaves the total
+            // unchanged, because the two share semantic models — the bind is prepaid, not extra.
             "var",
         };
 

--- a/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
+++ b/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
@@ -16,24 +16,53 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
     private readonly SemanticModel _model;
     private readonly List<Diagnostic> _diagnostics;
 
-    private UnsupportedFeatureScanner(SemanticModel model, List<Diagnostic> diagnostics)
+    /// <summary>Simple names of the types this scanner would reject (see <see cref="DeniedNamespaces"/>),
+    /// computed once per compilation. <see cref="VisitIdentifierName"/> fires on nearly every token in
+    /// the source, and asking the semantic model to bind each one is by far the scanner's dominant
+    /// cost; an identifier whose *text* is not in this set cannot possibly name a denied type, so it
+    /// needs no semantic query at all. See <see cref="CollectDeniedSimpleNames"/> for why this is
+    /// exact rather than a heuristic.</summary>
+    private readonly HashSet<string> _deniedSimpleNames;
+
+    /// <summary>Extra identifier texts this file must resolve semantically, contributed by its own
+    /// using directives: an alias's name (<c>using MyFile = System.IO.File;</c>) and the member names
+    /// a static import brings into scope (<c>using static System.IO.File;</c>) — the only ways a
+    /// denied type can be referenced without its own simple name appearing as an identifier. Null
+    /// until such a directive is seen, which keeps the hot path in <see cref="VisitIdentifierName"/>
+    /// down to a single set lookup for the overwhelming majority of files.</summary>
+    private HashSet<string>? _aliasedNames;
+
+    private UnsupportedFeatureScanner(SemanticModel model, List<Diagnostic> diagnostics, HashSet<string> deniedSimpleNames)
     {
         _model = model;
         _diagnostics = diagnostics;
+        _deniedSimpleNames = deniedSimpleNames;
     }
 
-    public static IReadOnlyList<Diagnostic> Scan(CSharpCompilation compilation)
+    /// <summary>
+    /// Scans every syntax tree for browser-incompatible constructs.
+    ///
+    /// <paramref name="models"/> is the same semantic-model cache the JS emitter will use. Sharing it
+    /// is what makes this scan close to free on a real build: a Roslyn <see cref="SemanticModel"/>
+    /// retains the bound form of every member it is asked about, so a member this scan binds (to
+    /// resolve, say, the inferred type of a <c>var</c>) is already bound when the emitter reaches it.
+    /// Pass null to scan against throw-away models — only useful when there is no emit to follow.
+    /// </summary>
+    public static IReadOnlyList<Diagnostic> Scan(CSharpCompilation compilation, TreeModel? models = null)
     {
+        var deniedSimpleNames = CollectDeniedSimpleNames(compilation);
+        models ??= new TreeModel(compilation);
+
         var allDiagnostics = new List<List<Diagnostic>>();
         Parallel.ForEach(compilation.SyntaxTrees, tree =>
         {
             var diagnostics = new List<Diagnostic>();
 
-            var model = compilation.GetSemanticModel(tree);
-            var scanner = new UnsupportedFeatureScanner(model, diagnostics);
+            var model = models.SemanticModelFor(tree);
+            var scanner = new UnsupportedFeatureScanner(model, diagnostics, deniedSimpleNames);
             scanner.Visit(tree.GetRoot());
 
-            if (diagnostics.Any())
+            if (diagnostics.Count > 0)
             {
                 lock (allDiagnostics)
                 {
@@ -42,6 +71,70 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
             }
         });
         return allDiagnostics.SelectMany(d => d).ToArray();
+    }
+
+    /// <summary>
+    /// The simple names of every type that <see cref="CheckDeniedType"/> would report — i.e. every
+    /// type in a denied namespace that is not on the allowed list. Enumerated from the compilation's
+    /// merged global namespace, so it covers the Transpose BCL, every referenced package, and source
+    /// types alike.
+    ///
+    /// This is a *sound* filter, not a heuristic: a syntactic identifier can only bind to a denied
+    /// type if the identifier's text equals that type's name — the one exception being an alias
+    /// (<c>using MyFile = System.IO.File;</c>) or a static import (<c>using static System.IO.File;</c>),
+    /// which name the denied type in the using directive itself and are checked there
+    /// (<see cref="VisitUsingDirective"/>).
+    /// </summary>
+    private static HashSet<string> CollectDeniedSimpleNames(CSharpCompilation compilation)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal)
+        {
+            // Native-sized integers are matched by identifier text, not by namespace.
+            "nint", "nuint",
+            // `var` binds to the inferred type, which may itself be denied even when that type's name
+            // appears nowhere in the file (`var s = Factory.OpenFile();`). It is the one identifier
+            // text that can name any type at all, so it always gets a semantic query.
+            "var",
+        };
+
+        foreach (var (segments, _) in DeniedNamespaces)
+        {
+            var ns = ResolveNamespace(compilation.GlobalNamespace, segments);
+            if (ns is null) continue;
+            AddTypeNames(ns, names);
+        }
+        return names;
+
+        static INamespaceSymbol? ResolveNamespace(INamespaceSymbol root, string[] segments)
+        {
+            var cur = root;
+            foreach (var segment in segments)
+            {
+                cur = cur.GetNamespaceMembers().FirstOrDefault(n => string.Equals(n.Name, segment, StringComparison.Ordinal));
+                if (cur is null) return null;
+            }
+            return cur;
+        }
+
+        static void AddTypeNames(INamespaceSymbol ns, HashSet<string> names)
+        {
+            // System.Threading.Tasks is the supported async model — its types are allowed wholesale,
+            // so keeping their names out of the filter spares a semantic query on every `Task`.
+            if (NamespaceMatches(ns, TasksNamespaceSegments)) return;
+
+            foreach (var type in ns.GetTypeMembers())
+                AddTypeAndNested(type, names);
+            foreach (var child in ns.GetNamespaceMembers())
+                AddTypeNames(child, names);
+        }
+
+        static void AddTypeAndNested(INamedTypeSymbol type, HashSet<string> names)
+        {
+            if (!AllowedThreadingTypes.Contains(type.ConstructUnboundGenericTypeSafeName()))
+                names.Add(type.Name);
+            foreach (var nested in type.GetTypeMembers())
+                AddTypeAndNested(nested, names);
+        }
     }
 
     private void Report(SyntaxNode node, string message)
@@ -65,6 +158,33 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
     {
         if (node.GlobalKeyword.RawKind != 0)
             Report(node, "Global usings are not supported; add per-file using directives instead.");
+
+        // An alias (`using MyFile = System.IO.File;`) or a static import (`using static System.IO.File;`)
+        // is the only way a denied type can be referenced without its own simple name appearing as an
+        // identifier — which is exactly what the fast path in VisitIdentifierName relies on. Rather
+        // than report the directive (that would reject an *unused* import, which the scanner never
+        // did before), widen this file's interesting-name set so the usage site is still resolved and
+        // reported where it occurs. A plain namespace import (`using System.IO;`) needs nothing:
+        // importing a namespace is harmless, and a type used from it appears by its own name.
+        //
+        // A using directive always precedes the members that can see it, so widening the set here —
+        // mid-walk — is in time for every usage.
+        if (node.Alias is not null)
+        {
+            (_aliasedNames ??= new HashSet<string>(StringComparer.Ordinal)).Add(node.Alias.Name.Identifier.ValueText);
+        }
+        else if (node.StaticKeyword.RawKind != 0 && node.NamespaceOrType is { } staticTarget)
+        {
+            // A static import puts the type's members in scope under their own names, so those names
+            // become resolvable identifiers that can reach a denied type.
+            if (_model.GetSymbolInfo(staticTarget).Symbol is INamedTypeSymbol imported
+                && DeniedNamespaceMessage(imported) is not null)
+            {
+                var set = _aliasedNames ??= new HashSet<string>(StringComparer.Ordinal);
+                foreach (var member in imported.GetMembers()) set.Add(member.Name);
+            }
+        }
+
         base.VisitUsingDirective(node);
     }
 
@@ -169,8 +289,15 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
 
     private void CheckDllImport(MethodDeclarationSyntax node)
     {
-        foreach (var attr in node.AttributeLists.SelectMany(a => a.Attributes))
+        foreach (var list in node.AttributeLists)
+        foreach (var attr in list.Attributes)
         {
+            // Screen on the written name before binding: resolving every attribute on every method
+            // is a real cost across a large project, and only these two attribute names can ever
+            // produce this diagnostic. `Name.ToString()` on the syntax covers the qualified form
+            // (`System.Runtime.InteropServices.DllImport`) as well as the bare one.
+            if (!LooksLikePInvokeAttributeName(attr.Name)) continue;
+
             var symbol = _model.GetSymbolInfo(attr).Symbol?.ContainingType;
             var name = symbol?.ToDisplayString();
             if (name is "System.Runtime.InteropServices.DllImportAttribute"
@@ -179,6 +306,20 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
                 Report(node, "Native interop (P/Invoke) is not supported in the browser environment.");
             }
         }
+    }
+
+    /// <summary>True if an attribute's written name could be <c>DllImport</c> or <c>LibraryImport</c>
+    /// (bare, with the <c>Attribute</c> suffix, or namespace-qualified).</summary>
+    private static bool LooksLikePInvokeAttributeName(NameSyntax name)
+    {
+        var simple = name switch
+        {
+            QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+            SimpleNameSyntax s => s.Identifier.ValueText,
+            AliasQualifiedNameSyntax a => a.Name.Identifier.ValueText,
+            _ => name.ToString(),
+        };
+        return simple is "DllImport" or "DllImportAttribute" or "LibraryImport" or "LibraryImportAttribute";
     }
 
     // ---- Language features not modeled by the runtime ----------------------
@@ -227,9 +368,21 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
     // Native-sized integers (nint/nuint) have no JS representation distinct from double.
     public override void VisitIdentifierName(IdentifierNameSyntax node)
     {
-        // VisitIdentifierName fires on nearly every identifier in the source, so it is the scanner's
-        // hottest path. Resolve the symbol once and reuse it for both checks below rather than
-        // querying the semantic model twice.
+        // VisitIdentifierName fires on nearly every identifier in the source, so it is by a wide
+        // margin the scanner's hottest path — and asking the semantic model to bind an identifier is
+        // not cheap (it binds the whole enclosing member). Screen by identifier *text* first: unless
+        // the text is the simple name of a type this scanner would reject, no semantic query can
+        // change the outcome, and the vast majority of identifiers exit here having allocated nothing.
+        // `var` is in the denied-name set too, so an inferred local whose type is never written out
+        // (`var s = Factory.OpenFile();`) is still caught.
+        var text = node.Identifier.ValueText;
+        if (!_deniedSimpleNames.Contains(text) && !(_aliasedNames?.Contains(text) ?? false))
+        {
+            base.VisitIdentifierName(node);
+            return;
+        }
+
+        // Resolve the symbol once and reuse it for both checks below rather than querying twice.
         var symbol = _model.GetSymbolInfo(node).Symbol;
 
         if (node.Identifier.Text is "nint" or "nuint"
@@ -258,7 +411,11 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
     // Span/ReadOnlySpan constant-string pattern matching (`span is "literal"`) is not modeled.
     public override void VisitIsPatternExpression(IsPatternExpressionSyntax node)
     {
-        if (node.Pattern is ConstantPatternSyntax
+        // Only a *string-literal* constant pattern can be the span-pattern form (`span is "text"`),
+        // so screen on the literal before binding the operand — `x is null`, `x is 0` and every
+        // other constant pattern would otherwise pay for a semantic query that cannot match.
+        if (node.Pattern is ConstantPatternSyntax { Expression: LiteralExpressionSyntax literal }
+            && literal.Token.IsKind(SyntaxKind.StringLiteralToken)
             && _model.GetTypeInfo(node.Expression).Type is INamedTypeSymbol t
             && t.OriginalDefinition.ToDisplayString() is "System.ReadOnlySpan<T>" or "System.Span<T>")
         {
@@ -337,30 +494,34 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
 
     private readonly HashSet<Location> _reportedApiLocations = new();
 
-    private void CheckDeniedType(INamedTypeSymbol type, SyntaxNode node)
+    /// <summary>The diagnostic message template for a type in a denied namespace, or null when the
+    /// type is fine. Matches against the namespace *symbol* (a cheap segment walk) before doing any
+    /// string work, so a type that is not denied costs nothing.</summary>
+    private static string? DeniedNamespaceMessage(INamedTypeSymbol type)
     {
-        // Fast path: the vast majority of identifiers resolve to types outside the denied
-        // namespaces. Match against the namespace *symbol* (a cheap segment walk) before doing any
-        // string formatting, so the common case allocates nothing. Only when a type is actually in a
-        // denied namespace do we pay for the allowed-list check and the diagnostic message.
         var containing = type.ContainingNamespace;
-        if (containing is null || containing.IsGlobalNamespace) return;
+        if (containing is null || containing.IsGlobalNamespace) return null;
 
         string? message = null;
         foreach (var (segments, msg) in DeniedNamespaces)
         {
             if (NamespaceMatches(containing, segments)) { message = msg; break; }
         }
-        if (message is null) return;
+        if (message is null) return null;
 
         // System.Threading.Tasks.* is the supported async model (Task, ValueTask, IPromise, the
         // completion source, cancellation exceptions, …) — allow the whole sub-namespace even though
         // its parent System.Threading is denied. The genuinely-unsupported threading primitives
         // (Thread, Monitor, locks, wait handles) live directly in System.Threading and stay denied.
-        if (NamespaceMatches(containing, TasksNamespaceSegments)) return;
+        if (NamespaceMatches(containing, TasksNamespaceSegments)) return null;
 
-        var metadataName = type.ConstructUnboundGenericTypeSafeName();
-        if (AllowedThreadingTypes.Contains(metadataName)) return;
+        return AllowedThreadingTypes.Contains(type.ConstructUnboundGenericTypeSafeName()) ? null : message;
+    }
+
+    private void CheckDeniedType(INamedTypeSymbol type, SyntaxNode node)
+    {
+        var message = DeniedNamespaceMessage(type);
+        if (message is null) return;
 
         if (_reportedApiLocations.Add(node.GetLocation()))
         {

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -1,0 +1,310 @@
+{
+  "Label": "baseline",
+  "Score": 92.4563483394478,
+  "CpuModel": "Intel(R) Xeon(R) Processor @ 2.80GHz",
+  "LogicalCores": 4,
+  "PhysicalCores": 4,
+  "TotalRamBytes": 16856244224,
+  "Os": "Ubuntu 24.04.4 LTS",
+  "Runtime": ".NET 10.0.10",
+  "Capabilities": [
+    "Vector\u003CT\u003E=256bit",
+    "Vector128.HwAccel",
+    "Vector256.HwAccel",
+    "SSE2",
+    "SSE3",
+    "SSSE3",
+    "SSE4.1",
+    "SSE4.2",
+    "AVX",
+    "AVX2",
+    "AVX512F",
+    "AVX512BW",
+    "FMA",
+    "BMI1",
+    "BMI2",
+    "LZCNT",
+    "POPCNT",
+    "AES",
+    "PCLMULQDQ"
+  ],
+  "Configuration": "Debug",
+  "Iterations": 3,
+  "CpuWorkloads": [
+    {
+      "Name": "pointer-chase",
+      "Ms": 125.8931,
+      "ReferenceMs": 85,
+      "Score": 67.5176002497357
+    },
+    {
+      "Name": "dictionary",
+      "Ms": 68.2548,
+      "ReferenceMs": 68,
+      "Score": 99.62669292123044
+    },
+    {
+      "Name": "string-churn",
+      "Ms": 69.3501,
+      "ReferenceMs": 62,
+      "Score": 89.40145724375309
+    },
+    {
+      "Name": "scalar-int",
+      "Ms": 68.9006,
+      "ReferenceMs": 69,
+      "Score": 100.14426579739508
+    },
+    {
+      "Name": "sort",
+      "Ms": 72.6847,
+      "ReferenceMs": 74,
+      "Score": 101.80959679272252
+    },
+    {
+      "Name": "memcpy",
+      "Ms": 60.8588,
+      "ReferenceMs": 62,
+      "Score": 101.87516020690516
+    }
+  ],
+  "Scenarios": [
+    {
+      "Name": "tesserae",
+      "Project": "/home/user/tesserae/Tesserae/Tesserae.csproj",
+      "Clean": true,
+      "WallMs": 17113.4951,
+      "MinWallMs": 16952.7989,
+      "StdDevMs": 1539.2562249570306,
+      "NormalisedWallMs": 15822.51264271033,
+      "CpuMs": 40827,
+      "AllocBytes": 1139321040,
+      "PeakWorkingSetBytes": 408256512,
+      "Phases": [
+        {
+          "Name": "resolve project (csproj \u002B globs \u002B references)",
+          "Ms": 39,
+          "Bytes": 15171336
+        },
+        {
+          "Name": "build compilation (parse \u002B references)",
+          "Ms": 1011,
+          "Bytes": 28999464
+        },
+        {
+          "Name": "bind \u002B diagnostics",
+          "Ms": 4397,
+          "Bytes": 150669136
+        },
+        {
+          "Name": "scan unsupported features",
+          "Ms": 2661,
+          "Bytes": 156950568
+        },
+        {
+          "Name": "emit .NET assembly",
+          "Ms": 4251,
+          "Bytes": 217261480
+        },
+        {
+          "Name": "  \u251C collect \u002B order types",
+          "Ms": 156,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C emit type bodies (parallel)",
+          "Ms": 2975,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C concatenate type bodies",
+          "Ms": 3,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u2514 reflection metadata (file)",
+          "Ms": 553,
+          "Bytes": 0
+        },
+        {
+          "Name": "emit JavaScript",
+          "Ms": 3706,
+          "Bytes": 450765920
+        },
+        {
+          "Name": "collect package resources (minify \u002B read files)",
+          "Ms": 104,
+          "Bytes": 41898184
+        },
+        {
+          "Name": "embed resources into DLL (Cecil)",
+          "Ms": 927,
+          "Bytes": 74279200
+        }
+      ]
+    },
+    {
+      "Name": "tesserae\u002Btests",
+      "Project": "/home/user/tesserae/Tesserae.Tests/Tesserae.Tests.csproj",
+      "Clean": true,
+      "WallMs": 25050.1328,
+      "MinWallMs": 24407.9194,
+      "StdDevMs": 442.4797433349279,
+      "NormalisedWallMs": 23160.438041062265,
+      "CpuMs": 67463,
+      "AllocBytes": 1701314016,
+      "PeakWorkingSetBytes": 535736320,
+      "Phases": [
+        {
+          "Name": "resolve project (csproj \u002B globs \u002B references)",
+          "Ms": 26,
+          "Bytes": 4081320
+        },
+        {
+          "Name": "build compilation (parse \u002B references)",
+          "Ms": 1229,
+          "Bytes": 34252440
+        },
+        {
+          "Name": "bind \u002B diagnostics",
+          "Ms": 4925,
+          "Bytes": 230451872
+        },
+        {
+          "Name": "scan unsupported features",
+          "Ms": 4901,
+          "Bytes": 343836984
+        },
+        {
+          "Name": "emit .NET assembly",
+          "Ms": 6701,
+          "Bytes": 298591416
+        },
+        {
+          "Name": "  \u251C collect \u002B order types",
+          "Ms": 283,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C emit type bodies (parallel)",
+          "Ms": 5022,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C concatenate type bodies",
+          "Ms": 3,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u2514 reflection metadata (file)",
+          "Ms": 604,
+          "Bytes": 0
+        },
+        {
+          "Name": "emit JavaScript",
+          "Ms": 5945,
+          "Bytes": 588120912
+        },
+        {
+          "Name": "collect package resources (minify \u002B read files)",
+          "Ms": 103,
+          "Bytes": 42755944
+        },
+        {
+          "Name": "embed resources into DLL (Cecil)",
+          "Ms": 771,
+          "Bytes": 90719960
+        },
+        {
+          "Name": "  \u251C reflection metadata (inline)",
+          "Ms": 26,
+          "Bytes": 0
+        },
+        {
+          "Name": "write site (minify \u002B resources \u002B html)",
+          "Ms": 111,
+          "Bytes": 50614304
+        }
+      ]
+    },
+    {
+      "Name": "tesserae\u002Btests-warm",
+      "Project": "/home/user/tesserae/Tesserae.Tests/Tesserae.Tests.csproj",
+      "Clean": false,
+      "WallMs": 9766.9346,
+      "MinWallMs": 9491.6256,
+      "StdDevMs": 172.88275256836187,
+      "NormalisedWallMs": 9030.151075862053,
+      "CpuMs": 25852,
+      "AllocBytes": 555140608,
+      "PeakWorkingSetBytes": 268320768,
+      "Phases": [
+        {
+          "Name": "resolve project (csproj \u002B globs \u002B references)",
+          "Ms": 24,
+          "Bytes": 4074680
+        },
+        {
+          "Name": "build compilation (parse \u002B references)",
+          "Ms": 441,
+          "Bytes": 10142912
+        },
+        {
+          "Name": "bind \u002B diagnostics",
+          "Ms": 1989,
+          "Bytes": 73809016
+        },
+        {
+          "Name": "scan unsupported features",
+          "Ms": 3270,
+          "Bytes": 181996496
+        },
+        {
+          "Name": "emit .NET assembly",
+          "Ms": 1751,
+          "Bytes": 77626704
+        },
+        {
+          "Name": "  \u251C collect \u002B order types",
+          "Ms": 58,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C emit type bodies (parallel)",
+          "Ms": 1511,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C concatenate type bodies",
+          "Ms": 1,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C reflection metadata (inline)",
+          "Ms": 48,
+          "Bytes": 0
+        },
+        {
+          "Name": "emit JavaScript",
+          "Ms": 1617,
+          "Bytes": 137398024
+        },
+        {
+          "Name": "collect package resources (minify \u002B read files)",
+          "Ms": 4,
+          "Bytes": 859152
+        },
+        {
+          "Name": "embed resources into DLL (Cecil)",
+          "Ms": 307,
+          "Bytes": 16573048
+        },
+        {
+          "Name": "write site (minify \u002B resources \u002B html)",
+          "Ms": 122,
+          "Bytes": 50670864
+        }
+      ]
+    }
+  ]
+}

--- a/docs/perf/optimized-release.json
+++ b/docs/perf/optimized-release.json
@@ -1,6 +1,6 @@
 {
-  "Label": "r2r-debug",
-  "Score": 95.16912972237111,
+  "Label": "r2r-release",
+  "Score": 87.18700001630394,
   "CpuModel": "Intel(R) Xeon(R) Processor @ 2.80GHz",
   "LogicalCores": 4,
   "PhysicalCores": 4,
@@ -28,44 +28,44 @@
     "AES",
     "PCLMULQDQ"
   ],
-  "Configuration": "Debug",
+  "Configuration": "Release",
   "Iterations": 3,
   "CpuWorkloads": [
     {
       "Name": "pointer-chase",
-      "Ms": 96.0204,
+      "Ms": 145.6865,
       "ReferenceMs": 85,
-      "Score": 88.5228555598602
+      "Score": 58.34445882082417
     },
     {
       "Name": "dictionary",
-      "Ms": 68.4894,
+      "Ms": 69.6849,
       "ReferenceMs": 68,
-      "Score": 99.28543687052303
+      "Score": 97.58211606818693
     },
     {
       "Name": "string-churn",
-      "Ms": 64.6071,
+      "Ms": 71.4104,
       "ReferenceMs": 62,
-      "Score": 95.9646849959215
+      "Score": 86.82208753906994
     },
     {
       "Name": "scalar-int",
-      "Ms": 69.6677,
+      "Ms": 69.1367,
       "ReferenceMs": 69,
-      "Score": 99.04159316297223
+      "Score": 99.80227578116975
     },
     {
       "Name": "sort",
-      "Ms": 73.5757,
+      "Ms": 73.5769,
       "ReferenceMs": 74,
-      "Score": 100.57668496528065
+      "Score": 100.57504461318703
     },
     {
       "Name": "memcpy",
-      "Ms": 70.1104,
+      "Ms": 70.0345,
       "ReferenceMs": 62,
-      "Score": 88.43195873935964
+      "Score": 88.52779701432866
     }
   ],
   "Scenarios": [
@@ -73,73 +73,68 @@
       "Name": "tesserae",
       "Project": "/home/user/transpose/benchmarks/tesserae/Tesserae/Tesserae.csproj",
       "Clean": true,
-      "WallMs": 6000.5959,
-      "MinWallMs": 5947.765,
-      "StdDevMs": 86.52063325166976,
-      "NormalisedWallMs": 5710.714896186283,
-      "CpuMs": 18345,
-      "AllocBytes": 633364248,
-      "PeakWorkingSetBytes": 426106880,
+      "WallMs": 9566.8616,
+      "MinWallMs": 9371.0963,
+      "StdDevMs": 207.66485336287298,
+      "NormalisedWallMs": 8341.059624751775,
+      "CpuMs": 26961,
+      "AllocBytes": 1154727640,
+      "PeakWorkingSetBytes": 765919232,
       "Phases": [
         {
           "Name": "resolve project (csproj \u002B globs \u002B references)",
-          "Ms": 37,
-          "Bytes": 15204624
+          "Ms": 46,
+          "Bytes": 15204632
         },
         {
           "Name": "build compilation (parse \u002B references)",
-          "Ms": 287,
-          "Bytes": 30345488
+          "Ms": 296,
+          "Bytes": 30236160
         },
         {
           "Name": "scan unsupported features",
-          "Ms": 1264,
-          "Bytes": 59321448
+          "Ms": 1354,
+          "Bytes": 58999232
         },
         {
           "Name": "bind \u002B emit .NET assembly",
-          "Ms": 1139,
-          "Bytes": 60018920
+          "Ms": 3254,
+          "Bytes": 208197384
         },
         {
           "Name": "  \u251C collect \u002B order types",
-          "Ms": 44,
+          "Ms": 49,
           "Bytes": 0
         },
         {
           "Name": "  \u251C emit type bodies (parallel)",
-          "Ms": 1487,
+          "Ms": 1262,
           "Bytes": 0
         },
         {
           "Name": "  \u251C concatenate type bodies",
-          "Ms": 4,
+          "Ms": 8,
           "Bytes": 0
         },
         {
           "Name": "  \u2514 reflection metadata (file)",
-          "Ms": 373,
+          "Ms": 436,
           "Bytes": 0
         },
         {
           "Name": "emit JavaScript",
-          "Ms": 1898,
-          "Bytes": 292558808
-        },
-        {
-          "Name": "body diagnostics (semantic models)",
-          "Ms": 899,
-          "Bytes": 78734872
+          "Ms": 1774,
+          "Bytes": 287385968
         },
         {
           "Name": "collect package resources (minify \u002B read files)",
-          "Ms": 60,
-          "Bytes": 41853344
+          "Ms": 2064,
+          "Bytes": 478582944
         },
         {
           "Name": "embed resources into DLL (Cecil)",
-          "Ms": 257,
-          "Bytes": 54054784
+          "Ms": 644,
+          "Bytes": 74102160
         }
       ]
     },
@@ -147,83 +142,78 @@
       "Name": "tesserae\u002Btests",
       "Project": "/home/user/transpose/benchmarks/tesserae/Tesserae.Tests/Tesserae.Tests.csproj",
       "Clean": true,
-      "WallMs": 7149.5414,
-      "MinWallMs": 7013.1789,
-      "StdDevMs": 80.29550481670829,
-      "NormalisedWallMs": 6804.156329520628,
-      "CpuMs": 22006,
-      "AllocBytes": 868722256,
-      "PeakWorkingSetBytes": 556404736,
+      "WallMs": 10720.8277,
+      "MinWallMs": 10427.7571,
+      "StdDevMs": 268.88126102548154,
+      "NormalisedWallMs": 9347.168048546917,
+      "CpuMs": 30524,
+      "AllocBytes": 1568793984,
+      "PeakWorkingSetBytes": 898740224,
       "Phases": [
         {
           "Name": "resolve project (csproj \u002B globs \u002B references)",
-          "Ms": 22,
-          "Bytes": 4106016
+          "Ms": 21,
+          "Bytes": 4106024
         },
         {
           "Name": "build compilation (parse \u002B references)",
-          "Ms": 359,
-          "Bytes": 35672016
+          "Ms": 331,
+          "Bytes": 35813336
         },
         {
           "Name": "scan unsupported features",
-          "Ms": 1438,
-          "Bytes": 102874592
+          "Ms": 1462,
+          "Bytes": 106570104
         },
         {
           "Name": "bind \u002B emit .NET assembly",
-          "Ms": 1185,
-          "Bytes": 64335800
+          "Ms": 3438,
+          "Bytes": 283595736
         },
         {
           "Name": "  \u251C collect \u002B order types",
-          "Ms": 61,
+          "Ms": 60,
           "Bytes": 0
         },
         {
           "Name": "  \u251C emit type bodies (parallel)",
-          "Ms": 1814,
+          "Ms": 1650,
           "Bytes": 0
         },
         {
           "Name": "  \u251C concatenate type bodies",
-          "Ms": 4,
+          "Ms": 7,
           "Bytes": 0
         },
         {
           "Name": "  \u2514 reflection metadata (file)",
-          "Ms": 328,
+          "Ms": 403,
           "Bytes": 0
         },
         {
           "Name": "emit JavaScript",
-          "Ms": 2242,
-          "Bytes": 372886432
-        },
-        {
-          "Name": "body diagnostics (semantic models)",
-          "Ms": 1150,
-          "Bytes": 120375840
+          "Ms": 2186,
+          "Bytes": 365456784
         },
         {
           "Name": "collect package resources (minify \u002B read files)",
-          "Ms": 47,
-          "Bytes": 42682344
+          "Ms": 2173,
+          "Bytes": 538141008
         },
         {
           "Name": "embed resources into DLL (Cecil)",
-          "Ms": 323,
-          "Bytes": 57804960
+          "Ms": 507,
+          "Bytes": 90611616
         },
         {
           "Name": "  \u251C reflection metadata (inline)",
-          "Ms": 16,
+          "Ms": 17,
           "Bytes": 0
         },
         {
           "Name": "write site (minify \u002B resources \u002B html)",
-          "Ms": 128,
-          "Bytes": 50716328
+          "Ms": 402,
+          "Bytes": 123838088
         }
       ]
     },
@@ -231,42 +221,42 @@
       "Name": "tesserae\u002Btests-warm",
       "Project": "/home/user/transpose/benchmarks/tesserae/Tesserae.Tests/Tesserae.Tests.csproj",
       "Clean": false,
-      "WallMs": 3375.9626,
-      "MinWallMs": 3365.9326,
-      "StdDevMs": 179.07445439105317,
-      "NormalisedWallMs": 3212.8742261727325,
-      "CpuMs": 9388,
-      "AllocBytes": 249779488,
-      "PeakWorkingSetBytes": 297766912,
+      "WallMs": 4283.0996,
+      "MinWallMs": 4273.7566,
+      "StdDevMs": 83.59388744701012,
+      "NormalisedWallMs": 3734.3060489503137,
+      "CpuMs": 11606,
+      "AllocBytes": 427586136,
+      "PeakWorkingSetBytes": 360378368,
       "Phases": [
         {
           "Name": "resolve project (csproj \u002B globs \u002B references)",
-          "Ms": 21,
-          "Bytes": 4114184
+          "Ms": 24,
+          "Bytes": 4108040
         },
         {
           "Name": "build compilation (parse \u002B references)",
-          "Ms": 189,
-          "Bytes": 11405904
+          "Ms": 178,
+          "Bytes": 11339144
         },
         {
           "Name": "scan unsupported features",
-          "Ms": 952,
-          "Bytes": 46187368
+          "Ms": 1044,
+          "Bytes": 48585552
         },
         {
           "Name": "bind \u002B emit .NET assembly",
-          "Ms": 365,
-          "Bytes": 4870792
+          "Ms": 1319,
+          "Bytes": 77688264
         },
         {
           "Name": "  \u251C collect \u002B order types",
-          "Ms": 38,
+          "Ms": 24,
           "Bytes": 0
         },
         {
           "Name": "  \u251C emit type bodies (parallel)",
-          "Ms": 814,
+          "Ms": 700,
           "Bytes": 0
         },
         {
@@ -276,33 +266,28 @@
         },
         {
           "Name": "  \u251C reflection metadata (inline)",
-          "Ms": 26,
+          "Ms": 24,
           "Bytes": 0
         },
         {
           "Name": "emit JavaScript",
-          "Ms": 887,
-          "Bytes": 84981312
-        },
-        {
-          "Name": "body diagnostics (semantic models)",
-          "Ms": 534,
-          "Bytes": 41603400
+          "Ms": 763,
+          "Bytes": 83458056
         },
         {
           "Name": "collect package resources (minify \u002B read files)",
-          "Ms": 98,
-          "Bytes": 843552
+          "Ms": 260,
+          "Bytes": 59764944
         },
         {
           "Name": "embed resources into DLL (Cecil)",
-          "Ms": 119,
-          "Bytes": 3805160
+          "Ms": 176,
+          "Bytes": 16569760
         },
         {
           "Name": "write site (minify \u002B resources \u002B html)",
-          "Ms": 141,
-          "Bytes": 50860640
+          "Ms": 373,
+          "Bytes": 123924528
         }
       ]
     }

--- a/docs/perf/optimized.json
+++ b/docs/perf/optimized.json
@@ -1,0 +1,295 @@
+{
+  "Label": "final",
+  "Score": 89.62062041105395,
+  "CpuModel": "Intel(R) Xeon(R) Processor @ 2.80GHz",
+  "LogicalCores": 4,
+  "PhysicalCores": 4,
+  "TotalRamBytes": 16856244224,
+  "Os": "Ubuntu 24.04.4 LTS",
+  "Runtime": ".NET 10.0.10",
+  "Capabilities": [
+    "Vector\u003CT\u003E=256bit",
+    "Vector128.HwAccel",
+    "Vector256.HwAccel",
+    "SSE2",
+    "SSE3",
+    "SSSE3",
+    "SSE4.1",
+    "SSE4.2",
+    "AVX",
+    "AVX2",
+    "AVX512F",
+    "AVX512BW",
+    "FMA",
+    "BMI1",
+    "BMI2",
+    "LZCNT",
+    "POPCNT",
+    "AES",
+    "PCLMULQDQ"
+  ],
+  "Configuration": "Debug",
+  "Iterations": 3,
+  "CpuWorkloads": [
+    {
+      "Name": "pointer-chase",
+      "Ms": 129.6232,
+      "ReferenceMs": 85,
+      "Score": 65.57468107560992
+    },
+    {
+      "Name": "dictionary",
+      "Ms": 71.1847,
+      "ReferenceMs": 68,
+      "Score": 95.5261453655069
+    },
+    {
+      "Name": "string-churn",
+      "Ms": 71.1303,
+      "ReferenceMs": 62,
+      "Score": 87.16397934494863
+    },
+    {
+      "Name": "scalar-int",
+      "Ms": 69.5169,
+      "ReferenceMs": 69,
+      "Score": 99.25643980096925
+    },
+    {
+      "Name": "sort",
+      "Ms": 73.9932,
+      "ReferenceMs": 74,
+      "Score": 100.00919003367876
+    },
+    {
+      "Name": "memcpy",
+      "Ms": 64.8542,
+      "ReferenceMs": 62,
+      "Score": 95.59905141070276
+    }
+  ],
+  "Scenarios": [
+    {
+      "Name": "tesserae",
+      "Project": "/home/user/tesserae/Tesserae/Tesserae.csproj",
+      "Clean": true,
+      "WallMs": 8071.7067,
+      "MinWallMs": 7942.359,
+      "StdDevMs": 97.05651839296156,
+      "NormalisedWallMs": 7233.913622300609,
+      "CpuMs": 23551,
+      "AllocBytes": 719449976,
+      "PeakWorkingSetBytes": 514670592,
+      "Phases": [
+        {
+          "Name": "resolve project (csproj \u002B globs \u002B references)",
+          "Ms": 47,
+          "Bytes": 15170496
+        },
+        {
+          "Name": "build compilation (parse \u002B references)",
+          "Ms": 396,
+          "Bytes": 30283544
+        },
+        {
+          "Name": "scan unsupported features",
+          "Ms": 1823,
+          "Bytes": 60181824
+        },
+        {
+          "Name": "bind \u002B emit .NET assembly",
+          "Ms": 3258,
+          "Bytes": 208596696
+        },
+        {
+          "Name": "  \u251C collect \u002B order types",
+          "Ms": 77,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C emit type bodies (parallel)",
+          "Ms": 1161,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C concatenate type bodies",
+          "Ms": 7,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u2514 reflection metadata (file)",
+          "Ms": 401,
+          "Bytes": 0
+        },
+        {
+          "Name": "emit JavaScript",
+          "Ms": 1689,
+          "Bytes": 287131696
+        },
+        {
+          "Name": "collect package resources (minify \u002B read files)",
+          "Ms": 49,
+          "Bytes": 41881744
+        },
+        {
+          "Name": "embed resources into DLL (Cecil)",
+          "Ms": 633,
+          "Bytes": 74120912
+        }
+      ]
+    },
+    {
+      "Name": "tesserae\u002Btests",
+      "Project": "/home/user/tesserae/Tesserae.Tests/Tesserae.Tests.csproj",
+      "Clean": true,
+      "WallMs": 9644.416,
+      "MinWallMs": 9426.7262,
+      "StdDevMs": 789.710140833484,
+      "NormalisedWallMs": 8643.385454222953,
+      "CpuMs": 28958,
+      "AllocBytes": 995145072,
+      "PeakWorkingSetBytes": 606613504,
+      "Phases": [
+        {
+          "Name": "resolve project (csproj \u002B globs \u002B references)",
+          "Ms": 30,
+          "Bytes": 4084160
+        },
+        {
+          "Name": "build compilation (parse \u002B references)",
+          "Ms": 482,
+          "Bytes": 35736216
+        },
+        {
+          "Name": "scan unsupported features",
+          "Ms": 1906,
+          "Bytes": 105874256
+        },
+        {
+          "Name": "bind \u002B emit .NET assembly",
+          "Ms": 4085,
+          "Bytes": 283199120
+        },
+        {
+          "Name": "  \u251C collect \u002B order types",
+          "Ms": 74,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C emit type bodies (parallel)",
+          "Ms": 1526,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C concatenate type bodies",
+          "Ms": 8,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u2514 reflection metadata (file)",
+          "Ms": 372,
+          "Bytes": 0
+        },
+        {
+          "Name": "emit JavaScript",
+          "Ms": 1972,
+          "Bytes": 366982992
+        },
+        {
+          "Name": "collect package resources (minify \u002B read files)",
+          "Ms": 52,
+          "Bytes": 42747016
+        },
+        {
+          "Name": "embed resources into DLL (Cecil)",
+          "Ms": 634,
+          "Bytes": 90635600
+        },
+        {
+          "Name": "  \u251C reflection metadata (inline)",
+          "Ms": 16,
+          "Bytes": 0
+        },
+        {
+          "Name": "write site (minify \u002B resources \u002B html)",
+          "Ms": 223,
+          "Bytes": 50577720
+        }
+      ]
+    },
+    {
+      "Name": "tesserae\u002Btests-warm",
+      "Project": "/home/user/tesserae/Tesserae.Tests/Tesserae.Tests.csproj",
+      "Clean": false,
+      "WallMs": 4724.3848,
+      "MinWallMs": 4652.8627,
+      "StdDevMs": 217.69888508406157,
+      "NormalisedWallMs": 4234.022968365531,
+      "CpuMs": 12665,
+      "AllocBytes": 297758488,
+      "PeakWorkingSetBytes": 298807296,
+      "Phases": [
+        {
+          "Name": "resolve project (csproj \u002B globs \u002B references)",
+          "Ms": 28,
+          "Bytes": 4091920
+        },
+        {
+          "Name": "build compilation (parse \u002B references)",
+          "Ms": 269,
+          "Bytes": 11492200
+        },
+        {
+          "Name": "scan unsupported features",
+          "Ms": 1546,
+          "Bytes": 49036640
+        },
+        {
+          "Name": "bind \u002B emit .NET assembly",
+          "Ms": 1566,
+          "Bytes": 79783696
+        },
+        {
+          "Name": "  \u251C collect \u002B order types",
+          "Ms": 31,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C emit type bodies (parallel)",
+          "Ms": 651,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C concatenate type bodies",
+          "Ms": 1,
+          "Bytes": 0
+        },
+        {
+          "Name": "  \u251C reflection metadata (inline)",
+          "Ms": 33,
+          "Bytes": 0
+        },
+        {
+          "Name": "emit JavaScript",
+          "Ms": 752,
+          "Bytes": 83156440
+        },
+        {
+          "Name": "collect package resources (minify \u002B read files)",
+          "Ms": 4,
+          "Bytes": 859152
+        },
+        {
+          "Name": "embed resources into DLL (Cecil)",
+          "Ms": 281,
+          "Bytes": 16585528
+        },
+        {
+          "Name": "write site (minify \u002B resources \u002B html)",
+          "Ms": 136,
+          "Bytes": 50663864
+        }
+      ]
+    }
+  ]
+}

--- a/docs/perf/optimized.md
+++ b/docs/perf/optimized.md
@@ -1,0 +1,75 @@
+# Transpose compiler benchmark — final
+
+- **CPU**: Intel(R) Xeon(R) Processor @ 2.80GHz — 4 physical / 4 logical cores
+- **RAM**: 15.7 GB
+- **OS / runtime**: Ubuntu 24.04.4 LTS · .NET 10.0.10 (X64)
+- **CPU features**: `Vector<T>=256bit Vector128.HwAccel Vector256.HwAccel SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512BW FMA BMI1 BMI2 LZCNT POPCNT AES PCLMULQDQ`
+- **CPU score**: **89.6** (100 = reference machine; normalised times are `measured × score/100`)
+- **Configuration**: Debug, 3 measured iteration(s) per scenario
+
+| scenario | wall (median) | normalised | ±stddev | cpu-time | alloc | peak WS |
+|---|--:|--:|--:|--:|--:|--:|
+| `tesserae` | 8.07 s | 7.23 s | 0.10 s | 23.55 s | 686.1 MB | 490.8 MB |
+| `tesserae+tests` | 9.64 s | 8.64 s | 0.79 s | 28.96 s | 949.0 MB | 578.5 MB |
+| `tesserae+tests-warm` | 4.72 s | 4.23 s | 0.22 s | 12.66 s | 284.0 MB | 285.0 MB |
+
+## `tesserae` phase breakdown
+
+| phase | ms | share | alloc |
+|---|--:|--:|--:|
+| resolve project (csproj + globs + references) | 47 | 0.6% | 14.5 MB |
+| build compilation (parse + references) | 396 | 5.0% | 28.9 MB |
+| scan unsupported features | 1,823 | 23.1% | 57.4 MB |
+| bind + emit .NET assembly | 3,258 | 41.3% | 198.9 MB |
+|   &boxvr; collect + order types | 77 |  | 0.0 MB |
+|   &boxvr; emit type bodies (parallel) | 1,161 |  | 0.0 MB |
+|   &boxvr; concatenate type bodies | 7 |  | 0.0 MB |
+|   &boxur; reflection metadata (file) | 401 |  | 0.0 MB |
+| emit JavaScript | 1,689 | 21.4% | 273.8 MB |
+| collect package resources (minify + read files) | 49 | 0.6% | 39.9 MB |
+| embed resources into DLL (Cecil) | 633 | 8.0% | 70.7 MB |
+
+## `tesserae+tests` phase breakdown
+
+| phase | ms | share | alloc |
+|---|--:|--:|--:|
+| resolve project (csproj + globs + references) | 30 | 0.3% | 3.9 MB |
+| build compilation (parse + references) | 482 | 5.1% | 34.1 MB |
+| scan unsupported features | 1,906 | 20.3% | 101.0 MB |
+| bind + emit .NET assembly | 4,085 | 43.5% | 270.1 MB |
+|   &boxvr; collect + order types | 74 |  | 0.0 MB |
+|   &boxvr; emit type bodies (parallel) | 1,526 |  | 0.0 MB |
+|   &boxvr; concatenate type bodies | 8 |  | 0.0 MB |
+|   &boxur; reflection metadata (file) | 372 |  | 0.0 MB |
+| emit JavaScript | 1,972 | 21.0% | 350.0 MB |
+| collect package resources (minify + read files) | 52 | 0.6% | 40.8 MB |
+| embed resources into DLL (Cecil) | 634 | 6.8% | 86.4 MB |
+|   &boxvr; reflection metadata (inline) | 16 |  | 0.0 MB |
+| write site (minify + resources + html) | 223 | 2.4% | 48.2 MB |
+
+## `tesserae+tests-warm` phase breakdown
+
+| phase | ms | share | alloc |
+|---|--:|--:|--:|
+| resolve project (csproj + globs + references) | 28 | 0.6% | 3.9 MB |
+| build compilation (parse + references) | 269 | 5.9% | 11.0 MB |
+| scan unsupported features | 1,546 | 33.7% | 46.8 MB |
+| bind + emit .NET assembly | 1,566 | 34.2% | 76.1 MB |
+|   &boxvr; collect + order types | 31 |  | 0.0 MB |
+|   &boxvr; emit type bodies (parallel) | 651 |  | 0.0 MB |
+|   &boxvr; concatenate type bodies | 1 |  | 0.0 MB |
+|   &boxvr; reflection metadata (inline) | 33 |  | 0.0 MB |
+| emit JavaScript | 752 | 16.4% | 79.3 MB |
+| collect package resources (minify + read files) | 4 | 0.1% | 0.8 MB |
+| embed resources into DLL (Cecil) | 281 | 6.1% | 15.8 MB |
+| write site (minify + resources + html) | 136 | 3.0% | 48.3 MB |
+
+```
+Comparison vs baseline 'baseline' (recorded on Intel(R) Xeon(R) Processor @ 2.80GHz, score 92.5)
+  scenario                   baseline      current        delta    alloc delta
+  ---------------------- ------------ ------------ ------------ --------------
+  tesserae                   15.82 s       7.23 s       -54.3%         -36.9%
+  tesserae+tests             23.16 s       8.64 s       -62.7%         -41.5%
+  tesserae+tests-warm         9.03 s       4.23 s       -53.1%         -46.4%
+  (negative = faster / less allocation than the baseline)
+```

--- a/docs/perf/optimized.md
+++ b/docs/perf/optimized.md
@@ -1,75 +1,78 @@
-# Transpose compiler benchmark — final
+# Transpose compiler benchmark — r2r-debug
 
 - **CPU**: Intel(R) Xeon(R) Processor @ 2.80GHz — 4 physical / 4 logical cores
 - **RAM**: 15.7 GB
 - **OS / runtime**: Ubuntu 24.04.4 LTS · .NET 10.0.10 (X64)
 - **CPU features**: `Vector<T>=256bit Vector128.HwAccel Vector256.HwAccel SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512BW FMA BMI1 BMI2 LZCNT POPCNT AES PCLMULQDQ`
-- **CPU score**: **89.6** (100 = reference machine; normalised times are `measured × score/100`)
+- **CPU score**: **95.2** (100 = reference machine; normalised times are `measured × score/100`)
 - **Configuration**: Debug, 3 measured iteration(s) per scenario
 
 | scenario | wall (median) | normalised | ±stddev | cpu-time | alloc | peak WS |
 |---|--:|--:|--:|--:|--:|--:|
-| `tesserae` | 8.07 s | 7.23 s | 0.10 s | 23.55 s | 686.1 MB | 490.8 MB |
-| `tesserae+tests` | 9.64 s | 8.64 s | 0.79 s | 28.96 s | 949.0 MB | 578.5 MB |
-| `tesserae+tests-warm` | 4.72 s | 4.23 s | 0.22 s | 12.66 s | 284.0 MB | 285.0 MB |
+| `tesserae` | 6.00 s | 5.71 s | 0.09 s | 18.34 s | 604.0 MB | 406.4 MB |
+| `tesserae+tests` | 7.15 s | 6.80 s | 0.08 s | 22.01 s | 828.5 MB | 530.6 MB |
+| `tesserae+tests-warm` | 3.38 s | 3.21 s | 0.18 s | 9.39 s | 238.2 MB | 284.0 MB |
 
 ## `tesserae` phase breakdown
 
 | phase | ms | share | alloc |
 |---|--:|--:|--:|
-| resolve project (csproj + globs + references) | 47 | 0.6% | 14.5 MB |
-| build compilation (parse + references) | 396 | 5.0% | 28.9 MB |
-| scan unsupported features | 1,823 | 23.1% | 57.4 MB |
-| bind + emit .NET assembly | 3,258 | 41.3% | 198.9 MB |
-|   &boxvr; collect + order types | 77 |  | 0.0 MB |
-|   &boxvr; emit type bodies (parallel) | 1,161 |  | 0.0 MB |
-|   &boxvr; concatenate type bodies | 7 |  | 0.0 MB |
-|   &boxur; reflection metadata (file) | 401 |  | 0.0 MB |
-| emit JavaScript | 1,689 | 21.4% | 273.8 MB |
-| collect package resources (minify + read files) | 49 | 0.6% | 39.9 MB |
-| embed resources into DLL (Cecil) | 633 | 8.0% | 70.7 MB |
+| resolve project (csproj + globs + references) | 37 | 0.6% | 14.5 MB |
+| build compilation (parse + references) | 287 | 4.9% | 28.9 MB |
+| scan unsupported features | 1,264 | 21.6% | 56.6 MB |
+| bind + emit .NET assembly | 1,139 | 19.5% | 57.2 MB |
+|   &boxvr; collect + order types | 44 |  | 0.0 MB |
+|   &boxvr; emit type bodies (parallel) | 1,487 |  | 0.0 MB |
+|   &boxvr; concatenate type bodies | 4 |  | 0.0 MB |
+|   &boxur; reflection metadata (file) | 373 |  | 0.0 MB |
+| emit JavaScript | 1,898 | 32.5% | 279.0 MB |
+| body diagnostics (semantic models) | 899 | 15.4% | 75.1 MB |
+| collect package resources (minify + read files) | 60 | 1.0% | 39.9 MB |
+| embed resources into DLL (Cecil) | 257 | 4.4% | 51.6 MB |
 
 ## `tesserae+tests` phase breakdown
 
 | phase | ms | share | alloc |
 |---|--:|--:|--:|
-| resolve project (csproj + globs + references) | 30 | 0.3% | 3.9 MB |
-| build compilation (parse + references) | 482 | 5.1% | 34.1 MB |
-| scan unsupported features | 1,906 | 20.3% | 101.0 MB |
-| bind + emit .NET assembly | 4,085 | 43.5% | 270.1 MB |
-|   &boxvr; collect + order types | 74 |  | 0.0 MB |
-|   &boxvr; emit type bodies (parallel) | 1,526 |  | 0.0 MB |
-|   &boxvr; concatenate type bodies | 8 |  | 0.0 MB |
-|   &boxur; reflection metadata (file) | 372 |  | 0.0 MB |
-| emit JavaScript | 1,972 | 21.0% | 350.0 MB |
-| collect package resources (minify + read files) | 52 | 0.6% | 40.8 MB |
-| embed resources into DLL (Cecil) | 634 | 6.8% | 86.4 MB |
+| resolve project (csproj + globs + references) | 22 | 0.3% | 3.9 MB |
+| build compilation (parse + references) | 359 | 5.2% | 34.0 MB |
+| scan unsupported features | 1,438 | 20.9% | 98.1 MB |
+| bind + emit .NET assembly | 1,185 | 17.2% | 61.4 MB |
+|   &boxvr; collect + order types | 61 |  | 0.0 MB |
+|   &boxvr; emit type bodies (parallel) | 1,814 |  | 0.0 MB |
+|   &boxvr; concatenate type bodies | 4 |  | 0.0 MB |
+|   &boxur; reflection metadata (file) | 328 |  | 0.0 MB |
+| emit JavaScript | 2,242 | 32.5% | 355.6 MB |
+| body diagnostics (semantic models) | 1,150 | 16.7% | 114.8 MB |
+| collect package resources (minify + read files) | 47 | 0.7% | 40.7 MB |
+| embed resources into DLL (Cecil) | 323 | 4.7% | 55.1 MB |
 |   &boxvr; reflection metadata (inline) | 16 |  | 0.0 MB |
-| write site (minify + resources + html) | 223 | 2.4% | 48.2 MB |
+| write site (minify + resources + html) | 128 | 1.9% | 48.4 MB |
 
 ## `tesserae+tests-warm` phase breakdown
 
 | phase | ms | share | alloc |
 |---|--:|--:|--:|
-| resolve project (csproj + globs + references) | 28 | 0.6% | 3.9 MB |
-| build compilation (parse + references) | 269 | 5.9% | 11.0 MB |
-| scan unsupported features | 1,546 | 33.7% | 46.8 MB |
-| bind + emit .NET assembly | 1,566 | 34.2% | 76.1 MB |
-|   &boxvr; collect + order types | 31 |  | 0.0 MB |
-|   &boxvr; emit type bodies (parallel) | 651 |  | 0.0 MB |
+| resolve project (csproj + globs + references) | 21 | 0.6% | 3.9 MB |
+| build compilation (parse + references) | 189 | 5.7% | 10.9 MB |
+| scan unsupported features | 952 | 28.8% | 44.0 MB |
+| bind + emit .NET assembly | 365 | 11.0% | 4.6 MB |
+|   &boxvr; collect + order types | 38 |  | 0.0 MB |
+|   &boxvr; emit type bodies (parallel) | 814 |  | 0.0 MB |
 |   &boxvr; concatenate type bodies | 1 |  | 0.0 MB |
-|   &boxvr; reflection metadata (inline) | 33 |  | 0.0 MB |
-| emit JavaScript | 752 | 16.4% | 79.3 MB |
-| collect package resources (minify + read files) | 4 | 0.1% | 0.8 MB |
-| embed resources into DLL (Cecil) | 281 | 6.1% | 15.8 MB |
-| write site (minify + resources + html) | 136 | 3.0% | 48.3 MB |
+|   &boxvr; reflection metadata (inline) | 26 |  | 0.0 MB |
+| emit JavaScript | 887 | 26.8% | 81.0 MB |
+| body diagnostics (semantic models) | 534 | 16.2% | 39.7 MB |
+| collect package resources (minify + read files) | 98 | 3.0% | 0.8 MB |
+| embed resources into DLL (Cecil) | 119 | 3.6% | 3.6 MB |
+| write site (minify + resources + html) | 141 | 4.3% | 48.5 MB |
 
 ```
 Comparison vs baseline 'baseline' (recorded on Intel(R) Xeon(R) Processor @ 2.80GHz, score 92.5)
   scenario                   baseline      current        delta    alloc delta
   ---------------------- ------------ ------------ ------------ --------------
-  tesserae                   15.82 s       7.23 s       -54.3%         -36.9%
-  tesserae+tests             23.16 s       8.64 s       -62.7%         -41.5%
-  tesserae+tests-warm         9.03 s       4.23 s       -53.1%         -46.4%
+  tesserae                   15.82 s       5.71 s       -63.9%         -44.4%
+  tesserae+tests             23.16 s       6.80 s       -70.6%         -48.9%
+  tesserae+tests-warm         9.03 s       3.21 s       -64.4%         -55.0%
   (negative = faster / less allocation than the baseline)
 ```


### PR DESCRIPTION
Compiling a clean-slate Tesserae goes from **15.82s to 5.71s (−63.9%)**, and Tesserae + its test project from **23.16s to 6.80s (−70.6%)**; a warm build is 9.03s → 3.21s (−64.4%) and allocations are down 44–55%. All timings are medians of 3, normalised by the CPU score so they are comparable across machines, measured against `79fcfc1`.

Two gates held for every change: the emitted site stays **byte-identical** (`diff -r` against a baseline compiler — output had to be made reproducible first), and the test suite stays green (**522 passed, 0 failed**, up from 499).

## Build performance

**Runtime configuration** — the two largest wins, both measured with `tps-bench`:

- **TieredPGO off (~25–30%).** PGO instruments tier-0 code to build a profile, and Roslyn's binder is exactly what instrumentation taxes hardest — but a compile ends in seconds, long before the better tier-1 code pays that tax back. Neutral on a one-file project. Tiered compilation itself stays *on*: disabling it entirely is faster on a big project but 2.3× slower on a small one.
- **Server GC (~15%).** A build makes ~900 MB of short-lived garbage across several parallel phases; on Workstation GC each collection stalls every worker.

These live in `Transpose.Compiler.csproj` and `runtimeconfig.template.json` and are load-bearing — together worth ~40% of a build.

**Compiler changes:**

- `UnsupportedFeatureScanner` screened its hottest path. `VisitIdentifierName` ran a semantic query on nearly every identifier; it now screens the identifier's text against the simple names of the types it would actually reject, precomputed per compilation. Sound rather than heuristic: `var` stays in the set so inferred types are still caught, and using-aliases / `using static` widen the set for their file. Same prefiltering for `DllImport` attributes and span constant-patterns. **2661 ms → 684 ms, 150 MB → 27 MB.**
- **Naming layer cached and de-LINQed** — member JS names, base names and interface-member lookups memoised, and the LINQ walks in the hot paths replaced with pattern-matching loops. **JS emit 2.3× faster.**
- Diagnostics now come from `Compilation.Emit` rather than a separate `GetDiagnostics` pass when an assembly is emitted (a failed emit falls back, since it stops before method bodies when declarations already err).
- Parsing and type collection parallelised (both per-file independent), preserving input order so bundle order is unchanged.
- One semantic-model cache (`TreeModel`) shared by the unsupported-feature scan and every emitter clone, so a member bound by the scan is already bound when the emitter reaches it.
- The package DLL is written once instead of twice.

**Reproducible output:** enumerator temporaries were named from `SyntaxNode.GetHashCode()`, a reference hash, so an unchanged project emitted a different bundle on every build. They now derive from the statement's span start — which is what makes the `diff -r` gate usable at all.

## Metadata-only assemblies, and refusing to pack one

Debug now emits a **metadata-only** assembly by default (full metadata, `throw null` bodies) — ~18% faster, and sound because a Transpose assembly binds against the stand-in BCL and can never execute. `--metadata-only-assembly` / `--no-metadata-only-assembly` override it, as does a project property.

Since such an assembly must never ship, the SDK refuses to package a Debug build: `GeneratePackageOnBuild` is forced off and `dotnet pack -c Debug` fails with **TPS1001**. The guard runs `BeforeTargets="GenerateNuspec;Pack"` — on `Pack` alone it fired *after* the `.nupkg` was already on disk.

## ReadyToRun, and CI that keeps it

Every invocation paid ~2.2s of pure JIT before doing any work (the floor for a one-file project). `TransposePackRidSpecificTools=true` makes one `dotnet pack` produce a ReadyToRun `Transpose.Compiler.<rid>` package per RID plus the outer selector package, so `dotnet tool install Transpose.Compiler` resolves the right one — verified end-to-end, including cross-OS/cross-arch crossgen2 from a Linux host, and that the installed tool's payload really is R2R. Worth **~1s off every invocation**.

`.devops/build-transpose-compiler.yml` gates on `tps-bench --verify-r2r` over the produced `.nupkg`s before pushing, so R2R cannot be lost silently. New `.devops/benchmark-transpose-compiler.yml` publishes an R2R compiler and benchmarks the `benchmarks/tesserae` submodule nightly in Debug and Release against `docs/perf/optimized.json`; it reports regressions but deliberately does not fail on them, since the hosted pool is too noisy to gate on.

Both Linux pipelines are pinned to **`ubuntu-22.04`**, not `ubuntu-latest`: `NuGetCommand@2` runs on Mono and the hosted images dropped Mono in 24.04, which fails the push. Should that image be retired, the fix is to replace the push with `dotnet nuget push` (no Mono) rather than bumping the image forward.

## Four bug fixes

**Every compilation error is now reported.** The error list was capped at 40, so a broken project took several compile cycles to fix and you could not tell whether the errors you could not see were the same problem or a different one. `--max-errors` now defaults to `0` (unlimited); a positive value still caps and says so. Ordering (file, then line, then column, then id) moved into a testable helper, and the runtime build no longer hardcodes 40.

**Diagnostics are in MSBuild's canonical format, so they reach the build.** `tps` printed `Main.cs(17,20): CS0103: <text>` — which reads like a diagnostic but matches nothing, because MSBuild scans a tool's output for `Origin : Subcategory Category Code : Text` and the mandatory `error`/`warning` category was absent. Every compile error was therefore invisible: on a project with two undefined names `dotnet build` reported exactly *one* error, MSB3073 "exited with code 1", while the real errors scrolled past as text no IDE could navigate to.

Everything now goes through `MsBuildDiagnostic`: the category is emitted, the path is made absolute (a relative one resolves against the *caller's* working directory) and keeps its 1-based `(line,column)`; tool-level failures — bad command line, unresolvable project, crash — are attributed to `tps` with a `TPS####` code instead of bare text; messages are flattened to one line, because MSBuild matches per line and would truncate a wrapped one; and warnings are printed in full rather than merely counted, so they reach the task list too.

The inverse matters as much — a *non*-diagnostic line that parses becomes an error nobody wrote — so the summary is worded `N error(s), by id: …` and never `N error(s):`, and the tests check both directions against the regex MSBuild itself applies (copied verbatim from `CanonicalError`).

Verified against real MSBuild rather than by inspection: piping `tps` output through an `Exec` task promotes all five diagnostics to build errors with file and line, from **both** stdout and stderr, and picks up none of the progress, timing or summary lines. End-to-end through the *shipped* Transpose SDK, the same broken project goes from 1 reported error to 3 — the two real `CS0103`s plus `MSB3073`.

**An `await` inside an expression IIFE no longer produces unparsable JavaScript.** `(await Query()).Nodes.TryGetFirst(out var n)` emitted a *plain* arrow containing an `await`, which is a JavaScript **syntax** error — so the whole bundle failed to parse, not just that call. The emitter handled this, but only for an awaited *argument* of an out/ref call; here the await is in the call's **receiver**, which lands inside the same holder IIFE.

Auditing the other wrappers found the same break in five more places, each reachable from ordinary async C#: a reordered named argument list (`M(c: await X(), a: await Y())`), an object/collection initializer (`new T(await A()) { P = await B() }`), building a concrete collection (`List<int> xs = [await X(), 2]`), a params collection (`Sum(await X(), 5, await Y())`), and a throw expression (`s ?? throw new E(await Msg())`).

All six now go through a shared `OpenIife`/`CloseIife` pair that takes the syntax emitted *inside* the wrapper and switches to `(await (async () => { … })())` when it contains an await in this async context. Passing the operands rather than the whole expression keeps output unchanged wherever the bug did not apply — the tesserae and tesserae-tests bundles are byte-identical before and after. A repro covering all seven shapes fails `node --check` before the fix and afterwards runs in Node to exactly the string native .NET prints.

**`<Import Project="…"/>` is followed.** This is how **shared projects** work — a `.shproj`'s companion `.projitems` holds the `<Compile>` items and every consumer imports it. `tps` reads the csproj as raw XML, so imports were invisible and all of that source silently vanished, failing with "type or namespace not found" for code that plainly existed.

New `ProjectXml` flattens a project and its transitive imports into one queryable view, keeping each element paired with the directory of the file that *declared* it — because MSBuild's two directory rules differ and a `.projitems` depends on both:

- `$(MSBuildThisFileDirectory)` → the declaring file's directory (trailing separator preserved)
- a plain relative `Include` → the *project* directory

Project-own elements come first, so the project's own property wins over an imported one. An import that cannot be resolved — a `$(MSBuildToolsPath)`-style SDK-internal one, or a missing file — is skipped rather than fatal, which is also what keeps SDK internals out. `IsPackageUpToDate` now stats the imported files too, so editing a `.projitems` invalidates the build. MSBuild evaluation stays deliberately shallow otherwise: conditions and arbitrary properties are still not evaluated.

## Tooling and docs

- **`Transpose.Bench` (`tps-bench`)** — prints CPU model / cores / RAM / ISA support, scores the machine with a short deterministic CPU+memory benchmark, then times clean-slate builds (wiping the bin/obj of the whole project closure) and reports wall/CPU time, allocations, peak working set and the per-phase breakdown, both raw and normalised. `ab.sh` interleaves two compilers for A/B. `--verify-r2r` inspects a build tree or a set of `.nupkg`s.
- `--timing` now reports per-phase allocations and GC/memory totals; `--timing-json` writes them machine-readably.
- `TODO.optimization.md` logs everything tried — **including what did not work**: parallelising scan∥emit and JS-emit∥asm-emit were both *slower* on 4 cores, and `JsWriter` pooling and a `ToDisplayString` cache both measured flat. Recorded reports live in `docs/perf/`.
- New **`transpose-performance`** skill with the harness, the profiling recipes, the correctness gate, and the measurement traps on this hardware (the host drifts 20–40% over minutes, so a single run means nothing).
- `benchmarks/tesserae` added as a submodule; `CLAUDE.md` updated throughout, including the diagnostic-format contract and the never-emit-a-raw-IIFE rule.

## Testing

- `522 passed, 0 failed, 17 skipped` (was 499).
- 8 tests in `ProjectImportTests.cs` (6 import + 2 error-reporting), 8 in `MsBuildDiagnosticFormatTests.cs`, and 7 in `EmitRegressionTests.cs` for the await-IIFE shapes. Every one of them was confirmed to **fail** against the commit before its fix.
- `NoPlainArrowIifeWrapsAnAwait` scans the emitted JavaScript for the invariant itself, so a new IIFE site added later without the async form is caught.
- Site output verified byte-identical for each change (the tesserae bundle, 2,139,782 bytes, and the tesserae-tests bundle, compare equal before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1UKt1G8NiLkgXWJKKgRUb