### PR TITLE
Fix binding the wrong copy of a referenced assembly

### DIFF
--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -234,7 +234,10 @@ public static class Program
         // embed its JS (+ tps.json resources) so another project can reference it and extract them.
         if (emitPackage)
         {
-            var (dllPath, items) = WritePackage(project, config, configuration, result);
+            var written = TryWritePackage(project, config, configuration, result);
+            if (written is null) return 2;
+
+            var (dllPath, items) = written.Value;
             Console.WriteLine($"\nOK — built package {project.AssemblyName}.dll ({result.AssemblyBytes!.Length:N0} bytes) with {items.Count} embedded resource(s) in {sw.ElapsedMilliseconds} ms.");
             Console.WriteLine($"  dll:      {dllPath}");
             Console.WriteLine($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
@@ -251,7 +254,11 @@ public static class Program
             // one and the SDK finds the <Assembly>.dll it declares as the build output.
             string? dllPath = null;
             if (result.AssemblyBytes is not null)
-                (dllPath, _) = WritePackage(project, config, configuration, result);
+            {
+                var package = TryWritePackage(project, config, configuration, result);
+                if (package is null) return 2;
+                dllPath = package.Value.dllPath;
+            }
 
             var outDir = siteDir ?? ResolveOutputDir(config, project.ProjectDir, configuration);
             var siteResult = PhaseTimings.Measure("write site (minify + resources + html)", () =>
@@ -543,8 +550,22 @@ public static class Program
             return false;
         }
 
-        WritePackage(project, tpscfg, configuration, result);
-        return true;
+        return TryWritePackage(project, tpscfg, configuration, result) is not null;
+    }
+
+    /// <summary>Writes a project's package DLL, turning a failure into a reported diagnostic (rather
+    /// than an unhandled exception) and a null result. Embedding the resources re-serializes the
+    /// assembly's metadata through Mono.Cecil, which resolves referenced assemblies as it goes — a
+    /// step that can fail on its own, after a clean compile.</summary>
+    private static (string dllPath, List<EmbeddedItem> items)? TryWritePackage(
+        ResolvedProject project, TransposeJson? config, string configuration, AssemblyBuildResult result)
+    {
+        try { return WritePackage(project, config, configuration, result); }
+        catch (Exception ex)
+        {
+            ReportCrash($"Writing the package for '{Path.GetFileName(project.CsprojPath)}'", ex);
+            return null;
+        }
     }
 
     /// <summary>Writes a project's emitted assembly and embeds its JS + resources, returning the DLL

--- a/Transpose/Transpose.Compiler/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler/ProjectResolver.cs
@@ -506,48 +506,66 @@ internal static class ProjectResolver
 
     // ---- reference resolution (NuGet global-packages cache) -----------------
 
+    /// <summary>
+    /// The assemblies a project's <c>&lt;PackageReference&gt;</c> items contribute, resolved from the
+    /// NuGet global-packages cache as <c>assembly simple name → dll path</c>.
+    ///
+    /// Precedence follows NuGet's own rules rather than the order the items happen to appear in: the
+    /// version the project declares itself wins over one reached through another package's
+    /// dependencies (NuGet's "direct dependency wins"), and between two transitive candidates the
+    /// higher version wins. Resolving in document order instead silently downgraded a package — a
+    /// csproj listing <c>Tesserae.GraphKit</c> above <c>Tesserae</c> compiled against the older
+    /// Tesserae that GraphKit's nuspec declares, ignoring the version written right there in the
+    /// csproj.
+    /// </summary>
     private static IEnumerable<(string name, string path)> ResolvePackageReferenceDlls(ProjectXml doc, List<string> roots)
     {
-        var resolved = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); // asmName → dll path
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);             // pkgId@version
-
+        // pkgId → the version the project declares (highest, if it declares one id twice).
+        var declared = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (pr, _) in doc.Elements("PackageReference"))
         {
             var id = pr.Attribute("Include")?.Value ?? pr.Attribute("Update")?.Value;
             var version = pr.Attribute("Version")?.Value ?? pr.Element(pr.Name.Namespace + "Version")?.Value;
             if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(version)) continue;
