### PR TITLE
Resolve Exception.StackTrace for a raw JavaScript error

### DIFF
--- a/BCL/Transpose.BCL/System/Exception.cs
+++ b/BCL/Transpose.BCL/System/Exception.cs
@@ -41,8 +41,16 @@ namespace System
         /// <summary>
         /// Gets a string representation of the immediate frames on the call stack.
         /// </summary>
+        /// <remarks>
+        /// Read through a helper rather than the plain member: a value caught by
+        /// <c>catch (Exception)</c> is either a real <see cref="Exception"/> — which carries the
+        /// <c>errorStack</c> captured in its constructor — or a raw JavaScript error thrown by interop
+        /// or a rejected promise, which has a native <c>stack</c> and no <c>errorStack</c>. C# matches
+        /// both, so reading the member directly returned undefined for the raw-error case.
+        /// </remarks>
         public virtual extern string StackTrace
         {
+            [Transpose.Template("TransposeR.stackTrace({this})")]
             get;
         }
 

--- a/Transpose/Transpose.Translator.Tests/ExceptionStackTraceTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ExceptionStackTraceTests.cs
@@ -1,0 +1,101 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// A value caught by <c>catch (Exception)</c> is either a real <c>System.Exception</c> — which
+    /// captured an <c>Error</c> into <c>errorStack</c> when it was constructed — or a RAW JavaScript
+    /// error thrown by interop or a rejected promise, which has a native <c>stack</c> and no
+    /// <c>errorStack</c>. C# matches both, but <c>StackTrace</c> read <c>errorStack.stack</c>
+    /// unconditionally, so it came back null for every raw error while a C#-thrown exception worked.
+    ///
+    /// The read now goes through <c>TransposeR.stackTrace</c>, which takes whichever shape arrived.
+    /// The alternative — normalising every caught value into a wrapper the way h5 does — was rejected:
+    /// it allocates on entry to every catch clause and makes <c>throw;</c> rethrow the wrapper rather
+    /// than the original error, losing its identity and native stack for any outer JS handler.
+    /// </summary>
+    [TestClass]
+    public class ExceptionStackTraceTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public void StackTraceReadsGoThroughTheHelper()
+        {
+            var code = @"
+using System;
+
+public class Program
+{
+    public static string Read()
+    {
+        try { throw new InvalidOperationException(""x""); }
+        catch (Exception e) { return e.StackTrace; }
+    }
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            Assert.IsTrue(result.Javascript!.Contains("TransposeR.stackTrace("),
+                "Exception.StackTrace must read through the helper so a raw JS error also resolves\n"
+                + result.Javascript);
+        }
+
+        /// <summary>A C#-thrown exception keeps its captured stack, and ToString() (which reads
+        /// StackTrace internally) still works.</summary>
+        [TestMethod]
+        public async Task CSharpThrownExceptionStillHasAStackTraceAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Program
+{
+    static void Deep() => throw new InvalidOperationException(""deep"");
+
+    public static void Main()
+    {
+        try { Deep(); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""has stack: "" + (e.StackTrace != null));
+            Console.WriteLine(""tostring: "" + e.ToString().Contains(""deep""));
+        }
+    }
+}");
+        }
+
+        /// <summary>A raw JS error crossing into C# resolves its native stack; a thrown non-Error
+        /// (a bare string, an object literal) has no stack and correctly yields null.</summary>
+        [TestMethod]
+        public async Task RawJavaScriptErrorExposesItsNativeStackAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw new TypeError('js boom');"")] public static extern void ThrowError();
+    [Script(""throw 'bare string';"")]            public static extern void ThrowString();
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        try { Native.ThrowError(); }
+        catch (Exception e) { Console.WriteLine(""error stack: "" + (e.StackTrace ?? """").Split('\n')[0]); }
+
+        try { Native.ThrowString(); }
+        catch (Exception e) { Console.WriteLine(""string stack null: "" + (e.StackTrace == null)); }
+    }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "error stack: TypeError: js boom",
+                "a raw JS error must expose its native stack through Exception.StackTrace");
+            StringAssert.Contains(js, "string stack null: True",
+                "a thrown non-Error has no stack, so StackTrace must be null rather than undefined");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -14,6 +14,15 @@
     // Box a char (a bare code-point number at runtime) so it stringifies / compares as its
     // character once widened to object — `object o = 'A'; o.ToString()` must be "A", not "65".
     TransposeR.boxChar = function (c) { return Transpose.box(c, System.Char, TransposeR.chr); };
+    // Exception.StackTrace. A value caught by `catch (Exception)` is either a real System.Exception,
+    // which captured an Error into `errorStack` when it was constructed, or a raw JS error thrown by
+    // interop / a rejected promise, which has a native `stack` and no `errorStack`. C# matches both,
+    // so read whichever shape arrived instead of assuming errorStack (a raw error gave undefined).
+    TransposeR.stackTrace = function (e) {
+        if (e === null || e === undefined) { return null; }
+        if (e.errorStack && e.errorStack.stack !== null && e.errorStack.stack !== undefined) { return e.errorStack.stack; }
+        return (e.stack !== null && e.stack !== undefined) ? e.stack : null;
+    };
     TransposeR.is = function (v, t) { return Transpose.is(v, t); };
     TransposeR.as = function (v, t) { return Transpose.as ? Transpose.as(v, t) : (Transpose.is(v, t) ? v : null); };
     TransposeR.equals = function (a, b) { return Transpose.equals ? Transpose.equals(a, b) : a === b; };


### PR DESCRIPTION
A value caught by `catch (Exception)` is either a real System.Exception -- which captured an Error into `errorStack` when it was constructed -- or a raw JS error thrown by interop or a rejected promise, which has a native `stack` and no `errorStack`. C# matches both, but StackTrace read `errorStack.stack` unconditionally, so it came back null for every raw error while a C#-thrown exception worked. The getter now goes through TransposeR.stackTrace, which takes whichever shape arrived: errorStack.stack, else the native stack, else null (a thrown string or object literal genuinely has no stack).

Normalising every caught value into a wrapper, as h5 does with System.Exception.create, was the alternative and is not worth it: matching and Message/GetType()/ToString() already work on a raw error, wrapping allocates on entry to every catch clause, and it makes `throw;` rethrow the wrapper instead of the original error -- losing its identity and native stack for any outer JS handler. This was the one member that genuinely did not resolve.

Requires a runtime rebuild: the [Template] lives on the BCL property and the helper in tps.shim.js.


Claude-Session: https://claude.ai/code/session_01NXGerzGWNNh3NQF6cCxw3T