### PR TITLE
Fix 64-bit integer and numeric type handling in patterns and operators

### DIFF
--- a/BCL/Transpose.BCL/Resources/Convert.js
+++ b/BCL/Transpose.BCL/Resources/Convert.js
@@ -1217,16 +1217,23 @@
                         return new System.Decimal(value, formatProvider);
                     }
 
-                    if (typeCode === typeCodes.Int64) {
+                    if (typeCode === typeCodes.Int64 || typeCode === typeCodes.UInt64) {
                         scope.internal.validateNumberRange(value, typeCode, true);
 
-                        return new System.Int64(value);
-                    }
+                        // Convert.ToInt64/ToUInt64 ROUND (half to even) like every other integral
+                        // target — they are not a truncating cast, which is what `(long)42.7` would be.
+                        // System.Int64/UInt64 truncate what they are handed, and this branch returned
+                        // before the rounding the narrower type codes get further down, so
+                        // Convert.ToInt64(42.7) came out 42 instead of 43.
+                        if (!System.Int64.is64Bit(value)) {
+                            var asFloat = value instanceof System.Decimal ? value.toFloat() : value;
 
-                    if (typeCode === typeCodes.UInt64) {
-                        scope.internal.validateNumberRange(value, typeCode, true);
+                            if (asFloat % 1 !== 0) {
+                                value = scope.internal.roundHalfToEven(asFloat);
+                            }
+                        }
 
-                        return new System.UInt64(value);
+                        return typeCode === typeCodes.Int64 ? new System.Int64(value) : new System.UInt64(value);
                     }
 
                     if (System.Int64.is64Bit(value)) {
@@ -1395,6 +1402,31 @@
 
         throwOverflow: function (typeName) {
             throw new System.OverflowException.$ctor1("Value was either too large or too small for '" + typeName + "'.");
+        },
+
+        // Round-half-to-even on a plain JS number, with no target-range check — the 64-bit variant of
+        // roundToInt below. roundToInt cannot serve the Int64/UInt64 type codes because their
+        // typeRanges entries are System.Int64/UInt64 *objects*, so its `maxValue + 0.5` would
+        // string-concatenate. A value with a fractional part is necessarily within +/-2^53, i.e. well
+        // inside the 64-bit range, so the caller's validateNumberRange is the only check needed.
+        roundHalfToEven: function (value) {
+            if (value % 1 === 0) {
+                return value;
+            }
+
+            var intPart = value >= 0 ? Math.floor(value) : -1 * Math.floor(-value),
+                floatPart = value - intPart;
+
+            // `% 2` rather than `& 1`: a bitwise op truncates to 32 bits, and intPart can exceed that.
+            if (value >= 0) {
+                if (floatPart > 0.5 || (floatPart === 0.5 && (intPart % 2) !== 0)) {
+                    ++intPart;
+                }
+            } else if (floatPart < -0.5 || (floatPart === -0.5 && (intPart % 2) !== 0)) {
+                --intPart;
+            }
+
+            return intPart;
         },
 
         roundToInt: function (value, typeCode) {

--- a/BCL/Transpose.BCL/Resources/Long.js
+++ b/BCL/Transpose.BCL/Resources/Long.js
@@ -306,11 +306,30 @@
     };
 
     System.Int64.prototype.div = function (l) {
-        return new this.T(this.value.div(this.T.getValue(l)));
+        var divisor = this.T.getValue(l);
+
+        // The underlying long library throws a bare JS Error("division by zero"), which no
+        // `catch (DivideByZeroException)` can see — the program just died. Mirror what the 32-bit
+        // Transpose.Int.div does. long.MinValue / -1 overflows in .NET rather than wrapping.
+        if (divisor.isZero()) {
+            throw new System.DivideByZeroException();
+        }
+
+        if (this.T === System.Int64 && this.eq(System.Int64.MinValue) && divisor.eq(System.Int64(-1).value)) {
+            throw new System.OverflowException();
+        }
+
+        return new this.T(this.value.div(divisor));
     };
 
     System.Int64.prototype.mod = function (l) {
-        return new this.T(this.value.mod(this.T.getValue(l)));
+        var divisor = this.T.getValue(l);
+
+        if (divisor.isZero()) {
+            throw new System.DivideByZeroException();
+        }
+
+        return new this.T(this.value.mod(divisor));
     };
 
     System.Int64.prototype.neg = function (overflow) {

--- a/BCL/Transpose.BCL/Resources/Nullable.js
+++ b/BCL/Transpose.BCL/Resources/Nullable.js
@@ -56,7 +56,21 @@
         },
 
         equals: function (a, b, fn) {
-            return !Transpose.hasValue(a) ? !Transpose.hasValue(b) : (fn ? fn(a, b) : Transpose.equals(a, b));
+            // Both sides need the null guard, not just `a`: with a value on the left and null on the
+            // right this fell through to Transpose.equals(someInt64, null), which reads `.low` off the
+            // null and throws. Lifted equality is "null equals only null, otherwise compare values".
+            if (!Transpose.hasValue(a) || !Transpose.hasValue(b)) {
+                return Transpose.hasValue(a) === Transpose.hasValue(b);
+            }
+
+            return fn ? fn(a, b) : Transpose.equals(a, b);
+        },
+
+        // `Nullable<T>.Equals(T other)` — the strongly-typed IEquatable<T> overload. The BCL templates
+        // it as equalsT (the same name a record's synthesized IEquatable<T>.Equals gets), and without
+        // it every `someNullable.Equals(value)` threw "equalsT is not a function".
+        equalsT: function (a, b) {
+            return System.Nullable.equals(a, b);
         },
 
         toString: function (a, fn) {

--- a/BCL/Transpose.BCL/Resources/linq.js
+++ b/BCL/Transpose.BCL/Resources/linq.js
@@ -1898,7 +1898,15 @@
             throw new System.InvalidOperationException.$ctor1("Sequence contains no elements");
         }
 
-        return (sum instanceof System.Decimal || System.Int64.is64Bit(sum)) ? sum.div(count) : (sum / count);
+        // Average(decimal) returns decimal, so Decimal.div (exact) is right there. Average(long) and
+        // Average(ulong) return DOUBLE in .NET — Int64.div would truncate (avg of 3,1,2,1 came out 1
+        // instead of 1.75), so read the sum's magnitude and divide as a float, matching .NET's
+        // `(double)sum / count`.
+        if (sum instanceof System.Decimal) {
+            return sum.div(count);
+        }
+
+        return System.Int64.is64Bit(sum) ? (sum.toNumber() / count) : (sum / count);
     };
 
     Enumerable.prototype.nullableAverage = function (selector, def) {

--- a/BCL/Transpose.BCL/Resources/linq.js
+++ b/BCL/Transpose.BCL/Resources/linq.js
@@ -1909,12 +1909,33 @@
         return System.Int64.is64Bit(sum) ? (sum.toNumber() / count) : (sum / count);
     };
 
+    // .NET's aggregates over a Nullable<T> sequence SKIP the null elements rather than propagating
+    // null. The rule used to be "if any element is null the result is null", which made
+    // `new long?[] { 1, 2, null, 3 }.Sum()` null instead of 6. Correct behaviour:
+    //   Sum          — total of the non-null values, 0 when there are none (never null).
+    //   Average      — null when there is no non-null value (it does NOT throw, unlike the
+    //                  non-nullable overload on an empty sequence).
+    //   Min / Max    — null when there is no non-null value.
+    // The selector is applied FIRST and nulls are dropped from its results, so
+    // `items.Sum(x => x.MaybeNull)` skips the projected nulls.
+
+    /// The non-null projected values of this sequence.
+    Enumerable.prototype.nonNullValues = function (selector) {
+        var seq = selector == null ? this : this.select(Utils.createLambda(selector));
+
+        return seq.where(function (x) { return !Transpose.isNull(x); });
+    };
+
     Enumerable.prototype.nullableAverage = function (selector, def) {
-        if (this.any(Transpose.isNull)) {
-            return null;
+        // The (selector, def) pair is overloaded the same way average() overloads it.
+        if (selector && !def && !Transpose.isFunction(selector)) {
+            def = selector;
+            selector = null;
         }
 
-        return this.average(selector, def);
+        var values = this.nonNullValues(selector);
+
+        return values.any() ? values.average(null, def) : null;
     };
 
     // Overload:function ()
@@ -1939,11 +1960,9 @@
     };
 
     Enumerable.prototype.nullableMax = function (selector) {
-        if (this.any(Transpose.isNull)) {
-            return null;
-        }
+        var values = this.nonNullValues(selector);
 
-        return this.max(selector);
+        return values.any() ? values.max() : null;
     };
 
     // Overload:function ()
@@ -1956,11 +1975,9 @@
     };
 
     Enumerable.prototype.nullableMin = function (selector) {
-        if (this.any(Transpose.isNull)) {
-            return null;
-        }
+        var values = this.nonNullValues(selector);
 
-        return this.min(selector);
+        return values.any() ? values.min() : null;
     };
 
     Enumerable.prototype.maxBy = function (keySelector) {
@@ -2004,11 +2021,15 @@
     };
 
     Enumerable.prototype.nullableSum = function (selector, def) {
-        if (this.any(Transpose.isNull)) {
-            return null;
+        // The (selector, def) pair is overloaded the same way sum() overloads it.
+        if (selector && !def && !Transpose.isFunction(selector)) {
+            def = selector;
+            selector = null;
         }
 
-        return this.sum(selector, def);
+        // No null result here: an all-null or empty sequence sums to zero. `def` carries the
+        // zero in the representation the element type needs (System.Int64.Zero, Decimal.Zero).
+        return this.nonNullValues(selector).sum(null, def);
     };
 
     /* Paging Methods */

--- a/BCL/Transpose.BCL/System/Console.cs
+++ b/BCL/Transpose.BCL/System/Console.cs
@@ -107,7 +107,10 @@ namespace System
 
             if (con && con.log)
             {
-                if (!Transpose.Script.IsDefined(value))
+                // `null` as well as `undefined`: .NET writes an empty line for a null object, and
+                // Transpose.isDefined(null) is true (it only tests for undefined), so a null fell
+                // through to the dereference below and threw "Cannot read properties of null".
+                if (value == null || !Transpose.Script.IsDefined(value))
                 {
                     con.log("");
                     return;
@@ -295,7 +298,10 @@ namespace System
 
             if (con && con.log)
             {
-                if (!Transpose.Script.IsDefined(value))
+                // `null` as well as `undefined`: .NET writes an empty line for a null object, and
+                // Transpose.isDefined(null) is true (it only tests for undefined), so a null fell
+                // through to the dereference below and threw "Cannot read properties of null".
+                if (value == null || !Transpose.Script.IsDefined(value))
                 {
                     con.log("");
                     return;
@@ -429,12 +435,12 @@ namespace System
         [Transpose.Template("System.Console.WriteLine(System.Console.TransformChars({buffer}, 0, {index}, {count}))")]
         public static extern void WriteLine(char[] buffer, int index, int count);
 
-        /// <summary>
-        /// Writes the text representation of the specified nullable decimal, followed by the current line terminator, to the standard output stream.
-        /// </summary>
-        /// <param name="value">The value to write.</param>
-        [Transpose.Template("System.Console.WriteLine({value} && {value}.toString(\"G\"))")]
-        public static extern void WriteLine(decimal? value);
+        // NOTE: there is deliberately no WriteLine(decimal?) overload. .NET has none, and adding one
+        // hijacked every nullable numeric: `int?`/`long?`/`short?` all convert implicitly to `decimal?`,
+        // which beats the boxing conversion to WriteLine(object), so `Console.WriteLine(someNullableInt)`
+        // bound here and its `{value}.toString("G")` template threw
+        // "RangeError: toString() radix argument must be between 2 and 36" on a plain JS number.
+        // WriteLine(object) handles null and every boxed numeric representation already.
 
         #endregion WriteLine
 

--- a/BCL/Transpose.BCL/System/Math.cs
+++ b/BCL/Transpose.BCL/System/Math.cs
@@ -277,6 +277,16 @@ namespace System
 
         public static extern double Pow(int x, int y);
 
+        // .NET has only Pow(double, double), so `Math.Pow(someLong, 2L)` resolves there. The extra
+        // decimal overload above makes that call ambiguous here (long converts implicitly to both
+        // double and decimal, neither better), so a long argument needs its own overload — the same
+        // reason Pow(int, int) exists.
+        [Transpose.Template("Math.pow(({x}).toNumber(), ({y}).toNumber())")]
+        public static extern double Pow(long x, long y);
+
+        [Transpose.Template("Math.pow(({x}).toNumber(), ({y}).toNumber())")]
+        public static extern double Pow(ulong x, ulong y);
+
         public static extern double Acos(double x);
 
         public static extern double Asin(double x);
@@ -302,6 +312,23 @@ namespace System
 
         [Transpose.Template("{value}.sign()")]
         public static extern int Sign(decimal value);
+
+        // .NET has Sign(long)/Sign(int)/…; without them an integer argument is ambiguous between
+        // Sign(double) and Sign(decimal). (There is deliberately no Sign(ulong) — .NET has none
+        // either, since a ulong is never negative.)
+        [Transpose.Template("({value}).sign()")]
+        public static extern int Sign(long value);
+
+        [Transpose.Template("Transpose.Int.sign({value})")]
+        public static extern int Sign(int value);
+
+        // The full 64-bit product of two 32-bit values — the point being that it does NOT wrap the
+        // way `a * b` in int arithmetic would.
+        [Transpose.Template("System.Int64({a}).mul(System.Int64({b}))")]
+        public static extern long BigMul(int a, int b);
+
+        [Transpose.Template("System.UInt64({a}).mul(System.UInt64({b}))")]
+        public static extern ulong BigMul(uint a, uint b);
 
         [Transpose.Template("Transpose.Math.divRem({a}, {b}, {result})")]
         public static extern int DivRem(int a, int b, out int result);

--- a/BCL/Transpose.BCL/shared/System/Random.cs
+++ b/BCL/Transpose.BCL/shared/System/Random.cs
@@ -35,11 +35,29 @@ namespace System
         private int[] SeedArray = new int[56];
 
         /// <summary>
-        /// Initializes a new instance of the Random class, using a time-dependent default seed value.
+        /// Initializes a new instance of the Random class, using a default seed value.
         /// </summary>
         public Random()
-          : this((int)DateTime.Now.Ticks)
+          : this(GenerateSeed())
         {
+        }
+
+        /// <summary>
+        /// A fresh seed for the parameterless constructor, drawn from the platform's
+        /// <c>Math.random()</c>.
+        /// </summary>
+        /// <remarks>
+        /// This replaces a <c>(int)DateTime.Now.Ticks</c> seed. Ticks are effectively
+        /// millisecond-resolution in JavaScript (they come from <c>Date</c>), so every
+        /// <c>new Random()</c> constructed within the same millisecond — a loop, or a handful of
+        /// objects built together — got the *same* seed and therefore produced the identical
+        /// sequence. <c>Math.random()</c> is independent per call.
+        /// </remarks>
+        private static int GenerateSeed()
+        {
+            // getRndInteger(0, int.MaxValue): Math.floor(Math.random() * (max - min)) + min.
+            // Math.random() is in [0, 1), so the result is a non-negative int < int.MaxValue.
+            return (int)(Math.Random() * int.MaxValue);
         }
 
         /// <summary>
@@ -231,11 +249,43 @@ namespace System
             }
         }
 
-        public virtual long NextInt64()
+        /// <summary>
+        /// Produces a value in the range [0, ulong.MaxValue] by stitching together three draws of
+        /// 22 + 22 + 20 bits. This is exactly how .NET composes 64 random bits out of
+        /// <see cref="Next(int)"/>, and matching it is what makes a seeded sequence of
+        /// <see cref="NextInt64()"/> agree with .NET value-for-value.
+        /// </summary>
+        private ulong NextUInt64()
         {
-            return NextInt64(long.MaxValue);
+            return ((ulong)(uint)Next(1 << 22))
+                 | (((ulong)(uint)Next(1 << 22)) << 22)
+                 | (((ulong)(uint)Next(1 << 20)) << 44);
         }
 
+        /// <summary>
+        /// Returns a non-negative random integer.
+        /// </summary>
+        /// <returns>A 64-bit signed integer that is greater than or equal to 0 and less than Int64.MaxValue.</returns>
+        public virtual long NextInt64()
+        {
+            while (true)
+            {
+                // Take the top 63 bits for a value in [0, long.MaxValue], and retry on the one
+                // excluded value so the result is in [0, long.MaxValue).
+                ulong result = NextUInt64() >> 1;
+
+                if (result != long.MaxValue)
+                {
+                    return (long)result;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a non-negative random integer that is less than the specified maximum.
+        /// </summary>
+        /// <param name="maxValue">The exclusive upper bound of the random number to be generated. maxValue must be greater than or equal to 0.</param>
+        /// <returns>A 64-bit signed integer that is greater than or equal to 0, and less than maxValue.</returns>
         public virtual long NextInt64(long maxValue)
         {
             if (maxValue < 0)
@@ -246,6 +296,12 @@ namespace System
             return NextInt64(0, maxValue);
         }
 
+        /// <summary>
+        /// Returns a random 64-bit integer that is within a specified range.
+        /// </summary>
+        /// <param name="minValue">The inclusive lower bound of the random number returned.</param>
+        /// <param name="maxValue">The exclusive upper bound of the random number returned. maxValue must be greater than or equal to minValue.</param>
+        /// <returns>A 64-bit signed integer greater than or equal to minValue and less than maxValue. If minValue equals maxValue, minValue is returned.</returns>
         public virtual long NextInt64(long minValue, long maxValue)
         {
             if (minValue > maxValue)
@@ -253,48 +309,81 @@ namespace System
                 throw new ArgumentOutOfRangeException("minValue", "minValue must be less than or equal to maxValue");
             }
 
-            ulong range = (ulong)(maxValue - minValue);
+            ulong exclusiveRange = (ulong)(maxValue - minValue);
 
-            if (range == 0)
+            if (exclusiveRange > 1)
             {
-                return minValue;
+                // Narrow to the smallest range [0, 2^bitsNeeded) that contains exclusiveRange, then
+                // redraw until the value falls inside the inner range (rejection sampling — an
+                // unbiased modulo would need a division on a 64-bit value).
+                int bitsNeeded = BitsNeeded(exclusiveRange);
+
+                while (true)
+                {
+                    ulong result = NextUInt64() >> (64 - bitsNeeded);
+
+                    if (result < exclusiveRange)
+                    {
+                        return (long)result + minValue;
+                    }
+                }
             }
 
-            if (range <= (ulong)int.MaxValue)
-            {
-                return (long)Next((int)range) + minValue;
-            }
-
-            byte[] buffer = new byte[8];
-            ulong result;
-            ulong limit = ulong.MaxValue - (ulong.MaxValue % range);
-
-            do
-            {
-                NextBytes(buffer);
-                result = BitConverter.ToUInt64(buffer, 0);
-            } while (result >= limit);
-
-            return (long)(result % range) + minValue;
+            // exclusiveRange is 0 or 1, so minValue is the only possible answer.
+            return minValue;
         }
 
+        /// <summary>The position of <paramref name="value"/>'s highest set bit, i.e.
+        /// <c>64 - BitOperations.LeadingZeroCount(value)</c> (which this BCL does not have).</summary>
+        private static int BitsNeeded(ulong value)
+        {
+            int bits = 0;
+
+            while (value != 0)
+            {
+                bits++;
+                value = value >> 1;
+            }
+
+            return bits;
+        }
+
+        /// <summary>
+        /// Returns a random floating-point number that is greater than or equal to 0.0, and less than 1.0.
+        /// </summary>
+        /// <returns>A single-precision floating point number that is greater than or equal to 0.0, and less than 1.0.</returns>
         public virtual float NextSingle()
         {
-            return (float)Sample();
+            while (true)
+            {
+                // Narrowing a double sample to float rounds, and rounding up from just under 1.0
+                // would break the exclusive upper bound — so redraw in that case, as .NET does.
+                float f = (float)Sample();
+
+                if (f < 1.0f)
+                {
+                    return f;
+                }
+            }
         }
 
-        private static Random t_shared;
+        private static Random s_shared;
 
+        /// <summary>
+        /// Provides a shared instance for use by any code that needs random numbers but has no need
+        /// for its own sequence. On .NET this instance is thread-safe; JavaScript is single-threaded,
+        /// so a plain instance suffices here.
+        /// </summary>
         public static Random Shared
         {
             get
             {
-                if (t_shared == null)
+                if (s_shared == null)
                 {
-                    t_shared = new Random();
+                    s_shared = new Random();
                 }
 
-                return t_shared;
+                return s_shared;
             }
         }
     }

--- a/H5.Translator.Roslyn.PORT_PLAN.md
+++ b/H5.Translator.Roslyn.PORT_PLAN.md
@@ -72,6 +72,9 @@ Roslyn diagnostics of severity `Error` abort translation and are surfaced to the
 | `[DllImport]` / `extern` | attribute / modifier | `Native interop is not supported` |
 | Threads, locks, `Monitor`, `Mutex`, `volatile` | symbol namespace / modifier | `Threading primitives are not supported` |
 | File / socket I/O (`System.IO`, `System.Net.Sockets`) | bound symbol namespace | `<API> is not supported in the browser` |
+| `checked` arithmetic on primitive integers | `CheckedStatement`/`CheckedExpression` | `checked arithmetic (overflow checking) is not supported` |
+| Inline arrays (`[InlineArray]` structs) | attribute on `StructDeclarationSyntax` | `Inline arrays are not supported` |
+| Enums with a 64-bit underlying type (`enum E : long`/`: ulong`) | `EnumDeclarationSyntax` base type | `An enum with a 64-bit underlying type is not supported` — members are emitted as JS numbers, exact only to 2^53 |
 
 The policy is **deny-by-namespace/symbol** for the runtime BCL (only the modeled surface is allowed) plus **deny-by-syntax** for the language constructs above. Anything unmodeled reports a clear "not supported" error at compile time rather than producing broken JS.
 

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -2313,7 +2313,7 @@ public class Program
             await RunTest(@"
 using System;
 [Flags] public enum Perm { None = 0, Read = 1, Write = 2, Exec = 4 }
-public enum Big : long { A = 1L, B = 5000000000L }
+public enum Big { A = 1, B = 50000000 }   // int-backed: a 64-bit underlying type is unsupported
 public class Program
 {
     public static void Main()

--- a/Transpose/Transpose.Translator.Tests/Ported/Int64OperationsTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Ported/Int64OperationsTests.cs
@@ -1,0 +1,807 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Ported
+{
+    /// <summary>
+    /// System.Int64 / System.UInt64 beyond the arithmetic already covered by
+    /// <see cref="NumericTypesTests"/> and <see cref="PrimitiveCastTests"/>.
+    ///
+    /// long/ulong are the awkward numeric types in a JS target: tps.js models them as
+    /// System.Int64/UInt64 *objects*, not plain numbers. Everything that assumes "a number is a
+    /// number" therefore has to be taught about them — JS `===` compares object identity, JS `+`
+    /// string-concatenates an object, and `typeof x === "number"` is false. Each test below pins one
+    /// place where that mattered.
+    /// </summary>
+    [TestClass]
+    public class Int64OperationsTests : TranslatorTestBase
+    {
+        /// <summary>
+        /// <c>switch</c> and constant patterns. A JS <c>switch</c> matches with <c>===</c>, so a
+        /// long subject never equalled any <c>case</c> constant and every switch silently fell
+        /// through to <c>default</c>.
+        /// </summary>
+        [TestMethod]
+        public async Task SwitchAndConstantPatterns_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long l = 2L;
+        ulong u = 2UL;
+        decimal m = 2m;
+
+        switch (l)
+        {
+            case 1L: Console.WriteLine("long one"); break;
+            case 2L: Console.WriteLine("long two"); break;
+            default: Console.WriteLine("long default"); break;
+        }
+
+        switch (u)
+        {
+            case 1UL: Console.WriteLine("ulong one"); break;
+            case 2UL: Console.WriteLine("ulong two"); break;
+            default: Console.WriteLine("ulong default"); break;
+        }
+
+        switch (m)
+        {
+            case 2m: Console.WriteLine("decimal two"); break;
+            default: Console.WriteLine("decimal default"); break;
+        }
+
+        // A case that must NOT match.
+        switch (l)
+        {
+            case 3L: Console.WriteLine("wrong"); break;
+            default: Console.WriteLine("correct default"); break;
+        }
+
+        // Switch expressions and `is` patterns over the same values.
+        Console.WriteLine(l switch { 1L => "a", 2L => "b", _ => "z" });
+        Console.WriteLine(u switch { 2UL => "u2", _ => "z" });
+        Console.WriteLine(m switch { 2m => "m2", _ => "z" });
+        Console.WriteLine(l is 2L);
+        Console.WriteLine(l is 3L);
+        Console.WriteLine(l is 1L or 2L);
+        Console.WriteLine(l is not 3L);
+        Console.WriteLine(l is > 1L and < 5L);
+        Console.WriteLine(l is > 5L);
+
+        // Relational patterns compared the two Int64 objects with a JS `>`, which coerces both to
+        // STRINGS — so `9L is > 10L` was true ("9" > "10" lexicographically). Digit counts must differ
+        // here for the test to have any teeth.
+        long nine = 9L;
+        Console.WriteLine(nine is > 10L);
+        Console.WriteLine(nine is < 10L);
+        Console.WriteLine(nine is >= 10L);
+        Console.WriteLine(nine is <= 10L);
+        Console.WriteLine(nine switch { > 10L => "gt", < 10L => "lt", _ => "eq" });
+
+        long negative = -5L;
+        Console.WriteLine(negative is > 3L);
+        Console.WriteLine(negative is < 3L);
+        Console.WriteLine(negative is > (-10L));
+
+        ulong un = 9UL;
+        Console.WriteLine(un is < 10UL);
+        Console.WriteLine(un is > 10UL);
+
+        decimal dm = 9m;
+        Console.WriteLine(dm is < 10m);
+        Console.WriteLine(dm is > 10m);
+
+        // Near the 64-bit boundary, where a string compare of equal-length digits happens to agree.
+        long huge = 9223372036854775806L;
+        Console.WriteLine(huge is > 9223372036854775805L);
+        Console.WriteLine(huge is < 9223372036854775807L);
+        Console.WriteLine(huge is >= 9223372036854775806L);
+
+        // A null Nullable matches neither a constant nor a relational pattern.
+        long? nul = null;
+        Console.WriteLine(nul is 2L);
+        Console.WriteLine(nul is > 1L);
+
+        // Nullable subjects.
+        long? n = 2L;
+        Console.WriteLine(n switch { 2L => "n2", null => "null", _ => "z" });
+        long? nn = null;
+        Console.WriteLine(nn switch { 2L => "n2", null => "null", _ => "z" });
+
+        // Edge values.
+        long big = long.MaxValue;
+        switch (big)
+        {
+            case long.MaxValue: Console.WriteLine("max"); break;
+            default: Console.WriteLine("not max"); break;
+        }
+
+        long min = long.MinValue;
+        Console.WriteLine(min is long.MinValue);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// Type tests and patterns against a BOXED long. The pattern emitter used
+        /// <c>typeof x === "number" &amp;&amp; Number.isInteger(x)</c> for every integer type, which
+        /// neither recognised the boxed Int64 object nor told long from int — <c>case long l</c>
+        /// matched a boxed int and the binding then threw "l.gt is not a function".
+        /// </summary>
+        [TestMethod]
+        public async Task BoxedTypeTestsAndPatterns_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    static string Describe(object o) => o switch
+    {
+        long l when l > 100L => "big long " + l,
+        long l => "long " + l,
+        ulong ul => "ulong " + ul,
+        int i => "int " + i,
+        decimal m => "decimal " + m,
+        _ => "other"
+    };
+
+    public static void Main()
+    {
+        long l = 5L;
+        ulong u = 5UL;
+        int i = 5;
+        decimal m = 5m;
+
+        // Boxing a variable and boxing a LITERAL must produce the same runtime type: `object o = 5L`
+        // used to emit a bare `5`, so o.GetType() reported Int32 and `o is long` was false.
+        object fromVariable = l;
+        object fromLiteral = 5L;
+        object uFromLiteral = 5UL;
+        object mFromLiteral = 5m;
+
+        Console.WriteLine(fromVariable.GetType().FullName);
+        Console.WriteLine(fromLiteral.GetType().FullName);
+        Console.WriteLine(uFromLiteral.GetType().FullName);
+        Console.WriteLine(mFromLiteral.GetType().FullName);
+
+        Console.WriteLine(fromVariable is long);
+        Console.WriteLine(fromLiteral is long);
+        Console.WriteLine(fromLiteral is int);
+        Console.WriteLine(uFromLiteral is ulong);
+        Console.WriteLine(uFromLiteral is long);
+        Console.WriteLine(mFromLiteral is decimal);
+
+        Console.WriteLine((long)fromLiteral);
+        Console.WriteLine((ulong)uFromLiteral);
+        Console.WriteLine(fromLiteral.ToString());
+
+        Console.WriteLine(Describe(l));
+        Console.WriteLine(Describe(200L));
+        Console.WriteLine(Describe(u));
+        Console.WriteLine(Describe(i));
+        Console.WriteLine(Describe(m));
+        Console.WriteLine(Describe("s"));
+
+        // Declaration patterns bind a usable Int64, so 64-bit operators work on the bound value.
+        if (fromLiteral is long bound) Console.WriteLine(bound * 3L);
+
+        // Arrays / collections of object keep the boxed representation.
+        object[] boxes = { 1L, 2UL, 3, 4m };
+        foreach (var b in boxes) Console.WriteLine(b.GetType().Name + " " + b);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// Lifted operators on <c>long?</c>/<c>ulong?</c>. The 64-bit branch matched on the type with
+        /// Nullable stripped and so claimed these first, emitting <c>System.Int64(null).add(1)</c> —
+        /// which is 1, not null, while <c>int? + 1</c> propagated correctly.
+        /// </summary>
+        [TestMethod]
+        public async Task NullableLiftedOperators_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long? l = null;
+        ulong? u = null;
+        decimal? m = null;
+        int? i = null;
+
+        // Arithmetic on a null operand yields null...
+        Console.WriteLine((l + 1L) == null);
+        Console.WriteLine((l - 1L) == null);
+        Console.WriteLine((l * 2L) == null);
+        Console.WriteLine((l / 2L) == null);
+        Console.WriteLine((l % 2L) == null);
+        Console.WriteLine((l & 2L) == null);
+        Console.WriteLine((l | 2L) == null);
+        Console.WriteLine((l ^ 2L) == null);
+        Console.WriteLine((l << 2) == null);
+        Console.WriteLine((l >> 2) == null);
+        Console.WriteLine((u + 1UL) == null);
+        Console.WriteLine((m + 1m) == null);
+        Console.WriteLine((i + 1) == null);
+        Console.WriteLine((i / 2) == null);
+
+        // ...and a relational comparison against null yields false, both ways round.
+        Console.WriteLine(l > 1L);
+        Console.WriteLine(l < 1L);
+        Console.WriteLine(l >= 1L);
+        Console.WriteLine(l <= 1L);
+
+        // With a value present the operators compute normally (integer division truncating).
+        long? k = 7L;
+        ulong? uk = 7UL;
+        int? ik = 7;
+
+        Console.WriteLine(k + 1L);
+        Console.WriteLine(k - 1L);
+        Console.WriteLine(k * 2L);
+        Console.WriteLine(k / 2L);
+        Console.WriteLine(k % 3L);
+        Console.WriteLine(k & 3L);
+        Console.WriteLine(k | 8L);
+        Console.WriteLine(k ^ 1L);
+        Console.WriteLine(k << 1);
+        Console.WriteLine(k >> 1);
+        Console.WriteLine(uk / 2UL);
+        Console.WriteLine(ik / 2);
+        Console.WriteLine(ik * 3);
+        Console.WriteLine(k > 1L);
+        Console.WriteLine(k < 1L);
+        Console.WriteLine(k == 7L);
+        Console.WriteLine(k != 7L);
+
+        // Promotion to floating point still applies through the lift.
+        Console.WriteLine(k * 0.5);
+        Console.WriteLine(l * 0.5 == null);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>The rest of the <c>long?</c> surface: members, defaults, conversions, printing.</summary>
+        [TestMethod]
+        public async Task NullableMembers_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    static long? Get(bool b) => b ? 5L : (long?)null;
+
+    public static void Main()
+    {
+        // `long? x = 7L` needs the same Int64 instance a plain long gets, or a later x.add(…) throws.
+        long? a = 7L;
+        long? b = null;
+        long? c = 7;          // int literal widened into long?
+        ulong? u = 7UL;
+
+        Console.WriteLine(a + "|" + b + "|" + c + "|" + u + "|");
+        Console.WriteLine(a.HasValue + " " + b.HasValue);
+        Console.WriteLine(a.Value);
+        Console.WriteLine(a.GetValueOrDefault() + " " + b.GetValueOrDefault() + " " + b.GetValueOrDefault(3L));
+        Console.WriteLine((a ?? 0L) + " " + (b ?? 0L));
+        Console.WriteLine(a == 7L);
+        Console.WriteLine(a != 7L);
+        Console.WriteLine(b == null);
+
+        // Lifted == between two Nullables compared the two Int64 OBJECTS with `===`, i.e. by
+        // identity, so equal values came out unequal.
+        long? sameAsA = 7L;
+        long? other = 8L;
+        long? alsoNull = null;
+        Console.WriteLine(a == sameAsA);
+        Console.WriteLine(a != sameAsA);
+        Console.WriteLine(a == other);
+        Console.WriteLine(a == b);
+        Console.WriteLine(b == alsoNull);
+        Console.WriteLine(b != alsoNull);
+
+        ulong? ua = 7UL, ub = 7UL;
+        Console.WriteLine(ua == ub);
+
+        decimal? da = 2.5m, db = 2.5m;
+        Console.WriteLine(da == db);
+        Console.WriteLine(a.Equals(7L));
+        Console.WriteLine(a.Equals(3L));
+        Console.WriteLine(a.ToString() + "|" + b.ToString() + "|");
+        Console.WriteLine((long)a);
+        Console.WriteLine(Get(true) + " " + Get(false) + "|");
+        Console.WriteLine(a + a);
+        Console.WriteLine(a * a);
+
+        long?[] arr = { 1L, null, 3L };
+        Console.WriteLine(string.Join(",", arr));
+
+        try { Console.WriteLine(b.Value); }
+        catch (InvalidOperationException) { Console.WriteLine("InvalidOperationException"); }
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// Compound assignment where the TARGET is floating point and the source is 64-bit. The
+        /// implicit long→double widening was not applied, so `d += someLong` string-concatenated the
+        /// Int64 object ("42" + "4" → "424") instead of adding.
+        /// </summary>
+        [TestMethod]
+        public async Task CompoundAssignmentAcrossTypes_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long l = 4L;
+        ulong ul = 4UL;
+
+        double d = 10.5;
+        d *= l; Console.WriteLine(d);
+        d += l; Console.WriteLine(d);
+        d -= l; Console.WriteLine(d);
+        d /= l; Console.WriteLine(d);
+        d %= l; Console.WriteLine(d);
+
+        float f = 10.5f;
+        f += l; Console.WriteLine(f);
+
+        double du = 10.5;
+        du += ul; Console.WriteLine(du);
+
+        decimal m = 10.5m;
+        m *= l; Console.WriteLine(m);
+
+        // 64-bit target with narrower sources.
+        long p = 10L; p *= 3;          Console.WriteLine(p);
+        long q = 10L; q += 'a';        Console.WriteLine(q);
+        long r = 10L; r -= (short)2;   Console.WriteLine(r);
+        ulong s = 10UL; s *= 3u;       Console.WriteLine(s);
+        long t = 10L; t >>= 2;         Console.WriteLine(t);
+        long v = -8L; v >>= 1;         Console.WriteLine(v);
+        ulong w = ulong.MaxValue; w >>= 1; Console.WriteLine(w);
+        long x = 1L; x <<= 40;         Console.WriteLine(x);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// Implicit long→double widening at every conversion site the emitter routes through
+        /// <c>EmitExpressionConverted</c>: arguments, returns, ternary branches, initializers.
+        /// </summary>
+        [TestMethod]
+        public async Task ImplicitWideningToFloating_Tests()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    static double TakeDouble(double d) => d * 2;
+    static float TakeFloat(float f) => f * 2;
+    static decimal TakeDecimal(decimal m) => m * 2;
+    static double Widen(long v) => v;
+
+    public static void Main()
+    {
+        long l = 21L;
+        ulong u = 21UL;
+
+        Console.WriteLine(TakeDouble(l));
+        Console.WriteLine(TakeDouble(u));
+        Console.WriteLine(TakeFloat(l));
+        Console.WriteLine(TakeDecimal(l));
+        Console.WriteLine(Widen(l));
+
+        double local = l;
+        Console.WriteLine(local + 0.5);
+
+        bool cond = true;
+        double t1 = cond ? l : 1.5;
+        double t2 = cond ? 1.5 : l;
+        Console.WriteLine(t1 + " " + t2);
+
+        double[] arr = { l, 2.5 };
+        Console.WriteLine(arr[0] + " " + arr[1]);
+
+        var list = new List<double> { l };
+        Console.WriteLine(list[0]);
+
+        Console.WriteLine(Math.Max(1.5, (double)l));
+        Console.WriteLine(Math.Sqrt(l));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>Division and modulo by zero must raise the .NET exceptions, catchably.</summary>
+        [TestMethod]
+        public async Task DivisionEdgeCases_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long zero = 0L;
+        ulong uzero = 0UL;
+        long min = long.MinValue;
+
+        // The long runtime used to throw a bare JS Error, which no catch clause could see.
+        try { Console.WriteLine(1L / zero); }
+        catch (DivideByZeroException) { Console.WriteLine("DivideByZeroException"); }
+
+        try { Console.WriteLine(1L % zero); }
+        catch (DivideByZeroException) { Console.WriteLine("DivideByZeroException"); }
+
+        try { Console.WriteLine(1UL / uzero); }
+        catch (DivideByZeroException) { Console.WriteLine("DivideByZeroException"); }
+
+        // long.MinValue / -1 overflows rather than wrapping.
+        try { Console.WriteLine(min / -1L); }
+        catch (OverflowException) { Console.WriteLine("OverflowException"); }
+
+        // Ordinary division truncates toward zero.
+        Console.WriteLine(7L / 2L);
+        Console.WriteLine(-7L / 2L);
+        Console.WriteLine(7L % 3L);
+        Console.WriteLine(-7L % 3L);
+        Console.WriteLine(ulong.MaxValue / 2UL);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>Shifts, bitwise operators and unchecked overflow wrapping across the full range.</summary>
+        [TestMethod]
+        public async Task ShiftsBitwiseAndWrapping_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long l = 1L;
+        ulong u = 1UL;
+        long max = long.MaxValue, min = long.MinValue;
+        ulong umax = ulong.MaxValue;
+        int n = 40;
+
+        Console.WriteLine(l << 40);
+        Console.WriteLine(l << 63);
+        Console.WriteLine(l << 64);   // the shift count is masked to & 63
+        Console.WriteLine(l << 65);
+        Console.WriteLine(l << n);
+        Console.WriteLine(min >> 1);
+        Console.WriteLine(-8L >> 2);
+        Console.WriteLine(umax >> 1);
+        Console.WriteLine(umax >> 63);
+        Console.WriteLine(u << 63);
+        Console.WriteLine(~l);
+        Console.WriteLine(~u);
+        Console.WriteLine(-l);
+
+        Console.WriteLine(0xFF00FF00FF00FF00UL & 0x00FF00FF00FF00FFUL);
+        Console.WriteLine(0xFF00FF00FF00FF00UL | 0x00FF00FF00FF00FFUL);
+        Console.WriteLine(0xFF00FF00FF00FF00UL ^ 0xFFFFFFFFFFFFFFFFUL);
+
+        // Unchecked wrapping at the range boundaries.
+        Console.WriteLine(max + 1L);
+        Console.WriteLine(min - 1L);
+        Console.WriteLine(umax + 1UL);
+        Console.WriteLine(max * 2L);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>Instance members, parsing and formatting on long/ulong.</summary>
+        [TestMethod]
+        public async Task MemberResolution_Tests()
+        {
+            var code = """
+using System;
+using System.Globalization;
+public class Program
+{
+    public static void Main()
+    {
+        long l = 1234567890123L;
+        ulong u = 12345678901234567890UL;
+
+        Console.WriteLine(l.ToString());
+        Console.WriteLine(l.ToString("N0", CultureInfo.InvariantCulture));
+        Console.WriteLine(l.ToString("X"));
+        Console.WriteLine(l.ToString("D20"));
+        Console.WriteLine(u.ToString());
+        Console.WriteLine(l.CompareTo(5L));
+        Console.WriteLine(l.CompareTo(l));
+        Console.WriteLine(5L.CompareTo(l));
+        Console.WriteLine(l.Equals(l));
+        Console.WriteLine(l.Equals(5L));
+        Console.WriteLine(l.GetHashCode() == l.GetHashCode());
+        Console.WriteLine(long.MinValue + " " + long.MaxValue);
+        Console.WriteLine(ulong.MinValue + " " + ulong.MaxValue);
+        Console.WriteLine(long.Parse("-9223372036854775808"));
+        Console.WriteLine(ulong.Parse("18446744073709551615"));
+        Console.WriteLine(long.TryParse("123", out long p) + " " + p);
+        Console.WriteLine(long.TryParse("bad", out long q) + " " + q);
+        Console.WriteLine(Convert.ToInt64("42"));
+        Console.WriteLine(Convert.ToUInt64("42"));
+        Console.WriteLine(Convert.ToDouble(l));
+        Console.WriteLine(Convert.ToInt32(5L));
+        Console.WriteLine(Convert.ToString(l));
+        Console.WriteLine(BitConverter.GetBytes(l).Length);
+        Console.WriteLine(BitConverter.ToInt64(BitConverter.GetBytes(l), 0));
+        Console.WriteLine(BitConverter.DoubleToInt64Bits(1.5));
+        Console.WriteLine(BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(1.5)));
+        Console.WriteLine(l.GetType().FullName);
+        Console.WriteLine(u.GetType().FullName);
+
+        // Interface dispatch.
+        IComparable<long> c = 5L;
+        Console.WriteLine(c.CompareTo(6L));
+        IEquatable<long> e = 5L;
+        Console.WriteLine(e.Equals(5L));
+        IComparable c2 = 5L;
+        Console.WriteLine(c2.CompareTo(6L));
+
+        // Interpolation and string.Format.
+        Console.WriteLine($"{l}");
+        Console.WriteLine($"{l:N0}");
+        Console.WriteLine(string.Format("{0} {1}", l, u));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>System.Math with long/ulong arguments — including the overloads that used to be
+        /// missing (so a long argument was ambiguous between the double and decimal ones).</summary>
+        [TestMethod]
+        public async Task MathWithInt64_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        long l = 21L;
+        ulong u = 21UL;
+
+        Console.WriteLine(Math.Abs(l));
+        Console.WriteLine(Math.Abs(-l));
+        Console.WriteLine(Math.Min(l, 5L));
+        Console.WriteLine(Math.Max(l, 5L));
+        Console.WriteLine(Math.Min(u, 5UL));
+        Console.WriteLine(Math.Max(u, 5UL));
+        Console.WriteLine(Math.Sign(l));
+        Console.WriteLine(Math.Sign(-l));
+        Console.WriteLine(Math.Sign(0L));
+        Console.WriteLine(Math.Sqrt(l));
+        Console.WriteLine(Math.Pow(l, 2L));
+        Console.WriteLine(Math.Pow(u, 2UL));
+        Console.WriteLine(Math.Clamp(l, 1L, 10L));
+        Console.WriteLine(Math.Clamp(l, 30L, 40L));
+        Console.WriteLine(Math.DivRem(17L, 5L, out long rem) + " r" + rem);
+
+        // BigMul keeps the full 64-bit product where int multiplication would wrap.
+        int i32 = int.MaxValue;
+        uint u32 = uint.MaxValue;
+        Console.WriteLine(Math.BigMul(i32, i32));
+        Console.WriteLine(Math.BigMul(u32, u32));
+        Console.WriteLine(i32 * i32);   // the wrapped 32-bit product, for contrast
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>Collections and LINQ keyed on / aggregating long values.</summary>
+        [TestMethod]
+        public async Task CollectionsAndLinq_Tests()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+public class Program
+{
+    public static void Main()
+    {
+        var list = new List<long> { 3L, 1L, 2L, 1L };
+
+        list.Sort();
+        Console.WriteLine(string.Join(",", list));
+        Console.WriteLine(list.Contains(2L) + " " + list.IndexOf(2L) + " " + list.Contains(9L));
+
+        // Average over long returns DOUBLE — Int64 division would truncate 7/4 to 1.
+        Console.WriteLine(list.Sum());
+        Console.WriteLine(list.Min());
+        Console.WriteLine(list.Max());
+        Console.WriteLine(list.Average());
+        Console.WriteLine(list.Average(x => x));
+        Console.WriteLine(new List<long> { 1L, 2L }.Average());
+
+        Console.WriteLine(string.Join(",", list.Distinct()));
+        Console.WriteLine(string.Join(",", list.OrderByDescending(x => x)));
+        Console.WriteLine(string.Join(",", list.GroupBy(x => x).Select(g => g.Key + ":" + g.Count())));
+        Console.WriteLine(list.Where(x => x > 1L).Count());
+        Console.WriteLine(list.Aggregate(0L, (a, b) => a + b));
+        Console.WriteLine(Enumerable.Range(1, 5).Select(i => (long)i).Sum());
+        Console.WriteLine(Enumerable.Range(1, 5).Sum(i => (long)i));
+
+        var dict = new Dictionary<long, string> { { 1L, "a" }, { 2L, "b" } };
+        Console.WriteLine(dict[1L] + dict[2L] + dict.ContainsKey(2L) + dict.ContainsKey(9L) + dict.Count);
+        dict[1L] = "z";
+        Console.WriteLine(dict[1L] + " " + dict.Count);
+
+        var set = new HashSet<long> { 1L, 2L, 1L };
+        Console.WriteLine(set.Count + " " + set.Contains(2L));
+
+        Console.WriteLine(Comparer<long>.Default.Compare(1L, 2L));
+        Console.WriteLine(EqualityComparer<long>.Default.Equals(1L, 1L));
+        Console.WriteLine(EqualityComparer<long>.Default.Equals(1L, 2L));
+
+        long[] arr = { 5L, 3L, 9L };
+        Array.Sort(arr);
+        Console.WriteLine(string.Join(",", arr));
+        Console.WriteLine(Array.IndexOf(arr, 9L));
+
+        var ulist = new List<ulong> { 3UL, 1UL };
+        ulist.Sort();
+        Console.WriteLine(string.Join(",", ulist));
+
+        var udict = new Dictionary<ulong, int> { { 18446744073709551615UL, 7 } };
+        Console.WriteLine(udict[18446744073709551615UL]);
+
+        // A long used as an array index / loop variable.
+        var strs = new[] { "a", "b", "c" };
+        long idx = 1L;
+        Console.WriteLine(strs[idx]);
+
+        var sb = new System.Text.StringBuilder();
+        for (long i = 0L; i < 3L; i++) sb.Append(strs[i]);
+        Console.WriteLine(sb.ToString());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// An enum with a 64-bit backing type. Its ordinals are emitted as plain JS numbers, so a
+        /// <c>(Big)someLong</c> cast has to read the magnitude out of the Int64 instance — otherwise
+        /// no member matched and ToString() printed the raw number.
+        ///
+        /// Ordinals are limited to JavaScript's exact-integer range (2^53); a member above that loses
+        /// precision, which is why <c>long.MaxValue</c> is not used here.
+        /// </summary>
+        [TestMethod]
+        public async Task Int64BackedEnum_Tests()
+        {
+            var code = """
+using System;
+
+public enum Big : long { A = 1L, B = 5000000000L }
+public enum UBig : ulong { X = 1UL, Y = 5000000000UL }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Big.B);
+        Console.WriteLine((long)Big.B);
+        Console.WriteLine(Big.B.ToString());
+        Console.WriteLine((Big)5000000000L);
+        Console.WriteLine(Enum.Parse<Big>("B"));
+        Console.WriteLine(UBig.Y);
+        Console.WriteLine((ulong)UBig.Y);
+
+        long raw = 5000000000L;
+        Console.WriteLine((Big)raw);
+        Console.WriteLine((Big)raw == Big.B);
+
+        Big v = Big.B;
+        switch (v)
+        {
+            case Big.A: Console.WriteLine("A"); break;
+            case Big.B: Console.WriteLine("B"); break;
+            default: Console.WriteLine("other"); break;
+        }
+
+        Console.WriteLine(v == Big.B);
+        Console.WriteLine(v is Big.B);
+        Console.WriteLine(v is Big.A);
+        Console.WriteLine(v is not Big.A);
+        Console.WriteLine(v is Big.A or Big.B);
+        Console.WriteLine(v switch { Big.A => "A", Big.B => "B", _ => "?" });
+
+        object boxed = Big.B;
+        Console.WriteLine(boxed.GetType().Name + " " + boxed);
+        Console.WriteLine(boxed is Big);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// `x is SomeType.Member` parses as an is-EXPRESSION rather than a pattern, and the emitter
+        /// read only the right side's type — so it emitted a TYPE test and `s is Small.A` was true for
+        /// every value of the enum. Not 64-bit-specific, but found while auditing this area.
+        /// </summary>
+        [TestMethod]
+        public async Task IsExpressionAgainstAConstant_Tests()
+        {
+            var code = """
+using System;
+
+public enum Small { A = 1, B = 2 }
+public enum Big : long { A = 1L, B = 5000000000L }
+
+public static class Limits
+{
+    public const int MaxInt = 7;
+    public const long MaxLong = 5000000000L;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Small s = Small.B;
+        Console.WriteLine(s is Small.B);
+        Console.WriteLine(s is Small.A);
+        Console.WriteLine(s is not Small.A);
+        Console.WriteLine(s is Small.A or Small.B);
+
+        Big b = Big.A;
+        Console.WriteLine(b is Big.A);
+        Console.WriteLine(b is Big.B);
+
+        int i = 7;
+        Console.WriteLine(i is Limits.MaxInt);
+        Console.WriteLine(i is 8);
+
+        long l = 5000000000L;
+        Console.WriteLine(l is Limits.MaxLong);
+        Console.WriteLine(l is 5000000001L);
+
+        // A genuine type test on the same syntax shape must still be a type test.
+        object o = "text";
+        Console.WriteLine(o is System.String);
+        Console.WriteLine(o is System.Int32);
+    }
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Ported/Int64OperationsTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Ported/Int64OperationsTests.cs
@@ -623,6 +623,132 @@ public class Program
             await RunTest(code);
         }
 
+        /// <summary>
+        /// <c>Convert.ToInt64</c>/<c>ToUInt64</c> ROUND (half to even) like every other integral
+        /// target — they are not a truncating cast. The 64-bit branch returned before the rounding the
+        /// narrower type codes get, so <c>Convert.ToInt64(42.7)</c> came out 42 instead of 43.
+        /// </summary>
+        [TestMethod]
+        public async Task ConvertToInt64Rounds_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Convert.ToInt64(42.7));
+        Console.WriteLine(Convert.ToInt64(42.2));
+        Console.WriteLine(Convert.ToInt64(-42.7));
+        Console.WriteLine(Convert.ToInt64(-42.2));
+
+        // Midpoints round to EVEN, not away from zero.
+        Console.WriteLine(Convert.ToInt64(42.5));
+        Console.WriteLine(Convert.ToInt64(43.5));
+        Console.WriteLine(Convert.ToInt64(-42.5));
+        Console.WriteLine(Convert.ToInt64(-43.5));
+
+        Console.WriteLine(Convert.ToUInt64(42.7));
+        Console.WriteLine(Convert.ToUInt64(42.5));
+        Console.WriteLine(Convert.ToUInt64(43.5));
+
+        // From float and decimal, not just double.
+        Console.WriteLine(Convert.ToInt64(42.7f));
+        Console.WriteLine(Convert.ToInt64(42.7m));
+        Console.WriteLine(Convert.ToInt64(43.5m));
+
+        // Already-integral values and other sources are untouched.
+        Console.WriteLine(Convert.ToInt64(42.0));
+        Console.WriteLine(Convert.ToInt64(42));
+        Console.WriteLine(Convert.ToInt64("42"));
+        Console.WriteLine(Convert.ToInt64(true));
+        Console.WriteLine(Convert.ToInt64(9007199254740993L));
+
+        // The narrower targets, which already rounded — kept here so the two stay consistent.
+        Console.WriteLine(Convert.ToInt32(42.7) + " " + Convert.ToInt32(42.5) + " " + Convert.ToInt32(43.5));
+        Console.WriteLine(Convert.ToUInt32(42.7) + " " + Convert.ToInt16(42.7) + " " + Convert.ToByte(42.7));
+
+        // A genuine cast still truncates — that is the difference being pinned down.
+        double d = 42.7;
+        Console.WriteLine((long)d);
+        Console.WriteLine((long)-42.7);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        /// <summary>
+        /// LINQ aggregates over a <c>Nullable&lt;T&gt;</c> sequence SKIP the nulls; they neither
+        /// propagate null nor throw. The runtime's rule was "if any element is null the result is
+        /// null", so <c>new long?[] { 1, 2, null, 3 }.Sum()</c> was null instead of 6 — and
+        /// <c>Average</c> on an all-null sequence threw instead of returning null.
+        /// </summary>
+        [TestMethod]
+        public async Task NullableLinqAggregatesSkipNulls_Tests()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+public class Program
+{
+    public static void Main()
+    {
+        var withNull = new long?[] { 1L, 2L, null, 3L };
+        var allNull = new long?[] { null, null };
+        var empty = new long?[] { };
+
+        // Nulls are skipped, and the count Average divides by excludes them: (1+2+3)/3 == 2.
+        Console.WriteLine(withNull.Sum());
+        Console.WriteLine(withNull.Average());
+        Console.WriteLine(withNull.Min());
+        Console.WriteLine(withNull.Max());
+        Console.WriteLine(withNull.Count());
+
+        // With no non-null value: Sum is 0, Average/Min/Max are null. Nothing throws.
+        Console.WriteLine(allNull.Sum());
+        Console.WriteLine(allNull.Average() == null);
+        Console.WriteLine(allNull.Min() == null);
+        Console.WriteLine(allNull.Max() == null);
+        Console.WriteLine(empty.Sum());
+        Console.WriteLine(empty.Average() == null);
+        Console.WriteLine(empty.Min() == null);
+
+        // The selector overloads drop nulls from the PROJECTED values.
+        Console.WriteLine(withNull.Sum(x => x));
+        Console.WriteLine(withNull.Average(x => x));
+        Console.WriteLine(withNull.Min(x => x));
+        Console.WriteLine(withNull.Max(x => x));
+        Console.WriteLine(new[] { 1, 2, 3 }.Sum(x => x == 2 ? (long?)null : x));
+        Console.WriteLine(new[] { 1, 2, 3 }.Average(x => x == 2 ? (long?)null : x));
+
+        // Every nullable numeric type, not just long?.
+        Console.WriteLine(new int?[] { 1, null, 3 }.Sum());
+        Console.WriteLine(new int?[] { 1, null, 3 }.Average());
+        Console.WriteLine(new long?[] { 1L, null, 3L }.Sum());
+        Console.WriteLine(new double?[] { 1.0, null, 3.0 }.Sum());
+        Console.WriteLine(new double?[] { 1.0, null, 3.0 }.Average());
+        Console.WriteLine(new decimal?[] { 1m, null, 3m }.Sum());
+        Console.WriteLine(new decimal?[] { 1m, null, 3m }.Average());
+        Console.WriteLine(new float?[] { 1f, null, 3f }.Sum());
+        Console.WriteLine(new int?[] { null, null }.Sum());
+        Console.WriteLine(new decimal?[] { null, null }.Sum());
+
+        // A sequence with no nulls is unchanged.
+        Console.WriteLine(new long?[] { 1L, 2L, 3L }.Sum());
+        Console.WriteLine(new long?[] { 1L, 2L, 3L }.Average());
+
+        // The NON-nullable overloads keep their own contract: Sum is 0 on empty, Average throws.
+        Console.WriteLine(new long[] { }.Sum());
+        try { Console.WriteLine(new long[] { }.Average()); }
+        catch (InvalidOperationException) { Console.WriteLine("InvalidOperationException"); }
+    }
+}
+""";
+            await RunTest(code);
+        }
+
         /// <summary>Collections and LINQ keyed on / aggregating long values.</summary>
         [TestMethod]
         public async Task CollectionsAndLinq_Tests()
@@ -696,56 +822,76 @@ public class Program
         }
 
         /// <summary>
-        /// An enum with a 64-bit backing type. Its ordinals are emitted as plain JS numbers, so a
-        /// <c>(Big)someLong</c> cast has to read the magnitude out of the Int64 instance — otherwise
-        /// no member matched and ToString() printed the raw number.
-        ///
-        /// Ordinals are limited to JavaScript's exact-integer range (2^53); a member above that loses
-        /// precision, which is why <c>long.MaxValue</c> is not used here.
+        /// An enum with a 64-bit underlying type is rejected: enum members are emitted as plain JS
+        /// numbers, which hold integers exactly only up to 2^53, so a member above that got a
+        /// different ordinal (<c>long.MaxValue</c> round-tripped to <c>long.MinValue</c>) and members
+        /// far apart could collide onto one value.
         /// </summary>
         [TestMethod]
-        public async Task Int64BackedEnum_Tests()
+        public async Task Int64BackedEnumIsUnsupported_Tests()
+        {
+            await RunTestExpectingError("""
+using System;
+
+public enum Big : long { A = 1L, B = 5000000000L }
+
+public class Program
+{
+    public static void Main() { Console.WriteLine(Big.B); }
+}
+""", "enum with a 64-bit underlying type");
+
+            await RunTestExpectingError("""
+using System;
+
+public enum UBig : ulong { X = 1UL, Y = 18446744073709551615UL }
+
+public class Program
+{
+    public static void Main() { Console.WriteLine(UBig.Y); }
+}
+""", "enum with a 64-bit underlying type");
+        }
+
+        /// <summary>Every underlying type narrower than 64 bits stays supported.</summary>
+        [TestMethod]
+        public async Task NarrowerBackedEnums_Tests()
         {
             var code = """
 using System;
 
-public enum Big : long { A = 1L, B = 5000000000L }
-public enum UBig : ulong { X = 1UL, Y = 5000000000UL }
+public enum Implicit { A = 1, B = 2 }
+public enum AsInt : int { A = 1, B = 2000000000 }
+public enum AsUInt : uint { A = 1, B = 4000000000 }
+public enum AsByte : byte { A = 1, B = 255 }
+public enum AsSByte : sbyte { A = 1, B = 127 }
+public enum AsShort : short { A = 1, B = 32767 }
+public enum AsUShort : ushort { A = 1, B = 65535 }
 
 public class Program
 {
     public static void Main()
     {
-        Console.WriteLine(Big.B);
-        Console.WriteLine((long)Big.B);
-        Console.WriteLine(Big.B.ToString());
-        Console.WriteLine((Big)5000000000L);
-        Console.WriteLine(Enum.Parse<Big>("B"));
-        Console.WriteLine(UBig.Y);
-        Console.WriteLine((ulong)UBig.Y);
+        Console.WriteLine(Implicit.B + " " + (int)Implicit.B);
+        Console.WriteLine(AsInt.B + " " + (int)AsInt.B);
+        Console.WriteLine(AsUInt.B + " " + (uint)AsUInt.B);
+        Console.WriteLine(AsByte.B + " " + (byte)AsByte.B);
+        Console.WriteLine(AsSByte.B + " " + (sbyte)AsSByte.B);
+        Console.WriteLine(AsShort.B + " " + (short)AsShort.B);
+        Console.WriteLine(AsUShort.B + " " + (ushort)AsUShort.B);
 
-        long raw = 5000000000L;
-        Console.WriteLine((Big)raw);
-        Console.WriteLine((Big)raw == Big.B);
+        // Widening an enum member to long still works — that is a cast, not a 64-bit backing.
+        Console.WriteLine((long)AsInt.B + 1L);
 
-        Big v = Big.B;
+        AsUInt v = AsUInt.B;
         switch (v)
         {
-            case Big.A: Console.WriteLine("A"); break;
-            case Big.B: Console.WriteLine("B"); break;
-            default: Console.WriteLine("other"); break;
+            case AsUInt.A: Console.WriteLine("A"); break;
+            case AsUInt.B: Console.WriteLine("B"); break;
         }
 
-        Console.WriteLine(v == Big.B);
-        Console.WriteLine(v is Big.B);
-        Console.WriteLine(v is Big.A);
-        Console.WriteLine(v is not Big.A);
-        Console.WriteLine(v is Big.A or Big.B);
-        Console.WriteLine(v switch { Big.A => "A", Big.B => "B", _ => "?" });
-
-        object boxed = Big.B;
-        Console.WriteLine(boxed.GetType().Name + " " + boxed);
-        Console.WriteLine(boxed is Big);
+        Console.WriteLine(v is AsUInt.B);
+        Console.WriteLine(v is AsUInt.A);
     }
 }
 """;
@@ -764,7 +910,7 @@ public class Program
 using System;
 
 public enum Small { A = 1, B = 2 }
-public enum Big : long { A = 1L, B = 5000000000L }
+public enum Big : uint { A = 1u, B = 4000000000u }
 
 public static class Limits
 {

--- a/Transpose/Transpose.Translator.Tests/Ported/NumericTypesTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Ported/NumericTypesTests.cs
@@ -294,6 +294,62 @@ public class Program
             await RunTest(code);
         }
 
+        /// <summary>
+        /// C# promotes <c>long op double</c> (and float) to floating point. long/ulong are Int64/UInt64
+        /// objects at runtime, so the emitter used to route these through Int64's methods and lift the
+        /// FLOATING operand with <c>System.Int64(…)</c> — truncating it. That made
+        /// <c>Random.Next(min, max)</c> (which computes <c>Sample() * range</c> with a long range)
+        /// always return <c>minValue</c>.
+        /// </summary>
+        [TestMethod]
+        public async Task MixedFloatingAndInt64Arithmetic_Tests()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        double d = 0.5;
+        float f = 0.25f;
+        long l = 100L;
+        ulong ul = 40UL;
+
+        // Arithmetic: the sample must NOT be truncated to an integer.
+        Console.WriteLine(d * l);
+        Console.WriteLine(l * d);
+        Console.WriteLine(d + l);
+        Console.WriteLine(d - l);
+        Console.WriteLine(d / l);
+        Console.WriteLine(l / d);
+        Console.WriteLine(l % 3.0);
+        Console.WriteLine(d * ul);
+        Console.WriteLine(f * l);
+        Console.WriteLine((int)(d * l));
+
+        // Comparisons are promoted the same way.
+        Console.WriteLine(d < l);
+        Console.WriteLine(d > l);
+        Console.WriteLine(d <= l);
+        Console.WriteLine(d >= l);
+        Console.WriteLine(d == l);
+        Console.WriteLine(d != l);
+        Console.WriteLine(0.5 > 0L);
+        Console.WriteLine(1.5 < 1L);
+
+        // A long that only round-trips exactly as a double.
+        long big = 1234567890123L;
+        Console.WriteLine(big * 0.5);
+        Console.WriteLine(big / 1000.0);
+
+        // Pure-long arithmetic must still go through Int64 (integer division, no float promotion).
+        Console.WriteLine(l / 3L);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
         [TestMethod]
         public async Task Single_Tests()
         {

--- a/Transpose/Transpose.Translator.Tests/Ported/RandomTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Ported/RandomTests.cs
@@ -6,9 +6,183 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Transpose.Translator.Tests.Ported
 {
+    /// <summary>
+    /// System.Random. Most tests print a *seeded* sequence and let the harness diff it against
+    /// native .NET, so the generator has to agree with .NET value-for-value, not merely stay in
+    /// range. The exceptions are the tests that exercise the seedless constructor, where only
+    /// distribution properties are observable.
+    /// </summary>
     [TestClass]
     public class RandomTests : TranslatorTestBase
     {
+        [TestMethod]
+        public async Task TestNextAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random(42);
+        for (int i = 0; i < 8; i++) Console.WriteLine(r.Next());
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task TestNextMaxValueAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random(42);
+        for (int i = 0; i < 10; i++) Console.WriteLine(r.Next(10));
+
+        // Documented edge cases.
+        Console.WriteLine(r.Next(0));
+        Console.WriteLine(r.Next(1));
+
+        try { r.Next(-1); Console.WriteLine(""no throw""); }
+        catch (ArgumentOutOfRangeException) { Console.WriteLine(""ArgumentOutOfRangeException""); }
+    }
+}");
+        }
+
+        /// <summary>
+        /// The two-argument overload used to return <c>minValue</c> every single time: it computes
+        /// <c>(int)(Sample() * range)</c> with a <c>long</c> range, and mixed double/long arithmetic
+        /// was emitted as <c>System.Int64(Sample()).mul(range)</c> — truncating the 0..1 sample to 0.
+        /// </summary>
+        [TestMethod]
+        public async Task TestNextMinMaxAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random(42);
+        for (int i = 0; i < 10; i++) Console.WriteLine(r.Next(0, 7));
+        for (int i = 0; i < 10; i++) Console.WriteLine(r.Next(3, 9));
+        for (int i = 0; i < 10; i++) Console.WriteLine(r.Next(-5, 5));
+
+        // A range wider than int.MaxValue takes the GetSampleForLargeRange path.
+        for (int i = 0; i < 5; i++) Console.WriteLine(r.Next(int.MinValue, int.MaxValue));
+
+        // Documented edge cases.
+        Console.WriteLine(r.Next(5, 5));
+        Console.WriteLine(r.Next(-3, -3));
+
+        try { r.Next(9, 3); Console.WriteLine(""no throw""); }
+        catch (ArgumentOutOfRangeException) { Console.WriteLine(""ArgumentOutOfRangeException""); }
+    }
+}");
+        }
+
+        /// <summary>
+        /// The regression that made the bug visible: the sequence has to actually move, and stay
+        /// inside the half-open range, for a seedless instance too.
+        /// </summary>
+        [TestMethod]
+        public async Task TestNextMinMaxIsNotConstantAsync()
+        {
+            await RunTest(
+                @"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random();
+
+        Check(r, 0, 7);
+        Check(r, 3, 9);
+        Check(r, -5, 5);
+        Check(r, 0, 2);
+    }
+
+    private static void Check(Random r, int min, int max)
+    {
+        var seen = new HashSet<int>();
+        bool inRange = true;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            int v = r.Next(min, max);
+            if (v < min || v >= max) inRange = false;
+            seen.Add(v);
+        }
+
+        Console.WriteLine(""["" + min + "","" + max + "") in range: "" + inRange);
+        Console.WriteLine(""["" + min + "","" + max + "") distinct values: "" + seen.Count);
+    }
+}");
+        }
+
+        /// <summary>
+        /// The samples are scaled to integers rather than printed directly: transpose's
+        /// <c>Console.WriteLine(double)</c> truncates to 14 significant digits (unrelated to Random),
+        /// which would mask the sequence comparison this test is for.
+        /// </summary>
+        [TestMethod]
+        public async Task TestNextDoubleAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random(42);
+        for (int i = 0; i < 8; i++) Console.WriteLine((long)(r.NextDouble() * 1000000000L));
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task TestNextDoubleIsInRangeAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random();
+        bool inRange = true;
+        bool varies = false;
+        double first = r.NextDouble();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            double d = r.NextDouble();
+            if (d < 0.0 || d >= 1.0) inRange = false;
+            if (d != first) varies = true;
+        }
+
+        Console.WriteLine(""NextDouble in [0,1): "" + inRange);
+        Console.WriteLine(""NextDouble varies: "" + varies);
+    }
+}");
+        }
+
         [TestMethod]
         public async Task TestNextInt64Async()
         {
@@ -23,24 +197,74 @@ public class Program
         var r = new Random(42);
 
         // Unbounded
-        long l1 = r.NextInt64();
-        Console.WriteLine(l1 >= 0);
+        for (int i = 0; i < 3; i++) Console.WriteLine(r.NextInt64());
 
         // Max value
-        long l2 = r.NextInt64(100);
-        Console.WriteLine(l2 >= 0 && l2 < 100);
+        for (int i = 0; i < 5; i++) Console.WriteLine(r.NextInt64(1000));
 
         // Range
-        long l3 = r.NextInt64(50, 60);
-        Console.WriteLine(l3 >= 50 && l3 < 60);
+        for (int i = 0; i < 10; i++) Console.WriteLine(r.NextInt64(50, 60));
 
-        // Large Range
-        long l4 = r.NextInt64(long.MaxValue - 100, long.MaxValue);
-        Console.WriteLine(l4 >= (long.MaxValue - 100) && l4 < long.MaxValue);
+        // Range wider than int.MaxValue
+        for (int i = 0; i < 3; i++) Console.WriteLine(r.NextInt64(long.MinValue, long.MaxValue));
+        for (int i = 0; i < 3; i++) Console.WriteLine(r.NextInt64(long.MaxValue - 100, long.MaxValue));
+
+        // Documented edge cases.
+        Console.WriteLine(r.NextInt64(0));
+        Console.WriteLine(r.NextInt64(1));
+        Console.WriteLine(r.NextInt64(7, 7));
+        Console.WriteLine(r.NextInt64(7, 8));
+
+        try { r.NextInt64(-1); Console.WriteLine(""no throw""); }
+        catch (ArgumentOutOfRangeException) { Console.WriteLine(""ArgumentOutOfRangeException""); }
+
+        try { r.NextInt64(9, 3); Console.WriteLine(""no throw""); }
+        catch (ArgumentOutOfRangeException) { Console.WriteLine(""ArgumentOutOfRangeException""); }
     }
 }");
         }
 