-            ResolvePackage(roots, id!, version!, resolved, visited);
+            if (!declared.TryGetValue(id!, out var already) || CompareVersions(version!, already) > 0)
+                declared[id!] = version!;
         }
 
-        return resolved.Select(kv => (kv.Key, kv.Value));
-    }
+        var resolved = new Dictionary<string, (string path, string version, bool declared)>(StringComparer.OrdinalIgnoreCase);
+        var visited  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);                     // pkgId@version
+        var queue    = new Queue<(string id, string version, bool isDeclared)>();
 
-    private static void ResolvePackage(
-        List<string> roots, string id, string version,
-        Dictionary<string, string> resolved, HashSet<string> visited)
-    {
-        var key = id + "@" + version;
-        if (!visited.Add(key)) return;
+        // Breadth-first from the declared set, so every declared package is resolved before any
+        // transitive one can offer the same assembly.
+        foreach (var (id, version) in declared) queue.Enqueue((id, version, true));
 
-        var pkgDir = roots
-            .Select(r => Path.Combine(r, id.ToLowerInvariant(), version))
-            .FirstOrDefault(Directory.Exists);
-        if (pkgDir is null) return;
-
-        var libDir = BestLibDir(pkgDir);
-        if (libDir is not null)
+        while (queue.Count > 0)
         {
-            foreach (var dll in Directory.GetFiles(libDir, "*.dll"))
+            var (id, version, isDeclared) = queue.Dequeue();
+
+            // A transitive dependency on a package the project declares itself is ignored outright:
+            // the declared version supersedes it, so its cache folder is never even read.
+            if (!isDeclared && declared.ContainsKey(id)) continue;
+            if (!visited.Add(id + "@" + version)) continue;
+
+            var pkgDir = roots
+                .Select(r => Path.Combine(r, id.ToLowerInvariant(), version))
+                .FirstOrDefault(Directory.Exists);
+            if (pkgDir is null) continue;
+
+            var libDir = BestLibDir(pkgDir);
+            if (libDir is not null)
             {
-                var name = Path.GetFileNameWithoutExtension(dll);
-                if (!resolved.ContainsKey(name)) resolved[name] = dll;
+                foreach (var dll in Directory.GetFiles(libDir, "*.dll"))
+                {
+                    var name = Path.GetFileNameWithoutExtension(dll);
+                    if (Wins(name, version, isDeclared)) resolved[name] = (dll, version, isDeclared);
+                }
             }
-        }
 
-        // Follow the package's declared dependencies so transitive BCL/interop types resolve.
-        var nuspec = Path.Combine(pkgDir, id.ToLowerInvariant() + ".nuspec");
-        if (File.Exists(nuspec))
-        {
+            // Follow the package's declared dependencies so transitive BCL/interop types resolve.
+            var nuspec = Path.Combine(pkgDir, id.ToLowerInvariant() + ".nuspec");
+            if (!File.Exists(nuspec)) continue;
             try
             {
                 var ndoc = XDocument.Load(nuspec);
@@ -556,11 +574,41 @@ internal static class ProjectResolver
                     var depId = dep.Attribute("id")?.Value;
                     var depVer = dep.Attribute("version")?.Value?.Trim('[', ']', '(', ')').Split(',')[0];
                     if (!string.IsNullOrWhiteSpace(depId) && !string.IsNullOrWhiteSpace(depVer))
-                        ResolvePackage(roots, depId!, depVer!, resolved, visited);
+                        queue.Enqueue((depId!, depVer!, false));
                 }
             }
             catch { /* best-effort transitive resolution */ }
         }
