### PR TITLE
Print diagnostics in MSBuild's canonical format so errors reach the b…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,33 @@ property is not guessed at: such an import or item is skipped, which is why SDK-
 `--metadata-only-assembly` / `--no-metadata-only-assembly`,
 `--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line).
 
+### Diagnostics are in MSBuild's canonical format
+
+Every error and warning `tps` prints goes through `MsBuildDiagnostic` (`Transpose.Compiler`), which
+writes the [canonical MSBuild/Visual Studio
+form](https://learn.microsoft.com/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks)
+`Origin : Subcategory Category Code : Text`:
+
+```
+/src/App/Main.cs(17,20): error CS0103: The name 'x' does not exist in the current context
+tps : error TPS0002: No .csproj found at '/src/Nope'.
+```
+
+MSBuild scans a tool's stdout **and** stderr line by line and promotes matching lines to real build
+errors/warnings, so this is what makes a `tps` compile error land in the IDE's error list, navigable
+to the file and line, instead of scrolling past as console text. Three rules follow from that:
+
+- The **`error`/`warning` category is mandatory** and the file must be an **absolute** path — a
+  relative one is resolved against the caller's working directory. Diagnostics with no source
+  location are attributed to the tool (`tps`), with a `TPS####` code (errors `TPS0001`–`TPS0099`,
+  warnings from `TPS0100`; the codes are a shipped contract, so retire rather than reuse one).
+- The text must be **one line**; MSBuild matches per line, so a multi-line message would be
+  truncated. A crash reports its exception chain on the diagnostic line and the stack frames
+  separately.
+- Everything else `tps` prints — progress, `--timing` tables, the "N error(s)" summary — must **not**
+  match, or a build grows errors nobody wrote. `MsBuildDiagnosticFormatTests` guards both directions
+  against MSBuild's own regex.
+
 ## Performance
 
 A clean build's cost, and how to measure it, is documented in **`TODO.optimization.md`** (the running