+        [TestMethod]
+        public async Task TestNextInt64IsInRangeAsync()
+        {
+            await RunTest(
+                @"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new Random();
+        var seen = new HashSet<long>();
+        bool inRange = true;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            long v = r.NextInt64(50, 60);
+            if (v < 50L || v >= 60L) inRange = false;
+            seen.Add(v);
+        }
+
+        Console.WriteLine(""NextInt64(50,60) in range: "" + inRange);
+        Console.WriteLine(""NextInt64(50,60) distinct values: "" + seen.Count);
+
+        bool nonNegative = true;
+        for (int i = 0; i < 200; i++)
+        {
+            if (r.NextInt64() < 0L) nonNegative = false;
+        }
+
+        Console.WriteLine(""NextInt64() non-negative: "" + nonNegative);
+    }
+}");
+        }
+
+        /// <summary>
+        /// Only the range is asserted, not the value: transpose keeps a <c>float</c> at double
+        /// precision, so printing one does not match .NET's single-precision rendering.
+        /// </summary>
         [TestMethod]
         public async Task TestNextSingleAsync()
         {
@@ -53,14 +277,25 @@ public class Program
     public static void Main()
     {
         var r = new Random(42);
-        float f = r.NextSingle();
-        Console.WriteLine(f >= 0.0f && f < 1.0f);
+        bool inRange = true;
+        bool varies = false;
+        float first = r.NextSingle();
+
+        for (int i = 0; i < 500; i++)
+        {
+            float f = r.NextSingle();
+            if (f < 0.0f || f >= 1.0f) inRange = false;
+            if (f != first) varies = true;
+        }
+
+        Console.WriteLine(""NextSingle in [0,1): "" + inRange);
+        Console.WriteLine(""NextSingle varies: "" + varies);
     }
 }");
         }
 
         [TestMethod]
