### PR TITLE
Unescape doubled braces in interpolated strings

### DIFF
--- a/.claude/skills/transpose-debugging/scripts/setup-toolkit.sh
+++ b/.claude/skills/transpose-debugging/scripts/setup-toolkit.sh
@@ -21,6 +21,18 @@ RUNTIME_DLL="$REPO/BCL/Transpose.BCL/bin/Debug/netstandard2.0/Transpose.dll"
 
 echo "repo: $REPO"
 
+# The runners reference Transpose.Translator.dll directly, so they must compile against the SAME
+# Roslyn version it does — a lower one is CS1705 ("uses Microsoft.CodeAnalysis vX which has a higher
+# version than referenced assembly"). Read it from the translator's csproj instead of pinning it here,
+# so bumping the translator's Roslyn doesn't silently break this script.
+ROSLYN_VERSION="$(sed -n 's/.*Microsoft\.CodeAnalysis\.CSharp" Version="\([^"]*\)".*/\1/p' \
+  "$REPO/Transpose/Transpose.Translator/Transpose.Translator.csproj" | head -1)"
+if [ -z "$ROSLYN_VERSION" ]; then
+  echo "could not determine the Microsoft.CodeAnalysis.CSharp version from Transpose.Translator.csproj" >&2
+  exit 1
+fi
+echo "roslyn: $ROSLYN_VERSION (from Transpose.Translator.csproj)"
+
 echo "==> building Release Transpose.Translator (referenced by the runners)"
 dotnet build "$REPO/Transpose/Transpose.Translator/Transpose.Translator.csproj" -c Release \
   | grep -E "error|Build succeeded" | tail -3
@@ -71,7 +83,7 @@ cat > /tmp/emitrunner/emitrunner.csproj <<EOF
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Transpose.Translator"><HintPath>$TR_REL_DLL</HintPath></Reference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$ROSLYN_VERSION" />
   </ItemGroup>
 </Project>
 EOF
@@ -109,7 +121,7 @@ cat > /tmp/jsonrunner/jsonrunner.csproj <<EOF
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Transpose.Translator"><HintPath>$TR_REL_DLL</HintPath></Reference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$ROSLYN_VERSION" />
   </ItemGroup>
 </Project>
 EOF
@@ -140,7 +152,14 @@ EOF
 
 echo "==> building the runner projects"
 for r in jsdumper emitrunner jsonrunner; do
-  dotnet build "/tmp/$r/$r.csproj" -c Debug | grep -E "error|Build succeeded" | tail -1
+  # Piping into grep would mask a failed build behind grep's exit status (set -e only sees the last
+  # command in a pipeline), so check dotnet's own status and surface the errors before bailing out.
+  if ! out="$(dotnet build "/tmp/$r/$r.csproj" -c Debug 2>&1)"; then
+    printf '%s\n' "$out" | grep -E "error" | head -10
+    echo "FAILED building /tmp/$r — see the errors above" >&2
+    exit 1
+  fi
+  printf '%s\n' "$out" | grep -E "error|Build succeeded" | tail -1
 done
 
 if [ ! -f "$RUNTIME_DLL" ]; then

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -311,6 +311,109 @@ public class Program
                 "a string-typed interpolation must not use the FormattableString factory\n" + result.Javascript);
         }
 
