### PR TITLE
Don't $-escape [GlobalMethods] members; emit consts as static fields

### DIFF
--- a/Transpose/Transpose.Translator.Tests/ConstFieldEmissionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ConstFieldEmissionTests.cs
@@ -1,0 +1,109 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// A <c>const</c> is inlined at every use site, but it must ALSO be emitted as a real static slot
+    /// holding its value, so the member exists for reflection, for a debugger, and for hand-written JS
+    /// reaching into the type. Transpose previously only inlined, so a type's consts were absent from
+    /// the emitted class entirely (the reference runtime emits them as static fields).
+    /// </summary>
+    [TestClass]
+    public class ConstFieldEmissionTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public void ConstsAreEmittedAsStaticFieldsAndStillInlined()
+        {
+            var code = @"
+public class Holder
+{
+    private const int    COUNT   = 42;
+    public  const string MARKER  = ""mark"";
+    public  const double RATIO   = 1.5;
+    public  const bool   ENABLED = true;
+    public  const string NOTHING = null;
+
+    public static int Use() => COUNT;
+}
+
+public class Program
+{
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+
+            Assert.IsTrue(js.Contains("COUNT: 42"), "a const must be emitted as a static field with its value\n" + js);
+            Assert.IsTrue(js.Contains("MARKER: \"mark\""), "string const missing from the emitted fields\n" + js);
+            Assert.IsTrue(js.Contains("RATIO: 1.5"), "double const missing from the emitted fields\n" + js);
+            Assert.IsTrue(js.Contains("ENABLED: true"), "bool const missing from the emitted fields\n" + js);
+            Assert.IsTrue(js.Contains("NOTHING: null"), "null string const missing from the emitted fields\n" + js);
+
+            // Still inlined at the use site — emitting the slot must not turn reads into field access.
+            Assert.IsTrue(js.Contains("return 42;"),
+                "a const use site must remain inlined, not become a field read\n" + js);
+        }
+
+        /// <summary>An enum's members are consts too, but the enum has its own emit path — the const
+        /// path must not emit them a second time.</summary>
+        [TestMethod]
+        public void EnumMembersAreNotDuplicatedAsStaticFields()
+        {
+            var code = @"
+public enum Color { Red, Green, Blue }
+
+public class Program
+{
+    public static Color Pick() => Color.Green;
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+
+            Assert.AreEqual(1, CountOccurrences(js, "Green: 1"),
+                "the enum's own emit path already declares its members; the const path must not repeat them\n" + js);
+            Assert.AreEqual(1, CountOccurrences(js, "fields: {"),
+                "an enum should emit exactly one fields block\n" + js);
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            var n = 0;
+            for (var i = haystack.IndexOf(needle); i >= 0; i = haystack.IndexOf(needle, i + needle.Length)) n++;
+            return n;
+        }
+
+        [TestMethod]
+        public async Task ConstBehaviourMatchesNativeAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Holder
+{
+    public const int    COUNT   = 42;
+    public const string MARKER  = ""mark"";
+    public const long   BIG     = 9007199254740993L;
+    public const Color  FAVOUR  = Color.Green;
+}
+
+public enum Color { Red, Green, Blue }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Holder.COUNT);
+        Console.WriteLine(Holder.MARKER);
+        Console.WriteLine(Holder.BIG);
+        Console.WriteLine(Holder.FAVOUR);
+    }
+}");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/GlobalMemberNamingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/GlobalMemberNamingTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// A static member whose name collides with a Function own-property (<c>name</c>, <c>length</c>,
+    /// <c>caller</c>, …) is emitted as <c>$name</c>, because a normal static lives on the type's
+    /// constructor function and <c>Class.name</c> is read-only. A <c>[GlobalMethods]</c> binding is
+    /// different: its members ARE the ambient JS globals and are emitted bare, so escaping invents an
+    /// identifier that was never declared — <c>window.name</c> came out as <c>$name</c>, a strict-mode
+    /// ReferenceError. Found in the Curiosity front-end: `Tooltip(name, …)` in EmojiSelector emitted
+    /// `$name` and threw, where h5 emitted the working `name`.
+    /// </summary>
+    [TestClass]
+    public class GlobalMemberNamingTests
+    {
+        private const string GLOBALS = @"
+using Transpose;
+
+[External]
+[GlobalMethods]
+public static class Globals
+{
+    public static extern string name   { get; set; }
+    public static extern int    length { get; }
+    public static extern string other  { get; set; }
+}
+";
+
+        [TestMethod]
+        public void GlobalMethodsMembersAreNotDollarEscaped()
+        {
+            var code = GLOBALS + @"
+public class Program
+{
+    public static string Read() => Globals.name + Globals.length + Globals.other;
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+
+            Assert.IsFalse(js.Contains("$name"),
+                "a [GlobalMethods] member named `name` is a bare global and must not be $-escaped\n" + js);
+            Assert.IsFalse(js.Contains("$length"),
+                "a [GlobalMethods] member named `length` is a bare global and must not be $-escaped\n" + js);
+        }
+
+        /// <summary>The escape must stay for a normal static, where the member really does live on the
+        /// type's constructor function and would otherwise collide with Function.name / Function.length.</summary>
+        [TestMethod]
+        public void OrdinaryStaticMembersKeepTheDollarEscape()
+        {
+            var code = @"
+public class Config
+{
+    public static string name   = ""x"";
+    public static int    length = 3;
+    public static string other  = ""y"";
+}
+
+public class Program
+{
+    public static string Read() => Config.name + Config.length + Config.other;
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+
+            Assert.IsTrue(js.Contains("$name"),
+                "an ordinary static named `name` must stay $-escaped (Function.name is read-only)\n" + js);
+            Assert.IsTrue(js.Contains("$length"),
+                "an ordinary static named `length` must stay $-escaped\n" + js);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -16,6 +16,13 @@ public sealed partial class Emitter
         var staticFields = type.GetMembers().Where(m => m.IsStatic).Select(m => m switch
         {
             IFieldSymbol f when !f.IsConst && f.AssociatedSymbol is null => ((string name, string def)?)(TransposeNaming.MemberJsName(f), FieldDefaultLiteral(f.Type)),
+            // A const is inlined at every use site, but it is also emitted as a real static slot
+            // holding its value: the member then exists for reflection, for a debugger, and for
+            // hand-written JS reaching into the type — matching the reference runtime, which
+            // exposes consts as static fields. An enum's members are consts too, but the enum type
+            // has its own emit path, so they must not be duplicated here.
+            IFieldSymbol { IsConst: true, ContainingType.TypeKind: not TypeKind.Enum } c when c.CanBeReferencedByName
+                => (TransposeNaming.MemberJsName(c), ConstantLiteral(c.ConstantValue, c.Type)),
             IPropertySymbol p when IsAutoProperty(p) => (TransposeNaming.MemberJsName(p), FieldDefaultLiteral(p.Type)),
             _ => null,
         }).Where(x => x is not null).Select(x => x!.Value).ToList();

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -461,9 +461,14 @@ internal static class TransposeNaming
         { "name", "length", "caller", "arguments", "prototype", "constructor" };
 
     /// <summary>Prefixes a static member whose JS name collides with a Function own-property
-    /// (name/length/…) with <c>$</c> — matching the reference runtime (enum member `name` → `$name`).</summary>
+    /// (name/length/…) with <c>$</c> — matching the reference runtime (enum member `name` → `$name`).
+    /// A member of a <c>[GlobalMethods]</c> binding is exempt: it is emitted as a BARE identifier, not
+    /// as a property of a constructor function, so there is nothing to collide with and the escape
+    /// would invent an undeclared global (`window.name` → `$name`, a strict-mode ReferenceError).</summary>
     private static string EscapeStaticReserved(ISymbol symbol, string name)
-        => symbol.IsStatic && _functionReserved.Contains(name) ? "$" + name : name;
+        => symbol.IsStatic && _functionReserved.Contains(name) && ScopePrefix(symbol.ContainingType) != ""
+            ? "$" + name
+            : name;
 
     /// <summary>The un-mangled JS name of a member (ignoring interface qualification).</summary>
     private static string LeafJsName(ISymbol symbol)


### PR DESCRIPTION
Two emit fixes found auditing the Curiosity front-end against the h5 baseline.

**[GlobalMethods] name/length were mangled into undeclared globals.** EscapeStaticReserved prefixes a static member whose JS name collides with a Function own-property (name, length, caller, ...) with `$`, because a normal static lives on the type's constructor function and Function.name is read-only. A [GlobalMethods] binding is different: its members ARE the ambient JS globals and are emitted bare, so the escape invented an identifier nobody declared. `Tooltip(name, ...)` in EmojiSelector emitted `$name` and threw a strict-mode ReferenceError where h5 emitted the working `name`. Members of a bare-global scope are now exempt; an ordinary static keeps the escape.

**Consts are now emitted as static fields as well as inlined.** A const was inlined at every use site and otherwise absent from the emitted class, so it existed for no reflection, debugger or hand-written JS reaching into the type -- the reference runtime exposes consts as static fields. They are now emitted into statics.fields holding their constant value, while use sites stay inlined. An enum's members are consts too but have their own emit path, so they are excluded and not duplicated.

Verified on the Curiosity front-end: the top 20 types by source size now match the h5 member sets except for C# events (whose backing slot h5 declares and Transpose does not -- behaviour is identical to native .NET, confirmed by subscribe/fire/unsubscribe) and members changed since the h5 build.


Claude-Session: https://claude.ai/code/session_01NXGerzGWNNh3NQF6cCxw3T