--- a/Transpose/Transpose.Compiler/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler/MsBuildDiagnostic.cs
@@ -1,0 +1,128 @@
+using Microsoft.CodeAnalysis;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// Formats every error and warning <c>tps</c> prints in the canonical MSBuild / Visual Studio
+/// diagnostic format, so a build that shells out to <c>tps</c> gets first-class errors and warnings
+/// instead of anonymous console text.
+///
+/// MSBuild scans a tool's stdout and stderr line by line and promotes anything matching this
+/// five-part shape to a real build error or warning (see
+/// <see href="https://learn.microsoft.com/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks"/>):
+///
+/// <code>
+///   Origin : Subcategory Category Code : Text
+///
+///   /src/App/Main.cs(17,20): error CS0103: The name 'x' does not exist in the current context
+///   tps : error TPS0002: No .csproj found at '/src/Nope'.
+/// </code>
+///
+/// The parts that matter here:
+///
+///   * <b>Origin</b> — the source file, as an **absolute** path plus <c>(line,column)</c> (1-based),
+///     which is what lets a double-click in the IDE jump to the offending line. Relative paths are
+///     legal but are resolved against the caller's working directory, so an absolute one is the only
+///     spelling that always lands in the right file. A diagnostic with no source location uses the
+///     tool name instead — locale-neutral, as the format requires.
+///   * <b>Category</b> — literally <c>error</c> or <c>warning</c>. This is the part that was missing
+///     before: <c>Main.cs(17,20): CS0103: …</c> looks like a diagnostic to a human but matches
+///     nothing, so every compile error was invisible to MSBuild and the IDE.
+///   * <b>Code</b> — the diagnostic id. Must contain no spaces.
+///   * <b>Text</b> — one line. MSBuild matches per line, so a message that wraps would have its tail
+///     dropped (or worse, parsed as another diagnostic); <see cref="SingleLine"/> flattens it.
+///
+/// Anything else <c>tps</c> prints — progress, phase timings, the "N error(s)" summary — must *not*
+/// look like a diagnostic, or MSBuild invents build errors out of the compiler's own chatter. The rule
+/// to keep in mind when adding output: a line is at risk when the word <c>error</c> or <c>warning</c>
+/// is preceded only by a colon-free run ending in a space (or starts the line) *and* is followed by a
+/// colon — <c>"warning: could not write …"</c> matches, whereas <c>"3 error(s), by id: CS0103×2"</c>
+/// does not, because the parser needs the colon right after the category and its optional code.
+/// MsBuildDiagnosticFormatTests guards both directions.
+/// </summary>
+internal static class MsBuildDiagnostic
+{
+    /// <summary>Origin for a diagnostic that has no source location. Locale-neutral by contract.</summary>
+    public const string ToolName = "tps";
+
+    // Codes for the compiler's own diagnostics — the ones that are not Roslyn's and so have no id of
+    // their own. TPS0001-0099 are errors, TPS0100+ warnings. They are part of the tool's contract
+    // once shipped (a build can suppress or escalate by code), so retire a code rather than reuse it.
+    public const string CodeInvalidCommandLine     = "TPS0001";
+    public const string CodeProjectNotFound        = "TPS0002";
+    public const string CodeProjectResolveFailed   = "TPS0003";
+    public const string CodeInternalError          = "TPS0004";
+    public const string CodeDependencyBuildFailed  = "TPS0005";
+    public const string CodeAssemblyEmitFailed     = "TPS0006";
+    public const string CodeReferenceNotFound      = "TPS0100";
+    public const string CodeMissingRuntimeBundle   = "TPS0101";
+    public const string CodeTimingJsonNotWritten   = "TPS0102";
+
+    /// <summary>Formats a Roslyn diagnostic, pointing at its source location when it has one.</summary>
+    public static string Format(Diagnostic d)
+    {
+        var span = d.Location.GetLineSpan();
+        var category = d.Severity == DiagnosticSeverity.Error ? "error" : "warning";
+        return string.IsNullOrEmpty(span.Path)
+            ? Format(category, d.Id, d.GetMessage())
+            : Format(category, d.Id, d.GetMessage(), span.Path,
+                     span.StartLinePosition.Line + 1, span.StartLinePosition.Character + 1);
+    }
+
+    /// <summary>
+    /// Formats one diagnostic line. Pass <paramref name="filePath"/> to point at a file (with
+    /// <paramref name="line"/>/<paramref name="column"/> 1-based, or 0 to omit the position);
+    /// omit it for a tool-level diagnostic, which is attributed to <see cref="ToolName"/>.
+    /// </summary>
+    public static string Format(string category, string code, string text,
+                               string? filePath = null, int line = 0, int column = 0)
+    {
+        // A file origin is written tight against the colon (`Main.cs(17,20): error CS0103: …`), the way
+        // csc writes it; the tool origin keeps the spaced form the documentation uses for a tool name
+        // (`cl : Command line warning D4024 : …`). Both parse identically.
+        var origin = $"{ToolName} ";
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            origin = AbsolutePath(filePath!);
+            if (line > 0) origin += column > 0 ? $"({line},{column})" : $"({line})";
+        }
+        // A diagnostic with no text at all parses but tells the user nothing, so say something.
+        var message = SingleLine(text);
+        return $"{origin}: {category} {code}: {(message.Length == 0 ? "(no message)" : message)}";
+    }
+
+    /// <summary>Writes an error for a failure that is not tied to a source file.</summary>
+    public static void WriteError(string code, string text)
+        => Console.Error.WriteLine(Format("error", code, text));
+
+    /// <summary>Writes a warning for a condition that is not tied to a source file. Warnings go to
+    /// stdout — they are not failures, and MSBuild parses both streams alike.</summary>
+    public static void WriteWarning(string code, string text)
+        => Console.WriteLine(Format("warning", code, text));
+
+    /// <summary>
+    /// Collapses a message to a single line: MSBuild parses line by line, so a newline in the middle
+    /// of a message would truncate it (an exception's stack trace is the usual culprit).
+    /// </summary>
+    public static string SingleLine(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "";
+        var sb = new System.Text.StringBuilder(text.Length);
+        var pendingSpace = false;
+        foreach (var c in text)
+        {
+            if (char.IsWhiteSpace(c)) { pendingSpace = sb.Length > 0; continue; }
+            if (pendingSpace) { sb.Append(' '); pendingSpace = false; }
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>The absolute form of a source path, which is what makes a diagnostic navigable. Falls
+    /// back to the path as given if it cannot be rooted (an in-memory tree name, say).</summary>
+    private static string AbsolutePath(string path)
+    {
+        try { return Path.GetFullPath(path); }
+        catch { return path; }
+    }
+}

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -61,7 +61,12 @@ public static class Program
                 case "--project" or "-p": projectArg = args[++i]; break;
                 default:
                     if (projectArg is null) projectArg = args[i];
-                    else { Console.Error.WriteLine($"Unexpected argument: {args[i]}"); return 1; }
+                    else
+                    {
+                        MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInvalidCommandLine,
+                            $"Unexpected argument '{args[i]}'.");
+                        return 1;
+                    }
                     break;
             }
         }