+        // ---- brace escaping in interpolated strings ---------------------------
+
+        [TestMethod]
+        public async Task InterpolatedStringUnescapesDoubledBracesAsync()
+        {
+            // `{{` / `}}` inside `$"…"` are escapes for a single literal brace. The string target
+            // concatenates the text segments directly, so the emitter must collapse them itself —
+            // nothing downstream runs a composite-format parser that would. Regression: every case
+            // below used to keep the braces doubled (`$"{{x}}"` -> "{{x}}" instead of "{x}").
+            await RunTest("""
+using System;
+public class Program
+{
+    const string C = $"const {{a}} b";
+    enum E { Red }
+    public static void Main()
+    {
+        var n = "W";
+        var ch = 'c';
+        Console.WriteLine($"{{{n}}}");
+        Console.WriteLine($"a {{ b }} c");
+        Console.WriteLine($"{{literal}} and {n}");
+        Console.WriteLine($@"verbatim {{x}} {n}");
+        Console.WriteLine("plain {{ not escaped }}");
+        Console.WriteLine($"json: {{ \"k\": {1 + 1} }}");
+        Console.WriteLine($"align {{a}} {n,8} {{b}}");
+        Console.WriteLine($"fmtclause {{a}} {42:X} {{b}}");
+        Console.WriteLine($"char {{a}} {ch} {{b}}");
+        Console.WriteLine($"enum {{a}} {E.Red} {{b}}");
+        Console.WriteLine($"{{}}");
+        Console.WriteLine($"{{{{}}}}");
+        Console.WriteLine($"{{{{{n}}}}}");
+        Console.WriteLine($"trailing {n}{{");
+        Console.WriteLine($"}}leading {n}");
+        Console.WriteLine($"nested {$"inner {{x}} {n}"} {{y}}");
+        Console.WriteLine(C);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RawInterpolatedStringKeepsLiteralBracesAsync()
+        {
+            // The opposite rule: a raw interpolated string has NO brace-doubling escape — the `$` count
+            // decides how many braces open an interpolation and shorter runs are literal text. So the
+            // text must NOT be unescaped, and when such a string becomes a FormattableString its literal
+            // braces have to be doubled to form a valid composite format string (a raw `{0}` would
+            // otherwise be misread as a placeholder).
+            await RunTest("""""
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        var n = "W";
+        Console.WriteLine($$"""raw {a} {{n}} }""");
+        Console.WriteLine($$$""""raw3 {a} {{b}} {{{n}}}"""");
+        FormattableString f = $$"""fsraw {0} {{n}} {b}""";
+        Console.WriteLine(f.Format);
+        Console.WriteLine(f.ToString());
+    }
+}
+""""");
+        }
+
+        [TestMethod]
+        public void InterpolatedStringEmitsSingleBraceForDoubledBrace()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main() { int a = 1; Console.WriteLine($"{{x}}={a}"); }
+}
+""";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("\"{x}=\""),
+                "$\"{{x}}={a}\" should emit the literal text \"{x}=\"\n" + result.Javascript);
+            Assert.IsFalse(result.Javascript!.Contains("{{x}}"),
+                "the doubled braces must not survive into the emitted string\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public void FormattableStringKeepsDoubledBracesInCompositeFormat()
+        {
+            // Inverse guard for the non-raw FormattableString path: there the composite format string
+            // is what gets emitted, and it *keeps* the doubling (matching FormattableString.Format).
+            var code = """
+using System;
+public class Program
+{
+    static void Use(FormattableString fs) { }
+    public static void Main() { int a = 1; Use($"lit {{x}} {a}"); }
+}
+""";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("FormattableStringFactory.Create(\"lit {{x}} {0}\", ["),
+                "the composite format string must keep the doubled braces\n" + result.Javascript);
+        }
+
         // ---- null string concatenation ----------------------------------------
 
         [TestMethod]

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -2382,6 +2382,48 @@ public sealed partial class Emitter
 
     // ---- interpolated string -----------------------------------------------
 
