### PR TITLE
Pin the Linux pipelines to ubuntu-22.04 so the NuGet push has Mono

### DIFF
--- a/.devops/benchmark-transpose-compiler.yml
+++ b/.devops/benchmark-transpose-compiler.yml
@@ -29,8 +29,12 @@ variables:
   publishDir: '$(Build.SourcesDirectory)/artifacts/bench-tps'
   reportDir: '$(Build.ArtifactStagingDirectory)/benchmark'
 
+# Same image as build-transpose-compiler.yml (pinned there because the NuGet push needs Mono). A
+# benchmark wants a fixed host anyway: score normalisation corrects for a faster or slower CPU, but not
+# for a different kernel or preinstalled SDK, so a floating "latest" would drift the baseline underneath
+# the comparison against docs/perf/optimized.json.
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-22.04'
 
 # Every compiler change gets a measurement, and a nightly run tracks drift in the runtime/SDK even
 # when nothing in the repo changed.

--- a/.devops/build-transpose-compiler.yml
+++ b/.devops/build-transpose-compiler.yml
@@ -12,12 +12,18 @@ variables:
 # Transpose.Compiler package that maps RIDs to them. `dotnet tool install Transpose.Compiler` keeps
 # working unchanged and resolves the right one automatically.
 #
-# Pool is ubuntu-latest: that host was verified end-to-end to cross-compile R2R for all nine RIDs
+# Pool is a Linux host: it was verified end-to-end to cross-compile R2R for all nine RIDs
 # (win/linux/osx x x64/arm64/x86/musl) from a single pack. Any host should manage it — crossgen2 targets
 # a RID rather than the host — but this is the configuration with evidence behind it. The verify step
 # below fails the build if R2R is ever silently lost, whatever the agent.
+#
+# Pinned to 22.04, *not* ubuntu-latest: the NuGetCommand@2 push at the end of this file runs on Mono,
+# and the hosted images dropped Mono in 24.04, so ubuntu-latest fails the push with
+# "you are using Ubuntu 24.04 or later without mono installed" (https://aka.ms/nuget-task-mono).
+# If this image is ever retired, the fix is to replace that task with a `dotnet nuget push`, which
+# needs no Mono — do not just bump the image back to latest.
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-22.04'
 
 trigger:
   branches:

--- a/TODO.optimization.md
+++ b/TODO.optimization.md
@@ -276,8 +276,10 @@ Things that cost time to work out, recorded so they do not have to be again:
   x64/arm64, plus win-x86 and musl for Alpine containers) — an extra RID costs one ~15 MB package per
   release, a missing one breaks somebody.
 - Cross-OS and cross-architecture R2R works: a single pack on Linux produced verified-R2R payloads for
-  win-x64, win-arm64, osx-arm64 and the rest. The compiler pipeline runs on `ubuntu-latest` because
-  that is the host this was verified on.
+  win-x64, win-arm64, osx-arm64 and the rest. The compiler pipeline therefore runs on a Linux agent —
+  pinned to `ubuntu-22.04`, not `ubuntu-latest`, because `NuGetCommand@2` runs on Mono and the hosted
+  images dropped Mono in 24.04 (the push fails with "Ubuntu 24.04 or later without mono installed").
+  If that image is retired, swap the push for `dotnet nuget push` rather than moving back to latest.
 - `tps-bench --verify-r2r <dir>` opens each produced `.nupkg` and checks the PE ManagedNativeHeader of
   the assemblies inside, so the pipeline gates on what it is about to push rather than on the build
   tree (which contains both the pre-publish IL copy and the R2R publish copy of every RID).


### PR DESCRIPTION
NuGetCommand@2 runs on Mono, and the hosted Ubuntu images dropped Mono in 24.04, so the compiler pipeline's push step failed on ubuntu-latest with "you are using Ubuntu 24.04 or later without mono installed" (https://aka.ms/nuget-task-mono). A Linux agent is still what the ReadyToRun cross-compile was verified on, so pin the image rather than move the pipeline back to Windows.

The benchmark pipeline moves to the same image: it has no Mono-dependent task, but a benchmark wants a fixed host — CPU-score normalisation corrects for a faster or slower machine, not for a different kernel or preinstalled SDK, so a floating "latest" would drift the baseline underneath the comparison against docs/perf/optimized.json.

Both files (and the R2R notes in TODO.optimization.md) record why the pin exists and that the fix, should 22.04 be retired, is to replace the push task with `dotnet nuget push` — which needs no Mono — not to bump the image back to latest.


Claude-Session: https://claude.ai/code/session_01N1UKt1G8NiLkgXWJKKgRUb