@@ -70,7 +75,8 @@ public static class Program
         var csproj = LocateProject(projectArg);
         if (csproj is null)
         {
-            Console.Error.WriteLine($"No .csproj found at '{projectArg}'.");
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectNotFound,
+                $"No .csproj found at '{projectArg}'.");
             return 1;
         }
 
@@ -116,7 +122,8 @@ public static class Program
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Failed to resolve project: {ex.Message}");
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
+                $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
             return 1;
         }
 
@@ -127,7 +134,9 @@ public static class Program
         {
             var full = Path.GetFullPath(r);
             if (File.Exists(full) && !project.ReferencePaths.Contains(full)) project.ReferencePaths.Add(full);
-            else if (!File.Exists(full)) Console.Error.WriteLine($"  warning: --reference not found: {full}");
+            else if (!File.Exists(full))
+                MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeReferenceNotFound,
+                    $"--reference not found: {full}");
         }
         foreach (var d in extraDefines)
             if (!project.DefineConstants.Contains(d)) project.DefineConstants.Add(d);
@@ -203,7 +212,7 @@ public static class Program
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Translator threw: {ex}");
+            ReportCrash("Translator", ex);
             return 2;
         }
 
@@ -288,7 +297,7 @@ public static class Program
                 project.Sources, project.AssemblyName, project.DefineConstants,
                 project.LanguageVersion, reflectionEnabled);
         }
-        catch (Exception ex) { Console.Error.WriteLine($"Runtime build threw: {ex}"); return 2; }
+        catch (Exception ex) { ReportCrash("Runtime build", ex); return 2; }
 
         if (!result.Success)
         {
@@ -360,7 +369,12 @@ public static class Program
         // corlib when compiling user code against it (every type would fail with CS0518).
         byte[] assemblyBytes;
         try { assemblyBytes = result.EmitAssembly!(bundles); }
-        catch (Exception ex) { Console.Error.WriteLine($"Runtime assembly emit failed: {ex.Message}"); return 2; }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeAssemblyEmitFailed,
+                $"Runtime assembly emit failed: {ex.Message}");
+            return 2;
+        }
         File.WriteAllBytes(dllPath, assemblyBytes);
 
         Console.WriteLine($"\nOK — built runtime {Path.GetFileName(dllPath)} with {bundles.Count} embedded bundle(s) in {sw.ElapsedMilliseconds} ms.");
@@ -434,7 +448,11 @@ public static class Program
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
             File.WriteAllText(path, sb.ToString());
         }
-        catch (Exception ex) { Console.Error.WriteLine($"  warning: could not write --timing-json: {ex.Message}"); }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeTimingJsonNotWritten,
+                $"could not write --timing-json: {ex.Message}");
+        }
     }
 
     private static string JsonString(string s)
@@ -477,7 +495,8 @@ public static class Program
             Console.WriteLine($"  building dependency: {name}");
             if (!BuildPackage(dep, configuration, maxErrors, metadataOnlyAssembly))
             {
-                Console.Error.WriteLine($"  dependency build FAILED: {name}");
+                MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeDependencyBuildFailed,
+                    $"Failed to build referenced project '{name}'.");
                 return false;
             }
         }
