### PR TITLE
Make every expression IIFE async when it wraps an await

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,3 +298,9 @@ Claude Code; read the `SKILL.md` directly in other contexts):
   `Transpose` and `Transpose.*` as runtime/BCL packages (fixed JS names), distinct from user
   libraries compiled with `--emit-package`.
 - Do not blanket-replace `h5`/`H5` — non-library tokens (HTML tags, hash locals) must be preserved.
+- **Never emit a raw `(() => { … })()` wrapper.** Where a C# expression needs statements to emit (out/ref
+  holders, object initializers, reordered named arguments, building a concrete collection, a throw
+  expression), go through `OpenIife`/`CloseIife` (`Emitter.Expressions2.cs`) and pass the syntax that will
+  be emitted *inside* the wrapper. If that syntax contains an `await`, the arrow must be `async` and the
+  call awaited — a bare `await` in a plain arrow is a JavaScript **syntax** error, so one such expression
+  makes the entire bundle fail to parse. `EmitRegressionTests.NoPlainArrowIifeWrapsAnAwait` guards this.

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -4,10 +4,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Transpose.Translator.Tests
 {
     /// <summary>
-    /// Regression tests for three emit bugs found compiling the Curiosity FrontEnd:
-    ///  - an out/ref call whose argument contains an `await` (e.g. bool.TryParse(await t, out var s))
-    ///    must run its holder IIFE as an `async` arrow and be awaited — a bare `await` inside a plain
-    ///    arrow is a syntax error ("Unexpected identifier 'Transpose'");
+    /// Regression tests for emit bugs found compiling the Curiosity FrontEnd and Mosaik:
+    ///  - an expression IIFE that wraps an `await` must be an `async` arrow and be awaited — a bare
+    ///    `await` inside a plain arrow is a syntax error ("Unexpected identifier 'Transpose'") that
+    ///    breaks the whole bundle, not just that call. This applies to every wrapper the emitter
+    ///    produces (out/ref holders, object initializers, reordered named arguments, concrete
+    ///    collections, throw expressions), and to an `await` anywhere inside them — including in a
+    ///    call's RECEIVER, e.g. `(await Query()).Nodes.TryGetFirst(out var n)`;
     ///  - a generic method threading its type argument (WithBody&lt;T&gt;(T)) called with an anonymous
     ///    type must pass System.Object for T, not an empty slot (which produced `WithBody$1(, {...})`);
     ///  - an iterator LOCAL FUNCTION (a nested `IEnumerable&lt;T&gt;` with `yield return`) must compile
@@ -57,6 +60,215 @@ public class Program
             Assert.IsTrue(result.Success, "translation should succeed");
             Assert.IsTrue(result.Javascript!.Contains("await (async () => {"),
                 "an out/ref call with an awaited argument should run its IIFE as an awaited async arrow\n" + result.Javascript);
+        }
+
+        // ---- await anywhere inside an expression IIFE --------------------------
+        //
+        // The emitter wraps a C# expression in an IIFE wherever emitting it needs statements: out/ref
+        // holders, an object initializer, argument temporaries for reordered named arguments, building a
+        // concrete collection, a throw expression. Every one of those has to become an `async` arrow —
+        // and be awaited — once the syntax it wraps contains an `await`, because a bare `await` inside a
+        // plain arrow is a *syntax* error, so the whole bundle fails to parse rather than just that call.
+        //
+        // Originally only an awaited *argument* of an out/ref call was handled, which left every other
+        // wrapper (and even the same call awaiting in its RECEIVER, the shape reported from Mosaik:
+        // `(await Query()).Nodes.TryGetFirst(out var n)`) emitting unparsable JavaScript.
+
+        [TestMethod]
+        public async Task AwaitInTheReceiverOfAnOutCallRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+public sealed class Box { public List<string> Nodes = new List<string>(); }
+public static class Ext
+{
+    public static bool TryGetFirst<T>(this IEnumerable<T> src, out T value)
+    {
+        foreach (var v in src) { value = v; return true; }
+        value = default(T);
+        return false;
+    }
+}
+public class Program
+{
+    static Task<Box> QueryAsync()
+    {
+        var b = new Box();
+        b.Nodes.Add(""first"");
+        return Task.FromResult(b);
+    }
+    static async Task Run()
+    {
+        // The await is in the receiver, not in an argument — it still lands inside the holder IIFE.
+        if ((await QueryAsync()).Nodes.TryGetFirst(out var n)) Console.WriteLine(""got:"" + n);
+        else Console.WriteLine(""none"");
+    }
+    public static void Main() { Run(); }
+}");
+        }
+
+        [TestMethod]
+        public async Task AwaitInReorderedNamedArgumentsRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading.Tasks;
+public class Program
+{
+    static string Join(string a = ""a"", string b = ""b"", string c = ""c"") => a + ""|"" + b + ""|"" + c;
+    static Task<string> TextAsync(string s) => Task.FromResult(s);
+    static async Task Run()
+    {
+        // Named arguments out of parameter order are evaluated into temps inside an IIFE to keep C#'s
+        // source-order evaluation; the awaits go with them.
+        Console.WriteLine(Join(c: await TextAsync(""C""), a: await TextAsync(""A"")));
+    }
+    public static void Main() { Run(); }
+}");
+        }
+
+        [TestMethod]
+        public async Task AwaitInAnObjectInitializerRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading.Tasks;
+public sealed class Bag
+{
+    public string Name;
+    public int Count;
+    public Bag() { }
+    public Bag(string seed) { Name = seed; }
+}
+public class Program
+{
+    static Task<string> TextAsync(string s) => Task.FromResult(s);
+    static Task<int> NumAsync(int i) => Task.FromResult(i);
+    static async Task Run()
+    {
+        var bag = new Bag(await TextAsync(""seed"")) { Count = await NumAsync(7) };
+        Console.WriteLine(bag.Name + "":"" + bag.Count);
+    }
+    public static void Main() { Run(); }
+}");
+        }
+
+        [TestMethod]
+        public async Task AwaitInACollectionExpressionRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+public class Program
+{
+    static Task<int> NumAsync(int i) => Task.FromResult(i);
+    static async Task Run()
+    {
+        // A concrete collection target is built and filled inside an IIFE.
+        List<int> xs = [await NumAsync(1), 2, await NumAsync(3)];
+        var total = 0;
+        foreach (var x in xs) total += x;
+        Console.WriteLine(""total:"" + total);
+    }
+    public static void Main() { Run(); }
+}");
+        }
+
+        [TestMethod]
+        public async Task AwaitInAParamsCollectionRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+public class Program
+{
+    static int Sum(params List<int> xs) { var t = 0; foreach (var x in xs) t += x; return t; }
+    static Task<int> NumAsync(int i) => Task.FromResult(i);
+    static async Task Run()
+    {
+        Console.WriteLine(""sum:"" + Sum(await NumAsync(4), 5, await NumAsync(6)));
+    }
+    public static void Main() { Run(); }
+}");
+        }
+
+        [TestMethod]
+        public async Task AwaitInAThrowExpressionRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading.Tasks;
+public class Program
+{
+    static Task<string> TextAsync(string s) => Task.FromResult(s);
+    static async Task Run()
+    {
+        string missing = null;
+        try { Console.WriteLine(missing ?? throw new InvalidOperationException(await TextAsync(""boom""))); }
+        catch (InvalidOperationException e) { Console.WriteLine(""caught:"" + e.Message); }
+    }
+    public static void Main() { Run(); }
+}");
+        }
+
+        /// <summary>
+        /// The invariant behind all of the above, checked on the emitted JavaScript so it also catches a
+        /// *new* IIFE site added later without the async form: no plain <c>(() =&gt; {</c> wrapper may
+        /// contain an <c>await</c>. Each wrapper is emitted on a single line, so scanning per line
+        /// finds the whole wrapper.
+        /// </summary>
+        [TestMethod]
+        public void NoPlainArrowIifeWrapsAnAwait()
+        {
+            var code = @"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+public sealed class Bag { public string Name; public int Count; public Bag(string s) { Name = s; } }
+public sealed class Box { public List<string> Nodes = new List<string>(); }
+public static class Ext
+{
+    public static bool TryGetFirst<T>(this IEnumerable<T> src, out T value)
+    {
+        foreach (var v in src) { value = v; return true; }
+        value = default(T); return false;
+    }
+}
+public class Program
+{
+    static string Join(string a = ""a"", string b = ""b"", string c = ""c"") => a + b + c;
+    static int Sum(params List<int> xs) => xs.Count;
+    static Task<string> TextAsync() => Task.FromResult(""x"");
+    static Task<int> NumAsync() => Task.FromResult(1);
+    static Task<Box> BoxAsync() => Task.FromResult(new Box());
+    static async Task Run()
+    {
+        if ((await BoxAsync()).Nodes.TryGetFirst(out var n)) Console.WriteLine(n);
+        if (int.TryParse(await TextAsync(), out var p)) Console.WriteLine(p);
+        Console.WriteLine(Join(c: await TextAsync(), a: await TextAsync()));
+        Console.WriteLine(new Bag(await TextAsync()) { Count = await NumAsync() }.Name);
+        List<int> xs = [await NumAsync(), 2];
+        Console.WriteLine(Sum(await NumAsync(), 3));
+        string missing = null;
+        Console.WriteLine(missing ?? throw new InvalidOperationException(await TextAsync()));
+    }
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed");
+
+            foreach (var line in result.Javascript!.Split('\n'))
+            {
+                var at = line.IndexOf("(() => {", System.StringComparison.Ordinal);
+                if (at < 0) continue;
+                Assert.IsFalse(line[at..].Contains("await", System.StringComparison.Ordinal),
+                    "a plain (non-async) arrow IIFE must never wrap an await — that is a JavaScript "
+                    + "syntax error that breaks the whole bundle:\n" + line.Trim());
+            }
         }
 
         // ---- generic method threading + anonymous type -------------------------

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -213,11 +213,15 @@ public sealed partial class Emitter
                 _w.Write(NameMangler.JsIdentifier(d.Identifier.Text));
                 break;
             case ThrowExpressionSyntax throwExpr:
-                // Arrow so a `this`-qualified thrown expression keeps the enclosing instance.
-                _w.Write("(() => { throw ");
+            {
+                // `x ?? throw new E(await Msg())` awaits inside the wrapper, so it needs the async form.
+                var hasAwait = OpenIife(throwExpr.Expression);
+                _w.Write("throw ");
                 EmitExpression(throwExpr.Expression);
-                _w.Write("; })()");
+                _w.Write("; ");
+                CloseIife(hasAwait);
                 break;
+            }
             case CheckedExpressionSyntax checkedExpr:
                 EmitExpression(checkedExpr.Expression);
                 break;

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -457,15 +457,10 @@ public sealed partial class Emitter
         var byName = new Dictionary<string, string>();
         var byPos = new List<string>();
 
-        // An out/ref template call whose arguments contain an `await` (e.g.
-        // bool.TryParse(await t.Text(), out var s)) must run the holder IIFE as an `async` arrow and be
-        // awaited — a bare `await` inside a plain arrow is a syntax error. The enclosing method is
-        // guaranteed async (C# only allows await there), so the surrounding `await` is valid.
-        var hasAwait = args.Any(a => ContainsAwait(a.Expression));
-
-        // Arrow (not `function`) so a `this`-qualified receiver inside the call resolves to the
-        // enclosing instance rather than being rebound to undefined in strict mode.
-        _w.Write(hasAwait ? "(await (async () => { " : "(() => { ");
+        // The whole invocation is the await scope, receiver included: `(await Q()).Items.TryGetFirst(out
+        // var n)` awaits in the *receiver*, which the template's {this} emits inside the IIFE just as an
+        // argument would.
+        var hasAwait = OpenIife(invocation);
         for (var i = 0; i < args.Count; i++)
         {
             var isRef = args[i].RefKindKeyword.IsKind(SyntaxKind.OutKeyword) || args[i].RefKindKeyword.IsKind(SyntaxKind.RefKeyword);
@@ -506,7 +501,8 @@ public sealed partial class Emitter
             EmitByRefWriteBackTarget(args[i].Expression);
             _w.Write($" = {holders[i]}.v; ");
         }
-        _w.Write(hasAwait ? "return $ret; })())" : "return $ret; })()");
+        _w.Write("return $ret; ");
+        CloseIife(hasAwait);
     }
 
     private void EmitByRefInvocation(InvocationExpressionSyntax invocation, IMethodSymbol symbol)
