### PR TITLE
Fix deconstruction targets to emit qualified field/property/indexer access

### DIFF
--- a/Transpose/Transpose.Translator.Tests/DeconstructionTargetTests.cs
+++ b/Transpose/Transpose.Translator.Tests/DeconstructionTargetTests.cs
@@ -1,0 +1,324 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Regression tests for the left-hand side of a deconstruction. Every target used to be reduced to
+    /// its bare source identifier, which is only correct for a local or parameter:
+    ///  - an implicit-<c>this</c> field/property (<c>(_a, _b) = Get();</c>) emitted <c>_a = …</c>, an
+    ///    assignment to an undeclared name — a <c>ReferenceError</c> under the bundle's "use strict".
+    ///    This is the Curiosity <c>SearchResultsComponent</c> crash:
+    ///    <c>(_firstViewportElement, _firstViewportElementTopOffset) = GetFirstVisibleChild();</c>
+    ///    (h5 emitted <c>H5.Deconstruct(…, H5.ref(this, "_firstViewportElement"), …)</c>);
+    ///  - a static field emitted the same unqualified name instead of <c>Type.Field</c>;
+    ///  - any other lvalue — <c>this.F</c>, <c>obj.F</c>, <c>arr[i]</c>, <c>map[k]</c> — matched no case
+    ///    at all and was DROPPED, which also shortened the target list and so shifted every later
+    ///    target onto the wrong tuple element (silently wrong values, no error);
+    ///  - a nested group (<c>var (a, (b, c))</c>) was dropped the same way.
+    /// Targets now bind through the shared simple-assignment emitter, so a deconstruction stores to a
+    /// field, property, indexer or array element exactly as <c>x = v</c> does.
+    /// </summary>
+    [TestClass]
+    public class DeconstructionTargetTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task InstanceFieldTargetsAreQualifiedAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Viewport
+{
+    private string _element = null;
+    private double _topOffset = 0;
+
+    private (string child, double top) GetFirstVisibleChild() => (""child"", 42.5);
+
+    public void Refresh()
+    {
+        (_element, _topOffset) = GetFirstVisibleChild();
+        Console.WriteLine(_element + "" "" + _topOffset);
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        new Viewport().Refresh();
+    }
+}");
+        }
+
+        [TestMethod]
+        public void ImplicitThisFieldTargetEmitsThisQualifier()
+        {
+            var code = @"
+public class Viewport
+{
+    private string _element = null;
+    private double _topOffset = 0;
+
+    private (string child, double top) GetFirstVisibleChild() => (""child"", 42.5);
+
+    public void Refresh()
+    {
+        (_element, _topOffset) = GetFirstVisibleChild();
+    }
+}
+
+public class Program
+{
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("this._element = "),
+                "an implicit-this field deconstruction target must be qualified with `this.`\n" + result.Javascript);
+            Assert.IsTrue(result.Javascript!.Contains("this._topOffset = "),
+                "an implicit-this field deconstruction target must be qualified with `this.`\n" + result.Javascript);
+        }
+
+        [TestMethod]
+        public async Task StaticFieldAndPropertyTargetsAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Program
+{
+    private static string _name = null;
+    private static double _value = 0;
+
+    public static string Name { get; set; }
+    public static double Value { get; set; }
+
+    private static (string, double) Get() => (""s"", 1.5);
+
+    public static void Main()
+    {
+        (_name, _value) = Get();
+        Console.WriteLine(_name + "" "" + _value);
+
+        (Name, Value) = Get();
+        Console.WriteLine(Name + "" "" + Value);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task ExplicitThisAndMemberAccessTargetsAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Box
+{
+    public int A;
+    public int B;
+}
+
+public class Holder
+{
+    public int F;
+    public Box Inner = new Box();
+
+    private (int, int) Get() => (1, 2);
+
+    public void Run()
+    {
+        (this.F, this.Inner.A) = Get();
+        Console.WriteLine(F + "" "" + Inner.A);
+
+        (Inner.A, Inner.B) = Get();
+        Console.WriteLine(Inner.A + "" "" + Inner.B);
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        new Holder().Run();
+    }
+}");
+        }
+
+        /// <summary>
+        /// A non-local target used to be dropped from the target list, which shifted every LATER target
+        /// down one tuple element — so the second target silently read Item1.
+        /// </summary>
+        [TestMethod]
+        public async Task NonLocalTargetDoesNotShiftLaterElementsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+public class Holder
+{
+    public string[] Arr = new string[2];
+    public Dictionary<string, int> Map = new Dictionary<string, int>();
+    public int Field;
+
+    private (string, double) GetPair() => (""first"", 42.5);
+
+    public void Run()
+    {
+        double after;
+        (Arr[0], after) = GetPair();
+        Console.WriteLine(Arr[0] + "" "" + after);
+
+        int tail;
+        (Map[""k""], tail) = (7, 9);
+        Console.WriteLine(Map[""k""] + "" "" + tail);
+
+        string trailing;
+        (Field, trailing) = (3, ""end"");
+        Console.WriteLine(Field + "" "" + trailing);
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        new Holder().Run();
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task NestedDeconstructionAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Program
+{
+    private static int _x;
+
+    public static void Main()
+    {
+        var (a, (b, c)) = (1, (2, 3));
+        Console.WriteLine(a + "" "" + b + "" "" + c);
+
+        int x, y, z;
+        (x, (y, z)) = (4, (5, 6));
+        Console.WriteLine(x + "" "" + y + "" "" + z);
+
+        int deep;
+        (_x, (deep, _)) = (7, (8, 9));
+        Console.WriteLine(_x + "" "" + deep);
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task DeconstructMethodIntoFieldsAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Point
+{
+    public int X;
+    public int Y;
+
+    public Point(int x, int y) { X = x; Y = y; }
+
+    public void Deconstruct(out int x, out int y) { x = X; y = Y; }
+}
+
+public class Holder
+{
+    public int A;
+    public int B;
+    public int[] Slot = new int[1];
+
+    public void Run()
+    {
+        (A, B) = new Point(11, 12);
+        Console.WriteLine(A + "" "" + B);
+
+        int local;
+        (Slot[0], local) = new Point(13, 14);
+        Console.WriteLine(Slot[0] + "" "" + local);
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        new Holder().Run();
+    }
+}");
+        }
+
+        /// <summary>foreach shares the binding emitter, so a nested designation must expand there too
+        /// (it used to be dropped, leaving the inner names undeclared).</summary>
+        [TestMethod]
+        public async Task ForEachNestedDeconstructionAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    public static void Main()
+    {
+        var rows = new List<(int, (string, double))>
+        {
+            (1, (""one"", 1.5)),
+            (2, (""two"", 2.5)),
+        };
+
+        foreach (var (id, (name, weight)) in rows)
+        {
+            Console.WriteLine(id + "" "" + name + "" "" + weight);
+        }
+
+        foreach (var (id, (_, weight)) in rows)
+        {
+            Console.WriteLine(id + "" "" + weight);
+        }
+    }
+}");
+        }
+
+        [TestMethod]
+        public async Task DiscardsPreservePositionAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Holder
+{
+    public int Last;
+
+    private (int, int, int) Get() => (1, 2, 3);
+
+    public void Run()
+    {
+        (_, _, Last) = Get();
+        Console.WriteLine(Last);
+
+        var (_, middle, _) = Get();
+        Console.WriteLine(middle);
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        new Holder().Run();
+    }
+}");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/EmitDeterminismTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitDeterminismTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The emitted bundle must be reproducible: compiling unchanged sources twice has to produce
+    /// byte-identical JavaScript, because that is the gate every compiler change is measured against
+    /// (diff a baseline build vs. a new one) and because a churning bundle defeats HTTP caching.
+    ///
+    /// Synthesized variable names are where this is easy to lose. <c>SyntaxNode.GetHashCode()</c> is
+    /// reference-based, so naming a temp from it gives a different name on every run — the enumerator
+    /// name was fixed to use the statement's source position for exactly this reason, but the
+    /// <c>using (expr)</c> resource variable still hashed the node and so renamed itself
+    /// (<c>$using2871</c> → <c>$using3236</c>) on every compile of the same file.
+    /// </summary>
+    [TestClass]
+    public class EmitDeterminismTests
+    {
+        [TestMethod]
+        public void SynthesizedTempNamesAreStableAcrossCompilations()
+        {
+            var code = @"
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+public class Program
+{
+    static IDisposable Open() => new MemoryStream();
+
+    static void Run(List<int> items)
+    {
+        using (Open())
+        {
+            foreach (var i in items) Console.WriteLine(i);
+        }
+
+        using (Open())
+        {
+            using (Open())
+            {
+                foreach (var i in items) Console.WriteLine(i);
+            }
+        }
+
+        using (Open()) Console.WriteLine(""last"");
+    }
+
+    public static void Main() { Run(new List<int>()); }
+}";
+            var first = new RoslynTranslator().Translate(code);
+            var second = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(first.Success, "first translation should succeed");
+            Assert.IsTrue(second.Success, "second translation should succeed");
+            Assert.AreEqual(first.Javascript, second.Javascript,
+                "translating unchanged sources twice must emit byte-identical JavaScript");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1981,81 +1981,9 @@ public sealed partial class Emitter
         var leftType = _model.GetTypeInfo(assignment.Left).Type;
         var rightType = _model.GetTypeInfo(assignment.Right).Type;
 
-        // Discard assignment: _ = expr → evaluate expr for its side effects only.
-        if (op == "=" && _model.GetSymbolInfo(assignment.Left).Symbol is IDiscardSymbol)
+        if (op == "=")
         {
-            EmitExpression(assignment.Right);
-            return;
-        }
-
-        // `this = expr` inside a struct member (JS cannot assign `this`): copy the value's fields
-        // onto the current instance, matching C# struct value-replacement semantics.
-        if (op == "=" && assignment.Left is ThisExpressionSyntax)
-        {
-            _w.Write("Object.assign(this, ");
-            EmitExpression(assignment.Right);
-            _w.Write(")");
-            return;
-        }
-
-        // Multi-dimensional array element write grid[i, j] = v → System.Array.set(grid, v, i, j).
-        if (op == "=" && assignment.Left is ElementAccessExpressionSyntax mdea
-            && mdea.ArgumentList.Arguments.Count > 1
-            && _model.GetTypeInfo(mdea.Expression).Type is IArrayTypeSymbol { Rank: > 1 })
-        {
-            _w.Write("System.Array.set(");
-            EmitExpression(mdea.Expression);
-            _w.Write(", ");
-            EmitExpressionConverted(assignment.Right, leftType);
-            foreach (var a in mdea.ArgumentList.Arguments) { _w.Write(", "); EmitExpression(a.Expression); }
-            _w.Write(")");
-            return;
-        }
-
-        // Indexer set on a collection: coll[i] = v → coll.setItem(i, v)
-        if (op == "=" && assignment.Left is ElementAccessExpressionSyntax ea
-            && _model.GetSymbolInfo(ea).Symbol is IPropertySymbol { IsIndexer: true } idx
-            && idx.ContainingType.SpecialType != SpecialType.System_String)
-        {
-            // Indexer setter [Template].
-            if (idx.SetMethod is { } setIdx && TransposeNaming.GetTemplate(setIdx.OriginalDefinition) is { } setIdxTpl)
-            {
-                var recv = Capture(() => EmitExpression(ea.Expression));
-                var args = ea.ArgumentList.Arguments.Select(a => Capture(() => EmitExpression(a.Expression))).ToList();
-                args.Add(Capture(() => EmitExpressionConverted(assignment.Right, leftType)));
-                WriteTemplate(setIdxTpl, idx.IsStatic, isExtension: false, recv, new(), args);
-                return;
-            }
-            // An [External] type's plain indexer sets via native bracket access (domElement["name"] = v).
-            if (TransposeNaming.IsNativeIndexer(idx))
-            {
-                EmitExpression(ea.Expression);
-                _w.Write("[");
-                EmitArgumentList(ea.ArgumentList);
-                _w.Write("] = ");
-                EmitExpressionConverted(assignment.Right, leftType);
-                return;
-            }
-            EmitExpression(ea.Expression);
-            _w.Write("." + TransposeNaming.IndexerAccessorName(idx, isGet: false) + "(");
-            EmitArgumentList(ea.ArgumentList);
-            _w.Write(", ");
-            EmitExpressionConverted(assignment.Right, leftType);
-            _w.Write(")");
-            return;
-        }
-
-        // Property setter with a [Template] (e.g. StringBuilder.Length → setLength({0})).
-        if (op == "=" && _model.GetSymbolInfo(assignment.Left).Symbol is IPropertySymbol { SetMethod: { } setter } setProp
-            && !setProp.IsIndexer
-            && TransposeNaming.GetTemplate(setter.OriginalDefinition) is { } setTemplate)
-        {
-            var recv = setProp.IsStatic ? TypeRef(setProp.ContainingType)
-                : assignment.Left is MemberAccessExpressionSyntax sma ? Capture(() => EmitExpression(sma.Expression))
-                : "this";
-            var val = Capture(() => EmitExpressionConverted(assignment.Right, leftType));
-            WriteTemplate(setTemplate, setProp.IsStatic, isExtension: false, recv,
-                new() { ["value"] = val }, new() { val });
+            EmitSimpleAssignmentTo(assignment.Left, () => EmitExpressionConverted(assignment.Right, leftType));
             return;
         }
 
@@ -2183,6 +2111,96 @@ public sealed partial class Emitter
         EmitExpression(assignment.Left);
         _w.Write($" {op} ");
         EmitExpressionConverted(assignment.Right, leftType);
+    }
+
+    /// <summary>
+    /// Emits a simple (<c>=</c>) assignment of a value written by <paramref name="emitValue"/> to any
+    /// assignable expression. Deconstruction targets bind through here too, so every lvalue form
+    /// behaves the same whether it is written by <c>x = v</c> or by <c>(x, y) = t</c>.
+    /// </summary>
+    private void EmitSimpleAssignmentTo(ExpressionSyntax left, Action emitValue)
+    {
+        // Discard assignment: _ = expr → evaluate expr for its side effects only.
+        if (_model.GetSymbolInfo(left).Symbol is IDiscardSymbol)
+        {
+            emitValue();
+            return;
+        }
+
+        // `this = expr` inside a struct member (JS cannot assign `this`): copy the value's fields
+        // onto the current instance, matching C# struct value-replacement semantics.
+        if (left is ThisExpressionSyntax)
+        {
+            _w.Write("Object.assign(this, ");
+            emitValue();
+            _w.Write(")");
+            return;
+        }
+
+        // Multi-dimensional array element write grid[i, j] = v → System.Array.set(grid, v, i, j).
+        if (left is ElementAccessExpressionSyntax mdea
+            && mdea.ArgumentList.Arguments.Count > 1
+            && _model.GetTypeInfo(mdea.Expression).Type is IArrayTypeSymbol { Rank: > 1 })
+        {
+            _w.Write("System.Array.set(");
+            EmitExpression(mdea.Expression);
+            _w.Write(", ");
+            emitValue();
+            foreach (var a in mdea.ArgumentList.Arguments) { _w.Write(", "); EmitExpression(a.Expression); }
+            _w.Write(")");
+            return;
+        }
+
+        // Indexer set on a collection: coll[i] = v → coll.setItem(i, v)
+        if (left is ElementAccessExpressionSyntax ea
+            && _model.GetSymbolInfo(ea).Symbol is IPropertySymbol { IsIndexer: true } idx
+            && idx.ContainingType.SpecialType != SpecialType.System_String)
+        {
+            // Indexer setter [Template].
+            if (idx.SetMethod is { } setIdx && TransposeNaming.GetTemplate(setIdx.OriginalDefinition) is { } setIdxTpl)
+            {
+                var recv = Capture(() => EmitExpression(ea.Expression));
+                var args = ea.ArgumentList.Arguments.Select(a => Capture(() => EmitExpression(a.Expression))).ToList();
+                args.Add(Capture(emitValue));
+                WriteTemplate(setIdxTpl, idx.IsStatic, isExtension: false, recv, new(), args);
+                return;
+            }
+            // An [External] type's plain indexer sets via native bracket access (domElement["name"] = v).
+            if (TransposeNaming.IsNativeIndexer(idx))
+            {
+                EmitExpression(ea.Expression);
+                _w.Write("[");
+                EmitArgumentList(ea.ArgumentList);
+                _w.Write("] = ");
+                emitValue();
+                return;
+            }
+            EmitExpression(ea.Expression);
+            _w.Write("." + TransposeNaming.IndexerAccessorName(idx, isGet: false) + "(");
+            EmitArgumentList(ea.ArgumentList);
+            _w.Write(", ");
+            emitValue();
+            _w.Write(")");
+            return;
+        }
+
+        // Property setter with a [Template] (e.g. StringBuilder.Length → setLength({0})).
+        if (_model.GetSymbolInfo(left).Symbol is IPropertySymbol { SetMethod: { } setter } setProp
+            && !setProp.IsIndexer
+            && TransposeNaming.GetTemplate(setter.OriginalDefinition) is { } setTemplate)
+        {
+            var recv = setProp.IsStatic ? TypeRef(setProp.ContainingType)
+                : left is MemberAccessExpressionSyntax sma ? Capture(() => EmitExpression(sma.Expression))
+                : "this";
+            var val = Capture(emitValue);
+            WriteTemplate(setTemplate, setProp.IsStatic, isExtension: false, recv,
+                new() { ["value"] = val }, new() { val });
+            return;
+        }
+
+        EmitExpression(left);
+        _w.Write(" = ");
+        emitValue();
     }
 
     /// <summary>The Int64/UInt64 or Decimal instance-method name for a compound-assignment operator

--- a/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -422,24 +423,45 @@ public sealed partial class Emitter
 
         var rhsType = _model.GetTypeInfo(assign.Right).Type;
         var isTuple = rhsType is { IsTupleType: true } || assign.Right is TupleExpressionSyntax;
-        EmitDeconstructionBindings(targets, temp, isTuple);
+        EmitDeconstructionBindings(targets, temp, isTuple, rhsType);
+    }
+
+    /// <summary>
+    /// One position of a deconstruction's left-hand side: a newly declared local
+    /// (<c>DeclaredName</c>), an existing lvalue to assign (<c>Assignee</c>), a nested group
+    /// (<c>Nested</c>), or — all three null — a discard.
+    /// </summary>
+    private readonly record struct DeconstructionTarget(
+        string?                        DeclaredName,
+        ExpressionSyntax?              Assignee,
+        List<DeconstructionTarget>?    Nested)
+    {
+        public static readonly DeconstructionTarget Discard = new(null, null, null);
+
+        public static DeconstructionTarget Declare(string name)               => new(name, null, null);
+        public static DeconstructionTarget Assign(ExpressionSyntax lvalue)    => new(null, lvalue, null);
+        public static DeconstructionTarget Group(List<DeconstructionTarget> t) => new(null, null, t);
+
+        public bool IsDiscard => DeclaredName is null && Assignee is null && Nested is null;
     }
 
     /// <summary>
     /// Binds deconstruction targets from an already-evaluated value <paramref name="temp"/>:
     /// tuple elements read <c>temp.Item{n}</c>, otherwise the value's Deconstruct(out …) runs.
+    /// A target that is not a fresh local is written through <see cref="EmitSimpleAssignmentTo"/>, so
+    /// a field, property, indexer or array element is qualified and stored the same way a plain
+    /// assignment to it would be — emitting the bare source name would produce an undeclared global.
     /// </summary>
     private void EmitDeconstructionBindings(
-        System.Collections.Generic.List<(string? name, bool isNew, bool isDiscard)> targets,
-        string temp, bool isTuple)
+        List<DeconstructionTarget> targets, string temp, bool isTuple, ITypeSymbol? valueType)
     {
+        var elementTypes = DeconstructionElementTypes(valueType, targets.Count);
+
         if (isTuple)
         {
             for (var i = 0; i < targets.Count; i++)
             {
-                var (name, isNew, isDiscard) = targets[i];
-                if (isDiscard) continue; // position preserved, no binding
-                _w.WriteLine($"{(isNew ? "let " : "")}{NameMangler.JsIdentifier(name!)} = {temp}.Item{i + 1};");
+                EmitDeconstructionBinding(targets[i], $"{temp}.Item{i + 1}", elementTypes[i], declare: true);
             }
             return;
         }
@@ -448,50 +470,94 @@ public sealed partial class Emitter
         var holders = targets.Select((_, i) => $"{temp}_h{i}").ToList();
         for (var i = 0; i < targets.Count; i++)
         {
-            if (targets[i].isNew && !targets[i].isDiscard) _w.WriteLine($"let {NameMangler.JsIdentifier(targets[i].name!)};");
+            if (targets[i].DeclaredName is { } name) _w.WriteLine($"let {NameMangler.JsIdentifier(name)};");
             _w.WriteLine($"let {holders[i]} = {{ v: null }};");
         }
+
         _w.WriteLine($"{temp}.Deconstruct({string.Join(", ", holders)});");
+
         for (var i = 0; i < targets.Count; i++)
         {
-            if (targets[i].isDiscard) continue;
-            _w.WriteLine($"{NameMangler.JsIdentifier(targets[i].name!)} = {holders[i]}.v;");
+            EmitDeconstructionBinding(targets[i], $"{holders[i]}.v", elementTypes[i], declare: false);
         }
     }
 
-    private System.Collections.Generic.IEnumerable<(string? name, bool isNew, bool isDiscard)> CollectDeconstructionTargets(ExpressionSyntax left)
+    /// <summary>Binds one deconstruction position to the JavaScript expression <paramref name="value"/>.
+    /// <paramref name="declare"/> is false on the Deconstruct path, where fresh locals were already
+    /// declared ahead of the call.</summary>
+    private void EmitDeconstructionBinding(DeconstructionTarget target, string value, ITypeSymbol? valueType, bool declare)
+    {
+        if (target.IsDiscard) return; // position preserved, no binding
+
+        if (target.Nested is { } nested)
+        {
+            var sub = NextTemp("$dc");
+            _w.WriteLine($"let {sub} = {value};");
+            EmitDeconstructionBindings(nested, sub, valueType is { IsTupleType: true }, valueType);
+            return;
+        }
+
+        if (target.DeclaredName is { } name)
+        {
+            _w.WriteLine($"{(declare ? "let " : "")}{NameMangler.JsIdentifier(name)} = {value};");
+            return;
+        }
+
+        EmitSimpleAssignmentTo(target.Assignee!, () => _w.Write(value));
+        _w.WriteLine(";");
+    }
+
+    /// <summary>The element types a value of <paramref name="valueType"/> deconstructs into — needed to
+    /// type a nested group. Nulls where the shape cannot be resolved.</summary>
+    private static ITypeSymbol?[] DeconstructionElementTypes(ITypeSymbol? valueType, int count)
+    {
+        if (valueType is INamedTypeSymbol { IsTupleType: true } tuple && tuple.TupleElements.Length == count)
+            return tuple.TupleElements.Select(e => (ITypeSymbol?)e.Type).ToArray();
+
+        var deconstruct = valueType?.GetMembers("Deconstruct").OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.Parameters.Length == count && m.Parameters.All(p => p.RefKind == RefKind.Out));
+
+        if (deconstruct is not null) return deconstruct.Parameters.Select(p => (ITypeSymbol?)p.Type).ToArray();
+
+        return new ITypeSymbol?[count];
+    }
+
+    private IEnumerable<DeconstructionTarget> CollectDeconstructionTargets(ExpressionSyntax left)
     {
         switch (left)
         {
             case TupleExpressionSyntax tuple:
-                foreach (var arg in tuple.Arguments)
-                {
-                    switch (arg.Expression)
-                    {
-                        case DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax d }:
-                            yield return (d.Identifier.Text, true, false);
-                            break;
-                        case DeclarationExpressionSyntax { Designation: DiscardDesignationSyntax }:
-                            yield return (null, false, true);
-                            break;
-                        case IdentifierNameSyntax { Identifier.Text: "_" } when _model.GetSymbolInfo(arg.Expression).Symbol is IDiscardSymbol:
-                            yield return (null, false, true);
-                            break;
-                        case IdentifierNameSyntax id:
-                            yield return (id.Identifier.Text, false, false);
-                            break;
-                    }
-                }
+                foreach (var arg in tuple.Arguments) yield return TargetForExpression(arg.Expression);
                 break;
-            case DeclarationExpressionSyntax { Designation: ParenthesizedVariableDesignationSyntax paren }:
-                foreach (var v in paren.Variables)
-                {
-                    if (v is SingleVariableDesignationSyntax single)
-                        yield return (single.Identifier.Text, true, false);
-                    else if (v is DiscardDesignationSyntax)
-                        yield return (null, false, true);
-                }
+            case DeclarationExpressionSyntax { Designation: { } designation }:
+                foreach (var t in TargetsForDesignation(designation)) yield return t;
                 break;
         }
     }