-        public async Task TestSharedAsync()
+        public async Task TestNextBytesAsync()
         {
             await RunTest(
                 @"
@@ -70,11 +305,188 @@ public class Program
 {
     public static void Main()
     {
+        var r = new Random(42);
 
-                // Just check it exists and works
-                var r = Random.Shared;
-                Console.WriteLine(r != null);
-                Console.WriteLine(r.Next() >= 0);
+        var buffer = new byte[16];
+        r.NextBytes(buffer);
+        Console.WriteLine(string.Join("","", buffer));
+
+        // An empty buffer is legal and consumes nothing.
+        r.NextBytes(new byte[0]);
+        Console.WriteLine(r.Next(1000));
+
+        try { r.NextBytes(null); Console.WriteLine(""no throw""); }
+        catch (ArgumentNullException) { Console.WriteLine(""ArgumentNullException""); }
+    }
+}");
+        }
+
+        /// <summary>
+        /// The same seed must replay the same sequence, and different seeds must not.
+        /// </summary>
+        [TestMethod]
+        public async Task TestSeedDeterminismAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new Random(12345);
+        var b = new Random(12345);
+        var c = new Random(54321);
+
+        bool sameSeedAgrees = true;
+        bool differentSeedDiffers = false;
+
+        for (int i = 0; i < 100; i++)
+        {
+            int x = a.Next(0, 1000);
+            int y = b.Next(0, 1000);
+            int z = c.Next(0, 1000);
+
+            if (x != y) sameSeedAgrees = false;
+            if (x != z) differentSeedDiffers = true;
+        }
+
+        Console.WriteLine(""same seed agrees: "" + sameSeedAgrees);
+        Console.WriteLine(""different seed differs: "" + differentSeedDiffers);
+
+        // Negative seeds and the int.MinValue special case are accepted.
+        Console.WriteLine(new Random(-7).Next(0, 100) == new Random(-7).Next(0, 100));
+        Console.WriteLine(new Random(int.MinValue).Next(0, 100) == new Random(int.MinValue).Next(0, 100));
+        Console.WriteLine(new Random(int.MaxValue).Next(0, 100) >= 0);
+        Console.WriteLine(new Random(0).Next(0, 100) >= 0);
+    }
+}");
+        }
+
+        /// <summary>
+        /// The seedless constructor seeds from <c>Math.random()</c> rather than
+        /// <c>(int)DateTime.Now.Ticks</c>. A tick seed only has millisecond resolution once
+        /// transpiled, so a batch of instances built in one go all shared a sequence.
+        /// </summary>
+        [TestMethod]
+        public async Task TestSeedlessInstancesDoNotShareASequenceAsync()
+        {
+            await RunTest(
+                @"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    public static void Main()
+    {
+        var seen = new HashSet<int>();
+
+        for (int i = 0; i < 50; i++)
+        {
+            seen.Add(new Random().Next());
+        }
+
+        // Tick-seeded instances created in the same millisecond collapsed to a single value.
+        Console.WriteLine(""distinct first draws (>1): "" + (seen.Count > 1));
+        Console.WriteLine(""mostly distinct (>40/50): "" + (seen.Count > 40));
+    }
+}");
+        }
+
+        /// <summary>Random.Shared, as in modern .NET.</summary>
+        [TestMethod]
+        public async Task TestSharedAsync()
+        {
+            await RunTest(
+                @"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Random.Shared != null);
+
+        // Same instance on every access.
+        Console.WriteLine(ReferenceEquals(Random.Shared, Random.Shared));
+
+        // Every member reachable through it, and in range.
+        bool inRange = true;
+        var seen = new HashSet<int>();
+
+        for (int i = 0; i < 500; i++)
+        {
+            int v = Random.Shared.Next(0, 10);
+            if (v < 0 || v >= 10) inRange = false;
+            seen.Add(v);
+
+            if (Random.Shared.Next() < 0) inRange = false;
+            if (Random.Shared.Next(100) is < 0 or >= 100) inRange = false;
+
+            double d = Random.Shared.NextDouble();
+            if (d < 0.0 || d >= 1.0) inRange = false;
+
+            float f = Random.Shared.NextSingle();
+            if (f < 0.0f || f >= 1.0f) inRange = false;
+
+            long l = Random.Shared.NextInt64(5, 15);
+            if (l < 5L || l >= 15L) inRange = false;
+        }
+
+        var buffer = new byte[8];
+        Random.Shared.NextBytes(buffer);
+        Console.WriteLine(""buffer length: "" + buffer.Length);
+
+        Console.WriteLine(""Shared in range: "" + inRange);
+        Console.WriteLine(""Shared distinct Next(0,10): "" + seen.Count);
+
+        // Shared advances a single sequence: consecutive draws are not locked together.
+        bool advances = false;
+        for (int i = 0; i < 100; i++)
+        {
+            if (Random.Shared.Next() != Random.Shared.Next()) advances = true;
+        }
+
+        Console.WriteLine(""Shared advances: "" + advances);
+    }
+}");
+        }
+
+        /// <summary>Random is <c>virtual</c> throughout, so a derived generator can override Sample.</summary>
+        [TestMethod]
+        public async Task TestDerivedRandomAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public class Fixed : Random
+{
+    private readonly double _value;
+    public Fixed(double value) { _value = value; }
+    protected override double Sample() { return _value; }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        // Sample() feeds Next(min,max)/Next(max)/NextDouble, so a fixed sample pins them all.
+        var r = new Fixed(0.5);
+        Console.WriteLine(r.Next(0, 10));
+        Console.WriteLine(r.Next(100));
+        Console.WriteLine(r.NextDouble());
+
+        var zero = new Fixed(0.0);
+        Console.WriteLine(zero.Next(3, 9));
+
+        // Just under 1.0 must stay below maxValue.
+        var high = new Fixed(0.9999999);
+        Console.WriteLine(high.Next(0, 10));
+        Console.WriteLine(high.Next(3, 9));
     }
 }");
         }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -313,6 +313,18 @@ public sealed partial class Emitter
             return;
         }
 