@@ -514,15 +510,10 @@ public sealed partial class Emitter
         var args = invocation.ArgumentList.Arguments;
         var holders = new string?[args.Count];
 
-        // An out/ref call whose arguments contain an `await` (e.g. bool.TryParse(await t.Text(), out var s))
-        // must run the holder IIFE as an `async` arrow and be awaited — a bare `await` inside a plain
-        // arrow is a syntax error. The enclosing method is guaranteed async (C# only allows await there),
-        // so the surrounding `await` is valid.
-        var hasAwait = args.Any(a => ContainsAwait(a.Expression));
-
-        // Arrow (not `function`) so a `this`-qualified receiver inside the call resolves to the
-        // enclosing instance rather than being rebound to undefined in strict mode.
-        _w.Write(hasAwait ? "(await (async () => { " : "(() => { ");
+        // The whole invocation is the await scope, receiver included — the reported failure was
+        // `(await Query()).Nodes.TryGetFirst(out var n)`, where the await sits in the receiver rather
+        // than in an argument, yet still lands inside the holder IIFE.
+        var hasAwait = OpenIife(invocation);
 
         for (var i = 0; i < args.Count; i++)
         {
@@ -651,7 +642,8 @@ public sealed partial class Emitter
             _w.Write($" = {holders[i]}.v; ");
         }
 