@@ -491,7 +510,12 @@ public static class Program
     {
         ResolvedProject project;
         try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
-        catch (Exception ex) { Console.Error.WriteLine($"    resolve failed: {ex.Message}"); return false; }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
+                $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
+            return false;
+        }
 
         var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
         var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
@@ -511,7 +535,7 @@ public static class Program
                                       ?? project.MetadataOnlyAssembly
                                       ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration));
         }
-        catch (Exception ex) { Console.Error.WriteLine($"    translator threw: {ex.Message}"); return false; }
+        catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex); return false; }
 
         if (!result.Success)
         {
@@ -569,7 +593,8 @@ public static class Program
             if (found.Length == 1) return Path.GetFullPath(found[0]);
             if (found.Length > 1)
             {
-                Console.Error.WriteLine($"Multiple .csproj files in '{arg}'; pass one explicitly.");
+                MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInvalidCommandLine,
+                    $"Multiple .csproj files in '{arg}'; pass one explicitly.");
                 return null;
             }
         }
@@ -605,26 +630,54 @@ public static class Program
 
         if (errors.Count > 0)
         {
-            Console.Error.WriteLine($"\n{errors.Count} error(s):");
+            // The summary lines are deliberately not in diagnostic form, and must stay that way: any
+            // line MSBuild can parse becomes a build error, so a summary could otherwise conjure an
+            // error nobody wrote. See MsBuildDiagnostic for the shape to avoid — writing the count as
+            // "N error(s), by id: …" rather than "N error(s):" keeps a colon from ever landing where
+            // the parser expects one.
             var byId = errors.GroupBy(d => d.Id).OrderByDescending(g => g.Count());
-            Console.Error.WriteLine("  by id: " + string.Join(", ", byId.Select(g => $"{g.Key}×{g.Count()}")));
+            Console.Error.WriteLine();
+            Console.Error.WriteLine($"{errors.Count} error(s), by id: "
+                + string.Join(", ", byId.Select(g => $"{g.Key}×{g.Count()}")));
             Console.Error.WriteLine();
             var shown = maxErrors > 0 ? errors.Take(maxErrors) : errors;
             foreach (var d in shown)
-                Console.Error.WriteLine("  " + Format(d));
+                Console.Error.WriteLine(MsBuildDiagnostic.Format(d));
             if (maxErrors > 0 && errors.Count > maxErrors)
-                Console.Error.WriteLine($"  … and {errors.Count - maxErrors} more (raise or drop --max-errors to see them).");
+                Console.Error.WriteLine($"… and {errors.Count - maxErrors} more (raise or drop --max-errors to see them)");
         }
 
+        // Warnings are printed in full too, not just counted: in canonical form they reach the IDE's
+        // task list, where a count on the console never would.
+        foreach (var d in warnings)
+            Console.WriteLine(MsBuildDiagnostic.Format(d));
         if (warnings.Count > 0)
-            Console.WriteLine($"\n{warnings.Count} warning(s).");
+            Console.WriteLine($"{warnings.Count} warning(s) total");
     }
 
-    private static string Format(Diagnostic d)
+    /// <summary>
+    /// Reports an unhandled exception from the translator as a single diagnostic — a crash is a build
+    /// failure the caller must see, and MSBuild only sees a line it can parse. The messages of the
+    /// whole exception chain go into that one line; the stack frames follow as plain text, since they
+    /// are what makes a crash actionable but cannot fit on one line.
+    ///
+    /// The frames are printed on their own rather than via <c>ex.ToString()</c> deliberately: an
+    /// exception message that happens to read like "... error: ..." would be parsed as a *second*
+    /// diagnostic, and frames alone can never match.
+    /// </summary>
+    private static void ReportCrash(string what, Exception ex)
     {
-        var loc = d.Location.GetLineSpan();
-        var file = string.IsNullOrEmpty(loc.Path) ? "" : $"{Path.GetFileName(loc.Path)}({loc.StartLinePosition.Line + 1},{loc.StartLinePosition.Character + 1}): ";
-        return $"{file}{d.Id}: {d.GetMessage()}";
+        var chain = new List<string>();
+        for (var e = ex; e is not null; e = e.InnerException)
+            chain.Add($"{e.GetType().Name}: {e.Message}");
+        MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInternalError,
+            $"{what} threw {string.Join(" ---> ", chain)}");
+
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (!ReferenceEquals(e, ex)) Console.Error.WriteLine($"--- inner {e.GetType().FullName}");
+            Console.Error.WriteLine(e.StackTrace);
+        }
     }
 
     private static void ShowHelp()