+
+    private DeconstructionTarget TargetForExpression(ExpressionSyntax expression)
+    {
+        switch (expression)
+        {
+            case DeclarationExpressionSyntax decl:
+                return TargetForDesignation(decl.Designation);
+            case TupleExpressionSyntax nested:
+                return DeconstructionTarget.Group(CollectDeconstructionTargets(nested).ToList());
+            default:
+                if (_model.GetSymbolInfo(expression).Symbol is IDiscardSymbol) return DeconstructionTarget.Discard;
+                return DeconstructionTarget.Assign(expression);
+        }
+    }
+
+    private DeconstructionTarget TargetForDesignation(VariableDesignationSyntax designation) => designation switch
+    {
+        SingleVariableDesignationSyntax single => DeconstructionTarget.Declare(single.Identifier.Text),
+        ParenthesizedVariableDesignationSyntax => DeconstructionTarget.Group(TargetsForDesignation(designation).ToList()),
+        _                                      => DeconstructionTarget.Discard,
+    };
+
+    private IEnumerable<DeconstructionTarget> TargetsForDesignation(VariableDesignationSyntax designation)
+        => designation is ParenthesizedVariableDesignationSyntax paren
+            ? paren.Variables.Select(TargetForDesignation)
+            : Enumerable.Empty<DeconstructionTarget>();
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -517,7 +517,8 @@ public sealed partial class Emitter
     private void EmitForEachVariable(ForEachVariableStatementSyntax forEach)
     {
         var enumVar = EmitEnumeratorInit(forEach, forEach.Expression);
-        var elementIsTuple = _model.GetForEachStatementInfo(forEach).ElementType is { IsTupleType: true };
+        var elementType = _model.GetForEachStatementInfo(forEach).ElementType;
+        var elementIsTuple = elementType is { IsTupleType: true };
         var targets = CollectDeconstructionTargets(forEach.Variable).ToList();
         _w.Write("try ");
         _w.Block(() =>
@@ -529,7 +530,7 @@ public sealed partial class Emitter
             {
                 var cur = enumVar + "c";
                 _w.WriteLine($"let {cur} = {enumVar}.current;");
-                EmitDeconstructionBindings(targets, cur, elementIsTuple);
+                EmitDeconstructionBindings(targets, cur, elementIsTuple, elementType);
                 EmitForEachBody(forEach.Statement);
             });
             _loopDepth--;
@@ -760,7 +761,12 @@ public sealed partial class Emitter
             }
             else if (usingStmt.Expression is not null)
             {
-                resourceVar = "$using" + Math.Abs(usingStmt.GetHashCode() % 10000);
+                // Name the resource from the statement's source position, not from
+                // SyntaxNode.GetHashCode() — a node's hash code is reference-based, so it varies
+                // between runs and made the emitted bundle differ byte-for-byte on every compile of
+                // unchanged sources. Same reasoning (and format) as the enumerator in
+                // EmitEnumeratorInit.
+                resourceVar = "$using" + usingStmt.SpanStart.ToString("x4");
                 _w.Write($"let {resourceVar} = ");
                 EmitExpression(usingStmt.Expression);
                 _w.WriteLine(";");


### PR DESCRIPTION
## Summary

Fixes a critical bug where deconstruction assignment targets that are not fresh local variables were either dropped entirely or emitted as unqualified names, causing runtime errors or silent value corruption.

## Problem

The deconstruction implementation had several issues:

1. **Implicit-`this` fields** (`(_a, _b) = Get()`) emitted bare `_a = …` instead of `this._a = …`, causing `ReferenceError` under strict mode (the Curiosity `SearchResultsComponent` crash)
2. **Static fields** emitted unqualified names instead of `Type.Field`
3. **Non-local lvalues** (fields, properties, indexers, array elements) were **dropped entirely** from the target list, which:
   - Shortened the target list
   - Shifted every subsequent target onto the wrong tuple element
   - Resulted in silently wrong values with no error
4. **Nested groups** (`var (a, (b, c))`) were dropped the same way

## Solution

Refactored deconstruction binding to use the shared `EmitSimpleAssignmentTo` method, which already handles all lvalue forms correctly (fields, properties, indexers, array elements, `this` assignment, discards). This ensures every deconstruction target is emitted exactly as a plain assignment to that lvalue would be.

### Key Changes

- **Extracted `EmitSimpleAssignmentTo` method** in `Emitter.Expressions2.cs`: Centralizes simple assignment logic for any lvalue, taking an `Action` to emit the value. This allows deconstruction targets to bind through the same path as regular assignments.

- **Redesigned deconstruction target representation** in `Emitter.Patterns.cs`:
  - Introduced `DeconstructionTarget` record struct to represent each position: a declared local, an existing lvalue to assign, a nested group, or a discard
  - Replaced tuple-based target collection with structured targets that preserve all information

- **Fixed target collection** to handle:
  - Nested deconstruction groups (e.g., `var (a, (b, c))`)
  - Existing lvalues (member access, indexers, array elements)
  - Proper discard handling

- **Enhanced binding emission** to:
  - Recursively handle nested groups by creating temporary variables
  - Route non-local targets through `EmitSimpleAssignmentTo` for correct qualification
  - Preserve element type information for nested groups

- **Added comprehensive test suite** (`DeconstructionTargetTests.cs`):
  - Instance field targets with implicit `this`
  - Static field and property targets
  - Explicit `this` and member access targets
  - Non-local targets (arrays, indexers, fields) that previously shifted later elements
  - Nested deconstruction groups
  - Deconstruct method calls into fields
  - Nested deconstruction in `foreach`
  - Discard handling

- **Added determinism test** (`EmitDeterminismTests.cs`) to ensure synthesized temp names are stable across compilations (using source position instead of node hash)

## Implementation Details

- Deconstruction now properly handles tuple vs. Deconstruct-method paths with correct element type tracking
- Nested groups create intermediate temporaries and recursively bind their targets
- All lvalue forms (fields, properties, indexers, array elements) are now correctly qualified and stored
- Discard positions are preserved in the target list without emitting bindings

https://claude.ai/code/session_01NXGerzGWNNh3NQF6cCxw3T