-        _w.Write(hasAwait ? "return $ret; })())" : "return $ret; })()");
+        _w.Write("return $ret; ");
+        CloseIife(hasAwait);
     }
 
     /// <summary>True if the expression contains an <c>await</c> in its own async context — i.e. not
@@ -665,6 +657,38 @@ public sealed partial class Emitter
         }
         return false;
     }
+
+    /// <summary>
+    /// Opens an expression IIFE — <c>(() =&gt; { … })()</c> — the construct used wherever a C# expression
+    /// needs statements to emit (out/ref holders, an object initializer, argument temporaries, …).
+    ///
+    /// When the wrapped syntax contains an <c>await</c> the arrow must be <c>async</c> and the call
+    /// awaited: <c>await</c> inside a plain arrow is a JavaScript *syntax* error, so the whole bundle
+    /// fails to parse — not just that one call. The enclosing function is guaranteed to be async, since
+    /// C# only allows <c>await</c> inside an async method or lambda and the emitter emits those as async
+    /// JS functions, so the added <c>await</c> is always legal.
+    ///
+    /// <paramref name="awaitScopes"/> must be the syntax that will actually be emitted *inside* the
+    /// IIFE — pass the operands, not the whole expression, so a call that awaits somewhere outside the
+    /// wrapper keeps its plain-arrow form.
+    /// </summary>
+    /// <returns>Whether the async form was written; hand it back to <see cref="CloseIife"/>.</returns>
+    private bool OpenIife(params SyntaxNode?[] awaitScopes)
+    {
+        var hasAwait = false;
+        foreach (var scope in awaitScopes)
+        {
+            if (scope is not null && ContainsAwait(scope)) { hasAwait = true; break; }
+        }
+        // Arrow (not `function`) so a `this`-qualified expression inside resolves to the enclosing
+        // instance rather than being rebound to undefined in strict mode.
+        _w.Write(hasAwait ? "(await (async () => { " : "(() => { ");
+        return hasAwait;
+    }
+
+    /// <summary>Closes an IIFE opened by <see cref="OpenIife"/> — the extra parenthesis balances the
+    /// <c>(await …</c> the async form opened with.</summary>
+    private void CloseIife(bool hasAwait) => _w.Write(hasAwait ? "})())" : "})()");
 
     /// <summary>True for a discard target (out _ or a discard designation).</summary>
     private bool IsDiscardTarget(ExpressionSyntax expr)