+        // Implicit widening of long/ulong to float/double → read the numeric magnitude. The 64-bit
+        // value is an Int64/UInt64 object at runtime, and leaving it raw means JS operates on the
+        // object: `d += someLong` string-concatenated ("42" + "4" → "424") because Int64 has no
+        // valueOf, and a `double` parameter received an Int64 instance.
+        if (IsFloatingType(targetType) && Is64BitInteger(sourceType) && !EmitsAsPlainJsNumber(expr))
+        {
+            _w.Write("(");
+            EmitExpression(expr);
+            _w.Write(").toNumber()");
+            return;
+        }
+
         // Implicit widening of a 32-bit integer to long/ulong → wrap as a 64-bit instance.
         // (Numeric literals already self-wrap via their converted type in EmitLiteral.)
         if (Is64BitInteger(targetType) && sourceType is not null && !Is64BitInteger(sourceType)
@@ -475,7 +487,15 @@ public sealed partial class Emitter
         switch (lit.Kind())
         {
             case SyntaxKind.NumericLiteralExpression:
-                var conv = _model.GetTypeInfo(lit).ConvertedType;
+                var litInfo = _model.GetTypeInfo(lit);
+                // The CONVERTED type decides the representation — `double d = 5L` emits the plain
+                // number 5. But a BOXING conversion (`object o = 5L`) converts to object, and the
+                // boxed value still has to be a real Int64/UInt64/Decimal instance: emitting a bare
+                // number made `o is long` false and `o.GetType()` report Int32.
+                // Nullable<T> is represented as the value or null, so `long? x = 7L` needs the same
+                // Int64 instance a plain `long` would get — otherwise x is a bare number and a later
+                // `x.add(…)` throws.
+                var conv = UnwrapNullable(_model.GetConversion(lit).IsBoxing ? litInfo.Type : litInfo.ConvertedType);
                 if (conv?.SpecialType is SpecialType.System_Int64 or SpecialType.System_UInt64
                     && lit.Token.Value is not double and not float and not decimal)
                     _w.Write(Long64Literal(lit.Token.Value!, conv.SpecialType == SpecialType.System_UInt64));

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1377,6 +1377,36 @@ public sealed partial class Emitter
         // is / as
         if (binary.IsKind(SyntaxKind.IsExpression))
         {
+            // `x is Foo.Bar` parses as an is-EXPRESSION — a type test — whenever the right side looks
+            // syntactically like a type name, even when it actually binds to a *constant*. An enum
+            // member is exactly that, and GetTypeInfo only reports the constant's type (the enum), so
+            // this used to emit `TransposeR.is(x, Small)`: true for every value of Small, making
+            // `s is Small.A` true when s was Small.B. (The nested forms — `is not Small.A`,
+            // `is Small.A or Small.B` — parse as real patterns and were always compared by value.)
+            if (_model.GetSymbolInfo(binary.Right).Symbol is IFieldSymbol constantField)
+            {
+                // binary.Right is type-NAME syntax (a QualifiedName), which EmitExpression cannot emit,
+                // so render the constant from its symbol the way a member access would.
+                var constantJs = constantField switch
+                {
+                    { ContainingType.TypeKind: TypeKind.Enum } enumField => Capture(() => EmitEnumMemberAccess(enumField)),
+                    { IsConst: true } c => ConstantLiteral(c.ConstantValue, c.Type),
+                    _ => null,
+                };
+
+                if (constantJs is not null)
+                {
+                    // The subject is repeated by the value-equality test, so bind it once.
+                    var subject = NextTemp("$is");
+                    _w.Write($"(function ({subject}) {{ return ");
+                    EmitConstantEqualityAgainst(subject, constantJs, constantField.Type);
+                    _w.Write("; })(");
+                    EmitExpression(binary.Left);
+                    _w.Write(")");
+                    return;
+                }
+            }
+
             var t = _model.GetTypeInfo(binary.Right).Type;
             _w.Write("TransposeR.is(");
             EmitExpression(binary.Left);
@@ -1450,6 +1480,42 @@ public sealed partial class Emitter
             return;
         }
 
+        // Lifted operators on Nullable<T>: a null operand makes an arithmetic result null
+        // and a relational result false (C# semantics). (Equality is fine with ===/!== since
+        // nullable is represented as value-or-null.)
+        //
+        // This is tested BEFORE the 64-bit and decimal branches below, which match on the operand
+        // types with Nullable stripped and so used to claim `long? + 1L` first, emitting
+        // `System.Int64(null).add(1)` — 1 rather than null, while `int? + 1` propagated correctly.
+        var arith = op is "+" or "-" or "*" or "/" or "%" or "&" or "|" or "^" or "<<" or ">>";
+        var relational = op is "<" or ">" or "<=" or ">=";
+        if ((arith || relational) && (IsNullableValueType(leftType) || IsNullableValueType(rightType)))
+        {
+            var l = Capture(() => EmitExpression(binary.Left));
+            var r = Capture(() => EmitExpression(binary.Right));
+            _w.Write($"({l} == null || {r} == null ? {(relational ? "false" : "null")} : ");
+            EmitLiftedInnerOperation(binary, l, r, op, leftType, rightType);
+            _w.Write(")");
+            return;
+        }
+
+        // Lifted == / != where the underlying type is a runtime OBJECT (long/ulong/decimal). A plain
+        // `===` compares object identity, so two `long?`s holding the same value were unequal.
+        // System.Nullable.equals is exactly C#'s lifted equality: null equals only null, otherwise
+        // value equality. (For plain-number underlying types `===` is already correct, null included.)
+        if (op is "==" or "!="
+            && (IsNullableValueType(leftType) || IsNullableValueType(rightType))
+            && (IsRuntimeObjectNumeric(leftType) || IsRuntimeObjectNumeric(rightType)))
+        {
+            if (op == "!=") _w.Write("!");
+            _w.Write("System.Nullable.equals(");
+            EmitExpression(binary.Left);
+            _w.Write(", ");
+            EmitExpression(binary.Right);
+            _w.Write(")");
+            return;
+        }
+
         // 64-bit integer arithmetic/comparison → System.Int64/UInt64 method calls. Decide on the
         // operands' DECLARED types, not the converted ones: `int >= uint` is promoted to `long` by
         // C#, but int/uint are plain JS numbers (only actual long/ulong are boxed Int64/UInt64
@@ -1460,6 +1526,18 @@ public sealed partial class Emitter
         // (`visualIndex.lt is not a function` in LogsView.ValidateVisibleRowHeights).
         var leftDeclared = _model.GetTypeInfo(binary.Left).Type ?? leftType;
         var rightDeclared = _model.GetTypeInfo(binary.Right).Type ?? rightType;
+        // `long op double` (and float, and vice-versa) is promoted to floating point by C#, so it
+        // must NOT go through the Int64 path: that lifts the FLOATING operand with System.Int64(…),
+        // truncating it. `Sample() * range` in Random.Next(min, max) became
+        // `System.Int64(Sample()).mul(range)` — the 0..1 sample truncated to 0, so the overload
+        // always returned minValue. Read the 64-bit operand's magnitude and use plain JS arithmetic.
+        if ((Is64BitInteger(leftDeclared) || Is64BitInteger(rightDeclared))
+            && (IsFloatingType(leftDeclared) || IsFloatingType(rightDeclared))
+            && Long64Op(binary) is not null)
+        {
+            EmitFloatingWith64BitOperand(binary, leftDeclared, rightDeclared);
+            return;
+        }
         // `long op decimal` (and vice-versa) is promoted to decimal by C#, so it must go through the
         // decimal path below — not Int64 (which would do integer division etc.). Guard against a
         // decimal operand here.
@@ -1542,19 +1620,6 @@ public sealed partial class Emitter
             return;
         }
 
-        // Lifted operators on Nullable<T>: a null operand makes an arithmetic result null
-        // and a relational result false (C# semantics). (Equality is fine with ===/!== since
-        // nullable is represented as value-or-null.)
-        var arith = op is "+" or "-" or "*" or "%";
-        var relational = op is "<" or ">" or "<=" or ">=";
-        if ((arith || relational) && (IsNullableValueType(leftType) || IsNullableValueType(rightType)))
-        {
-            var l = Capture(() => EmitExpression(binary.Left));
-            var r = Capture(() => EmitExpression(binary.Right));
-            _w.Write($"({l} == null || {r} == null ? {(relational ? "false" : "null")} : {l} {op} {r})");
-            return;
-        }
-
         // Managed (H5-parity) 32-bit integer arithmetic: wrap results that overflow / need
         // unsigned reinterpretation, so `int + int`, `uint << n`, etc. match .NET's unchecked
         // semantics rather than JS Number arithmetic.
@@ -1628,6 +1693,100 @@ public sealed partial class Emitter
 
     private static bool IsNullableValueType(ITypeSymbol? t)
         => t is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };
+
+    /// <summary><c>T</c> for a <c>Nullable&lt;T&gt;</c>, otherwise the type unchanged.</summary>
+    private static ITypeSymbol? UnwrapNullable(ITypeSymbol? t)
+        => t is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T, TypeArguments.Length: 1 } n
+            ? n.TypeArguments[0]
+            : t;
+
+    /// <summary>
+    /// The non-null half of a lifted <c>Nullable&lt;T&gt;</c> operator. The operands arrive as
+    /// already-emitted JS snippets (they are evaluated twice — once for the null test, once here —
+    /// so the caller captures them), and the operation is chosen by T's runtime representation:
+    /// long/ulong and decimal are objects with method arithmetic, integer division truncates, and
+    /// everything else is the plain JS operator.
+    /// </summary>
+    private void EmitLiftedInnerOperation(BinaryExpressionSyntax binary, string left, string right,
+        string op, ITypeSymbol? leftType, ITypeSymbol? rightType)
+    {
+        // Decide on the operands' DECLARED types, as the non-nullable 64-bit path does: `long? * 0.5`
+        // converts the left operand to double?, but at runtime it is still an Int64 instance.
+        var lu = UnwrapNullable(_model.GetTypeInfo(binary.Left).Type ?? leftType);
+        var ru = UnwrapNullable(_model.GetTypeInfo(binary.Right).Type ?? rightType);
+        var resultType = UnwrapNullable(_model.GetTypeInfo(binary).Type);
+
+        // Promoted to floating point despite a 64-bit operand (`long? * 0.5`): read the 64-bit
+        // side's magnitude and use plain JS arithmetic, as the non-nullable path does.
+        if ((Is64BitInteger(lu) || Is64BitInteger(ru)) && (IsFloatingType(lu) || IsFloatingType(ru)))
+        {
+            _w.Write(Is64BitInteger(lu) ? $"({left}).toNumber()" : left);
+            _w.Write($" {op} ");
+            _w.Write(Is64BitInteger(ru) ? $"({right}).toNumber()" : right);
+            return;
+        }
+
+        if ((Is64BitInteger(lu) || Is64BitInteger(ru)) && Long64Op(binary) is { } longOp)
+        {
+            var unsigned = Is64BitUnsigned(lu) || Is64BitUnsigned(ru);
+            if (longOp == "shr" && unsigned) longOp = "shru";
+
+            // The receiver must be a 64-bit instance; lift a plain-number left operand.
+            if (Is64BitInteger(lu)) _w.Write(left);
+            else { _w.Write(unsigned ? "System.UInt64(" : "System.Int64("); _w.Write(left); _w.Write(")"); }
+
+            _w.Write($".{longOp}({right})");
+            return;
+        }
+
+        if ((IsDecimalType(lu) || IsDecimalType(ru)) && DecimalOp(binary) is { } decOp)
+        {
+            if (IsDecimalType(lu)) _w.Write(left);
+            else { _w.Write("System.Decimal("); _w.Write(left); _w.Write(")"); }
+
+            _w.Write($".{decOp}(");
+
+            if (IsDecimalType(ru)) _w.Write(right);
+            else { _w.Write("System.Decimal("); _w.Write(right); _w.Write(")"); }
+
+            _w.Write(")");
+            return;
+        }
+
+        var clip = Integer32Clip(resultType);
+
+        // Integer division truncates toward zero; JS `/` does not.
+        if (op == "/" && IsIntegerType(lu) && IsIntegerType(ru))
+        {
+            if (clip is not null) { _w.Write(clip); _w.Write("("); }
+            _w.Write($"TransposeR.idiv({left}, {right})");
+            if (clip is not null) _w.Write(")");
+            return;
+        }
+
+        // 32-bit multiplication wraps; route through Math.imul as the non-nullable path does.
+        if (op == "*" && clip is not null)
+        {
+            _w.Write(resultType!.SpecialType == SpecialType.System_UInt32 ? "Transpose.Int.umul(" : "Transpose.Int.mul(");
+            _w.Write($"{left}, {right})");
+            return;
+        }
+
+        // A uint32 result needs unsigned reinterpretation (JS `+`/bitwise yield a signed int32),
+        // and `uint >>` is a logical shift — the same wrapping TryEmitInteger32Binary applies.
+        var unsigned32 = resultType?.SpecialType == SpecialType.System_UInt32;
+        var jsOp = op == ">>" && unsigned32 ? ">>>" : op;
+        var needsClip = clip is not null && op switch
+        {
+            "+" or "-" => true,
+            "&" or "|" or "^" or "<<" => unsigned32,
+            _ => false,
+        };
+
+        if (needsClip) { _w.Write(clip!); _w.Write("("); }
+        _w.Write($"{left} {jsOp} {right}");
+        if (needsClip) _w.Write(")");
+    }
 
     /// <summary>
     /// A type whose == / != is value equality rather than JS reference identity: records and