--- a/Transpose/Transpose.Compiler/RuntimeAssembler.cs
+++ b/Transpose/Transpose.Compiler/RuntimeAssembler.cs
@@ -49,7 +49,12 @@ internal static class RuntimeAssembler
                 var rel = f.GetString();
                 if (string.IsNullOrEmpty(rel)) continue;
                 var path = Path.Combine(projectDir, rel!.Replace('\\', '/'));
-                if (!File.Exists(path)) { System.Console.Error.WriteLine($"  warning: runtime bundle file missing: {rel}"); continue; }
+                if (!File.Exists(path))
+                {
+                    MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeMissingRuntimeBundle,
+                        $"runtime bundle file missing: {rel}");
+                    continue;
+                }
                 if (remark.Length > 0) sb.Append(remark.Replace("{name}", Path.GetFileName(path)));
                 sb.Append(File.ReadAllText(path));
             }

--- a/Transpose/Transpose.Translator.Tests/MsBuildDiagnosticFormatTests.cs
+++ b/Transpose/Transpose.Translator.Tests/MsBuildDiagnosticFormatTests.cs
@@ -1,0 +1,162 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Pins the console format of every error and warning <c>tps</c> prints to the canonical
+/// MSBuild/Visual Studio diagnostic format, so a build that shells out to <c>tps</c> gets real
+/// errors and warnings instead of anonymous text (see <see cref="MsBuildDiagnostic"/>).
+///
+/// The oracle is MSBuild's own parser: <see cref="Canonical"/> is the regular expression
+/// <c>CanonicalError.Parse</c> applies to each line of a tool's output, copied verbatim from
+/// <c>Microsoft.Build.Utilities.Core</c>. Matching it is the whole contract — a diagnostic line that
+/// does not match is invisible to the build, and a *non*-diagnostic line that does match becomes a
+/// build error invented out of the compiler's own chatter, which is why both directions are tested.
+/// </summary>
+[TestClass]
+public sealed class MsBuildDiagnosticFormatTests
+{
+    /// <summary>
+    /// Verbatim from MSBuild's <c>CanonicalError</c> (the origin/category/code/text form):
+    /// <c>Origin : Subcategory Category Code : Text</c>. Case-insensitive, as MSBuild applies it.
+    /// </summary>
+    private const string Canonical =
+        @"^\s*(((?<ORIGIN>(((\d+>)?[a-zA-Z]?:[^:]*)|([^:]*))):)|())(?<SUBCATEGORY>(()|([^:]*? )))(?<CATEGORY>(error|warning))( \s*(?<CODE>[^: ]*))?\s*:(?<TEXT>.*)$";
+
+    private static Match Parse(string line) => Regex.Match(line, Canonical, RegexOptions.IgnoreCase);
+
+    /// <summary>The first error Roslyn reports for a snippet, so the test formats a real diagnostic
+    /// (with a real location and message) rather than a hand-built stand-in.</summary>
+    private static Diagnostic FirstError(string fileName, string code)
+        => new RoslynTranslator().Translate(new[] { (fileName, code) }, "FmtTest")
+            .Errors.First(d => d.Id == "CS0103");
+
+    [TestMethod]
+    public void ADiagnosticWithASourceLocationIsParsedByMsBuild()
+    {
+        var d = FirstError("Main.cs", "public class C { public int M() { return Missing(); } }");
+        var line = MsBuildDiagnostic.Format(d);
+
+        var m = Parse(line);
+        Assert.IsTrue(m.Success, $"MSBuild would not recognise this as a diagnostic: {line}");
+        Assert.AreEqual("error", m.Groups["CATEGORY"].Value, "category must be literally 'error'");
+        Assert.AreEqual("CS0103", m.Groups["CODE"].Value);
+        StringAssert.Contains(m.Groups["TEXT"].Value, "does not exist");
+
+        // The origin is what makes the diagnostic navigable: a file, then its 1-based line/column.
+        StringAssert.Matches(m.Groups["ORIGIN"].Value, new Regex(@"Main\.cs\(1,4[0-9]\)$"),
+            "origin must be the file with a (line,column) position");
+    }
+
+    [TestMethod]
+    public void TheSourcePathIsAbsolute()
+    {
+        // A relative path is legal but is resolved against the caller's working directory, which is not
+        // ours to assume — only an absolute path always lands in the right file when double-clicked.
+        var line = MsBuildDiagnostic.Format("error", "CS0103", "nope", Path.Combine("sub", "Main.cs"), 3, 9);
+
+        var origin = Parse(line).Groups["ORIGIN"].Value;
+        Assert.IsTrue(Path.IsPathRooted(origin), $"origin must be rooted: {origin}");
+        StringAssert.EndsWith(origin, $"Main.cs(3,9)");
+    }
+
+    [TestMethod]
+    public void AToolLevelDiagnosticIsAttributedToTheToolAndStillParses()
+    {
+        var line = MsBuildDiagnostic.Format("error", MsBuildDiagnostic.CodeProjectNotFound,
+            "No .csproj found at '/nope'.");
+
+        var m = Parse(line);
+        Assert.IsTrue(m.Success, $"MSBuild would not recognise this as a diagnostic: {line}");
+        Assert.AreEqual("tps", m.Groups["ORIGIN"].Value.Trim(), "a tool-level diagnostic names the tool");
+        Assert.AreEqual("error", m.Groups["CATEGORY"].Value);
+        Assert.AreEqual("TPS0002", m.Groups["CODE"].Value);
+    }
+
+    [TestMethod]
+    public void AWarningIsCategorisedAsAWarning()
+    {
+        var d = Microsoft.CodeAnalysis.Diagnostic.Create(
+            new DiagnosticDescriptor("TPS9999", "t", "a warning message", "c", DiagnosticSeverity.Warning, true),
+            Location.None);
+
+        var m = Parse(MsBuildDiagnostic.Format(d));
+        Assert.AreEqual("warning", m.Groups["CATEGORY"].Value);
+        Assert.AreEqual("TPS9999", m.Groups["CODE"].Value);
+    }
+
+    [TestMethod]
+    public void AMultiLineMessageIsFlattenedOntoOneLine()
+    {
+        // MSBuild matches line by line, so a newline mid-message would truncate the diagnostic — and
+        // leave its tail loose on the console, where it may parse as something else entirely.
+        var line = MsBuildDiagnostic.Format("error", "TPS0004", "Boom\n   at Foo.Bar()\r\n   at Baz()");
+
+        Assert.IsFalse(line.Contains('\n') || line.Contains('\r'), "the formatted line must be one line");
+        StringAssert.Contains(Parse(line).Groups["TEXT"].Value, "Boom at Foo.Bar() at Baz()");
+    }
+
+    [TestMethod]
+    public void AnEmptyMessageStillSaysSomething()
+    {
+        var m = Parse(MsBuildDiagnostic.Format("error", "TPS0004", "   "));
+        Assert.IsTrue(m.Success);
+        Assert.AreNotEqual("", m.Groups["TEXT"].Value.Trim(), "an empty diagnostic tells the user nothing");
+    }
+
+    [TestMethod]
+    public void EveryReportedErrorIsParsable()
+    {
+        // The whole error list, not just a sample: ordering and truncation must not produce a line the
+        // build cannot read.
+        var errors = Program.OrderErrorsForReport(
+            new RoslynTranslator().Translate(new[]
+            {
+                ("A.cs", "public class A { public int M() { return X(); } }"),
+                ("B.cs", "public class B { public int M() { return Y(); } }"),
+            }, "FmtTest").Errors.ToList());
+
+        Assert.IsTrue(errors.Count >= 2);
+        foreach (var d in errors)
+            Assert.IsTrue(Parse(MsBuildDiagnostic.Format(d)).Success,
+                $"MSBuild would not recognise: {MsBuildDiagnostic.Format(d)}");
+    }
+
+    /// <summary>
+    /// The other half of the contract: the compiler's own progress, summary and timing output must not
+    /// look like a diagnostic. These lines are real output from <c>tps</c>; if one of them ever starts
+    /// matching, a plain build grows an error nobody wrote — which is exactly why the error summary
+    /// does not end in "error(s):".
+    /// </summary>
+    [TestMethod]
+    public void TheCompilersOwnChatterIsNotMistakenForADiagnostic()
+    {
+        string[] lines =
+        [
+            "tps: compiling App.csproj",
+            "  sources:    263 file(s) (own sources only)",
+            "  references: 3 assembly(ies) — Transpose, Transpose.Core",
+            "  config:     Debug",
+            "  assembly:   metadata only (throw-null bodies, not packable)",
+            "  scanning for unsupported features",
+            "  emitting JavaScript: 12/263",
+            "3 error(s), by id: CS0103×2, CS0246×1",
+            "… and 245 more (raise or drop --max-errors to see them)",
+            "12 warning(s) total",
+            "FAILED in 1621 ms.",
+            "FAILED building referenced projects.",
+            "  timing breakdown:",
+            "      120 ms   12.0%     30 MB alloc  bind + diagnostics (error path)",
+            "  dependency up-to-date: Tesserae",
+            "OK — built package app.dll (1,234 bytes) with 2 embedded resource(s) in 900 ms.",
+            "--- inner System.InvalidOperationException",
+            "   at Transpose.Translator.Emit.Emitter.Emit() in /src/Emitter.cs:line 42",
+        ];
+
+        foreach (var line in lines)
+            Assert.IsFalse(Parse(line).Success,
+                $"MSBuild would invent a diagnostic out of this line: {line}");
+    }
+}