+    /// <summary>
+    /// True for a raw interpolated string (<c>$"""…"""</c>, any number of <c>$</c>). Raw strings have
+    /// no brace-doubling escape — the <c>$</c> count decides how many consecutive braces open an
+    /// interpolation, and any shorter brace run is literal text (doubling in a single-<c>$</c> raw
+    /// string is CS9006/CS9007, not an escape). Classic and verbatim interpolated strings do use
+    /// <c>{{</c>/<c>}}</c>, so the two families need opposite brace handling.
+    /// </summary>
+    private static bool IsRawInterpolatedString(InterpolatedStringExpressionSyntax interp)
+        => interp.StringStartToken.Kind() is SyntaxKind.InterpolatedSingleLineRawStringStartToken
+                                          or SyntaxKind.InterpolatedMultiLineRawStringStartToken;
+
+    /// <summary>
+    /// The literal text of an interpolated-string text segment. Roslyn's <c>ValueText</c> decodes
+    /// standard escape sequences (<c>\n</c>, <c>\"</c>) but deliberately KEEPS composite-format brace
+    /// escaping (<c>{{</c>/<c>}}</c>) for classic/verbatim interpolated strings, so those must be
+    /// collapsed to a single brace here — the string target concatenates the text directly and never
+    /// passes it through a composite-format parser that would unescape it. A raw string's ValueText
+    /// already holds literal braces and is used verbatim.
+    /// </summary>
+    private static string InterpolatedTextValue(InterpolatedStringExpressionSyntax interp, InterpolatedStringTextSyntax text)
+    {
+        var value = text.TextToken.ValueText;
+        if (IsRawInterpolatedString(interp) || value.IndexOfAny(Braces) < 0) return value;
+        // Non-overlapping left-to-right, matching C#: "{{{{" is two literal braces, not one.
+        return value.Replace("{{", "{").Replace("}}", "}");
+    }
+
+    /// <summary>
+    /// The same text segment rendered for a <em>composite format string</em> (the
+    /// <c>FormattableStringFactory.Create</c> first argument), where a literal brace is escaped by
+    /// doubling. Classic/verbatim ValueText is already in that form; a raw string's literal braces
+    /// must be doubled, or a raw <c>{0}</c> would be misread as a placeholder.
+    /// </summary>
+    private static string CompositeFormatTextValue(InterpolatedStringExpressionSyntax interp, InterpolatedStringTextSyntax text)
+    {
+        var value = text.TextToken.ValueText;
+        if (!IsRawInterpolatedString(interp) || value.IndexOfAny(Braces) < 0) return value;
+        return value.Replace("{", "{{").Replace("}", "}}");
+    }
+
+    private static readonly char[] Braces = ['{', '}'];
+
     private void EmitInterpolatedString(InterpolatedStringExpressionSyntax interp)
     {
         // An interpolated string CONVERTED to FormattableString / IFormattable is not a plain string:
@@ -2405,7 +2447,7 @@ public sealed partial class Emitter
             {
                 case InterpolatedStringTextSyntax text:
                     if (!first) _w.Write(" + ");
-                    _w.Write(JsString(text.TextToken.ValueText));
+                    _w.Write(JsString(InterpolatedTextValue(interp, text)));
                     first = false; hadContent = true;
                     break;
                 case InterpolationSyntax interpolation:
@@ -2465,10 +2507,7 @@ public sealed partial class Emitter
             switch (content)
             {
                 case InterpolatedStringTextSyntax text:
-                    // ValueText decodes standard escape sequences (\n, \") but KEEPS composite-format
-                    // brace escaping ({{ / }}) for interpolated-string text tokens, which is exactly the
-                    // composite format string FormattableStringFactory.Create expects — use it verbatim.
-                    format.Append(text.TextToken.ValueText);
+                    format.Append(CompositeFormatTextValue(interp, text));
                     break;
                 case InterpolationSyntax interpolation:
                     format.Append('{').Append(args.Count);


### PR DESCRIPTION
`{{` and `}}` inside `$"…"` are escapes for a single literal brace, but the
emitter wrote the text segment's ValueText straight into the concatenation.
Roslyn's ValueText decodes standard escapes (`\n`, `\"`) while deliberately
KEEPING the brace doubling, and nothing downstream of a string-target
interpolation runs a composite-format parser that would resolve it — so
`$"{{x}}"` emitted `"{{x}}"` where .NET yields `{x}`. Anything that builds
braced text by interpolation (JSON, CSS, generated code) came out with every
literal brace doubled.

Raw interpolated strings need the opposite treatment: they have no doubling
escape at all — the `$` count decides how many consecutive braces open an
interpolation and shorter runs are literal text — so their ValueText already
holds literal braces. That also means the FormattableString path, which emits a
composite format string, had the inverse bug: a raw string's literal braces were
passed through undoubled, so `FormattableString f = $$"""{0} {{n}}"""` produced
Format `{0} {0}` and rendered the literal `{0}` as the argument.

Split the two rules into `InterpolatedTextValue` (collapse, for concatenation)
and `CompositeFormatTextValue` (double, for the format string), keyed off the
start token kind. Constant interpolated strings were already correct — they go
through Roslyn's own constant value.

Also fix the transpose-debugging setup script, which blocked this
investigation: it pinned Microsoft.CodeAnalysis.CSharp 5.3.0 while the
translator moved to 5.6.0 (CS1705), and its build loop piped dotnet into grep,
so a failed runner build was masked by grep's exit status and reported as
success. The version is now read from Transpose.Translator.csproj.