@@ -1705,6 +1864,63 @@ public sealed partial class Emitter
         _w.Write($".{op}(");
         EmitExpression(binary.Right);
         _w.Write(")");
+    }
+
+    /// <summary>
+    /// Emits a binary operator whose operands C# promoted to <c>double</c>/<c>float</c> even though one
+    /// of them is a <c>long</c>/<c>ulong</c> (an Int64/UInt64 object at runtime, not a JS number).
+    /// The 64-bit side is read with <c>.toNumber()</c> — the same magnitude read an explicit
+    /// <c>(double)someLong</c> cast emits — and the operator itself is plain JS, so the arithmetic is
+    /// floating point as .NET does it.
+    /// </summary>
+    private void EmitFloatingWith64BitOperand(BinaryExpressionSyntax binary, ITypeSymbol? leftType, ITypeSymbol? rightType)
+    {
+        var jsOp = binary.Kind() switch
+        {
+            SyntaxKind.EqualsExpression => "===",
+            SyntaxKind.NotEqualsExpression => "!==",
+            _ => binary.OperatorToken.Text,
+        };
+
+        EmitOperandAsNumber(binary.Left, leftType);
+        _w.Write($" {jsOp} ");
+        EmitOperandAsNumber(binary.Right, rightType);
+
+        void EmitOperandAsNumber(ExpressionSyntax operand, ITypeSymbol? type)
+        {
+            if (!Is64BitInteger(type) || EmitsAsPlainJsNumber(operand)) { EmitExpression(operand); return; }
+            _w.Write("(");
+            EmitExpression(operand);
+            _w.Write(").toNumber()");
+        }
+    }
+
+    /// <summary>
+    /// True if a <c>long</c>/<c>ulong</c>-typed operand is nevertheless emitted as a plain JS number,
+    /// so it must not be given a <c>.toNumber()</c> call. A numeric literal follows its CONVERTED type
+    /// (see <c>EmitLiteral</c>): in <c>0.5 &gt; 0L</c> the literal is converted to double and emitted
+    /// as <c>0</c>. A long-typed *identifier* in the same position is not — it stays an Int64 object.
+    /// </summary>
+    private bool EmitsAsPlainJsNumber(ExpressionSyntax operand)
+    {
+        var e = operand;
+        while (true)
+        {
+            switch (e)
+            {
+                case ParenthesizedExpressionSyntax paren:
+                    e = paren.Expression;
+                    continue;
+                // `-1L` / `+1L`: the sign is emitted around the literal, which folds the same way.
+                case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.UnaryMinusExpression or (int)SyntaxKind.UnaryPlusExpression } unary:
+                    e = unary.Operand;
+                    continue;
+            }
+            break;
+        }
+
+        return e.IsKind(SyntaxKind.NumericLiteralExpression)
+            && !Is64BitInteger(_model.GetTypeInfo(e).ConvertedType);
     }
 
     /// <summary>True if a string-typed concat operand can never be null, so it needs no <c>?? ""</c>