### PR DESCRIPTION
…uild

tps printed compile errors as `Main.cs(17,20): CS0103: <text>`, which reads like a diagnostic but matches nothing: MSBuild scans a tool's output for `Origin : Subcategory Category Code : Text` and the mandatory `error`/`warning` category was missing. So every compile error was invisible to the build. On a project with two undefined names, `dotnet build` reported exactly one error — MSB3073, "the command ... exited with code 1" — and the real errors scrolled past as console text, unnavigable and absent from the IDE's error list.

Every error and warning now goes through MsBuildDiagnostic:

- The category is emitted, the source path is made absolute (a relative one is resolved against the caller's working directory, not ours to assume) and keeps its 1-based (line,column), so a double-click lands on the offending line.
- Diagnostics with no source location — a bad command line, a project that will not resolve, a translator crash — are attributed to the tool and carry a TPS#### code (errors TPS0001-0099, warnings from TPS0100) rather than being bare text no build can see.
- Messages are flattened to one line, because MSBuild matches per line: a multi-line message would be truncated and its tail left loose on the console. A crash reports its whole exception chain on the diagnostic line and prints the stack frames separately (ex.ToString() risked an exception message that itself reads like "... error: ..." parsing as a second diagnostic).
- Warnings are printed in full instead of only counted, so they reach the task list too.

The inverse also matters: a non-diagnostic line that parses becomes an error nobody wrote, so the error summary is worded "N error(s), by id: ..." — never "N error(s):" — and MsBuildDiagnosticFormatTests checks both directions against the regex MSBuild itself applies (copied verbatim from CanonicalError).

Verified against real MSBuild rather than by inspection: piping tps's output through an Exec task shows all five diagnostics promoted to build errors (with file and line) from both stdout and stderr, and none of the progress, timing or summary lines picked up. End-to-end through the shipped Transpose SDK, the same broken project goes from 1 reported error to 3 — the two real CS0103s plus MSB3073. Emitted output is unchanged: the tesserae bundle is byte-identical (2,139,782 bytes) and the suite is green at 515 tests.


Claude-Session: https://claude.ai/code/session_01N1UKt1G8NiLkgXWJKKgRUb