@@ -764,10 +788,11 @@ public sealed partial class Emitter
             if (reordered && !hasParams)
             {
                 if (lead) _w.Write(", ");
-                // Arrow (not `function`) so a `this`-qualified argument (e.g. a named arg
-                // `wrapResults: this._wrapResults`) resolves to the enclosing instance rather than
-                // being rebound to undefined in strict mode.
-                _w.Write("...(() => { var $ = [");
+                // Every argument is evaluated inside this wrapper, so an await in any of them makes it
+                // an async IIFE: `M(b: await X(), a: 1)`.
+                _w.Write("...");
+                var reorderHasAwait = OpenIife(argList);
+                _w.Write("var $ = [");
                 for (var k = 0; k < args.Count; k++)
                 {
                     if (k > 0) _w.Write(", ");
@@ -782,7 +807,8 @@ public sealed partial class Emitter
                     var src = Array.IndexOf(paramIndexOf, i);
                     _w.Write(src >= 0 ? $"$[{src}]" : "void 0");
                 }
-                _w.Write("]; })()");
+                _w.Write("]; ");
+                CloseIife(reorderHasAwait);
                 return;
             }
 
@@ -898,7 +924,7 @@ public sealed partial class Emitter
                         EmitExpressionConverted(trailing[i].Expression, paramsElem);
                     }
                     _w.Write("]");
-                });
+                }, trailing);
             }
             return;
         }
@@ -943,7 +969,7 @@ public sealed partial class Emitter
                 _w.Write("[");
                 EmitExpressionConverted(arg, paramsElem);
                 _w.Write("]");
-            });
+            }, [arg]);
         }
     }
 