@@ -2318,6 +2534,16 @@ public sealed partial class Emitter
 
         // --- from 64-bit to floating: read the numeric magnitude. ---
         if (Is64BitInteger(sourceType) && IsFloatingType(targetType))
+        {
+            _w.Write("("); EmitExpression(expr); _w.Write(").toNumber()");
+            return;
+        }
+
+        // --- from 64-bit to an enum: enum ordinals are emitted as plain JS numbers even when the
+        // enum's underlying type is long/ulong, so `(SomeLongEnum)someLong` must read the magnitude.
+        // Leaving the Int64 instance in place made System.Enum.toString fail to match any member and
+        // print the raw number instead of the member name. ---
+        if (Is64BitInteger(sourceType) && targetType is { TypeKind: TypeKind.Enum })
         {
             _w.Write("("); EmitExpression(expr); _w.Write(").toNumber()");
             return;
@@ -2961,9 +3187,9 @@ public sealed partial class Emitter
     private string EnumConstantLiteral(INamedTypeSymbol enumType, object value)
     {
         var mode = TransposeNaming.EnumEmitMode(enumType);
-        var v = Convert.ToInt64(value);
+        var v = EnumOrdinalText(value);
         var field = enumType.GetMembers().OfType<IFieldSymbol>()
-            .FirstOrDefault(f => f.HasConstantValue && Convert.ToInt64(f.ConstantValue) == v);
+            .FirstOrDefault(f => f.HasConstantValue && EnumOrdinalText(f.ConstantValue) == v);
         return field is not null ? JsString(TransposeNaming.EnumStringName(field, mode)) : "null";
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
@@ -79,8 +79,7 @@ public sealed partial class Emitter
                     EmitTypeTest(subject, typeSym);
                 else
                 {
-                    _w.Write($"{subject} === ");
-                    EmitExpression(constant.Expression);
+                    EmitConstantEqualityTest(subject, constant.Expression);
                 }
                 break;
 
@@ -106,8 +105,7 @@ public sealed partial class Emitter
                 break;
 
             case RelationalPatternSyntax rel:
-                _w.Write($"{subject} {rel.OperatorToken.Text} ");
-                EmitExpression(rel.Expression);
+                EmitRelationalPatternTest(subject, rel);
                 break;
 
             case ParenthesizedPatternSyntax paren:
@@ -279,6 +277,79 @@ public sealed partial class Emitter
         }
     }
 