+
+        return resolved.Select(kv => (kv.Key, kv.Value.path));
+
+        bool Wins(string name, string version, bool isDeclared)
+        {
+            if (!resolved.TryGetValue(name, out var current)) return true;
+            if (current.declared) return false;                        // a declared version is never displaced
+            return isDeclared || CompareVersions(version, current.version) > 0;
+        }
+    }
+
+    /// <summary>Compares two NuGet version strings by their numeric segments, ignoring any
+    /// prerelease/metadata suffix — enough to pick between two versions of one package in the cache
+    /// (a full NuGet.Versioning dependency would buy nothing here).</summary>
+    private static int CompareVersions(string a, string b)
+    {
+        var left  = Segments(a);
+        var right = Segments(b);
+
+        for (var i = 0; i < Math.Max(left.Length, right.Length); i++)
+        {
+            var x = i < left.Length ? left[i] : 0;
+            var y = i < right.Length ? right[i] : 0;
+            if (x != y) return x.CompareTo(y);
+        }
+        return 0;
+
+        static int[] Segments(string v) => v.Trim().Split('-', '+')[0].Split('.')
+            .Select(s => int.TryParse(s, out var n) ? n : 0)
+            .ToArray();
     }
 
     private static string? BestLibDir(string pkgDir)

--- a/Transpose/Transpose.Compiler/ResourceEmbedder.cs
+++ b/Transpose/Transpose.Compiler/ResourceEmbedder.cs
@@ -44,13 +44,8 @@ internal static class ResourceEmbedder
     {
         // Cecil resolves referenced assemblies when it re-serializes metadata on Write() — e.g. to
         // determine the underlying type of a parameter's default value whose type is a referenced
-        // enum. The default resolver only searches the assembly's own directory, so seed it with the
-        // directories of the project's references (NuGet-cache DLLs, sibling project bin folders).
-        var resolver = new DefaultAssemblyResolver();
-        resolver.AddSearchDirectory(Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!);
-        if (referencePaths is not null)
-            foreach (var dir in referencePaths.Select(p => Path.GetDirectoryName(Path.GetFullPath(p))!).Distinct())
-                resolver.AddSearchDirectory(dir);
+        // enum. It must resolve to the very files the compilation bound to, hence the resolver below.
+        using var resolver = new ReferencePathResolver(assemblyPath, referencePaths);
 
         using var source = new MemoryStream(assemblyBytes, writable: false);
         using var asm = AssemblyDefinition.ReadAssembly(source, new ReaderParameters { AssemblyResolver = resolver });
@@ -80,5 +75,66 @@ internal static class ResourceEmbedder
         Replace(ManifestName, Utf8NoBom.GetBytes(json));
 
         asm.Write(assemblyPath);
+    }
+
+    /// <summary>
+    /// Resolves an assembly reference to the exact file the compilation bound to, keyed by the
+    /// assembly's simple name.
+    ///
+    /// Cecil's own <see cref="DefaultAssemblyResolver"/> searches *directories* instead: it takes the
+    /// first <c>&lt;name&gt;.dll</c> it finds, in the order the directories were added, and never looks at
+    /// the assembly's version. The first candidate is the folder the DLL is being written to — where a
+    /// copy-local copy of a referenced assembly from an earlier build routinely sits — plus Cecil's own
+    /// implicit <c>.</c> and <c>bin</c> entries (relative to the process working directory). Binding to
+    /// one of those instead of the reference Roslyn compiled against makes a type that exists in the
+    /// real reference look missing, and re-serializing a constant of that type then fails:
+    /// <c>Mono.Cecil.ResolutionException: Failed to resolve Tesserae.PixelAvatarDesign</c> — from a
+    /// project whose C# compiled cleanly against a package that does define the enum.
+    ///
+    /// A name outside the reference set still falls back to the old directory search, so nothing that
+    /// resolves today stops resolving.
+    /// </summary>
+    private sealed class ReferencePathResolver : IAssemblyResolver
+    {
+        private readonly Dictionary<string, string>              _byName;
+        private readonly Dictionary<string, AssemblyDefinition>  _opened  = new(StringComparer.OrdinalIgnoreCase);
+        private readonly DefaultAssemblyResolver                 _byDirectory = new();
+
+        public ReferencePathResolver(string assemblyPath, IEnumerable<string>? referencePaths)
+        {
+            _byName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _byDirectory.AddSearchDirectory(Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!);
+
+            foreach (var reference in referencePaths ?? Enumerable.Empty<string>())
+            {
+                var full = Path.GetFullPath(reference);
+                if (!File.Exists(full)) continue;
+                // First wins, matching how the resolved reference set itself is built.
+                if (!_byName.ContainsKey(Path.GetFileNameWithoutExtension(full)))
+                    _byName[Path.GetFileNameWithoutExtension(full)] = full;
+                _byDirectory.AddSearchDirectory(Path.GetDirectoryName(full)!);
+            }
+        }
+
+        public AssemblyDefinition Resolve(AssemblyNameReference name)
+            => Resolve(name, new ReaderParameters());
+
+        public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (_opened.TryGetValue(name.Name, out var already)) return already;
+            if (!_byName.TryGetValue(name.Name, out var path)) return _byDirectory.Resolve(name, parameters);
+
+            parameters.AssemblyResolver ??= this;
+            var assembly = AssemblyDefinition.ReadAssembly(path, parameters);
+            _opened[name.Name] = assembly;
+            return assembly;
+        }
+
+        public void Dispose()
+        {
+            foreach (var assembly in _opened.Values) assembly.Dispose();
+            _opened.Clear();
+            _byDirectory.Dispose();
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/PackageReferenceResolutionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/PackageReferenceResolutionTests.cs
@@ -1,0 +1,144 @@
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers which assembly a <c>&lt;PackageReference&gt;</c> resolves to when the same package is reachable
+/// more than once — directly and through another package's dependencies, or through two packages that
+/// each want a different version.
+///
+/// <c>tps</c> reads the csproj itself instead of letting NuGet resolve the graph, so it has to apply
+/// NuGet's precedence by hand: the version the project declares wins over any transitive one, and the
+/// higher version wins between two transitive candidates. Resolving in document order instead silently
+/// compiled a project against an older package — e.g. a csproj listing <c>Tesserae.GraphKit</c> above
+/// <c>Tesserae</c> bound to the Tesserae version GraphKit's nuspec names rather than the one written in
+/// the csproj, so types added in the newer Tesserae looked absent.
+/// </summary>
+[TestClass]
+public sealed class PackageReferenceResolutionTests
+{
+    private string  _root     = "";
+    private string  _cache    = "";
+    private string? _previousCacheEnv;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root  = Path.Combine(Path.GetTempPath(), "tps-pkgref-" + Guid.NewGuid().ToString("N"));
+        _cache = Path.Combine(_root, "packages");
+        Directory.CreateDirectory(_cache);
+
+        // NuGetRoots() honours NUGET_PACKAGES first, so the fake cache below is what gets resolved.
+        _previousCacheEnv = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", _cache);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", _previousCacheEnv);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>Lays out one package in the fake cache the way NuGet extracts it: lowercase
+    /// <c>&lt;id&gt;/&lt;version&gt;/</c> holding <c>lib/netstandard2.0/</c> and a lowercase nuspec.</summary>
+    private void Package(string id, string version, string[] assemblies, params (string id, string version)[] dependencies)
+    {
+        var lib = Path.Combine(_cache, id.ToLowerInvariant(), version, "lib", "netstandard2.0");
+        Directory.CreateDirectory(lib);
+        foreach (var assembly in assemblies)
+            File.WriteAllBytes(Path.Combine(lib, assembly + ".dll"), new byte[] { 0 });
+
+        var deps = string.Join("\n", dependencies.Select(d => $"        <dependency id=\"{d.id}\" version=\"{d.version}\" />"));
+        File.WriteAllText(Path.Combine(_cache, id.ToLowerInvariant(), version, id.ToLowerInvariant() + ".nuspec"), $@"<?xml version=""1.0""?>
+<package>
+  <metadata>
+    <id>{id}</id>
+    <version>{version}</version>
+    <dependencies>
+      <group targetFramework="".NETStandard2.0"">
+{deps}
+      </group>
+    </dependencies>
+  </metadata>
+</package>");
+    }
+
+    private string Csproj(params string[] packageReferences)
+    {
+        var items = string.Join("\n", packageReferences.Select(r => "    " + r));
+        var path  = Path.Combine(_root, "app", "app.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, $@"<Project>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+{items}
+  </ItemGroup>
+</Project>");
+        return path;
+    }
+
+    private static string Reference(ResolvedProject project, string assemblyName)
+        => project.ReferencePaths.Single(p => Path.GetFileNameWithoutExtension(p).Equals(assemblyName, StringComparison.OrdinalIgnoreCase));
+
+    [TestMethod]
+    public void TheDeclaredVersionWinsOverATransitiveDependencyOnAnOlderOne()
+    {
+        Package("Toolkit", "2026.7.68568", new[] { "tk" });
+        Package("Toolkit", "2026.7.68553", new[] { "tk" });
+        Package("Toolkit.Charts", "26.7.3033", new[] { "Toolkit.Charts" }, ("Toolkit", "2026.7.68553"));
+
+        // Charts first: under document-order resolution its older Toolkit dependency won.
+        var project = ProjectResolver.Resolve(Csproj(
+            @"<PackageReference Include=""Toolkit.Charts"" Version=""26.7.3033"" />",
+            @"<PackageReference Include=""Toolkit"" Version=""2026.7.68568"" />"));
+
+        StringAssert.Contains(Reference(project, "tk"), "2026.7.68568",
+            "the version the csproj declares must win over a transitive dependency on an older one");
+    }
+
+    [TestMethod]
+    public void TheDeclaredVersionWinsRegardlessOfWhereItIsListed()
+    {
+        Package("Toolkit", "2026.7.68568", new[] { "tk" });
+        Package("Toolkit", "2026.7.68553", new[] { "tk" });
+        Package("Toolkit.Charts", "26.7.3033", new[] { "Toolkit.Charts" }, ("Toolkit", "2026.7.68553"));
+
+        var project = ProjectResolver.Resolve(Csproj(
+            @"<PackageReference Include=""Toolkit"" Version=""2026.7.68568"" />",
+            @"<PackageReference Include=""Toolkit.Charts"" Version=""26.7.3033"" />"));
+
+        StringAssert.Contains(Reference(project, "tk"), "2026.7.68568");
+    }
+
+    [TestMethod]
+    public void TheHighestVersionWinsBetweenTwoTransitiveCandidates()
+    {
+        Package("Shared", "1.0.0", new[] { "shared" });
+        Package("Shared", "2.5.0", new[] { "shared" });
+        Package("Left",  "1.0.0", new[] { "left" },  ("Shared", "1.0.0"));
+        Package("Right", "1.0.0", new[] { "right" }, ("Shared", "2.5.0"));
+
+        var project = ProjectResolver.Resolve(Csproj(
+            @"<PackageReference Include=""Left"" Version=""1.0.0"" />",
+            @"<PackageReference Include=""Right"" Version=""1.0.0"" />"));
+
+        StringAssert.Contains(Reference(project, "shared"), "2.5.0",
+            "with no declared version, the higher transitive candidate must win");
+    }
+
+    [TestMethod]
+    public void TransitiveDependenciesStillResolveWhenNothingElseProvidesThem()
+    {
+        Package("Runtime", "26.7.3027", new[] { "Runtime" });
+        Package("Widgets", "1.0.0", new[] { "widgets" }, ("Runtime", "26.7.3027"));
+
+        var project = ProjectResolver.Resolve(Csproj(
+            @"<PackageReference Include=""Widgets"" Version=""1.0.0"" />"));
+
+        StringAssert.Contains(Reference(project, "Runtime"), "26.7.3027",
+            "a transitively-referenced package must still be resolved");
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ResourceEmbedderTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ResourceEmbedderTests.cs
@@ -1,0 +1,113 @@
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers how <see cref="ResourceEmbedder"/> resolves the assemblies a package DLL references.
+///
+/// Embedding the compiled JavaScript re-serializes the emitted assembly's metadata through Mono.Cecil,
+/// and Cecil resolves a referenced assembly whenever it has to encode a constant whose type lives there
+/// — a <c>const</c> field or a parameter's default value of a referenced enum, because the constant
+/// blob stores the enum's *underlying* type. Cecil's own resolver searches directories by simple name
+/// and takes the first <c>&lt;name&gt;.dll</c> it finds, starting with the folder the DLL is written to,
+/// where a copy-local copy of a reference from an earlier build routinely sits. Binding there instead of
+/// to the reference the compilation used made a type that plainly exists look missing:
+/// <c>Mono.Cecil.ResolutionException: Failed to resolve Tesserae.PixelAvatarDesign</c>, from a project
+/// whose C# compiled cleanly against a package that does define the enum.
+/// </summary>
+[TestClass]
+public sealed class ResourceEmbedderTests
+{
+    private string _root = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-embed-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>Compiles one source file into a real assembly at <paramref name="rel"/>.</summary>
+    private string BuildAssembly(string rel, string assemblyName, string source, params string[] references)
+    {
+        var result = new RoslynTranslator().BuildAssembly(
+            new[] { (assemblyName + ".cs", source) }, assemblyName, references,
+            emitAssembly: true, emitDebugInformation: false);
+
+        Assert.IsTrue(result.Success, $"{assemblyName} failed to compile: " +
+            string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+
+        var path = Path.Combine(_root, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, result.AssemblyBytes!);
+        return path;
+    }
+
+    private static IReadOnlyList<EmbeddedItem> OneScript()
+        => new[] { new EmbeddedItem("app.js", System.Text.Encoding.UTF8.GetBytes("// js"), null) };
+
+    [TestMethod]
+    public void ResolvesAReferencedEnumConstantThroughTheReferenceTheCompilationUsed()
+    {
+        // The reported bug. `lib` exists twice: the real reference the app compiled against, and an
+        // older copy — same file name, no `Design` enum — left in the output folder by an earlier build.
+        var lib = BuildAssembly("packages/lib/lib.dll", "lib",
+            "namespace Pkg { public enum Design { Black, Sudo } }");
+        BuildAssembly("bin/lib.dll", "lib",
+            "namespace Pkg { public enum SomethingElse { One } }");
+
+        var appBytes = CompileApp(lib);
+        var appPath  = Path.Combine(_root, "bin", "app.dll");
+
+        ResourceEmbedder.Embed(appPath, appBytes, OneScript(), new[] { lib });
+
+        Assert.IsTrue(ResourceEmbedder.HasManifest(appPath), "the package must carry its resource manifest");
+        using var written = AssemblyDefinition.ReadAssembly(appPath);
+        var design = written.MainModule.GetType("App.Avatar").Fields.Single(f => f.Name == "DESIGN");
+        Assert.AreEqual(1, design.Constant, "the enum constant must survive the round-trip");
+    }
+
+    [TestMethod]
+    public void FallsBackToADirectorySearchForAnAssemblyOutsideTheReferenceSet()
+    {
+        // A reference the caller didn't pass still resolves the way it always did — from the output
+        // folder next to the DLL being written.
+        var lib = BuildAssembly("bin/lib.dll", "lib",
+            "namespace Pkg { public enum Design { Black, Sudo } }");
+
+        var appBytes = CompileApp(lib);
+        var appPath  = Path.Combine(_root, "bin", "app.dll");
+
+        ResourceEmbedder.Embed(appPath, appBytes, OneScript(), referencePaths: null);
+
+        Assert.IsTrue(ResourceEmbedder.HasManifest(appPath));
+    }
+
+    /// <summary>An assembly holding both constant shapes that make Cecil resolve a referenced type:
+    /// a <c>const</c> field (the reported crash) and a parameter default value.</summary>
+    private byte[] CompileApp(string libPath)
+    {
+        var result = new RoslynTranslator().BuildAssembly(
+            new[] { ("app.cs", @"
+using Pkg;
+namespace App
+{
+    public static class Avatar
+    {
+        public const Design DESIGN = Design.Sudo;
+        public static int New(Design design = Design.Sudo) => (int)design;
+    }
+}") }, "app", new[] { libPath }, emitAssembly: true, emitDebugInformation: false);
+
+        Assert.IsTrue(result.Success, "app failed to compile: " +
+            string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+        return result.AssemblyBytes!;
+    }
+}


### PR DESCRIPTION
Fixes the crash reported while building the Curiosity front-end against Tesserae `2026.7.68568`:

```
Unhandled exception. Mono.Cecil.ResolutionException: Failed to resolve Tesserae.PixelAvatarDesign
   at Mono.Cecil.MetadataBuilder.GetConstantType(TypeReference constant_type, Object constant)
   at Mono.Cecil.MetadataBuilder.AddConstant(IConstantProvider owner, TypeReference type)
   at Mono.Cecil.MetadataBuilder.AddField(FieldDefinition field)
   …
   at Transpose.Compiler.ResourceEmbedder.Embed(…) ResourceEmbedder.cs:line 82
   at Transpose.Compiler.Program.WritePackage(…) Program.cs:line 569
```

(also reported with `AddParameter` in the frame instead of `AddField`) — from a project whose C# had just compiled cleanly against a package that *does* define the enum.

Nothing was wrong with the enum, or with the calling code. `tps` was binding a **different copy** of `tss.dll` than the one it compiled against. There turned out to be two independent ways for that to happen.

## 1. Cecil resolved the reference by directory search (the reported crash)

Embedding the JS re-serializes the emitted assembly's metadata through Mono.Cecil. A `const PixelAvatarDesign DESIGN = …` (→ `AddField`) or a `PixelAvatarAnimation animation = …` parameter default (→ `AddParameter`) stores the enum's **underlying** type in the constant blob, so Cecil must resolve the assembly the enum lives in.

Cecil's `DefaultAssemblyResolver` searches *directories* by simple name: it takes the first `<name>.dll` it finds, in the order the directories were added, and never looks at the version. The first candidate `Embed` seeded was the folder the DLL is written to — where a copy-local copy of a reference from an earlier build routinely sits (the h5-era compiler mirrored every referenced package's lib files into the output folder on every build, and nothing ever cleaned them). Cecil's own implicit `.` and `bin` entries, relative to the process working directory, are ahead of that again.

So Roslyn used `…/tesserae/2026.7.68568/lib/netstandard2.0/tss.dll` (has the enum) while Cecil read a stale `bin/Debug/netstandard2.0/tss.dll` (doesn't) → `ResolutionException` after a clean compile.

`ResourceEmbedder` now resolves each reference to the exact path the compilation used, keyed by simple name, and falls back to the old directory search only for a name outside the reference set — so nothing that resolves today stops resolving.

## 2. Reference resolution took the first candidate, not the right one

Because `tps` reads the csproj instead of letting NuGet resolve the graph, it has to apply NuGet's precedence by hand — and it was taking whichever candidate it walked into first, in csproj document order. A csproj listing `Tesserae.GraphKit` above `Tesserae` therefore compiled against the older Tesserae that GraphKit's nuspec declares, silently ignoring the version written right there in the csproj (verified with a probe project: it really did read the older `tss.dll`).

Resolution now follows NuGet's rules, which is also what the h5 compiler effectively did:

- a version the project declares wins over any transitive one — the superseded package's cache folder is not even read;
- between two transitive candidates, the higher version wins.

## 3. A package-write failure is now a diagnostic

`WritePackage` was called outside any handler, so a Cecil failure escaped `Main` and printed a raw stack trace. It now goes through `ReportCrash`, i.e. a canonical MSBuild `error TPS0004` line plus the frames on stderr, like every other failure in the compiler.

## Verification

- **Reproduced exactly**: dropping Tesserae `2026.7.68539`'s `tss.dll` (predates PixelAvatar) into `Mosaik.FrontEnd.Core/bin/Debug/netstandard2.0/` and building that project reproduces the reported exception frame for frame. With this change the same build succeeds with the stale DLL still in place.
- **Tests**: suite green at 601 tests, including 6 new ones — `ResourceEmbedderTests` (the stale-copy case, and the directory-search fallback) and `PackageReferenceResolutionTests` (declared-wins, order-independence, highest transitive wins, transitive still resolves). The two that matter fail without these fixes, with the same `ResolutionException` / wrong-version assertions.
- **Emitted output unchanged**: `diff -r` of the `Tesserae.Tests` site built with a baseline compiler vs. this one is identical.

## Note for a follow-up

The package path still post-processes with Cecil instead of passing the resources to `Compilation.Emit`, the way `--build-runtime` already does. That would remove this failure class entirely and skip reading and rewriting a tens-of-megabytes assembly, but it needs the JS emitted before the assembly emit, which currently costs an extra full bind — worth measuring separately given how much the emit dominates a build.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZqnHzuCPCBCSEVsoMQknJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZqnHzuCPCBCSEVsoMQknJ)_