@@ -995,11 +1021,15 @@ public sealed partial class Emitter
     {
         if (initializer is { Expressions.Count: > 0 })
         {
-            _w.Write("(() => { var $o = ");
+            // Both the constructor arguments and the initializer body are emitted inside the wrapper, so
+            // either can carry the await: `new T(await A()) { X = await B() }`.
+            var hasAwait = OpenIife(argList, initializer);
+            _w.Write("var $o = ");
             EmitBareConstruction(type, ctor, argList);
             _w.Write("; ");
             EmitInitializer("$o", initializer);
-            _w.Write("return $o; })()");
+            _w.Write("return $o; ");
+            CloseIife(hasAwait);
             return;
         }
 
@@ -2757,7 +2787,7 @@ public sealed partial class Emitter
             _w.Write("]");
         }
 
-        EmitCollectionOf(_model.GetTypeInfo(collection).ConvertedType, EmitArray);
+        EmitCollectionOf(_model.GetTypeInfo(collection).ConvertedType, EmitArray, [collection]);
     }
 
     /// <summary>
@@ -2767,7 +2797,10 @@ public sealed partial class Emitter
     /// natively; a concrete collection (e.g. List&lt;T&gt;) is built and filled via <c>add</c>
     /// (works regardless of its constructor overload numbering).
     /// </summary>
-    private void EmitCollectionOf(ITypeSymbol? target, Action emitArrayLiteral)
+    /// <param name="awaitScopes">The syntax <paramref name="emitArrayLiteral"/> will emit, so an
+    /// awaited element (<c>List&lt;int&gt; l = [await X()]</c>) gets an async IIFE.</param>
+    private void EmitCollectionOf(ITypeSymbol? target, Action emitArrayLiteral,
+                                  IReadOnlyList<SyntaxNode>? awaitScopes = null)
     {
         // A concrete array target tags the literal with its element type (System.Array.init) so the
         // value's runtime type carries $elementType — same as a `new T[]{…}` creation.
@@ -2788,9 +2821,11 @@ public sealed partial class Emitter
             return;
         }
 
-        _w.Write($"(() => {{ var $c = new ({TypeRef(target)})(); var $s = ");
+        var hasAwait = OpenIife(awaitScopes is null ? [] : [.. awaitScopes]);
+        _w.Write($"var $c = new ({TypeRef(target)})(); var $s = ");
         emitArrayLiteral();
-        _w.Write("; for (var $i = 0; $i < $s.length; $i++) { $c.add($s[$i]); } return $c; })()");
+        _w.Write("; for (var $i = 0; $i < $s.length; $i++) { $c.add($s[$i]); } return $c; ");
+        CloseIife(hasAwait);
     }
 
     /// <summary>The element type of a params parameter (array element or the collection's T).</summary>


### PR DESCRIPTION
`(await Query()).Nodes.TryGetFirst(out var n)` emitted a plain arrow containing an await:

    if ((() => { var $ref0 = { v: null }; var $ret = Ext.TryGetFirst(T,
        ((await Transpose.toPromise(...))).Nodes, $ref0); … })())

which is a JavaScript *syntax* error, so the whole bundle failed to parse — not just that call. The emitter already handled this, but only for an awaited argument of an out/ref call; here the await is in the call's RECEIVER, which lands inside the same holder IIFE.

Auditing the other wrappers found the same break in five more places, each reachable from ordinary async C#:

  - a reordered named argument list        M(c: await X(), a: await Y())
  - an object/collection initializer       new T(await A()) { P = await B() }
  - building a concrete collection         List<int> xs = [await X(), 2]
  - a params collection                    Sum(await X(), 5, await Y())
  - a throw expression                     s ?? throw new E(await Msg())

All six now go through a shared OpenIife/CloseIife pair, which takes the syntax that will be emitted *inside* the wrapper and switches to `(await (async () => { … })())` when it contains an await in this async context. Passing the operands rather than the whole expression keeps a call that awaits outside the wrapper on its plain-arrow form, so output is unchanged wherever the bug did not apply: the tesserae and tesserae-tests bundles are byte-identical before and after.

The enclosing function is always async — C# only allows await inside an async method or lambda, and the emitter emits those as async JS — so the added await is always legal.

Verified end to end: a repro covering all seven shapes fails `node --check` before the fix and, after it, runs in Node to exactly the string native .NET prints ("first / ok12 / A|b|C / seed7 / 6 / 15 / caught:boom"). Six new RunTest-based regression tests (which diff Node against native Roslyn) plus NoPlainArrowIifeWrapsAnAwait — an invariant scan of the emitted JS that will catch a new IIFE site added without the async form — all fail against the parent commit and pass now. Suite green at 522.


Claude-Session: https://claude.ai/code/session_01N1UKt1G8NiLkgXWJKKgRUb