+    /// <summary>
+    /// Emits a value-equality test between an already-emitted <paramref name="subject"/> and a
+    /// constant expression. long/ulong/decimal are System.Int64/UInt64/Decimal *instances* at
+    /// runtime, so JS <c>===</c> compares object identity and is never true for two separately
+    /// constructed values — <c>switch (someLong) { case 2L: }</c> and <c>x is 2L</c> silently fell
+    /// through to the default arm. Those go through <c>Transpose.equals</c>; everything else keeps
+    /// <c>===</c>.
+    /// </summary>
+    private void EmitConstantEqualityTest(string subject, ExpressionSyntax constant)
+    {
+        var info = _model.GetTypeInfo(constant);
+        EmitConstantEqualityAgainst(subject, Capture(() => EmitExpression(constant)), info.ConvertedType ?? info.Type);
+    }
+
+    /// <summary>
+    /// <see cref="EmitConstantEqualityTest"/> against an already-emitted constant (for callers whose
+    /// right-hand side is not an emittable expression node — see the is-expression path, where an enum
+    /// member arrives as type-name syntax).
+    /// </summary>
+    private void EmitConstantEqualityAgainst(string subject, string constantJs, ITypeSymbol? constantType)
+    {
+        if (IsRuntimeObjectNumeric(constantType))
+        {
+            // The null guard matters when the subject is a Nullable: `((long?)null) is 2L` is false in
+            // C#, but Transpose.equals would reach into the null's `.low` and throw.
+            _w.Write($"({subject} != null && Transpose.equals({subject}, {constantJs}))");
+            return;
+        }
+
+        _w.Write($"{subject} === {constantJs}");
+    }
+
+    /// <summary>
+    /// A relational pattern (<c>is &gt; 10L</c>). System.Int64/UInt64/Decimal instances have no
+    /// <c>valueOf</c>, so a JS <c>&gt;</c> coerces both operands to STRINGS and compares them
+    /// lexicographically — <c>9L is &gt; 10L</c> came out true ("9" &gt; "10"). Route those through the
+    /// type's own comparison method, as the binary-operator path already does.
+    /// </summary>
+    private void EmitRelationalPatternTest(string subject, RelationalPatternSyntax rel)
+    {
+        var info = _model.GetTypeInfo(rel.Expression);
+        var method = rel.OperatorToken.Text switch
+        {
+            ">" => "gt",
+            ">=" => "gte",
+            "<" => "lt",
+            "<=" => "lte",
+            _ => null,
+        };
+
+        if (method is not null && IsRuntimeObjectNumeric(info.ConvertedType ?? info.Type))
+        {
+            // A Nullable subject that is null matches no relational pattern.
+            _w.Write($"({subject} != null && {subject}.{method}(");
+            EmitExpression(rel.Expression);
+            _w.Write("))");
+            return;
+        }
+
+        _w.Write($"{subject} {rel.OperatorToken.Text} ");
+        EmitExpression(rel.Expression);
+    }
+
+    /// <summary>long / ulong / decimal, or the Nullable form of one — the numeric types tps.js models
+    /// as objects rather than plain JS numbers.</summary>
+    private static bool IsRuntimeObjectNumeric(ITypeSymbol? type)
+    {
+        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T, TypeArguments.Length: 1 } nullable)
+            type = nullable.TypeArguments[0];
+
+        return Is64BitInteger(type) || IsDecimalType(type);
+    }
+
     private void EmitTypeTest(string subject, ITypeSymbol? type)
     {
         if (type is null) { _w.Write("true"); return; }
@@ -293,21 +364,24 @@ public sealed partial class Emitter
                 _w.Write($"typeof {subject} === \"boolean\"");
                 return;
             // Integer types: number AND integral (best-effort distinction from double).
-            case SpecialType.System_Int32 or SpecialType.System_Int64 or SpecialType.System_Int16
+            // long/ulong are excluded — see the note below.
+            case SpecialType.System_Int32 or SpecialType.System_Int16
                 or SpecialType.System_Byte or SpecialType.System_SByte or SpecialType.System_UInt16
-                or SpecialType.System_UInt32 or SpecialType.System_UInt64 or SpecialType.System_Char:
+                or SpecialType.System_UInt32 or SpecialType.System_Char:
                 _w.Write($"(typeof {subject} === \"number\" && Number.isInteger({subject}))");
                 return;
-            case SpecialType.System_Double or SpecialType.System_Single or SpecialType.System_Decimal:
+            case SpecialType.System_Double or SpecialType.System_Single:
                 _w.Write($"typeof {subject} === \"number\"");
                 return;
         }
 
-        // Note: enums fall through to the runtime type check below. They box to `object` as a
-        // Transpose.box carrying their enum type (so o.GetType()/o.ToString() stay correct), NOT a
-        // plain number — a `typeof === "number"` test would both miss the boxed form and fail to
-        // tell one enum type from another (or from int). TransposeR.is understands the boxed
-        // representation, matching the plain `x is EnumType` expression path.
+        // Note: enums, long/ulong and decimal fall through to the runtime type check below.
+        // Enums box to `object` as a Transpose.box carrying their enum type (so o.GetType()/
+        // o.ToString() stay correct) and long/ulong/decimal box as System.Int64/UInt64/Decimal
+        // instances — none of them a plain number. A `typeof === "number"` test would both miss the
+        // boxed form and fail to tell one such type from another (`case long l` matched a boxed int,
+        // then `l.gt(…)` threw "l.gt is not a function"). TransposeR.is understands the boxed
+        // representations, matching the plain `x is T` expression path.
         _w.Write($"TransposeR.is({subject}, {TypeRef(type)})");
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -794,7 +794,12 @@ public sealed partial class Emitter
             .SelectMany(s => s.Labels)
             .Any(l => l is CasePatternSwitchLabelSyntax);
 
-        if (hasPatterns)
+        // A long/ulong/decimal subject is a runtime object, so a JS `switch` — which matches with
+        // `===`, i.e. object identity — never hit any `case` and always fell through to `default`.
+        // The if/else chain compares by value.
+        var governingType = _model.GetTypeInfo(switchStmt.Expression).Type;
+
+        if (hasPatterns || IsRuntimeObjectNumeric(governingType))
         {
             EmitPatternSwitch(switchStmt);
             return;
@@ -876,8 +881,7 @@ public sealed partial class Emitter
                         }
                         break;
                     case CaseSwitchLabelSyntax constLabel:
-                        _w.Write($"{subject} === ");
-                        EmitExpression(constLabel.Value);
+                        EmitConstantEqualityTest(subject, constLabel.Value);
                         break;
                 }
                 _w.Write(")");

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -236,11 +236,25 @@ public sealed partial class Emitter
         if (mode is 3 or 4 or 5 or 6)
         {
             var zero = enumType.GetMembers().OfType<IFieldSymbol>()
-                .FirstOrDefault(f => f.HasConstantValue && Convert.ToInt64(f.ConstantValue) == 0);
+                .FirstOrDefault(f => f.HasConstantValue && EnumOrdinalText(f.ConstantValue) == "0");
             return zero is not null ? JsString(TransposeNaming.EnumStringName(zero, mode)) : "null";
         }
         return "0";
     }
+
+    /// <summary>
+    /// An enum member's underlying constant as an invariant decimal string, used both to emit the
+    /// ordinal and to match members by value. Deliberately not <c>Convert.ToInt64</c>: a
+    /// <c>ulong</c>-backed enum can hold values above <c>long.MaxValue</c>, and
+    /// <c>ulong.MaxValue</c> made the translator itself throw "Value was either too large or too
+    /// small for an Int64".
+    /// </summary>
+    internal static string EnumOrdinalText(object? constantValue) => constantValue switch
+    {
+        null => "0",
+        ulong u => u.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        _ => Convert.ToInt64(constantValue).ToString(System.Globalization.CultureInfo.InvariantCulture),
+    };
 
     private void EmitEnum(INamedTypeSymbol type)
     {
@@ -268,7 +282,7 @@ public sealed partial class Emitter
                     {
                         var value = stringMode
                             ? JsString(TransposeNaming.EnumStringName(fields[i], mode))
-                            : Convert.ToInt64(fields[i].ConstantValue).ToString(System.Globalization.CultureInfo.InvariantCulture);
+                            : EnumOrdinalText(fields[i].ConstantValue);
                         _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(fields[i]))}: {value}");
                         _w.WriteLine(i < fields.Count - 1 ? "," : "");
                     }

--- a/Transpose/Transpose.Translator/Emit/TreeModel.cs
+++ b/Transpose/Transpose.Translator/Emit/TreeModel.cs
@@ -43,6 +43,10 @@ internal sealed class TreeModel
     public ISymbol? GetDeclaredSymbol(SyntaxNode node) => For(node).GetDeclaredSymbol(node);
     public Optional<object?> GetConstantValue(SyntaxNode node) => For(node).GetConstantValue(node);
 
+    /// <summary>The conversion C# applies to an expression at its usage site — notably whether it is
+    /// a boxing conversion, which <see cref="GetTypeInfo"/> only reports as "converted to object".</summary>
+    public Conversion GetConversion(ExpressionSyntax node) => For(node).GetConversion(node);
+
     public ForEachStatementInfo GetForEachStatementInfo(CommonForEachStatementSyntax node)
         => For(node).GetForEachStatementInfo(node);
 

--- a/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
+++ b/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
@@ -426,6 +426,23 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
         base.VisitIsPatternExpression(node);
     }
 
+    // An enum's members are emitted as plain JS numbers, so a 64-bit underlying type cannot be
+    // represented: JavaScript numbers hold integers exactly only up to 2^53, and the runtime matches a
+    // value to its member by that number. `enum E : long { X = long.MaxValue }` silently produced a
+    // different ordinal (long.MaxValue round-tripped to long.MinValue), and members far apart above
+    // 2^53 could collide onto one value. int/uint and narrower are safe and unaffected.
+    public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
+    {
+        if (node.BaseList?.Types.FirstOrDefault()?.Type is { } baseType
+            && _model.GetTypeInfo(baseType).Type?.SpecialType
+                is SpecialType.System_Int64 or SpecialType.System_UInt64)
+        {
+            Report(node, $"An enum with a 64-bit underlying type ('{baseType}') is not supported in the browser environment; enum members are JavaScript numbers, which represent integers exactly only up to 2^53.");
+        }
+
+        base.VisitEnumDeclaration(node);
+    }
+
     // Inline arrays ([InlineArray] structs, C# 12) have no JS representation.
     public override void VisitStructDeclaration(StructDeclarationSyntax node)
     {


### PR DESCRIPTION
## Summary

This PR fixes multiple issues with 64-bit integer (`long`/`ulong`) and numeric type handling in the Transpose compiler and runtime. The changes address pattern matching, operator overloading, nullable lifting, type conversions, and edge cases in the Random class.

## Key Changes

### Compiler (Emitter)

- **Pattern matching for constants**: Fixed `is` expressions with enum members and constant patterns. These were parsed as type tests rather than value comparisons, causing incorrect matches. Now detects when the right side is a constant field and emits proper value-equality tests via `EmitConstantEqualityAgainst`.

- **Relational patterns**: Added `EmitRelationalPatternTest` to properly handle relational patterns (`is > 1L`, `is < 10L`, etc.) on 64-bit integers, which were incorrectly coercing to strings in JavaScript comparisons.

- **Nullable lifted operators**: Fixed arithmetic and relational operators on `long?`/`ulong?`. The 64-bit branch was matching with `Nullable` stripped, claiming these types first and emitting incorrect code (e.g., `System.Int64(null).add(1)` returning 1 instead of null). Now checks for nullable types before the 64-bit branch and properly propagates null.

- **Lifted equality on object-based numerics**: Added special handling for `==`/`!=` on nullable 64-bit integers and decimals, which are runtime objects. Plain `===` compares object identity; now uses `System.Nullable.equals` for value equality.

- **Mixed floating-point and 64-bit arithmetic**: Fixed promotion of `long op double` (and `float`). These were incorrectly routed through `Int64` methods, which lifted the floating operand with `System.Int64(…)`, truncating it. Example: `Random.Next(min, max)` computes `Sample() * range` with a long range, which was always returning `minValue`. Now detects this case and uses plain JavaScript arithmetic.

- **Implicit widening to floating point**: Added conversion handling in `EmitExpressionConverted` to read the numeric magnitude when widening 64-bit integers to `float`/`double`, preventing string concatenation and other object-based operations.

- **Enum member `is` expressions**: Fixed detection of enum constants in `is` expressions. The pattern emitter now recognizes when a syntactic type name actually binds to an enum member constant and emits value comparison instead of type test.

- **Switch statements with patterns**: Ensured switch statements with pattern labels properly handle 64-bit integer subjects by using value-equality tests rather than identity comparisons.

### Runtime (BCL)

- **Random.GenerateSeed()**: Replaced `DateTime.Now.Ticks` (millisecond resolution in JS) with `Math.random()` for the parameterless constructor. Multiple `new Random()` calls within the same millisecond were getting identical seeds and producing identical sequences.

- **Random.NextInt64()**: Implemented proper 64-bit random generation by stitching together three draws (22 + 22 + 20 bits) to match .NET's algorithm exactly, ensuring seeded sequences agree value-for-value.

- **Random.Next(min, max)**: Fixed the two-argument overload which was returning `minValue` every time due to mixed `double`/`long` arithmetic being truncated.

- **Random.NextBytes()**: Added null check and proper buffer handling.

- **Long.js division**: Added proper exception handling for division by zero (throwing `DivideByZeroException` instead of bare JS Error) and overflow detection for `long.MinValue / -1`.

- **LINQ Average**: Fixed `Average()` on `long`/`ulong` sequences to return `double` (matching .NET) instead of truncating via `Int64.div`. Also fixed nullable aggregate behavior to skip null elements rather than propagating null.

- **Nullable.equals**: Fixed to properly guard both sides for null before calling the equality function, preventing incorrect results when comparing nullable 64-bit integers.

- **Console.Write(null)**: Added explicit null check to handle null objects correctly (write empty line, not throw).

- **Convert.ToInt64/ToUInt

https://claude.ai/code/session_014ypEMc3corJL7eA7RsLUoq