### PR TITLE
Add opt-out incremental compilation (--incremental)

### DIFF
--- a/.claude/skills/transpose-performance/SKILL.md
+++ b/.claude/skills/transpose-performance/SKILL.md
@@ -14,9 +14,19 @@ description: >-
 
 # Optimizing Transpose compilation
 
-`tps` is a plain CLI with no cache and no compile server (deliberately — see CLAUDE.md), so a build's
-cost is whatever one process does from scratch. This skill is the loop for measuring that and making
-it smaller without changing a byte of emitted JavaScript.
+`tps` is a plain CLI with no compile server (deliberately — see CLAUDE.md), so a build's cost is
+whatever one process does from scratch. This skill is the loop for measuring that and making it
+smaller without changing a byte of emitted JavaScript.
+
+**Not doing the build at all** is the other lever: `tps --incremental` (opt-in) reuses the previous
+build's output where its inputs are unchanged. Read [`TODO.incremental.md`](../../../TODO.incremental.md)
+for what it reuses and why that is sound. Two consequences for measuring:
+
+- Benchmark with the cache **off** unless you are measuring the cache. `tps-bench`'s clean-slate
+  scenarios wipe `bin/obj` (and therefore `obj/tps-cache`), so they are unaffected — but an ad-hoc
+  repeat run of `tps --incremental` on an unchanged project takes 0.4 s and means nothing.
+- The correctness gate for a cache change is `scripts/verify-incremental.sh` (incremental output vs. a
+  from-scratch build, over several edit shapes) on top of the usual `compare-site.sh`.
 
 **Read [`TODO.optimization.md`](../../../TODO.optimization.md) first.** It is the running log of every
 optimization tried, with measurements — including the ones that *did not work*, which is most of the
@@ -189,6 +199,16 @@ A compiler optimization that changes output is a bug, not an optimization. Befor
 3. **Touching `UnsupportedFeatureScanner`**: also diff the diagnostics of a file exercising every rule
    (pointers, `unsafe`, `checked`, `nint`, P/Invoke, `System.IO`/`System.Threading` types, a using
    alias and a static import) — see the scanner section of `TODO.optimization.md`.
+4. **Touching the incremental cache** (`BuildCache`, `IncrementalPlan`, or anything the emitter caches
+   per type): run the edit-shape gate, which builds the site incrementally and from scratch for each
+   kind of edit and byte-compares them. An incremental build that is wrong emits plausible output
+   rather than failing, so this is the check that matters:
+   ```bash
+   TPS=$TPS REPO=benchmarks/tesserae \
+     .claude/skills/transpose-performance/scripts/verify-incremental.sh
+   ```
+   Also bump `BuildCache.FormatVersion` whenever the cache layout or the reuse rules change, or a
+   developer's existing cache will be read under the new rules.
 
 ## What the cost structure actually looks like
 

--- a/.claude/skills/transpose-performance/scripts/verify-incremental.sh
+++ b/.claude/skills/transpose-performance/scripts/verify-incremental.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Correctness gate for the incremental cache (`tps --incremental`): for each shape of edit, the site an
+# incremental build produces must be byte-identical to the one a from-scratch build of the same sources
+# produces. An incremental build that is wrong produces plausible output rather than failing, so this
+# is the check that has to pass before the cache can be trusted — see TODO.incremental.md.
+#
+#   TPS=<tps> [REPO=<tesserae checkout>] verify-incremental.sh
+#
+# The line numbers the edits target are specific to the tesserae corpus at the time of writing; if an
+# edit stops applying (the script says so), re-point it at any method body / declaration.
+set -uo pipefail
+
+TPS=${TPS:?}
+REPO=${REPO:-$(dirname "$0")/../../../../benchmarks/tesserae}   # a sibling checkout works too: REPO=<path>
+APP=$REPO/Tesserae.Tests/Tesserae.Tests.csproj
+LIB=$REPO/Tesserae/src/Components/Toast.cs
+APPSRC=$REPO/Tesserae.Tests/src/App.cs
+SITE=$REPO/Tesserae.Tests/bin/Debug/netstandard2.0/tps
+CMP=$(dirname "$0")/compare-site.sh
+fail=0
+
+clean() { rm -rf "$REPO"/Tesserae/bin "$REPO"/Tesserae/obj "$REPO"/Tesserae.Tests/bin "$REPO"/Tesserae.Tests/obj; }
+reset_sources() { (cd "$REPO" && git checkout -- Tesserae/src/Components/Toast.cs Tesserae.Tests/src/App.cs); }
+
+# check <name> <edit-command>
+check() {
+  local name=$1; shift
+  echo "───────── $name"
+  reset_sources; clean
+  "$TPS" --project "$APP" -c Debug --incremental >/dev/null 2>&1 || { echo "  cold build FAILED"; fail=1; return; }
+  eval "$@"
+  "$TPS" --project "$APP" -c Debug --incremental > /tmp/v-inc.log 2>&1 || { echo "  incremental FAILED"; tail -20 /tmp/v-inc.log; fail=1; return; }
+  grep -E "cache:" /tmp/v-inc.log | sed 's/^/  /'
+  rm -rf /tmp/v-site-inc; cp -r "$SITE" /tmp/v-site-inc
+  clean
+  "$TPS" --project "$APP" -c Debug --no-incremental >/dev/null 2>&1 || { echo "  scratch build FAILED"; fail=1; return; }
+  rm -rf /tmp/v-site-full; cp -r "$SITE" /tmp/v-site-full
+  if bash "$CMP" /tmp/v-site-inc /tmp/v-site-full | tail -1 | grep -q IDENTICAL; then
+    echo "  OK — identical to a from-scratch build"
+  else
+    echo "  MISMATCH"; bash "$CMP" /tmp/v-site-inc /tmp/v-site-full | head -20; fail=1
+  fi
+}
+
+check "app: method body edited" \
+  "sed -i '130s/You clicked on the icon/You clicked V1/' $APPSRC"
+
+check "library: method body edited" \
+  "sed -i '411s/tss-toast-/V2-/' $LIB"
+
+check "library + app: both bodies edited" \
+  "sed -i '411s/tss-toast-/V3-/' $LIB; sed -i '130s/You clicked on the icon/You clicked V3/' $APPSRC"
+
+check "library: new public method (declaration change)" \
+  "sed -i '408a\\        public Toast AddedByVerify(int n) { return this; }' $LIB"
+
+check "app: statement added to a body" \
+  "sed -i '43a\\            var verifyLocal = allSidebarItems.Count;' $APPSRC"
+
+check "library: field initializer changed (declaration surface)" \
+  "sed -i '26s/= true;/= false;/' $LIB"
+
+check "library: whole file untouched, only whitespace in a body" \
+  "sed -i '411s/^            /                /' $LIB"
+
+reset_sources
+echo "───────── result"
+[ $fail -eq 0 ] && echo "ALL SCENARIOS IDENTICAL" || echo "FAILURES PRESENT"
+exit $fail

--- a/.claude/skills/transpose-performance/scripts/verify-incremental.sh
+++ b/.claude/skills/transpose-performance/scripts/verify-incremental.sh
@@ -6,6 +6,9 @@
 #
 #   TPS=<tps> [REPO=<tesserae checkout>] verify-incremental.sh
 #
+# Run by .devops/benchmark-transpose-compiler.yml, where it *fails* the build: unlike a performance
+# comparison this is a deterministic question, so there is no noise to tolerate.
+#
 # The line numbers the edits target are specific to the tesserae corpus at the time of writing; if an
 # edit stops applying (the script says so), re-point it at any method body / declaration.
 set -uo pipefail
@@ -22,13 +25,16 @@ fail=0
 clean() { rm -rf "$REPO"/Tesserae/bin "$REPO"/Tesserae/obj "$REPO"/Tesserae.Tests/bin "$REPO"/Tesserae.Tests/obj; }
 reset_sources() { (cd "$REPO" && git checkout -- Tesserae/src/Components/Toast.cs Tesserae.Tests/src/App.cs); }
 
-# check <name> <edit-command>
+# check <name> <edit-command> [setup-command]
+# The setup command, when given, is applied *before* the cold build — for scenarios where the edit has
+# to change something that already existed (e.g. the value of a const the app already consumes).
 check() {
-  local name=$1; shift
+  local name=$1 edit=$2 setup=${3:-}
   echo "───────── $name"
   reset_sources; clean
+  [ -n "$setup" ] && eval "$setup"
   "$TPS" --project "$APP" -c Debug --incremental >/dev/null 2>&1 || { echo "  cold build FAILED"; fail=1; return; }
-  eval "$@"
+  eval "$edit"
   "$TPS" --project "$APP" -c Debug --incremental > /tmp/v-inc.log 2>&1 || { echo "  incremental FAILED"; tail -20 /tmp/v-inc.log; fail=1; return; }
   grep -E "cache:" /tmp/v-inc.log | sed 's/^/  /'
   rm -rf /tmp/v-site-inc; cp -r "$SITE" /tmp/v-site-inc
@@ -62,6 +68,18 @@ check "library: field initializer changed (declaration surface)" \
 
 check "library: whole file untouched, only whitespace in a body" \
   "sed -i '411s/^            /                /' $LIB"
+
+# The sharpest test of the metadata fingerprint (BuildCache.ReferenceMetadataFingerprint), which is what
+# lets a consumer reuse its compilation when a referenced library's *metadata* is unchanged: a const the
+# app consumes. Constants live in metadata, so changing one has to invalidate the app — and it does.
+# (Worth knowing while reading this: Transpose does not fold a cross-assembly const into the consumer's
+# bundle, it emits `tss.Toast.VerifyConstProbe` and lets the runtime read it, so the value itself only
+# ever lives in the library's bundle. The comparison holds either way — which is the point of comparing
+# bytes rather than reasoning about them.)
+check "library: const the app consumes changes value" \
+  "sed -i 's/VerifyConstProbe = \"AAA\"/VerifyConstProbe = \"BBB\"/' $LIB" \
+  "sed -i '20a\\        public const string VerifyConstProbe = \"AAA\";' $LIB;
+   sed -i '21a\\            System.Console.WriteLine(Tesserae.Toast.VerifyConstProbe);' $APPSRC"
 
 reset_sources
 echo "───────── result"

--- a/.devops/benchmark-transpose-compiler.yml
+++ b/.devops/benchmark-transpose-compiler.yml
@@ -1,4 +1,9 @@
-# Compiler performance benchmark.
+# Compiler performance benchmark, plus the incremental-build correctness gate.
+#
+# The gate lives here rather than in build-transpose-compiler.yml because this is the pipeline that
+# already checks out the tesserae corpus and publishes the compiler the way it ships. Unlike the
+# benchmark below it *does* fail the build: whether an incremental build reproduces a from-scratch one
+# byte for byte is a deterministic question, so there is no noise to tolerate.
 #
 # Compiles a real project — the tesserae submodule under benchmarks/tesserae, 263 files / ~69k lines,
 # plus a second project that depends on it — with the ReadyToRun-published compiler, and records
@@ -86,6 +91,20 @@ steps:
     dotnet publish "$(compiler)" -c $(buildConfiguration) -r $(benchRid) --self-contained false \
       -p:PublishReadyToRun=true -o "$(publishDir)"
   displayName: 'publish the compiler (ReadyToRun, $(benchRid))'
+
+# The correctness gate for `tps --incremental`, before anything is measured: an incremental build that
+# is wrong emits plausible output rather than failing, so nothing downstream would notice. For each
+# shape of edit — a body in the app, a body in the referenced library, both, a new method, a changed
+# field initializer, a const the app consumes — it builds the site incrementally and from scratch and
+# byte-compares the two.
+#
+# It edits and `git checkout --`s files inside the corpus submodule, so it runs before the benchmark
+# (which wants a clean slate anyway) and leaves the working tree as it found it.
+- script: |
+    set -euo pipefail
+    TPS="$(publishDir)/tps" REPO="$(corpus)" \
+      "$(Build.SourcesDirectory)/.claude/skills/transpose-performance/scripts/verify-incremental.sh"
+  displayName: 'verify incremental builds are byte-identical to full builds'
 
 - task: DotNetCoreCLI@2
   displayName: 'build bench'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,10 @@ tps --project <proj.csproj> --configuration <cfg> --assembly-version <v>
 `tps` reads the csproj directly (no MSBuild evaluation), globs `**/*.cs`, resolves
 `PackageReference`s from the NuGet cache, synthesizes `[assembly: ...]` from `<AssemblyAttribute>`
 items, transpiles, and writes the site (runtime + bundle + resources + `index.html`) or a package
-DLL (`--emit-package`). **There is no compilation server and no cache** — the new compiler is a
-plain CLI, by design.
+DLL (`--emit-package`). **There is no compilation server** — the new compiler is a plain CLI, by
+design. There *is* an opt-in build cache (`--incremental`, off by default) — see
+**`TODO.incremental.md`** for what it reuses, why that is sound, and what it measures; a build with
+the cache disabled behaves exactly as it always did.
 
 Because there is no MSBuild evaluation, `ProjectXml` does the one bit of evaluation that changes
 which files compile: it follows `<Import Project="…"/>` transitively and flattens the result, so a
@@ -171,6 +173,7 @@ property is not guessed at: such an import or item is skipped, which is why SDK-
 `--out/-o`, `--site-dir`, `--configuration/-c`, `--emit-package`, `--separate-assemblies`,
 `--with-runtime`, `--reference/-r <dll>` (extra assemblies not in the NuGet cache),
 `--define/-D <SYM>`, `--assembly-version <v>`, `--project/-p`, `--quiet/-q`,
+`--incremental` / `--no-incremental` / `--cache-dir <dir>` (reuse the previous build; off by default),
 `--timing` (per-phase time + allocations), `--timing-json <file>`,
 `--metadata-only-assembly` / `--no-metadata-only-assembly`,
 `--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line).
@@ -264,8 +267,16 @@ The short version:
 - **MSBuild evaluation** stays deliberately shallow: `<Import>` is followed (see above) but
   conditions, arbitrary properties, `Directory.Build.props` and item metadata are not evaluated.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
+- **Incremental compilation (prototype, opt-in).** `--incremental` reuses the previous build of a
+  project: nothing at all is compiled when every input hashes the same (20× on tesserae), and an edit
+  confined to method/accessor bodies keeps the cached JavaScript of every untouched type, the
+  reflection metadata and (in Debug) the metadata-only assembly (~2×). Output is byte-identical either
+  way. Still to decide: making it the default, and re-emitting only the *dependent* types when a
+  declaration changes. See **`TODO.incremental.md`**.
 
-Caching and the compilation server are intentionally **out of scope**.
+A compilation server is still intentionally **out of scope** — though the measurements in
+`TODO.incremental.md` say what it would be worth (the residual cost of an incremental build is almost
+entirely Roslyn re-importing `Transpose.dll`'s metadata in a fresh process).
 
 ## Debugging, testing & auditing skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,9 @@ A user project references the `Transpose.Build.Target` SDK, which runs `tps` onc
 tps --project <proj.csproj> --configuration <cfg> --assembly-version <v>
 ```
 
+The SDK passes `--incremental` by default; a project turns it off with
+`<TransposeIncremental>false</TransposeIncremental>`.
+
 `tps` reads the csproj directly (no MSBuild evaluation), globs `**/*.cs`, resolves
 `PackageReference`s from the NuGet cache, synthesizes `[assembly: ...]` from `<AssemblyAttribute>`
 items, transpiles, and writes the site (runtime + bundle + resources + `index.html`) or a package
@@ -205,6 +208,25 @@ to the file and line, instead of scrolling past as console text. Three rules fol
   match, or a build grows errors nobody wrote. `MsBuildDiagnosticFormatTests` guards both directions
   against MSBuild's own regex.
 
+#### Why `dotnet build` looks silent (and why that is not fixable here)
+
+Since .NET 9, `dotnet build` defaults to MSBuild's **terminal logger** whenever stdout is a terminal.
+It renders *only* errors, warnings and a per-project summary: every `Message` and every line an
+`Exec`ed tool writes is dropped at default verbosity **and** at `-v:normal`, whatever its importance
+and regardless of `ConsoleToMsBuild`. Only `-v:detailed`/`-v:diagnostic` or `-tl:false` bring them
+back — measured across all four channels (`Message` high/normal, `Exec` stdout, `Exec` stderr).
+
+So the canonical diagnostic form above is exactly what makes a `tps` error visible; the progress
+lines, the `OK — built …` summary and the timing table cannot be surfaced from a targets file at all.
+This is **not** a regression against h5: an h5 project built with the real `h5` toolchain shows all of
+its `[info] …` lines under `-tl:false` and **none** under `-tl:true`, identically — the two SDKs'
+`Exec` invocations are the same shape. If you remember h5 printing them, that was the classic logger
+(pre-.NET 9, a pipe, or CI).
+
+What the SDK does about it: `_TransposeBuild` writes the compiler's full captured output to
+`obj/<Configuration>/<tfm>/tps.log` on every build, and the failure error (`TPS1002`) points there.
+For an interactive build that should show its work, use `dotnet build -tl:false`.
+
 ## Performance
 
 A clean build's cost, and how to measure it, is documented in **`TODO.optimization.md`** (the running
@@ -220,7 +242,8 @@ The short version:
   in `Transpose.Compiler.csproj` (plus `runtimeconfig.template.json`) are together worth ~40% of a
   build. Do not "tidy them away".
 - Any change here must keep the emitted site **byte-identical** — output is reproducible, so
-  `diff -r` against a baseline compiler is the gate. The 499-test suite is the other gate.
+  `diff -r` against a baseline compiler is the gate. The emitted **assembly** is reproducible as well
+  (`deterministic: true`), so the DLL is diffable too. The test suite is the other gate.
 - The benchmark corpus is the **tesserae** submodule at `benchmarks/tesserae`
   (`git submodule update --init benchmarks/tesserae`). Recorded reports live in `docs/perf/`.
 - **Debug and Release are structurally different builds.** Debug emits a *metadata-only* assembly
@@ -267,12 +290,15 @@ The short version:
 - **MSBuild evaluation** stays deliberately shallow: `<Import>` is followed (see above) but
   conditions, arbitrary properties, `Directory.Build.props` and item metadata are not evaluated.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
-- **Incremental compilation (prototype, opt-in).** `--incremental` reuses the previous build of a
-  project: nothing at all is compiled when every input hashes the same (20× on tesserae), and an edit
-  confined to method/accessor bodies keeps the cached JavaScript of every untouched type, the
-  reflection metadata and (in Debug) the metadata-only assembly (~2×). Output is byte-identical either
-  way. Still to decide: making it the default, and re-emitting only the *dependent* types when a
-  declaration changes. See **`TODO.incremental.md`**.
+- **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
+  reuses the previous build of a project: nothing at all is compiled when every input hashes the same
+  (19× on tesserae), and an edit confined to method/accessor bodies keeps the cached JavaScript of every
+  untouched type, the reflection metadata, the scanner's denied-name filter and (in Debug) the
+  metadata-only assembly (~2×). A body-only edit in a referenced library leaves its consumers'
+  compilation cached too, because a package DLL now carries a `.tpsmeta` sidecar hashing the *metadata*
+  a consumer actually binds against. Output is byte-identical either way, gated in CI over eight edit
+  shapes. The `tps` CLI still defaults to off; the SDK opts in. Remaining: re-emitting only the
+  *dependent* types when a declaration changes. See **`TODO.incremental.md`**.
 
 A compilation server is still intentionally **out of scope** — though the measurements in
 `TODO.incremental.md` say what it would be worth (the residual cost of an incremental build is almost

--- a/TODO.incremental.md
+++ b/TODO.incremental.md
@@ -16,28 +16,41 @@ already did.
 
 ## Where things stand
 
-`tps --incremental` (off by default; `--cache-dir <dir>` / `TRANSPOSE_CACHE_DIR` to relocate the
-cache, `TRANSPOSE_INCREMENTAL=1` to enable it for a session). Measured on the tesserae corpus,
-`-c Debug`, medians of 3 interleaved runs, 4-core container:
+`tps --incremental`. The **SDK turns it on** (`<TransposeIncremental>false</TransposeIncremental>` in
+the .csproj to opt out); the bare CLI still defaults to off. `--cache-dir <dir>` /
+`TRANSPOSE_CACHE_DIR` relocate the cache, `TRANSPOSE_INCREMENTAL=1` enables it for a session.
+
+Measured on the tesserae corpus, `-c Debug`, medians of 3 interleaved runs, 4-core container:
 
 | scenario | today | `--incremental` | speedup |
 |---|--:|--:|--:|
-| library (263 files → package DLL), nothing changed | 7.98 s | **0.40 s** | **20×** |
-| library, one method body edited | 7.98 s | **4.09 s** | **1.95×** |
-| library, clean build (cache written) | 7.98 s | 8.06 s | −1% |
-| app (site build, library up to date), nothing changed | 4.27 s | **0.41 s** | **10×** |
-| app, one method body edited in the app | 4.27 s | **3.46 s** | 1.23× |
-| app, one method body edited in the **library** | 8.82 s | **4.44 s** | **2.0×** |
+| library (263 files → package DLL), nothing changed | 7.31 s | **0.38 s** | **19×** |
+| library, one method body edited | 7.31 s | **3.88 s** | **1.9×** |
+| library, clean build (cache written) | 7.31 s | 7.50 s | −1% |
+| app (site build, library up to date), nothing changed | 4.15 s | **0.45 s** | **9×** |
+| app, one method body edited in the app | 4.15 s | **3.58 s** | 1.16× |
+| app, one method body edited in the **library** | 8.99 s | **4.35 s** | **2.1×** |
+
+Through `dotnet build` (which is what a developer actually types) the same library body edit goes from
+**10.4 s to 5.0 s**.
 
 Every one of those outputs is **byte-identical** to a from-scratch build of the same sources,
-verified with `compare-site.sh` over the whole `Tesserae.Tests` site across seven edit shapes
-(app body, library body, both, a new public method, a statement added to a body, a changed field
-initializer, whitespace in a body). The 584-test suite stays green, plus 8 new tests in
-`IncrementalEmitTests.cs`.
+verified with `compare-site.sh` over the whole `Tesserae.Tests` site across eight edit shapes (app
+body, library body, both, a new public method, a statement added to a body, a changed field
+initializer, whitespace in a body, and a `const` the app consumes). That gate now runs in CI —
+`.devops/benchmark-transpose-compiler.yml` fails on a mismatch. The 584-test suite stays green, plus 8
+new tests in `IncrementalEmitTests.cs`.
 
 The ~1% cold-build cost is the price of admission: hashing every file's declaration surface (~150 ms
 on 270 files) and writing ~5 MB of cache. Measured by an interleaved A/B of four clean-build pairs
 (7.19 s vs 7.26 s) — i.e. inside the noise.
+
+The emitted **assembly is now reproducible** too (`deterministic: true` in `CompilationBuilder`).
+Before that, two compiles of identical sources produced DLLs differing in 16 bytes (a fresh module
+MVID and a wall-clock PE timestamp); Mono.Cecil preserves both through the resource embed, so the
+shipped DLL is now byte-identical across builds and `diff -r` is a usable gate on it. That change was
+made for the cache — an incremental build reusing a cached assembly must be indistinguishable from one
+that re-emitted it — but it is worth having on its own.
 
 ---
 
@@ -76,11 +89,11 @@ It is the coarsest condition under which each phase's output provably cannot mov
   a function of the declarations. This is the single biggest win available (~19% of a build) and the
   claim most worth distrusting, so it was tested rather than argued: a body edit adding a closure, a
   local function, an 8-case string switch and an iterator local function to one method produces a
-  fresh metadata-only assembly that differs from the reused one in exactly **16 bytes** — the module
-  MVID and the PE timestamp — with identical length and identical metadata. (Those 16 bytes already
-  differ between any two full builds; Roslyn's emit here is not deterministic, and neither is
-  Mono.Cecil's resource embed, which restamps 17–18 bytes of the final DLL every time.) In Release the
-  assembly is full IL and is *not* reused.
+  fresh metadata-only assembly that differed from the reused one in exactly **16 bytes** — the module
+  MVID and the PE timestamp — with identical length and identical metadata. Those 16 bytes differed
+  between any two full builds as well, which is what prompted turning on `deterministic: true`; with it
+  the two are now *identical*, so the test is a plain `cmp`. In Release the assembly is full IL and is
+  *not* reused.
 
 `IncrementalPlan.DeclarationHash` establishes the condition: a SHA-256 of each file's text with every
 method/accessor/operator/constructor body and expression-body cut out and replaced by a marker. Field
@@ -155,32 +168,81 @@ second, and the no-op case is already there without one.
 
 Roughly in expected-value order.
 
-- **Decide the default.** It is opt-in, because a stale cache is a *silently wrong* build rather than a
-  failed one. Before flipping it on: put the `compare-site.sh` gate for the seven edit shapes into CI
-  (the script in `.claude/skills/transpose-performance/scripts/` plus
-  `/tmp/.../verify-incremental.sh`, which should move into the repo), and have the
-  `Transpose.Build.Target` SDK pass `--incremental` so a normal `dotnet build` benefits.
 - **Declaration-level dependency tracking**, so a changed *declaration* re-emits only the types that
-  bind to it instead of everything. This is the big remaining tier: adding a method is at least as
-  common an edit as changing a body, and today it costs a full build. It needs the emitter to record,
-  per type, which other types' member sets it consulted — feasible (every symbol query already goes
-  through `TreeModel`) but invasive, and the reverse-dependency closure has to include overload
-  numbering, which makes *any* member added to a type invalidate every caller of that type. Worth
-  prototyping against real edit traces before committing to it.
-- **Reuse across `--emit-package` and site modes.** The cache is keyed on output mode, so a project
-  built both ways caches twice. Harmless but wasteful.
+  bind to it instead of everything. This is the whole remaining tier: adding a method is at least as
+  common an edit as changing a body, and today it costs a full build.
+
+  It needs the emitter to record, per type, which other types' member sets it consulted. **Do not
+  reach for the cheap approximation** — invalidating "every type in a file that mentions the changed
+  type's name" is *unsound*, because a type's emitted JavaScript can depend on another type without
+  ever naming it: `var x = Factory.Create();` followed by `x.Foo()` bakes in `Foo`'s overload-numbered
+  JS name with neither the type's name nor the file's text mentioning it. Extension methods, implicit
+  conversions and inherited members do the same. The dependency set has to come from the symbols the
+  emitter actually asked about (every query already goes through `TreeModel`, which is the natural
+  place to record them), and the closure has to include overload numbering — which means *any* member
+  added to a type invalidates every caller of that type. Prototype it against real edit traces before
+  committing to it.
+- **Turn it on for the bare CLI too.** The SDK already opts in, so the exposure is the same either
+  way; what is left is deciding whether `tps` on its own should default to on. The argument for
+  waiting is that a stale cache is a silently wrong build rather than a failed one, and the CI gate has
+  only just started running.
 - **The runtime build (`--build-runtime`) has no cache.** It is a maintainer-only operation, so the
   risk/benefit is worse; but it binds the BCL three times over and would benefit most.
-- **`ProjectResolver.IsPackageUpToDate` and the cache now answer overlapping questions** by different
-  means (timestamps vs. content hashes). The timestamp check runs first and can send a project into a
-  build the cache then declares up to date — harmless (it becomes a "0 files changed" replay) but it
-  should be one mechanism, not two.
-- **Cache eviction.** Nothing prunes `obj/tps-cache`; it is one generation per configuration, so it
-  cannot grow, but a `--cache-dir` shared across many projects accumulates directories forever.
-- **Make the emitted assembly deterministic** (`CSharpCompilationOptions.WithDeterministic(true)`) and
-  stop Cecil restamping the MVID. Then a body-only edit would produce a byte-identical DLL, the
-  content/metadata key split would be unnecessary, and `diff -r` would become a usable gate on the DLL
-  as well as the site.
-- **`--incremental --timing` reports a phase that no longer does what its name says.** "scan
-  unsupported features" is now mostly metadata import; splitting that out would make the floor visible
-  in the timing table instead of only in this document.
+- **Cache eviction.** Nothing prunes `obj/tps-cache`; it holds one generation per configuration and
+  output mode, so it cannot grow, but a `--cache-dir` shared across many projects accumulates
+  directories forever.
+- **`--timing`'s phase names now understate what they measure.** "scan unsupported features" is mostly
+  reference-metadata import on an incremental build; the `├ walk files` sub-phase makes the split
+  visible (parent minus sub-phases = the fixed cost), but the parent's name is still misleading. Any
+  rename churns the phase names in `docs/perf/*.json`, which `tps-bench --baseline` matches on.
+- **A compilation server** remains out of scope, but the numbers above say what it would be worth: the
+  residual ~1.5 s of a body-only build is almost entirely Roslyn re-importing `Transpose.dll`'s
+  metadata in a fresh process, and a server is the only thing that can remove it.
+
+## Done since the first draft
+
+- **The SDK opts in** (`<TransposeIncremental>`, default true) — `Transpose.Build.Target/Sdk/Sdk.targets`.
+- **The CI gate** — `.devops/benchmark-transpose-compiler.yml` runs
+  `scripts/verify-incremental.sh` and fails the build on a mismatch.
+- **Dependency projects are cached too**, and the timestamp up-to-date screen is no longer layered in
+  front of the cache: with `--incremental`, `ProjectResolver.IsPackageUpToDate` is skipped and
+  `BuildPackage` decides by content hash, which also closes the hole where a checkout moving an mtime
+  backwards left a dirty project looking clean.
+- **Reproducible assembly emit** (`deterministic: true`) — see above.
+- **The cache is scoped by output mode** as well as configuration, so a project built both as a package
+  and as a site no longer has the two builds take turns overwriting one cache.
+- **`obj/.../tps.log`** — the compiler's full output, on disk on every build, because MSBuild's
+  terminal logger discards it (see below).
+
+## The compiler's output under `dotnet build`
+
+Worth writing down, because it looks like a bug in the SDK target and is not one.
+
+Since .NET 9, `dotnet build` uses MSBuild's **terminal logger** whenever stdout is a terminal, and it
+renders only errors, warnings and a per-project summary. Measured across every channel a targets file
+has — `Message` at high and normal importance, `Exec` stdout, `Exec` stderr, with and without
+`ConsoleToMsBuild`, with `StandardOutputImportance="high"` — **none** of them is displayed at default
+verbosity or at `-v:normal`. Only `-v:detailed`/`-v:diagnostic` or `-tl:false` bring them back. Lines
+that MSBuild's diagnostic regex promotes to a warning or error *are* shown, including the
+tool-attributed `tps : warning TPS0100: …` form, which is what makes `MsBuildDiagnostic`'s canonical
+output land in the terminal and the IDE error list.
+
+This is not a regression against h5. Built with the real `h5` toolchain, an h5 project prints all of
+its `[info] …` lines under `-tl:false` and **zero** under `-tl:true` — the same as `tps`. The two SDKs'
+`Exec` invocations are identical in shape (`ConsoleToMsBuild="True"`, `ContinueOnError="ErrorAndStop"`,
+no custom importance or error regex), and h5's compiler writes plain ZLogger lines with no
+MSBuild-parseable prefix. A memory of h5 printing its log during a build is a memory of the classic
+console logger: pre-.NET 9, a redirected stdout, or CI.
+
+Consequences, all of them already applied:
+
+- `_TransposeBuild` writes the captured output to `obj/<Configuration>/<tfm>/tps.log` on every build,
+  success included, and adds it to `FileWrites` so `dotnet clean` removes it.
+- The failure error is coded (`TPS1002`) and says where the log is and how to see the output live,
+  instead of "see logs for error message".
+- Nothing else can be done from a targets file. `dotnet build -tl:false` is the answer for an
+  interactive build that should show its work.
+
+One cosmetic gap left: the terminal logger's per-project line ends in an empty `→` for Transpose
+projects, because the SDK clears the intermediate-assembly items the logger derives that path from.
+Pointing it at the built site would be a nice touch and is unexplored.

--- a/TODO.incremental.md
+++ b/TODO.incremental.md
@@ -1,0 +1,186 @@
+# TODO.incremental.md — incremental compilation in `tps`
+
+What it takes to make `tps` reuse a previous build, what the prototype behind `--incremental` actually
+does, what it measured on the tesserae corpus, and what is left.
+
+Companion to [`TODO.optimization.md`](TODO.optimization.md), which is about making a *single* build
+cheaper. This is about not doing one at all. The two are complementary and the second is now the
+bigger lever: a clean build of tesserae is ~7 s and about half of that is work a previous build
+already did.
+
+> `CLAUDE.md` used to read "Caching and the compilation server are intentionally **out of scope**".
+> The caching half of that is what this document revisits; the compilation-server half still stands,
+> and the measurements below say exactly what it would be worth.
+
+---
+
+## Where things stand
+
+`tps --incremental` (off by default; `--cache-dir <dir>` / `TRANSPOSE_CACHE_DIR` to relocate the
+cache, `TRANSPOSE_INCREMENTAL=1` to enable it for a session). Measured on the tesserae corpus,
+`-c Debug`, medians of 3 interleaved runs, 4-core container:
+
+| scenario | today | `--incremental` | speedup |
+|---|--:|--:|--:|
+| library (263 files → package DLL), nothing changed | 7.98 s | **0.40 s** | **20×** |
+| library, one method body edited | 7.98 s | **4.09 s** | **1.95×** |
+| library, clean build (cache written) | 7.98 s | 8.06 s | −1% |
+| app (site build, library up to date), nothing changed | 4.27 s | **0.41 s** | **10×** |
+| app, one method body edited in the app | 4.27 s | **3.46 s** | 1.23× |
+| app, one method body edited in the **library** | 8.82 s | **4.44 s** | **2.0×** |
+
+Every one of those outputs is **byte-identical** to a from-scratch build of the same sources,
+verified with `compare-site.sh` over the whole `Tesserae.Tests` site across seven edit shapes
+(app body, library body, both, a new public method, a statement added to a body, a changed field
+initializer, whitespace in a body). The 584-test suite stays green, plus 8 new tests in
+`IncrementalEmitTests.cs`.
+
+The ~1% cold-build cost is the price of admission: hashing every file's declaration surface (~150 ms
+on 270 files) and writing ~5 MB of cache. Measured by an interleaved A/B of four clean-build pairs
+(7.19 s vs 7.26 s) — i.e. inside the noise.
+
+---
+
+## The design
+
+Three verdicts, decided by `Transpose.Compiler/BuildCache.cs` before the translator is even
+constructed:
+
+| verdict | when | what happens |
+|---|---|---|
+| **UpToDate** | every input hashes the same **and** every output file is still on disk with the same length and write time | nothing is compiled |
+| **BodyOnlyChange** | files changed, but every change is inside a method/accessor body | unchanged types keep their cached JavaScript; only changed files are scanned and diagnosed; the reflection metadata, the scanner's denied-name filter and (in a metadata-only configuration) the .NET assembly are reused |
+| **FullBuild** | anything else — a declaration moved, a file appeared or vanished, a reference or setting changed, no cache | compile everything, write a fresh cache |
+
+The reuse *mechanism* lives in `Transpose.Translator/Compilation/IncrementalPlan.cs`: the translator
+does no file I/O and holds no policy, it just consults a plan. The reuse *policy* — and the soundness
+argument — lives entirely in `BuildCache`.
+
+### Why "body-only" is the right dividing line
+
+It is the coarsest condition under which each phase's output provably cannot move:
+
+* **Per-type JavaScript.** A type's emitted JS is a function of its own syntax plus the *declarations*
+  it binds against: member names, overload numbering (`$ctorN`, `foo$1`), `[Template]`/`[Name]`
+  attributes, constants, base types. None of that can shift because a body elsewhere changed. The
+  emitter already emits every type into its own `JsWriter` in parallel and concatenates them in
+  dependency order, so a per-type cache slots straight in — and crucially `NameMangler` derives every
+  name from the symbol alone, with **no global counter** whose value depends on how many types were
+  emitted. (That was the property to check first; had names been allocated by emit order, per-type
+  caching would have been impossible without renaming everything.)
+* **Diagnostics.** A body can only produce a diagnostic in its own file. So an unchanged file's Roslyn
+  body diagnostics and its unsupported-feature scan verdict both still stand — and the cached build
+  succeeded, or nothing was cached.
+* **Reflection metadata.** It describes types, members, signatures and attributes: declarations.
+* **The .NET assembly**, in Debug. A metadata-only emit has no method bodies at all, so its content is
+  a function of the declarations. This is the single biggest win available (~19% of a build) and the
+  claim most worth distrusting, so it was tested rather than argued: a body edit adding a closure, a
+  local function, an 8-case string switch and an iterator local function to one method produces a
+  fresh metadata-only assembly that differs from the reused one in exactly **16 bytes** — the module
+  MVID and the PE timestamp — with identical length and identical metadata. (Those 16 bytes already
+  differ between any two full builds; Roslyn's emit here is not deterministic, and neither is
+  Mono.Cecil's resource embed, which restamps 17–18 bytes of the final DLL every time.) In Release the
+  assembly is full IL and is *not* reused.
+
+`IncrementalPlan.DeclarationHash` establishes the condition: a SHA-256 of each file's text with every
+method/accessor/operator/constructor body and expression-body cut out and replaced by a marker. Field
+initializers, default parameter values, attribute arguments and base lists are deliberately **kept** —
+a constant folds into other files' output and an attribute argument steers emission. Being a hash of
+text rather than of a normalised syntax model, it over-reports (reformatting a declaration, or
+swapping `=> expr;` for `{ return expr; }`, forces a full rebuild) and never under-reports. That
+asymmetry is the whole point and `TheDeclarationHashMayOverReportButNeverUnderReports` pins it down.
+Only the files whose *text* hash changed are re-parsed to answer it, so the check costs nothing on a
+large project.
+
+### Two keys, not one
+
+A referenced Transpose package contributes two different things: its **metadata**, which the consumer
+binds against, and its **embedded JavaScript**, which the consumer copies into the site untouched. So
+the cache carries two keys:
+
+* `SettingsKey` — configuration, defines, language version, output mode, `tps.json` (+ the
+  per-configuration overlay), reflection settings, and every reference by its *metadata* fingerprint.
+  A change here means a full rebuild.
+* `ContentKey` — additionally every reference by its raw bytes. A change here alone means the
+  compilation is still valid but the outputs are stale.
+
+That second tier is what makes the multi-project inner loop work. A dependency rebuilt after a
+body-only edit of its own has *identical metadata* but a different DLL — Mono.Cecil stamps a fresh
+MVID on every embed, so the bytes never compare equal. Without the split, editing a method body in
+Tesserae would force a full rebuild of every project referencing it. So a package build now writes a
+`<Assembly>.dll.tpsmeta` sidecar next to its DLL holding the hash of the assembly Roslyn emitted
+(before the resources went in), and consumers fingerprint that instead of the DLL. The consumer then
+lands on "0 files changed, bodies only", and since nothing it emits can differ, it skips the
+compilation **entirely** (`TryReplayCompilation`) and only rewrites its outputs.
+
+### Where the cache lives
+
+`<project>/obj/tps-cache/<Configuration>/` — so `dotnet clean`, `rm -rf obj` and `tps-bench`'s
+clean-slate scenarios all drop it, and Debug/Release (structurally different builds) never share.
+`--cache-dir` puts it anywhere, keying projects apart by a slug; a temp folder is fine, since losing
+the cache only ever costs a full build. Contents: `manifest.json` (keys, per-file text +
+declaration hashes, output file list), `types.js` (per-type JavaScript, one framed blob rather than
+500 files), `bundle.js`, `meta.js`, `assembly.bin`, `denied-names.txt`. ~5 MB for tesserae.
+
+A cache is also keyed on the compiler's own identity — assembly version, informational version, and
+the write times of `tps.dll` and `Transpose.Translator.dll`, so rebuilding the compiler in place
+invalidates it rather than silently mixing emitters.
+
+---
+
+## What a body-only build still spends, and why
+
+`tesserae` library project, one method body edited (3.9 s):
+
+| phase | ms | what it is |
+|---|--:|---|
+| scan unsupported features | 1 433 | **one file** is scanned. This is not scanning — it is Roslyn building the compilation's symbol tables and importing the reference metadata, which lands on whichever phase binds first |
+| emit JavaScript | 630 | 431 ms of it emitting the one changed type and checking reuse for the other 499 |
+| embed resources into DLL (Cecil) | 385 | the JavaScript changed, so the DLL must be rewritten |
+| body diagnostics | 270 | the changed file only |
+| build compilation (parse) | 236 | all 270 files, in parallel |
+| hash declaration surface | 144 | changed files only; the rest carried forward from the manifest |
+| resolve project + minify | 135 | |
+
+**The floor is the reference metadata import.** A one-file project referencing the same packages takes
+1.74 s end to end, and `Transpose.dll` is 10.6 MB imported with `MetadataImportOptions.All` (required
+so overload numbering matches). That cost is paid per process and no on-disk cache can avoid it. It is
+also the precise size of the prize a **compilation server** would collect: keeping the
+`MetadataReference` alive across builds would take a body-only edit from ~3.9 s to well under a
+second, and the no-op case is already there without one.
+
+---
+
+## What is left
+
+Roughly in expected-value order.
+
+- **Decide the default.** It is opt-in, because a stale cache is a *silently wrong* build rather than a
+  failed one. Before flipping it on: put the `compare-site.sh` gate for the seven edit shapes into CI
+  (the script in `.claude/skills/transpose-performance/scripts/` plus
+  `/tmp/.../verify-incremental.sh`, which should move into the repo), and have the
+  `Transpose.Build.Target` SDK pass `--incremental` so a normal `dotnet build` benefits.
+- **Declaration-level dependency tracking**, so a changed *declaration* re-emits only the types that
+  bind to it instead of everything. This is the big remaining tier: adding a method is at least as
+  common an edit as changing a body, and today it costs a full build. It needs the emitter to record,
+  per type, which other types' member sets it consulted — feasible (every symbol query already goes
+  through `TreeModel`) but invasive, and the reverse-dependency closure has to include overload
+  numbering, which makes *any* member added to a type invalidate every caller of that type. Worth
+  prototyping against real edit traces before committing to it.
+- **Reuse across `--emit-package` and site modes.** The cache is keyed on output mode, so a project
+  built both ways caches twice. Harmless but wasteful.
+- **The runtime build (`--build-runtime`) has no cache.** It is a maintainer-only operation, so the
+  risk/benefit is worse; but it binds the BCL three times over and would benefit most.
+- **`ProjectResolver.IsPackageUpToDate` and the cache now answer overlapping questions** by different
+  means (timestamps vs. content hashes). The timestamp check runs first and can send a project into a
+  build the cache then declares up to date — harmless (it becomes a "0 files changed" replay) but it
+  should be one mechanism, not two.
+- **Cache eviction.** Nothing prunes `obj/tps-cache`; it is one generation per configuration, so it
+  cannot grow, but a `--cache-dir` shared across many projects accumulates directories forever.
+- **Make the emitted assembly deterministic** (`CSharpCompilationOptions.WithDeterministic(true)`) and
+  stop Cecil restamping the MVID. Then a body-only edit would produce a byte-identical DLL, the
+  content/metadata key split would be unnecessary, and `diff -r` would become a usable gate on the DLL
+  as well as the site.
+- **`--incremental --timing` reports a phase that no longer does what its name says.** "scan
+  unsupported features" is now mostly metadata import; splitting that out would make the floor visible
+  in the timing table instead of only in this document.

--- a/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
+++ b/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
@@ -123,6 +123,25 @@
     <UpdateTranspose Condition="'$(UpdateTranspose)' == ''">false</UpdateTranspose>
     <UseLocalTranspose Condition="'$(UseLocalTranspose)' == ''">false</UseLocalTranspose>
     <SkipOnlineCheck Condition="'$(SkipOnlineCheck)' == ''">false</SkipOnlineCheck>
+
+    <!-- Reuse the previous build of this project where its inputs are unchanged: nothing is compiled
+         when every source file and reference hashes the same, and an edit confined to method or
+         accessor bodies keeps the cached JavaScript of every type it did not touch. Emitted output is
+         byte-identical either way, and the cache lives in the project's obj/ so `dotnet clean` drops
+         it. See TODO.incremental.md in the Transpose repository for the reuse rules.
+
+         Set <TransposeIncremental>false</TransposeIncremental> in the .csproj to turn it off — for a
+         release build that should always compile from scratch, or to rule the cache out while
+         diagnosing a build problem. -->
+    <TransposeIncremental Condition="'$(TransposeIncremental)' == ''">true</TransposeIncremental>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- The tps command line, shared by the global-tool and local-tool invocations below so the two
+         cannot drift apart. -->
+    <_TransposeArgs>--project "$(ProjectPath)" --configuration "$(Configuration)" --assembly-version "$(AssemblyVersion)"</_TransposeArgs>
+    <_TransposeArgs Condition="'$(TransposeIncremental)' == 'true'">$(_TransposeArgs) --incremental</_TransposeArgs>
+    <_TransposeArgs Condition="'$(TransposeIncremental)' != 'true'">$(_TransposeArgs) --no-incremental</_TransposeArgs>
   </PropertyGroup>
 
 
@@ -470,18 +489,47 @@
     <Message Importance="high" Text="Deleting previous assembly: $(ProjectDir)$(OutputPath)$(TargetName)$(TargetExt)"/>
     <Delete Files="$(ProjectDir)$(OutputPath)$(TargetName)$(TargetExt)"/>
 
-    <!-- This is where tps is finally called to compile the C# to JavaScript. -->
+    <!-- This is where tps is finally called to compile the C# to JavaScript.
+
+         A note on why you may not see any of the compiler's output. MSBuild's **terminal logger** —
+         the default for `dotnet build` since .NET 9 whenever stdout is a terminal — renders only
+         errors, warnings and a per-project summary. Every `Message`, and every line an `Exec`ed tool
+         writes, is dropped at default verbosity and at `-v:normal`, whatever its importance and
+         regardless of ConsoleToMsBuild; only `-v:detailed`/`-v:diagnostic` or `-tl:false` bring them
+         back. (Verified against MSBuild directly; the classic console logger still shows everything,
+         which is why a piped or CI build looks fine and an interactive one looks silent.)
+
+         So `tps` compile errors and warnings do reach the terminal — that is what the canonical
+         `file(line,col): error CS….` / `tps : warning TPS….` form in MsBuildDiagnostic buys — but the
+         progress lines, the "OK — built …" summary and the per-phase timing table cannot be surfaced
+         by any means available to this file. Rather than leave the build's own account of itself
+         unrecoverable, the captured output always goes to obj/tps.log, and the failure error says so. -->
     <Message Importance="high" Text="Transpose compilation begins now... " />
 
-    <Exec Command="tps --project &quot;$(ProjectPath)&quot; --configuration &quot;$(Configuration)&quot; --assembly-version &quot;$(AssemblyVersion)&quot;" ConsoleToMsBuild="True" WorkingDirectory="$(ProjectDir)" ContinueOnError="ErrorAndStop" IgnoreExitCode="false" Condition="!$(UseLocalTranspose)">
+    <Exec Command="tps $(_TransposeArgs)" ConsoleToMsBuild="True" WorkingDirectory="$(ProjectDir)" ContinueOnError="ErrorAndStop" IgnoreExitCode="false" Condition="!$(UseLocalTranspose)">
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+      <Output TaskParameter="ConsoleOutput" ItemName="_TransposeConsoleOutput" />
     </Exec>
 
-    <Exec Command="dotnet tool run tps --project &quot;$(ProjectPath)&quot; --configuration &quot;$(Configuration)&quot; --assembly-version &quot;$(AssemblyVersion)&quot;" ConsoleToMsBuild="True" WorkingDirectory="$(ProjectDir)" ContinueOnError="ErrorAndStop" IgnoreExitCode="false" Condition="$(UseLocalTranspose)">
+    <Exec Command="dotnet tool run tps $(_TransposeArgs)" ConsoleToMsBuild="True" WorkingDirectory="$(ProjectDir)" ContinueOnError="ErrorAndStop" IgnoreExitCode="false" Condition="$(UseLocalTranspose)">
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+      <Output TaskParameter="ConsoleOutput" ItemName="_TransposeConsoleOutput" />
     </Exec>
 
-    <Error Text="Transpose compilation failed, see logs for error message" Condition="'$(ExitCode)' != '0'"/>
+    <!-- The compiler's full output, always on disk whatever logger the build is using. Written on
+         success too: "why did this build take 12 seconds" and "what did it actually emit" are questions
+         the terminal logger cannot answer. -->
+    <MakeDir Directories="$(ProjectDir)$(IntermediateOutputPath)" Condition="'@(_TransposeConsoleOutput)' != ''" />
+    <WriteLinesToFile File="$(ProjectDir)$(IntermediateOutputPath)tps.log"
+                      Lines="@(_TransposeConsoleOutput)"
+                      Overwrite="true" Encoding="UTF-8"
+                      Condition="'@(_TransposeConsoleOutput)' != ''" />
+    <ItemGroup>
+      <FileWrites Include="$(ProjectDir)$(IntermediateOutputPath)tps.log" />
+    </ItemGroup>
+
+    <Error Code="TPS1002" Condition="'$(ExitCode)' != '0'"
+           Text="The Transpose compiler failed (exit code $(ExitCode)). Its errors are listed above; if none are shown, MSBuild's terminal logger has hidden them — the compiler's full output is in $(IntermediateOutputPath)tps.log, or re-run with `dotnet build -tl:false` (or -v:detailed)." />
 
     <Message Importance="high" Text="... Transpose compilation finished!" />
   </Target>

--- a/Transpose/Transpose.Compiler/BuildCache.cs
+++ b/Transpose/Transpose.Compiler/BuildCache.cs
@@ -95,21 +95,23 @@ internal sealed class BuildCache
     /// project emits, but it does mean the outputs are stale, so the build must run and rewrite them
     /// while still reusing everything it emitted last time.
     /// </summary>
-    public static BuildCache Open(ResolvedProject project, string configuration, IEnumerable<string> settings,
-        IEnumerable<string> contentExtras, string? cacheDirOverride)
+    /// <param name="mode">The output shape this build produces (<c>package</c>, <c>site</c>,
+    /// <c>bundle</c>). It is part of the cache's *path*, not just its key: a project built both ways
+    /// would otherwise have the two builds take turns invalidating and overwriting one cache, and
+    /// neither would ever hit.</param>
+    public static BuildCache Open(ResolvedProject project, string configuration, string mode,
+        IEnumerable<string> settings, IEnumerable<string> contentExtras, string? cacheDirOverride)
     {
         var settingsKey = HashStrings(settings.Prepend($"format={FormatVersion}").Prepend($"compiler={CompilerId()}"));
         var contentKey = HashStrings(contentExtras.Prepend(settingsKey));
 
-        // A cache is per project *and* per configuration: Debug and Release are structurally different
-        // builds (metadata-only vs full IL, formatted vs minified bundles).
-        var root = cacheDirOverride
-                   ?? Environment.GetEnvironmentVariable("TRANSPOSE_CACHE_DIR")
-                   ?? Path.Combine(project.ProjectDir, "obj", "tps-cache");
-        var dir = cacheDirOverride is null && Environment.GetEnvironmentVariable("TRANSPOSE_CACHE_DIR") is null
-            ? Path.Combine(root, configuration)
+        // A cache is per project, per configuration and per output mode: Debug and Release are
+        // structurally different builds (metadata-only vs full IL, formatted vs minified bundles).
+        var explicitRoot = cacheDirOverride ?? Environment.GetEnvironmentVariable("TRANSPOSE_CACHE_DIR");
+        var dir = explicitRoot is null
+            ? Path.Combine(project.ProjectDir, "obj", "tps-cache", configuration, mode)
             // An explicit shared cache root (e.g. a temp folder) has to keep projects apart itself.
-            : Path.Combine(root, ProjectSlug(project.CsprojPath), configuration);
+            : Path.Combine(explicitRoot, ProjectSlug(project.CsprojPath), configuration, mode);
 
         var textHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (path, text) in project.Sources) textHashes[path] = HashString(text);

--- a/Transpose/Transpose.Compiler/BuildCache.cs
+++ b/Transpose/Transpose.Compiler/BuildCache.cs
@@ -1,0 +1,549 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.CodeAnalysis.CSharp;
+using Transpose.Translator;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// The on-disk build cache behind <c>--incremental</c>: what the previous build of this project
+/// produced, and the decision about how much of it the current build may reuse.
+///
+/// `tps` is a plain CLI — a fresh process per build, no compilation server (see CLAUDE.md) — so
+/// nothing of Roslyn's bound state survives between builds. What *can* survive is the output of the
+/// phases whose inputs are unchanged, and this class decides which those are. There are exactly three
+/// verdicts:
+///
+/// <list type="bullet">
+/// <item><b>UpToDate</b> — every input hashes the same as last time and every output file is still on
+/// disk unchanged. Nothing is compiled at all.</item>
+/// <item><b>BodyOnlyChange</b> — some files changed, but only inside method/accessor bodies: no
+/// declaration was added, removed, renamed or re-signed anywhere. The unchanged files' types keep
+/// their cached JavaScript, only the changed files are scanned and diagnosed, the reflection metadata
+/// is reused, and (in a metadata-only configuration) so is the .NET assembly.</item>
+/// <item><b>FullBuild</b> — anything else: a declaration moved, a file was added or removed, a
+/// reference or a build setting changed, or there is no usable cache. The build runs from scratch and
+/// writes a fresh cache.</item>
+/// </list>
+///
+/// Why that middle tier is sound is argued in <see cref="IncrementalPlan"/>; this class's job is to
+/// establish its precondition, conservatively. Every input that could change an output is in the
+/// settings key or one of the per-file hashes, and anything unrecognised falls back to FullBuild.
+///
+/// The cache lives in the project's <c>obj/</c> (so <c>dotnet clean</c>, a `rm -rf obj`, and
+/// <c>tps-bench</c>'s clean-slate scenarios all drop it), or wherever <c>--cache-dir</c> /
+/// <c>TRANSPOSE_CACHE_DIR</c> points — a temp directory works fine, since a missing or stale cache
+/// only ever costs a full build.
+/// </summary>
+internal sealed class BuildCache
+{
+    /// <summary>Bumped whenever the cache layout or the reuse rules change, so an older cache written
+    /// by a different compiler is ignored rather than misread.</summary>
+    private const int FormatVersion = 1;
+
+    private const string ManifestFile = "manifest.json";
+    private const string TypesFile = "types.js";
+    private const string MetaFile = "meta.js";
+    private const string InlineMetaFile = "inline-meta.js";
+    private const string AssemblyFile = "assembly.bin";
+    private const string DeniedNamesFile = "denied-names.txt";
+    private const string BundleFile = "bundle.js";
+
+    internal enum Verdict
+    {
+        /// <summary>Compile everything and write a fresh cache.</summary>
+        FullBuild,
+
+        /// <summary>Only method/accessor bodies changed — reuse everything declaration-derived.</summary>
+        BodyOnlyChange,
+
+        /// <summary>Nothing changed and the outputs are intact — do nothing.</summary>
+        UpToDate,
+    }
+
+    private readonly string _dir;
+    private readonly string _settingsKey;
+    private readonly string _contentKey;
+    private readonly Dictionary<string, string> _textHashes;
+    private readonly ResolvedProject _project;
+    private Manifest? _previous;
+
+    private BuildCache(string dir, string settingsKey, string contentKey,
+        Dictionary<string, string> textHashes, ResolvedProject project)
+    {
+        _dir = dir;
+        _settingsKey = settingsKey;
+        _contentKey = contentKey;
+        _textHashes = textHashes;
+        _project = project;
+    }
+
+    /// <summary>Where this project's cache lives.</summary>
+    public string Directory => _dir;
+
+    /// <summary>
+    /// Opens (without validating) the cache for a project.
+    ///
+    /// There are two keys, because two different questions have to be answered. <paramref
+    /// name="settings"/> is everything that can change *what this project compiles to* — the
+    /// configuration, defines, language version, output mode, tps.json, reflection settings, and the
+    /// declaration-level identity of every reference. A change there invalidates the whole cache.
+    /// <paramref name="contentExtras"/> is what can change only *what this project has to write out* —
+    /// most importantly the full byte content of a referenced Transpose package, whose embedded
+    /// JavaScript is copied into the site verbatim. A change there cannot alter a single byte this
+    /// project emits, but it does mean the outputs are stale, so the build must run and rewrite them
+    /// while still reusing everything it emitted last time.
+    /// </summary>
+    public static BuildCache Open(ResolvedProject project, string configuration, IEnumerable<string> settings,
+        IEnumerable<string> contentExtras, string? cacheDirOverride)
+    {
+        var settingsKey = HashStrings(settings.Prepend($"format={FormatVersion}").Prepend($"compiler={CompilerId()}"));
+        var contentKey = HashStrings(contentExtras.Prepend(settingsKey));
+
+        // A cache is per project *and* per configuration: Debug and Release are structurally different
+        // builds (metadata-only vs full IL, formatted vs minified bundles).
+        var root = cacheDirOverride
+                   ?? Environment.GetEnvironmentVariable("TRANSPOSE_CACHE_DIR")
+                   ?? Path.Combine(project.ProjectDir, "obj", "tps-cache");
+        var dir = cacheDirOverride is null && Environment.GetEnvironmentVariable("TRANSPOSE_CACHE_DIR") is null
+            ? Path.Combine(root, configuration)
+            // An explicit shared cache root (e.g. a temp folder) has to keep projects apart itself.
+            : Path.Combine(root, ProjectSlug(project.CsprojPath), configuration);
+
+        var textHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (path, text) in project.Sources) textHashes[path] = HashString(text);
+
+        return new BuildCache(dir, settingsKey, contentKey, textHashes, project);
+    }
+
+    /// <summary>
+    /// How much of the cache this build may reuse, and the files it must recompile. Returns the changed
+    /// source paths for a <see cref="Verdict.BodyOnlyChange"/>; empty otherwise.
+    /// </summary>
+    public (Verdict verdict, List<string> changedSources, string? reason) Decide()
+    {
+        _previous = LoadManifest();
+        if (_previous is null) return (Verdict.FullBuild, new List<string>(), "no cache");
+        if (_previous.FormatVersion != FormatVersion) return (Verdict.FullBuild, new List<string>(), "cache format changed");
+        if (_previous.SettingsKey != _settingsKey) return (Verdict.FullBuild, new List<string>(), "build settings or references changed");
+
+        // The *set* of files has to match: a new or deleted file changes which types exist and in what
+        // order the bundle emits them, which is a declaration-level change by definition.
+        if (_previous.Sources.Count != _textHashes.Count)
+            return (Verdict.FullBuild, new List<string>(), "source file added or removed");
+
+        var changed = new List<string>();
+        foreach (var entry in _previous.Sources)
+        {
+            if (!_textHashes.TryGetValue(entry.Path, out var now))
+                return (Verdict.FullBuild, new List<string>(), $"source file removed ({Path.GetFileName(entry.Path)})");
+            if (now != entry.Text) changed.Add(entry.Path);
+        }
+
+        // A referenced package's content changed without its declarations changing — e.g. a dependency
+        // project was rebuilt after a body-only edit of its own. Nothing this project emits can differ,
+        // but its outputs embed or copy that content, so they have to be written again.
+        var contentStale = _previous.ContentKey != _contentKey;
+
+        if (changed.Count == 0 && !contentStale)
+            return OutputsIntact()
+                ? (Verdict.UpToDate, new List<string>(), null)
+                : (Verdict.FullBuild, new List<string>(), "an output file was modified or deleted");
+
+        // The one question that separates a body-only edit from everything else. Only the changed files
+        // need re-parsing to answer it, which is why this is cheap even on a large project.
+        var previousDecl = _previous.Sources.ToDictionary(s => s.Path, s => s.Decl, StringComparer.OrdinalIgnoreCase);
+        var texts = _project.Sources.ToDictionary(s => s.path, s => s.text, StringComparer.OrdinalIgnoreCase);
+        foreach (var path in changed)
+        {
+            var tree = CompilationBuilder.ParseOne(path, texts[path], _project.LanguageVersion, _project.DefineConstants);
+            if (IncrementalPlan.DeclarationHash(tree) != previousDecl[path])
+                return (Verdict.FullBuild, new List<string>(), $"declarations changed in {Path.GetFileName(path)}");
+        }
+
+        if (!_previous.HasTypes) return (Verdict.FullBuild, new List<string>(), "cached JavaScript missing");
+
+        return (Verdict.BodyOnlyChange, changed,
+            contentStale && changed.Count == 0 ? "a referenced package was rebuilt, its declarations unchanged" : null);
+    }
+
+    /// <summary>
+    /// The plan to hand the translator. For a full build it carries nothing reusable but still collects
+    /// what this build produces, so the cache can be written afterwards.
+    /// </summary>
+    public IncrementalPlan CreatePlan(Verdict verdict, List<string> changedSources, bool canReuseAssembly)
+    {
+        if (verdict != Verdict.BodyOnlyChange)
+            return new IncrementalPlan
+            {
+                // Nothing is reusable: every file counts as changed, so every type is re-emitted and
+                // every file is scanned and diagnosed, exactly as a non-incremental build would.
+                ChangedSources = _textHashes.Keys.ToList(),
+                TypeJs = new Dictionary<string, string>(),
+            };
+
+        var types = ReadTypes();
+        return new IncrementalPlan
+        {
+            ChangedSources = changedSources,
+            TypeJs = types,
+            PreviousDeclarationHashes = _previous!.Sources.ToDictionary(s => s.Path, s => s.Decl, StringComparer.Ordinal),
+            MetadataScript = _previous!.HasMetadataScript ? File.ReadAllText(Path.Combine(_dir, MetaFile)) : null,
+            InlineMetadata = _previous.HasInlineMetadata ? File.ReadAllText(Path.Combine(_dir, InlineMetaFile)) : null,
+            DeniedSimpleNames = _previous.HasDeniedNames && File.Exists(Path.Combine(_dir, DeniedNamesFile))
+                ? File.ReadAllLines(Path.Combine(_dir, DeniedNamesFile))
+                : null,
+            AssemblyBytes = canReuseAssembly && _previous.HasAssembly && File.Exists(Path.Combine(_dir, AssemblyFile))
+                ? File.ReadAllBytes(Path.Combine(_dir, AssemblyFile))
+                : null,
+        };
+    }
+
+    /// <summary>
+    /// The previous build's finished output, when this build's own inputs are all unchanged and only a
+    /// referenced package was rebuilt. Nothing this project emits can differ — so rather than reuse the
+    /// cache *within* a compilation, skip the compilation entirely and go straight to writing the
+    /// outputs (which do have to change: they carry the reference's JavaScript).
+    ///
+    /// Returns null when the cache cannot supply a complete result, in which case the caller compiles
+    /// normally. Requires the cached assembly, so it only applies to a metadata-only configuration.
+    /// </summary>
+    public AssemblyBuildResult? TryReplayCompilation(bool canReuseAssembly)
+    {
+        if (_previous is null || !canReuseAssembly || !_previous.HasAssembly) return null;
+        var bundle = Path.Combine(_dir, BundleFile);
+        var assembly = Path.Combine(_dir, AssemblyFile);
+        if (!File.Exists(bundle) || !File.Exists(assembly)) return null;
+        try
+        {
+            return new AssemblyBuildResult(
+                File.ReadAllText(bundle),
+                _previous.HasMetadataScript ? File.ReadAllText(Path.Combine(_dir, MetaFile)) : null,
+                File.ReadAllBytes(assembly),
+                Array.Empty<Microsoft.CodeAnalysis.Diagnostic>());
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Records a new set of output files against the existing cache entry, for a build that reused the
+    /// previous compilation wholesale (see <see cref="TryReplayCompilation"/>). Everything else in the
+    /// manifest — the source hashes, the per-type JavaScript — is still current and is left alone.
+    /// </summary>
+    public void SaveOutputsOnly(IEnumerable<string> outputs)
+    {
+        if (_previous is null) return;
+        try
+        {
+            _previous.ContentKey = _contentKey;
+            _previous.Outputs = outputs.Where(File.Exists).Select(Describe).ToList();
+            File.WriteAllText(Path.Combine(_dir, ManifestFile), JsonSerializer.Serialize(_previous, ManifestJson));
+        }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeCacheNotWritten,
+                $"could not update the incremental build cache in '{_dir}': {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Writes the cache for the next build: the per-type JavaScript in bundle order, the reflection
+    /// metadata, the emitted assembly, the per-file hashes, and the outputs this build produced (so a
+    /// later run can tell whether they are still the ones it wrote).
+    ///
+    /// A failure here is never fatal — the cache is an optimisation, and a build that produced correct
+    /// output must not fail because a temp directory was not writable.
+    /// </summary>
+    public void Save(IncrementalPlan plan, AssemblyBuildResult result, IEnumerable<string> outputs)
+    {
+        try
+        {
+            System.IO.Directory.CreateDirectory(_dir);
+
+            WriteTypes(plan);
+
+            // The finished bundle, so a later build whose own inputs are all unchanged can skip the
+            // compilation outright rather than reassembling the bundle from the per-type pieces.
+            if (result.Javascript is { } bundle) File.WriteAllText(Path.Combine(_dir, BundleFile), bundle);
+            else File.Delete(Path.Combine(_dir, BundleFile));
+
+            if (result.MetadataJavascript is { } meta) File.WriteAllText(Path.Combine(_dir, MetaFile), meta);
+            else File.Delete(Path.Combine(_dir, MetaFile));
+
+            if (plan.FinalInlineMetadata is { } inline) File.WriteAllText(Path.Combine(_dir, InlineMetaFile), inline);
+            else File.Delete(Path.Combine(_dir, InlineMetaFile));
+
+            if (result.AssemblyBytes is { } asm) File.WriteAllBytes(Path.Combine(_dir, AssemblyFile), asm);
+            else File.Delete(Path.Combine(_dir, AssemblyFile));
+
+            if (plan.FinalDeniedSimpleNames is { } denied)
+                File.WriteAllLines(Path.Combine(_dir, DeniedNamesFile), denied);
+            else File.Delete(Path.Combine(_dir, DeniedNamesFile));
+
+            var declHashes = result.DeclarationHashes ?? new Dictionary<string, string>();
+            var manifest = new Manifest
+            {
+                FormatVersion = FormatVersion,
+                SettingsKey = _settingsKey,
+                ContentKey = _contentKey,
+                HasTypes = plan.FinalOrder.Count > 0,
+                HasMetadataScript = result.MetadataJavascript is not null,
+                HasInlineMetadata = plan.FinalInlineMetadata is not null,
+                HasAssembly = result.AssemblyBytes is not null,
+                HasDeniedNames = plan.FinalDeniedSimpleNames is not null,
+                Sources = _project.Sources
+                    .Select(s => new SourceEntry
+                    {
+                        Path = s.path,
+                        Text = _textHashes[s.path],
+                        Decl = declHashes.TryGetValue(s.path, out var d) ? d : "",
+                    })
+                    .ToList(),
+                Outputs = outputs.Where(File.Exists).Select(Describe).ToList(),
+            };
+            File.WriteAllText(Path.Combine(_dir, ManifestFile),
+                JsonSerializer.Serialize(manifest, ManifestJson));
+        }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeCacheNotWritten,
+                $"could not write the incremental build cache in '{_dir}': {ex.Message}");
+        }
+    }
+
+    /// <summary>Deletes the cache — used when a build fails, so a broken state is never reused.</summary>
+    public void Invalidate()
+    {
+        try { if (System.IO.Directory.Exists(_dir)) System.IO.Directory.Delete(_dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    /// <summary>The output files the previous build recorded, so a caller can report them.</summary>
+    public IReadOnlyList<string> PreviousOutputs => _previous?.Outputs.Select(o => o.Path).ToList() ?? new List<string>();
+
+    // ---- outputs ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Whether every file the previous build wrote is still there, the same length, with the same
+    /// write time. This is what makes "nothing changed" mean "nothing needs doing": without it, a
+    /// deleted site folder or a hand-edited bundle would be silently left broken.
+    /// </summary>
+    private bool OutputsIntact()
+    {
+        if (_previous!.Outputs.Count == 0) return false;
+        foreach (var recorded in _previous.Outputs)
+        {
+            if (!File.Exists(recorded.Path)) return false;
+            var now = Describe(recorded.Path);
+            if (now.Length != recorded.Length || now.Ticks != recorded.Ticks) return false;
+        }
+        return true;
+    }
+
+    private static OutputEntry Describe(string path)
+    {
+        var info = new FileInfo(path);
+        return new OutputEntry { Path = path, Length = info.Length, Ticks = info.LastWriteTimeUtc.Ticks };
+    }
+
+    // ---- per-type JavaScript store ---------------------------------------------------------------
+
+    // One file rather than 500: a project has hundreds of types, and a single framed blob is one read
+    // and one write instead of hundreds of directory operations. Frame = "<key>\t<utf8 length>\n<js>".
+
+    private void WriteTypes(IncrementalPlan plan)
+    {
+        var path = Path.Combine(_dir, TypesFile);
+        if (plan.FinalOrder.Count == 0) { File.Delete(path); return; }
+
+        using var stream = File.Create(path);
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+        foreach (var key in plan.FinalOrder)
+        {
+            var js = plan.FinalTypeJs[key];
+            writer.Write(key);
+            writer.Write('\t');
+            writer.Write(Encoding.UTF8.GetByteCount(js));
+            writer.Write('\n');
+            writer.Write(js);
+        }
+    }
+
+    private Dictionary<string, string> ReadTypes()
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        var path = Path.Combine(_dir, TypesFile);
+        if (!File.Exists(path)) return result;
+
+        var bytes = File.ReadAllBytes(path);
+        var at = 0;
+        while (at < bytes.Length)
+        {
+            var tab = Array.IndexOf(bytes, (byte)'\t', at);
+            if (tab < 0) break;
+            var nl = Array.IndexOf(bytes, (byte)'\n', tab);
+            if (nl < 0) break;
+            var key = Encoding.UTF8.GetString(bytes, at, tab - at);
+            if (!int.TryParse(Encoding.UTF8.GetString(bytes, tab + 1, nl - tab - 1), out var length)) break;
+            if (nl + 1 + length > bytes.Length) break;
+            result[key] = Encoding.UTF8.GetString(bytes, nl + 1, length);
+            at = nl + 1 + length;
+        }
+        return result;
+    }
+
+    // ---- manifest --------------------------------------------------------------------------------
+
+    private static readonly JsonSerializerOptions ManifestJson = new() { WriteIndented = false };
+
+    private Manifest? LoadManifest()
+    {
+        var path = Path.Combine(_dir, ManifestFile);
+        if (!File.Exists(path)) return null;
+        try { return JsonSerializer.Deserialize<Manifest>(File.ReadAllText(path), ManifestJson); }
+        catch { return null; } // an unreadable cache is simply no cache
+    }
+
+    private sealed class Manifest
+    {
+        public int FormatVersion { get; set; }
+        public string SettingsKey { get; set; } = "";
+        public string ContentKey { get; set; } = "";
+        public bool HasTypes { get; set; }
+        public bool HasMetadataScript { get; set; }
+        public bool HasInlineMetadata { get; set; }
+        public bool HasAssembly { get; set; }
+        public bool HasDeniedNames { get; set; }
+        public List<SourceEntry> Sources { get; set; } = new();
+        public List<OutputEntry> Outputs { get; set; } = new();
+    }
+
+    private sealed class SourceEntry
+    {
+        public string Path { get; set; } = "";
+
+        /// <summary>Hash of the whole file — decides whether it has to be looked at at all.</summary>
+        public string Text { get; set; } = "";
+
+        /// <summary>Hash of the file minus method/accessor bodies — decides whether the change is
+        /// confined to bodies. See <see cref="IncrementalPlan.DeclarationHash"/>.</summary>
+        public string Decl { get; set; } = "";
+    }
+
+    private sealed class OutputEntry
+    {
+        public string Path { get; set; } = "";
+        public long Length { get; set; }
+        public long Ticks { get; set; }
+    }
+
+    // ---- fingerprints ----------------------------------------------------------------------------
+
+    /// <summary>
+    /// A referenced assembly's fingerprint. Package DLLs in the NuGet cache are immutable and a
+    /// sibling project's DLL is rewritten wholesale by its own build, so path + length + write time
+    /// identifies the content without reading megabytes of metadata on every build.
+    /// </summary>
+    public static string ReferenceFingerprint(string path)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            return $"{path}|{info.Length}|{info.LastWriteTimeUtc.Ticks}";
+        }
+        catch { return $"{path}|missing"; }
+    }
+
+    /// <summary>
+    /// The *declaration-level* fingerprint of a referenced assembly: what a consumer's emitted
+    /// JavaScript actually depends on. Everything a consumer reads from a reference — member names,
+    /// overload numbering over the full member set, <c>[Template]</c>/<c>[Name]</c> attributes,
+    /// constants — comes from its metadata; the JavaScript embedded alongside it is copied through
+    /// untouched, never consulted.
+    ///
+    /// So a Transpose project writes <see cref="MetadataSidecarSuffix"/> next to its DLL recording the
+    /// hash of the assembly Roslyn emitted, before the resources were embedded, and a consumer prefers
+    /// that over the DLL's bytes. That is what lets a body-only edit in a referenced library leave its
+    /// consumers' compilation cached: the library's metadata is identical (in a metadata-only
+    /// configuration it *is* the same bytes), even though its DLL was rewritten — Mono.Cecil stamps a
+    /// fresh MVID and timestamp on every embed, so the DLL never compares equal twice.
+    /// </summary>
+    public static string ReferenceMetadataFingerprint(string path)
+    {
+        var sidecar = path + MetadataSidecarSuffix;
+        try
+        {
+            if (File.Exists(sidecar)) return $"{path}|meta:{File.ReadAllText(sidecar).Trim()}";
+        }
+        catch { /* fall through to the byte fingerprint */ }
+        return ReferenceFingerprint(path);
+    }
+
+    /// <summary>Written next to a project's package DLL; see <see cref="ReferenceMetadataFingerprint"/>.</summary>
+    public const string MetadataSidecarSuffix = ".tpsmeta";
+
+    /// <summary>Records the hash of a project's emitted assembly metadata next to its DLL, for
+    /// consumers to fingerprint. Best effort: without it a consumer simply rebuilds more often.</summary>
+    public static void WriteMetadataSidecar(string dllPath, byte[]? assemblyBytes)
+    {
+        if (assemblyBytes is null) return;
+        try { File.WriteAllText(dllPath + MetadataSidecarSuffix, Convert.ToHexString(SHA256.HashData(assemblyBytes))); }
+        catch { /* best effort */ }
+    }
+
+    /// <summary>Fingerprint of a file's contents, or a marker when it does not exist.</summary>
+    public static string FileContentFingerprint(string path)
+    {
+        try { return File.Exists(path) ? HashString(File.ReadAllText(path)) : "absent"; }
+        catch { return "unreadable"; }
+    }
+
+    /// <summary>The identity of this compiler build. A different compiler emits different JavaScript,
+    /// so its cache must not be reused: the informational version covers a released tool, and the
+    /// assembly's own write time covers a developer rebuilding the compiler in place.</summary>
+    private static string CompilerId()
+    {
+        var asm = typeof(BuildCache).Assembly;
+        var version = asm.GetName().Version?.ToString() ?? "0";
+        var informational = asm
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion ?? "";
+        var stamp = "";
+        try
+        {
+            var location = asm.Location;
+            if (!string.IsNullOrEmpty(location) && File.Exists(location))
+                stamp = File.GetLastWriteTimeUtc(location).Ticks.ToString();
+        }
+        catch { /* single-file or trimmed host: the versions alone have to do */ }
+        // The translator is a separate assembly and is where nearly all emit changes land.
+        var translator = "";
+        try
+        {
+            var tloc = typeof(RoslynTranslator).Assembly.Location;
+            if (!string.IsNullOrEmpty(tloc) && File.Exists(tloc))
+                translator = File.GetLastWriteTimeUtc(tloc).Ticks.ToString();
+        }
+        catch { /* ditto */ }
+        return $"{version}|{informational}|{stamp}|{translator}";
+    }
+
+    private static string ProjectSlug(string csprojPath)
+        => Path.GetFileNameWithoutExtension(csprojPath) + "-" + HashString(Path.GetFullPath(csprojPath)).Substring(0, 12);
+
+    private static string HashString(string text)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
+
+    private static string HashStrings(IEnumerable<string> parts)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        foreach (var part in parts)
+        {
+            hash.AppendData(Encoding.UTF8.GetBytes(part));
+            hash.AppendData(new byte[] { 0 });
+        }
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+}

--- a/Transpose/Transpose.Compiler/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler/MsBuildDiagnostic.cs
@@ -57,6 +57,7 @@ internal static class MsBuildDiagnostic
     public const string CodeReferenceNotFound      = "TPS0100";
     public const string CodeMissingRuntimeBundle   = "TPS0101";
     public const string CodeTimingJsonNotWritten   = "TPS0102";
+    public const string CodeCacheNotWritten        = "TPS0103";
 
     /// <summary>Formats a Roslyn diagnostic, pointing at its source location when it has one.</summary>
     public static string Format(Diagnostic d)

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -37,6 +37,11 @@ public static class Program
         // Overrides the project's <TransposeMetadataOnlyAssembly>, which in turn overrides the
         // per-configuration default. Null = nothing on the command line expressed a preference.
         bool? metadataOnlyAssembly = null;
+        // Incremental builds are opt-in: reusing a previous build's output is only correct while the
+        // rules in BuildCache/IncrementalPlan hold, and a stale cache is a silently wrong build rather
+        // than a failed one. TRANSPOSE_INCREMENTAL=1 turns it on for a whole session.
+        var incremental = Environment.GetEnvironmentVariable("TRANSPOSE_INCREMENTAL") is "1" or "true";
+        string? cacheDir = null;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -55,6 +60,9 @@ public static class Program
                 case "--define" or "-D": extraDefines.Add(args[++i]); break;
                 case "--timing": PhaseTimings.Enabled = true; break;
                 case "--timing-json": _timingJsonPath = args[++i]; PhaseTimings.Enabled = true; break;
+                case "--incremental": incremental = true; break;
+                case "--no-incremental": incremental = false; break;
+                case "--cache-dir": cacheDir = args[++i]; incremental = true; break;
                 case "--metadata-only-assembly": metadataOnlyAssembly = true; break;
                 case "--no-metadata-only-assembly": metadataOnlyAssembly = false; break;
                 case "--assembly-version": assemblyVersion = args[++i]; break;
@@ -182,7 +190,7 @@ public static class Program
         // separate-assembly / package mode this project binds against its dependencies' built DLLs
         // and extracts their embedded JS, so each must be compiled — in dependency order — before
         // this one. Up-to-date packages are skipped.
-        if (separateAssemblies && !EnsureReferencedProjectsBuilt(csproj, configuration, maxErrors, metadataOnlyAssembly))
+        if (separateAssemblies && !EnsureReferencedProjectsBuilt(csproj, configuration, maxErrors, metadataOnlyAssembly, incremental, cacheDir))
         {
             Console.Error.WriteLine("\nFAILED building referenced projects.");
             return 1;
@@ -193,11 +201,52 @@ public static class Program
         // references this one. Emitting the DLL (with the compiled JS embedded, like a package) means
         // every project — app or library — produces the DLL the SDK/consumers expect.
         var isSiteBuild = !emitPackage && !buildRuntime && outPath is null && tpscfg is not null;
+
+        // Incremental build (--incremental): consult the cache written by the previous build of this
+        // project. This happens *after* the referenced projects were rebuilt above, so a dependency's
+        // freshly written DLL is part of what gets fingerprinted.
+        BuildCache? cache = null;
+        var verdict = BuildCache.Verdict.FullBuild;
+        var changedSources = new List<string>();
+        if (incremental)
+        {
+            cache = BuildCache.Open(project, configuration,
+                BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
+                    metadataOnly, emitPackage, isSiteBuild, separateAssemblies, withRuntime, outPath, siteDir,
+                    assemblyVersion),
+                BuildContentFingerprint(project),
+                cacheDir);
+            (verdict, changedSources, var reason) = cache.Decide();
+
+            if (verdict == BuildCache.Verdict.UpToDate)
+            {
+                Console.WriteLine($"\nOK — everything up to date, nothing to compile ({sw.ElapsedMilliseconds} ms).");
+                foreach (var output in cache.PreviousOutputs.Take(4)) Console.WriteLine($"  output:   {output}");
+                if (cache.PreviousOutputs.Count > 4)
+                    Console.WriteLine($"            … and {cache.PreviousOutputs.Count - 4} more");
+                PrintTimings(sw.ElapsedMilliseconds);
+                return 0;
+            }
+            Console.WriteLine(verdict == BuildCache.Verdict.BodyOnlyChange
+                ? $"  cache:      {changedSources.Count} file(s) changed, method bodies only — reusing cached declarations"
+                : $"  cache:      full build ({reason})");
+        }
+        // Nothing in this project changed — only a referenced package's content did (its declarations
+        // are identical). The compilation would reproduce the cached bundle byte for byte, so skip it
+        // and go straight to writing the outputs, which do have to be rewritten.
+        var replayed = incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
+            ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)
+            : null;
+        if (replayed is not null)
+            Console.WriteLine("  cache:      reusing the previous compilation in full — writing outputs only");
+
+        var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
+
         var translator = new RoslynTranslator();
         AssemblyBuildResult result;
         try
         {
-            result = translator.BuildAssembly(
+            result = replayed ?? translator.BuildAssembly(
                 project.Sources,
                 project.AssemblyName,
                 project.ReferencePaths,
@@ -208,7 +257,8 @@ public static class Program
                 emitAssembly: emitPackage || isSiteBuild,
                 assemblyVersion: assemblyVersion,
                 emitDebugInformation: project.EmitDebugInformation,
-                metadataOnlyAssembly: metadataOnly);
+                metadataOnlyAssembly: metadataOnly,
+                incremental: plan);
         }
         catch (Exception ex)
         {
@@ -238,6 +288,7 @@ public static class Program
             if (written is null) return 2;
 
             var (dllPath, items) = written.Value;
+            SaveCache(cache, plan, result, new[] { dllPath });
             Console.WriteLine($"\nOK — built package {project.AssemblyName}.dll ({result.AssemblyBytes!.Length:N0} bytes) with {items.Count} embedded resource(s) in {sw.ElapsedMilliseconds} ms.");
             Console.WriteLine($"  dll:      {dllPath}");
             Console.WriteLine($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
@@ -263,6 +314,9 @@ public static class Program
             var outDir = siteDir ?? ResolveOutputDir(config, project.ProjectDir, configuration);
             var siteResult = PhaseTimings.Measure("write site (minify + resources + html)", () =>
                 OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript));
+            // Every file in the site counts as an output: a rebuild must notice if any of them was
+            // deleted or edited, otherwise "up to date" would leave a broken site in place.
+            SaveCache(cache, plan, result, SiteOutputs(outDir, dllPath));
             Console.WriteLine($"\nOK — built site in {outDir} ({js.Length:N0} bytes of {config.FileName}) in {sw.ElapsedMilliseconds} ms.");
             Console.WriteLine($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
             if (dllPath is not null) Console.WriteLine($"  dll:        {dllPath}");
@@ -281,9 +335,98 @@ public static class Program
         outPath ??= Path.Combine(project.ProjectDir, "bin", project.AssemblyName + ".js");
         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outPath))!);
         File.WriteAllText(outPath, js);
+        SaveCache(cache, plan, result, new[] { Path.GetFullPath(outPath) });
         Console.WriteLine($"\nOK — wrote {js.Length:N0} bytes to {outPath} in {sw.ElapsedMilliseconds} ms.");
         PrintTimings(sw.ElapsedMilliseconds);
         return 0;
+    }
+
+    /// <summary>
+    /// Persists the cache after a successful build. A build that reused the previous compilation whole
+    /// (no plan) has nothing new to record but its new output files; any other build writes the lot.
+    /// </summary>
+    private static void SaveCache(BuildCache? cache, IncrementalPlan? plan, AssemblyBuildResult result,
+        IEnumerable<string> outputs)
+    {
+        if (cache is null) return;
+        if (plan is null) cache.SaveOutputsOnly(outputs);
+        else cache.Save(plan, result, outputs);
+    }
+
+    /// <summary>Every file under the assembled site, plus the emitted DLL — the outputs an incremental
+    /// build has to find unchanged before it may declare the project up to date.</summary>
+    private static IEnumerable<string> SiteOutputs(string outDir, string? dllPath)
+    {
+        if (dllPath is not null) yield return dllPath;
+        if (!Directory.Exists(outDir)) yield break;
+        foreach (var file in Directory.EnumerateFiles(outDir, "*", SearchOption.AllDirectories))
+            yield return file;
+    }
+
+    /// <summary>
+    /// Everything about a build other than its source files: the settings, the output shape, and a
+    /// fingerprint of every referenced assembly and config file. A change to any of these can change
+    /// every byte of the output, so it invalidates the whole cache rather than any part of it.
+    ///
+    /// Anything the compiler starts to read in future has to be added here. That is the one
+    /// maintenance obligation the cache imposes: an input nobody fingerprints is an input whose change
+    /// goes unnoticed.
+    /// </summary>
+    private static IEnumerable<string> BuildSettingsFingerprint(
+        ResolvedProject project, string configuration, TransposeJson? tpscfg, bool reflectionEnabled,
+        MetadataTarget metadataTarget, bool metadataOnly, bool emitPackage, bool isSiteBuild,
+        bool separateAssemblies, bool withRuntime, string? outPath, string? siteDir, string? assemblyVersion)
+    {
+        yield return $"configuration={configuration}";
+        yield return $"assembly={project.AssemblyName}";
+        yield return $"tfm={project.TargetFramework}";
+        yield return $"lang={project.LanguageVersion}";
+        yield return $"defines={string.Join(";", project.DefineConstants)}";
+        yield return $"reflection={reflectionEnabled}/{metadataTarget}";
+        yield return $"metadataOnly={metadataOnly}";
+        yield return $"debugInfo={project.EmitDebugInformation}";
+        yield return $"minifyLocals={project.MinifyLocalVariables}";
+        yield return $"assemblyVersion={assemblyVersion}";
+        yield return $"mode={(emitPackage ? "package" : isSiteBuild ? "site" : "bundle")}";
+        yield return $"separate={separateAssemblies};runtime={withRuntime}";
+        yield return $"out={outPath};siteDir={siteDir}";
+        yield return $"tpsjson={tpscfg is null}";
+
+        // The project file and its tps.json (plus the per-configuration overlay) by content: they
+        // decide which files compile, what gets embedded and how the site is laid out.
+        yield return "csproj=" + BuildCache.FileContentFingerprint(project.CsprojPath);
+        yield return "tps.json=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, "tps.json"));
+        yield return $"tps.{configuration}.json="
+            + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, $"tps.{configuration}.json"));
+
+        // Every referenced assembly, by the part of it this project's output depends on: its metadata.
+        // A package upgrade or a dependency whose declarations moved changes emitted names (overload
+        // numbering counts the reference's full member set), so it is a full-rebuild input; a dependency
+        // rebuilt from a body-only edit of its own is not (see ReferenceMetadataFingerprint).
+        foreach (var reference in project.ReferencePaths.OrderBy(p => p, StringComparer.Ordinal))
+            yield return "ref=" + BuildCache.ReferenceMetadataFingerprint(reference);
+
+        // The Transpose base assembly and the JS runtime it carries are injected by the translator, not
+        // by the project, so they have to be fingerprinted explicitly.
+        yield return "bcl=" + BuildCache.ReferenceFingerprint(TransposeAssemblies.TransposeDllPath);
+
+        // Resources the site/package build reads straight from disk (tps.json `resources`): tps.json's
+        // own hash covers *which* files are listed, but not what is in them.
+        if (tpscfg is not null)
+            foreach (var file in tpscfg.Resources.SelectMany(g => g.Files).OrderBy(n => n, StringComparer.Ordinal))
+                yield return "res=" + file + "=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, file));
+    }
+
+    /// <summary>
+    /// The inputs that cannot change a byte this project *emits*, but do change what it has to *write*:
+    /// the full content of every referenced assembly, whose embedded JavaScript and resources are copied
+    /// into the site and re-embedded into this project's own DLL. A change here means "rebuild the
+    /// outputs, keep the compilation" — see <see cref="BuildCache.Open"/>.
+    /// </summary>
+    private static IEnumerable<string> BuildContentFingerprint(ResolvedProject project)
+    {
+        foreach (var reference in project.ReferencePaths.OrderBy(p => p, StringComparer.Ordinal))
+            yield return "refbytes=" + BuildCache.ReferenceFingerprint(reference);
     }
 
     /// <summary>
@@ -489,7 +632,8 @@ public static class Program
     /// which builds project references (each producing a DLL with its JS embedded) before the
     /// project that consumes them.
     /// </summary>
-    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors, bool? metadataOnlyAssembly)
+    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors,
+        bool? metadataOnlyAssembly, bool incremental, string? cacheDir)
     {
         foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
         {
@@ -500,7 +644,7 @@ public static class Program
                 continue;
             }
             Console.WriteLine($"  building dependency: {name}");
-            if (!BuildPackage(dep, configuration, maxErrors, metadataOnlyAssembly))
+            if (!BuildPackage(dep, configuration, maxErrors, metadataOnlyAssembly, incremental, cacheDir))
             {
                 MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeDependencyBuildFailed,
                     $"Failed to build referenced project '{name}'.");
@@ -513,7 +657,8 @@ public static class Program
     /// <summary>Compiles one project into its Transpose package DLL (the .NET assembly with the compiled JS
     /// and tps.json resources embedded). Its own project references are consumed as their built DLLs,
     /// so they must already have been built (this is called in dependency order).</summary>
-    private static bool BuildPackage(string csproj, string configuration, int maxErrors, bool? metadataOnlyAssembly)
+    private static bool BuildPackage(string csproj, string configuration, int maxErrors, bool? metadataOnlyAssembly,
+        bool incremental, string? cacheDir)
     {
         ResolvedProject project;
         try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
@@ -526,21 +671,52 @@ public static class Program
 
         var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
         var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
+        var assemblyVersion = ProjectResolver.ReadAssemblyVersion(csproj);
+        // Each dependency reads its own csproj property, but a command-line override applies to the
+        // whole invocation.
+        var metadataOnly = metadataOnlyAssembly
+                           ?? project.MetadataOnlyAssembly
+                           ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration);
+
+        // A dependency gets the same treatment as the root project: its own cache, in its own obj/.
+        // Without this, editing a method body in a referenced library — the common case in a
+        // solution — would still cost that library a full rebuild.
+        BuildCache? cache = null;
+        var verdict = BuildCache.Verdict.FullBuild;
+        var changedSources = new List<string>();
+        if (incremental)
+        {
+            cache = BuildCache.Open(project, configuration,
+                BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
+                    metadataOnly, emitPackage: true, isSiteBuild: false, separateAssemblies: true,
+                    withRuntime: false, outPath: null, siteDir: null, assemblyVersion: assemblyVersion),
+                BuildContentFingerprint(project),
+                cacheDir);
+            (verdict, changedSources, var reason) = cache.Decide();
+            // "Up to date" cannot happen here: ProjectResolver.IsPackageUpToDate already screened that
+            // out by timestamp before this project was queued for a build. If the cache disagrees (a
+            // touched-but-identical file), treat it as a body-only build with nothing changed.
+            Console.WriteLine(verdict == BuildCache.Verdict.FullBuild
+                ? $"    cache: full build ({reason})"
+                : $"    cache: {changedSources.Count} file(s) changed, method bodies only");
+            if (verdict == BuildCache.Verdict.UpToDate) verdict = BuildCache.Verdict.BodyOnlyChange;
+        }
+        var replayed = incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
+            ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)
+            : null;
+        var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
 
         AssemblyBuildResult result;
         try
         {
-            result = new RoslynTranslator().BuildAssembly(
+            result = replayed ?? new RoslynTranslator().BuildAssembly(
                 project.Sources, project.AssemblyName, project.ReferencePaths,
                 project.DefineConstants, project.LanguageVersion,
                 reflectionEnabled, metadataTarget, emitAssembly: true,
-                assemblyVersion: ProjectResolver.ReadAssemblyVersion(csproj),
+                assemblyVersion: assemblyVersion,
                 emitDebugInformation: project.EmitDebugInformation,
-                // Each dependency reads its own csproj property, but a command-line override applies
-                // to the whole invocation.
-                metadataOnlyAssembly: metadataOnlyAssembly
-                                      ?? project.MetadataOnlyAssembly
-                                      ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration));
+                metadataOnlyAssembly: metadataOnly,
+                incremental: plan);
         }
         catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex); return false; }
 
@@ -550,7 +726,10 @@ public static class Program
             return false;
         }
 
-        return TryWritePackage(project, tpscfg, configuration, result) is not null;
+        var written = TryWritePackage(project, tpscfg, configuration, result);
+        if (written is null) return false;
+        SaveCache(cache, plan, result, new[] { written.Value.dllPath });
+        return true;
     }
 
     /// <summary>Writes a project's package DLL, turning a failure into a reported diagnostic (rather
@@ -589,6 +768,10 @@ public static class Program
         // Writes the DLL — the emitted assembly plus the embedded resources — in one pass.
         PhaseTimings.Measure("embed resources into DLL (Cecil)",
             () => ResourceEmbedder.Embed(dllPath, result.AssemblyBytes!, items, project.ReferencePaths));
+        // Record what a consumer's compilation actually depends on — this assembly's metadata — so a
+        // rebuild of this project does not force a rebuild of everything referencing it when only its
+        // method bodies moved. Cecil restamps the DLL's MVID on every embed, so its bytes cannot serve.
+        BuildCache.WriteMetadataSidecar(dllPath, result.AssemblyBytes);
         return (dllPath, items);
     }
 
@@ -734,6 +917,19 @@ public static class Program
                                     can pin it with <TransposeMetadataOnlyAssembly>. The Transpose SDK
                                     refuses to pack a Debug build, so a metadata-only assembly cannot
                                     reach a NuGet feed.
+              --incremental, --no-incremental
+                                    Reuse the previous build of this project where its inputs are
+                                    unchanged (off by default). A build whose files all hash the same
+                                    does nothing at all; one whose edits are confined to method and
+                                    accessor bodies keeps the cached JavaScript of every type it did
+                                    not touch, the reflection metadata, and — in a metadata-only
+                                    configuration — the .NET assembly. Anything else (a changed
+                                    declaration, a new or deleted file, a different reference or
+                                    setting) is a full build. Emitted output is byte-identical either
+                                    way; the cache lives in the project's obj/tps-cache/.
+              --cache-dir <dir>     Put the incremental cache under <dir> instead of the project's
+                                    obj/ (implies --incremental). A temp directory is fine — losing
+                                    the cache only costs a full build.
               --timing              Print a per-phase timing/allocation breakdown of the build
               --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON
               -q, --quiet           Suppress warning output

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -211,6 +211,7 @@ public static class Program
         if (incremental)
         {
             cache = BuildCache.Open(project, configuration,
+                OutputMode(emitPackage, isSiteBuild),
                 BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
                     metadataOnly, emitPackage, isSiteBuild, separateAssemblies, withRuntime, outPath, siteDir,
                     assemblyVersion),
@@ -387,7 +388,7 @@ public static class Program
         yield return $"debugInfo={project.EmitDebugInformation}";
         yield return $"minifyLocals={project.MinifyLocalVariables}";
         yield return $"assemblyVersion={assemblyVersion}";
-        yield return $"mode={(emitPackage ? "package" : isSiteBuild ? "site" : "bundle")}";
+        yield return $"mode={OutputMode(emitPackage, isSiteBuild)}";
         yield return $"separate={separateAssemblies};runtime={withRuntime}";
         yield return $"out={outPath};siteDir={siteDir}";
         yield return $"tpsjson={tpscfg is null}";
@@ -416,6 +417,11 @@ public static class Program
             foreach (var file in tpscfg.Resources.SelectMany(g => g.Files).OrderBy(n => n, StringComparer.Ordinal))
                 yield return "res=" + file + "=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, file));
     }
+
+    /// <summary>What shape of output this build produces — the distributable package DLL, a runnable
+    /// site, or a single .js bundle. Each gets its own cache.</summary>
+    private static string OutputMode(bool emitPackage, bool isSiteBuild)
+        => emitPackage ? "package" : isSiteBuild ? "site" : "bundle";
 
     /// <summary>
     /// The inputs that cannot change a byte this project *emits*, but do change what it has to *write*:
@@ -638,7 +644,14 @@ public static class Program
         foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
         {
             var name = Path.GetFileNameWithoutExtension(dep);
-            if (ProjectResolver.IsPackageUpToDate(dep, configuration))
+            // Without the cache, a dependency's freshness is judged by timestamps. With it, that
+            // question is answered better inside BuildPackage — by hashing the content — so the
+            // timestamp screen is skipped rather than layered on top: it can only disagree by calling a
+            // project dirty when it is not (a touched file, a checkout that moved an mtime backwards),
+            // and the cache then resolves that to "nothing to do" for the price of hashing the sources.
+            // Two mechanisms answering the same question, weaker one first, is how a build ends up
+            // rebuilding for reasons nobody can explain.
+            if (!incremental && ProjectResolver.IsPackageUpToDate(dep, configuration))
             {
                 Console.WriteLine($"  dependency up-to-date: {name}");
                 continue;
@@ -687,19 +700,25 @@ public static class Program
         if (incremental)
         {
             cache = BuildCache.Open(project, configuration,
+                OutputMode(emitPackage: true, isSiteBuild: false),
                 BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
                     metadataOnly, emitPackage: true, isSiteBuild: false, separateAssemblies: true,
                     withRuntime: false, outPath: null, siteDir: null, assemblyVersion: assemblyVersion),
                 BuildContentFingerprint(project),
                 cacheDir);
             (verdict, changedSources, var reason) = cache.Decide();
-            // "Up to date" cannot happen here: ProjectResolver.IsPackageUpToDate already screened that
-            // out by timestamp before this project was queued for a build. If the cache disagrees (a
-            // touched-but-identical file), treat it as a body-only build with nothing changed.
+            if (verdict == BuildCache.Verdict.UpToDate)
+            {
+                // Every input and output of the dependency is unchanged, so its package DLL is already
+                // the one this build wants. This is the incremental replacement for the timestamp screen
+                // in EnsureReferencedProjectsBuilt, and it is cheaper than the replay path below
+                // because it does not even rewrite the DLL.
+                Console.WriteLine("    cache: up to date, nothing to do");
+                return true;
+            }
             Console.WriteLine(verdict == BuildCache.Verdict.FullBuild
                 ? $"    cache: full build ({reason})"
                 : $"    cache: {changedSources.Count} file(s) changed, method bodies only");
-            if (verdict == BuildCache.Verdict.UpToDate) verdict = BuildCache.Verdict.BodyOnlyChange;
         }
         var replayed = incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
             ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)

--- a/Transpose/Transpose.Translator.Tests/IncrementalEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/IncrementalEmitTests.cs
@@ -1,0 +1,225 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The two invariants the incremental build cache rests on (see <see cref="IncrementalPlan"/> and
+    /// <c>Transpose.Compiler.BuildCache</c>):
+    ///
+    /// 1. the declaration-surface hash notices *every* change outside a method/accessor body and
+    ///    ignores changes inside one — it is what decides whether a cached build may be reused at all;
+    /// 2. splicing a type's cached JavaScript back in produces exactly the bundle a full build would,
+    ///    so an incremental build's output is byte-identical rather than merely equivalent.
+    ///
+    /// If either slips, an incremental build is silently *wrong* — it produces plausible output instead
+    /// of failing — which is why they are unit-tested rather than left to a whole-project comparison.
+    /// </summary>
+    [TestClass]
+    public class IncrementalEmitTests
+    {
+        private const string GreeterCs = @"
+using System;
+
+public class Greeter
+{
+    private int _count = 1;
+
+    public string Name { get; set; }
+
+    public string Greet(string who)
+    {
+        var prefix = ""hello "";
+        return prefix + who + _count;
+    }
+
+    public int Twice(int n) => n * 2;
+}
+";
+
+        private const string OtherCs = @"
+public class Other
+{
+    public string Use(Greeter g) { return g.Greet(""x"") + g.Twice(2); }
+}
+";
+
+        private static string Hash(string source)
+            => IncrementalPlan.DeclarationHash(
+                CompilationBuilder.ParseOne("Greeter.cs", source, LanguageVersion.Latest, null));
+
+        // ---- the declaration-surface hash ------------------------------------------------------
+
+        [TestMethod]
+        public void BodyEditsDoNotChangeTheDeclarationHash()
+        {
+            var edits = new (string what, string source)[]
+            {
+                ("a string literal in a body", GreeterCs.Replace(@"""hello """, @"""hi there """)),
+                ("statements, a closure and a local function added to a body",
+                    GreeterCs.Replace(@"var prefix = ""hello "";",
+                        @"Func<int,int> f = n => n + 1; int L(int q) { return f(q); } var prefix = ""hello "" + L(2);")),
+                ("an expression-bodied member's body", GreeterCs.Replace("=> n * 2;", "=> n * 3;")),
+                ("whitespace inside a body", GreeterCs.Replace("return prefix + who", "return    prefix + who")),
+            };
+
+            foreach (var (what, edited) in edits)
+            {
+                Assert.AreNotEqual(GreeterCs, edited, $"the test's own edit did not apply: {what}");
+                Assert.AreEqual(Hash(GreeterCs), Hash(edited),
+                    $"{what} is confined to a method body and must not count as a declaration change");
+            }
+        }
+
+        [TestMethod]
+        public void DeclarationEditsChangeTheDeclarationHash()
+        {
+            var edits = new (string what, string source)[]
+            {
+                ("a new method", GreeterCs.Replace("public int Twice", "public void Added() { } public int Twice")),
+                ("a renamed method", GreeterCs.Replace("public int Twice", "public int Thrice")),
+                ("a new overload", GreeterCs.Replace("public int Twice", "public int Twice(long n) => 0; public int Twice")),
+                ("an added optional parameter", GreeterCs.Replace("Twice(int n)", "Twice(int n, int m = 0)")),
+                ("a property initializer", GreeterCs.Replace("public string Name { get; set; }", @"public string Name { get; set; } = ""a"";")),
+                ("a field initializer", GreeterCs.Replace("_count = 1", "_count = 2")),
+                ("a new attribute", GreeterCs.Replace("public class Greeter", "[Obsolete] public class Greeter")),
+                ("a changed base list", GreeterCs.Replace("public class Greeter", "public class Greeter : IDisposable")),
+                ("a new type", GreeterCs + "public class Extra { }"),
+                ("changed accessibility", GreeterCs.Replace("public int Twice", "internal int Twice")),
+            };
+
+            foreach (var (what, edited) in edits)
+            {
+                Assert.AreNotEqual(GreeterCs, edited, $"the test's own edit did not apply: {what}");
+                Assert.AreNotEqual(Hash(GreeterCs), Hash(edited),
+                    $"{what} is a declaration change and must invalidate the cache");
+            }
+        }
+
+        [TestMethod]
+        public void TheDeclarationHashIsStableAcrossParses()
+            => Assert.AreEqual(Hash(GreeterCs), Hash(GreeterCs));
+
+        /// <summary>
+        /// The hash is a hash of *text* with the body spans cut out, so a few body-only edits still
+        /// change it — swapping <c>=&gt; expr;</c> for <c>{ return expr; }</c> moves the trailing
+        /// semicolon, and reformatting a declaration changes its text. Those cost a full rebuild that
+        /// was not strictly necessary, which is the safe direction to be wrong in: the hash must never
+        /// miss a change, and may report one that turns out not to matter. This test pins that
+        /// asymmetry down so nobody "fixes" it into an under-reporting normaliser by accident.
+        /// </summary>
+        [TestMethod]
+        public void TheDeclarationHashMayOverReportButNeverUnderReports()
+        {
+            Assert.AreNotEqual(Hash(GreeterCs), Hash(GreeterCs.Replace("=> n * 2;", "{ return n * 2; }")),
+                "an over-report is allowed here — it only costs a full rebuild");
+            Assert.AreNotEqual(Hash(GreeterCs), Hash(GreeterCs.Replace("public int Twice", "public  int  Twice")),
+                "reformatting a declaration is an over-report too");
+        }
+
+        // ---- reusing cached per-type JavaScript ------------------------------------------------
+
+        [TestMethod]
+        public void ReusingEveryTypeReproducesTheFullBundleExactly()
+        {
+            var (fullJs, fullMeta) = Emit(GreeterCs, OtherCs, plan: null);
+
+            // Round-trip: take the per-type JavaScript a build recorded, feed it back as the cache for
+            // a build in which no file changed, and the bundle — type order, prelude, reflection
+            // metadata and all — has to come out identical.
+            var recording = Record(GreeterCs, OtherCs);
+            var replay = Plan(changed: new string[0], cached: recording);
+            var (reusedJs, reusedMeta) = Emit(GreeterCs, OtherCs, replay);
+
+            Assert.AreEqual(2, replay.ReusedTypes, "both types should have come from the cache");
+            Assert.AreEqual(0, replay.ReemittedTypes);
+            Assert.AreEqual(fullJs, reusedJs);
+            Assert.AreEqual(fullMeta, reusedMeta);
+        }
+
+        [TestMethod]
+        public void ReusingTheUnchangedFilesTypesMatchesAFullBuild()
+        {
+            var recording = Record(GreeterCs, OtherCs);
+
+            // Greeter.cs was edited inside a body; Other.cs was not touched, so `Other` — which calls
+            // both of Greeter's methods, and so depends on their emitted names — is reused from the
+            // cache. The bundle must still equal a full build of the edited sources.
+            var editedGreeter = GreeterCs.Replace(@"""hello """, @"""good day """);
+            var plan = Plan(changed: new[] { "Greeter.cs" }, cached: recording);
+            var (incrementalJs, incrementalMeta) = Emit(editedGreeter, OtherCs, plan);
+
+            Assert.AreEqual(1, plan.ReusedTypes, "Other lives in an unchanged file and must be reused");
+            Assert.AreEqual(1, plan.ReemittedTypes, "Greeter's file changed and must be re-emitted");
+
+            var (fullJs, fullMeta) = Emit(editedGreeter, OtherCs, plan: null);
+            Assert.AreEqual(fullJs, incrementalJs);
+            Assert.AreEqual(fullMeta, incrementalMeta);
+            Assert.IsTrue(incrementalJs.Contains("good day"), "the edit has to reach the output");
+        }
+
+        [TestMethod]
+        public void ACachedEntryIsNeverUsedForAChangedFile()
+        {
+            // A cache entry that does not match the current source must be ignored when its file is in
+            // the changed set — otherwise a real edit would be silently dropped.
+            var poisoned = new Dictionary<string, string>
+            {
+                ["global::Greeter"] = "/* stale Greeter */",
+                ["global::Other"] = "/* stale Other */",
+            };
+            var editedGreeter = GreeterCs.Replace(@"""hello """, @"""fresh """);
+            var plan = Plan(changed: new[] { "Greeter.cs", "Other.cs" }, cached: poisoned);
+            var (js, _) = Emit(editedGreeter, OtherCs, plan);
+
+            Assert.AreEqual(0, plan.ReusedTypes);
+            Assert.IsFalse(js.Contains("stale"));
+            Assert.IsTrue(js.Contains("fresh "));
+        }
+
+        [TestMethod]
+        public void TypeKeysDistinguishArityAndNesting()
+        {
+            var source = @"
+public class Box { public class Inner { } }
+public class Box<T> { }
+public class Box<T, U> { }
+namespace N { public class Box { } }
+";
+            var recorded = Record(source, "");
+            CollectionAssert.IsSubsetOf(
+                new[] { "global::Box", "global::Box.Inner", "global::Box<T>", "global::Box<T, U>", "global::N.Box" },
+                recorded.Keys.ToList());
+        }
+
+        // ---- helpers ---------------------------------------------------------------------------
+
+        /// <summary>The per-type JavaScript a build of these sources produces — i.e. what the cache
+        /// would hold afterwards.</summary>
+        private static Dictionary<string, string> Record(string greeter, string other)
+        {
+            var plan = Plan(new string[0], new Dictionary<string, string>());
+            Emit(greeter, other, plan);
+            return plan.FinalTypeJs.ToDictionary(kv => kv.Key, kv => kv.Value);
+        }
+
+        private static IncrementalPlan Plan(string[] changed, IReadOnlyDictionary<string, string> cached)
+            => new IncrementalPlan { ChangedSources = changed, TypeJs = cached };
+
+        private static (string javascript, string? metadata) Emit(string greeter, string other, IncrementalPlan? plan)
+        {
+            var sources = new List<(string, string)> { ("Greeter.cs", greeter) };
+            if (other.Length > 0) sources.Add(("Other.cs", other));
+
+            var result = new RoslynTranslator().BuildAssembly(
+                sources, "App", null, null, LanguageVersion.Latest,
+                reflectionEnabled: true, metadataTarget: MetadataTarget.File,
+                emitAssembly: false, incremental: plan);
+
+            Assert.IsTrue(result.Success, string.Join("\n", result.Errors.Select(e => e.GetMessage())));
+            return (result.Javascript!, result.MetadataJavascript);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
+++ b/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
@@ -25,6 +25,13 @@ public sealed class AssemblyBuildResult
     public byte[]? AssemblyBytes { get; }
     public IReadOnlyList<Diagnostic> Diagnostics { get; }
 
+    /// <summary>
+    /// Per source file, a hash of everything in it except method/accessor bodies — the input the next
+    /// build's incremental check compares against to decide whether an edit touched declarations. Null
+    /// unless the build was given an <see cref="IncrementalPlan"/> (i.e. caching is on).
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? DeclarationHashes { get; init; }
+
     public IEnumerable<Diagnostic> Errors => Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
     public bool Success => Javascript is not null && !Errors.Any();
 }

--- a/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
+++ b/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
@@ -23,10 +23,7 @@ public static class CompilationBuilder
         IEnumerable<string>? preprocessorSymbols = null,
         bool selfContainedBcl = false)
     {
-        var parseOptions = new CSharpParseOptions(languageVersion)
-            .WithFeatures(new[] { new KeyValuePair<string, string>("strict", "false") });
-        if (preprocessorSymbols is not null)
-            parseOptions = parseOptions.WithPreprocessorSymbols(preprocessorSymbols);
+        var parseOptions = ParseOptionsFor(languageVersion, preprocessorSymbols);
 
         // Give each source text an explicit encoding: emitting the assembly with embedded debug
         // information (as the package build does) requires it — Roslyn otherwise reports CS8055
@@ -44,6 +41,7 @@ public static class CompilationBuilder
                 Microsoft.CodeAnalysis.Text.SourceText.From(text, System.Text.Encoding.UTF8),
                 parseOptions, path: path);
         });
+
         var trees = treeArray;
 
         // Nullable reference types only exist from C# 8; enabling the annotations context
@@ -80,6 +78,27 @@ public static class CompilationBuilder
             references: references,
             options: options);
     }
+
+    /// <summary>
+    /// The parse options a build uses. Exposed so anything that has to re-parse a single file
+    /// *outside* a compilation — the incremental cache, hashing one file's declaration surface —
+    /// produces the same tree this would, and therefore the same hash.
+    /// </summary>
+    public static CSharpParseOptions ParseOptionsFor(LanguageVersion languageVersion, IEnumerable<string>? preprocessorSymbols)
+    {
+        var parseOptions = new CSharpParseOptions(languageVersion)
+            .WithFeatures(new[] { new KeyValuePair<string, string>("strict", "false") });
+        if (preprocessorSymbols is not null)
+            parseOptions = parseOptions.WithPreprocessorSymbols(preprocessorSymbols);
+        return parseOptions;
+    }
+
+    /// <summary>Parses one source file exactly as <see cref="Build"/> would.</summary>
+    public static SyntaxTree ParseOne(string path, string text, LanguageVersion languageVersion,
+        IEnumerable<string>? preprocessorSymbols)
+        => CSharpSyntaxTree.ParseText(
+            Microsoft.CodeAnalysis.Text.SourceText.From(text, System.Text.Encoding.UTF8),
+            ParseOptionsFor(languageVersion, preprocessorSymbols), path: path);
 
     /// <summary>
     /// References the Transpose assembly (Transpose.dll) as the sole BCL, exactly like the Transpose

--- a/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
+++ b/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
@@ -60,7 +60,15 @@ public static class CompilationBuilder
             // (built with --emit-package) numbers its overloads (e.g. $ctorN) over its FULL member
             // set including private ones; the consumer must see the same set for its call sites to
             // resolve to the same JS names.
-            metadataImportOptions: MetadataImportOptions.All);
+            metadataImportOptions: MetadataImportOptions.All,
+            // Emit the assembly reproducibly: without this Roslyn stamps a fresh module MVID and a
+            // wall-clock PE timestamp on every emit, so two compiles of identical sources produced
+            // assemblies differing in 16 bytes. The emitted *JavaScript* was already reproducible; this
+            // extends that to the DLL — which makes it diffable as a correctness gate, and means an
+            // incremental build that reuses a cached assembly is indistinguishable from one that
+            // re-emitted it. (Mono.Cecil preserves both stamps through the resource embed, so the
+            // shipped DLL is byte-identical across builds; measured.)
+            deterministic: true);
         
         // The base runtime library (Transpose.BCL) *defines* the BCL (System.Object, …), so it is
         // compiled self-contained with no base reference — like compiling corlib. Every other

--- a/Transpose/Transpose.Translator/Compilation/IncrementalPlan.cs
+++ b/Transpose/Transpose.Translator/Compilation/IncrementalPlan.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// What a build is allowed to reuse from the previous one, and what it produced for the next.
+///
+/// The translator itself owns no cache and does no file I/O: the CLI (<c>Transpose.Compiler</c>'s
+/// <c>BuildCache</c>) decides what is still valid, hands the reusable pieces over in a plan, and
+/// persists whatever the build reports back here. That keeps the reuse *policy* — which is where the
+/// soundness argument lives — in one place, and leaves the translator with a mechanical rule:
+///
+///   * a type whose declaring files are all unchanged reuses its cached JavaScript verbatim,
+///   * a tree that is unchanged is neither rescanned nor re-diagnosed,
+///   * the reflection-metadata block and the .NET assembly are reused when the caller says so.
+///
+/// The plan is only ever populated when the *declaration surface* of every file is unchanged — i.e.
+/// the edit touched method/accessor bodies only. That is what makes the rule above sound:
+///
+///   * emitted JavaScript for a type is a function of that type's own syntax plus the *declarations*
+///     it binds against (member names and overload numbering, <c>[Template]</c>/<c>[Name]</c>
+///     attributes, constants, base types). None of that can move when only bodies changed elsewhere,
+///     and <see cref="NameMangler"/> derives every name from the symbol alone — there is no global
+///     counter whose value depends on how many types were emitted.
+///   * a body can only produce diagnostics in its own file, so an unchanged file's diagnostics
+///     (Roslyn's and the unsupported-feature scan's) are unchanged too.
+///   * the reflection metadata and a metadata-only assembly describe declarations only.
+/// </summary>
+public sealed class IncrementalPlan
+{
+    /// <summary>Absolute paths of the source files whose text changed since the cached build. Only
+    /// these are rescanned, re-diagnosed, and have their types re-emitted.</summary>
+    public required IReadOnlyCollection<string> ChangedSources { get; init; }
+
+    /// <summary>Cached JavaScript per type, keyed by <see cref="TypeKey"/>.</summary>
+    public required IReadOnlyDictionary<string, string> TypeJs { get; init; }
+
+    /// <summary>The previous build's declaration-surface hashes. An unchanged file's hash is by
+    /// definition still its hash, so only the changed files are re-hashed and the rest are carried
+    /// forward — otherwise the cache would re-walk every file on every build to produce data it
+    /// already has.</summary>
+    public IReadOnlyDictionary<string, string>? PreviousDeclarationHashes { get; init; }
+
+    /// <summary>The cached standalone reflection-metadata script (<c>reflection.target = file</c>),
+    /// or null when the caller wants it rebuilt.</summary>
+    public string? MetadataScript { get; init; }
+
+    /// <summary>The cached inline reflection-metadata block (<c>reflection.target = inline</c>), or
+    /// null when the caller wants it rebuilt.</summary>
+    public string? InlineMetadata { get; init; }
+
+    /// <summary>
+    /// The unsupported-feature scanner's pre-computed filter — the simple names of every type in a
+    /// denied namespace, across the BCL, every referenced package and the project's own types (see
+    /// <c>UnsupportedFeatureScanner.CollectDeniedSimpleNames</c>). Building it means walking the merged
+    /// global namespace of every reference, which on a real project costs more than scanning the files
+    /// themselves, and it is a function of the references plus the declaration surface — both fixed on
+    /// a body-only edit. Null when the caller wants it rebuilt.
+    /// </summary>
+    public IReadOnlyCollection<string>? DeniedSimpleNames { get; init; }
+
+    /// <summary>The cached .NET assembly to reuse instead of running <c>Compilation.Emit</c>. Only
+    /// ever supplied for a metadata-only assembly, whose content is a function of the declarations
+    /// alone (see <c>ResolvedProject.MetadataOnlyAssembly</c>).</summary>
+    public byte[]? AssemblyBytes { get; init; }
+
+    // ---- what this build produced, for the caller to persist -------------------------------------
+
+    /// <summary>Every type's JavaScript as it went into the bundle — reused and re-emitted alike — so
+    /// the caller can write the complete cache back without holding the previous one.</summary>
+    public ConcurrentDictionary<string, string> FinalTypeJs { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>The type keys in bundle order.</summary>
+    public List<string> FinalOrder { get; } = new();
+
+    /// <summary>The inline metadata block this build used, cached or freshly built.</summary>
+    public string? FinalInlineMetadata { get; set; }
+
+    /// <summary>The scanner's denied-name filter this build used, cached or freshly built.</summary>
+    public IReadOnlyCollection<string>? FinalDeniedSimpleNames { get; set; }
+
+    private int _reused;
+    private int _reemitted;
+
+    /// <summary>How many types took their JavaScript from the cache.</summary>
+    public int ReusedTypes => _reused;
+
+    /// <summary>How many types were re-emitted.</summary>
+    public int ReemittedTypes => _reemitted;
+
+    private HashSet<string>? _changedSet;
+
+    private HashSet<string> ChangedSet => _changedSet ??=
+        new HashSet<string>(ChangedSources, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Whether a syntax tree has to be rescanned/re-diagnosed this build.</summary>
+    public bool IsChanged(SyntaxTree tree) => ChangedSet.Contains(tree.FilePath);
+
+    /// <summary>
+    /// The cached JavaScript for a type, or null when it must be re-emitted: either one of the files
+    /// declaring it changed (a <c>partial</c> type is declared in several, and every one of them
+    /// counts), or the cache has never seen it.
+    /// </summary>
+    public string? TryReuse(INamedTypeSymbol type)
+    {
+        foreach (var reference in type.OriginalDefinition.DeclaringSyntaxReferences)
+            if (ChangedSet.Contains(reference.SyntaxTree.FilePath))
+                return null;
+        return TypeJs.TryGetValue(TypeKey(type), out var js) ? js : null;
+    }
+
+    internal void RecordReused() => System.Threading.Interlocked.Increment(ref _reused);
+    internal void RecordReemitted() => System.Threading.Interlocked.Increment(ref _reemitted);
+
+    /// <summary>
+    /// A stable identity for a type across compiler processes. The fully-qualified display form
+    /// distinguishes namespaces, containing types and generic arity (<c>Foo.Bar&lt;T&gt;</c> versus
+    /// <c>Foo.Bar&lt;T, U&gt;</c>), which is exactly what the emitted JavaScript keys off.
+    /// </summary>
+    public static string TypeKey(INamedTypeSymbol type)
+        => type.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+    /// <summary>
+    /// A hash per source file of everything in it *except* method/accessor bodies — the file's
+    /// declaration surface. Two builds whose files all hash the same declared exactly the same types,
+    /// members, signatures, attributes, constants and initializers, so every conclusion in the class
+    /// comment above holds; any difference at all forces a full rebuild.
+    ///
+    /// This is deliberately a hash of *text* rather than of a normalised syntax model: it over-reports
+    /// (reformatting a declaration counts as a change) and never under-reports, which is the right
+    /// direction for a cache. Roslyn's own equivalent, <c>SyntaxNode.IsEquivalentTo(other,
+    /// topLevel: true)</c>, needs both trees in memory — a cache only has a hash of the old one.
+    /// </summary>
+    public static Dictionary<string, string> DeclarationHashes(IEnumerable<SyntaxTree> trees, IncrementalPlan? plan = null)
+    {
+        var known = plan?.PreviousDeclarationHashes;
+        var result = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        Parallel.ForEach(trees, tree =>
+        {
+            if (known is not null && !plan!.IsChanged(tree) && known.TryGetValue(tree.FilePath, out var cached))
+                result[tree.FilePath] = cached;
+            else
+                result[tree.FilePath] = DeclarationHash(tree);
+        });
+        return new Dictionary<string, string>(result, StringComparer.Ordinal);
+    }
+
+    /// <summary>The declaration-surface hash of one tree — see <see cref="DeclarationHashes"/>.</summary>
+    public static string DeclarationHash(SyntaxTree tree)
+    {
+        var root = tree.GetRoot();
+        var text = tree.GetText();
+
+        // The spans to leave out: every executable body. A body cannot introduce, remove or rename a
+        // member, so a change confined to one is invisible to any other file.
+        var bodies = new List<TextSpan>();
+        foreach (var node in root.DescendantNodes())
+        {
+            switch (node)
+            {
+                // Methods, constructors, operators, destructors.
+                case BaseMethodDeclarationSyntax m:
+                    Add(m.Body); Add(m.ExpressionBody);
+                    break;
+                // get/set/init/add/remove.
+                case AccessorDeclarationSyntax a:
+                    Add(a.Body); Add(a.ExpressionBody);
+                    break;
+                // `int P => expr;` — the expression *is* the getter body.
+                case PropertyDeclarationSyntax p:
+                    Add(p.ExpressionBody);
+                    break;
+                case IndexerDeclarationSyntax ix:
+                    Add(ix.ExpressionBody);
+                    break;
+            }
+        }
+        // Field initializers, default parameter values, attribute arguments and base-list arguments are
+        // *not* excluded: a constant folds into other files' output, an initializer runs as part of the
+        // type's construction, and an attribute argument steers emission ([Template], [Name]).
+
+        bodies.Sort(static (x, y) => x.Start.CompareTo(y.Start));
+
+        using var sha = System.Security.Cryptography.IncrementalHash.CreateHash(
+            System.Security.Cryptography.HashAlgorithmName.SHA256);
+        var full = text.ToString();
+        var at = 0;
+        foreach (var span in bodies)
+        {
+            // Nested bodies (a local function inside a method) are already inside an earlier span.
+            if (span.Start < at) continue;
+            AppendUtf8(sha, full.AsSpan(at, span.Start - at));
+            AppendUtf8(sha, " body ".AsSpan()); // a marker, so removing a body is not the same as emptying it
+            at = span.End;
+        }
+        AppendUtf8(sha, full.AsSpan(at));
+        return Convert.ToHexString(sha.GetHashAndReset());
+
+        void Add(SyntaxNode? node) { if (node is not null) bodies.Add(node.Span); }
+    }
+
+    private static void AppendUtf8(System.Security.Cryptography.IncrementalHash sha, ReadOnlySpan<char> chars)
+    {
+        if (chars.Length == 0) return;
+        var bytes = new byte[System.Text.Encoding.UTF8.GetMaxByteCount(chars.Length)];
+        var written = System.Text.Encoding.UTF8.GetBytes(chars, bytes);
+        sha.AppendData(bytes, 0, written);
+    }
+}

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -83,7 +83,8 @@ public sealed class RoslynTranslator
         bool emitAssembly = true,
         string? assemblyVersion = null,
         bool emitDebugInformation = true,
-        bool metadataOnlyAssembly = false)
+        bool metadataOnlyAssembly = false,
+        IncrementalPlan? incremental = null)
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -91,6 +92,19 @@ public sealed class RoslynTranslator
                 sources, assemblyName, languageVersion,
                 extraReferencePaths: extraReferencePaths,
                 preprocessorSymbols: preprocessorSymbols));
+
+        // The declaration-surface hash of every file, for the *next* build's cache. Computed from the
+        // trees this build already parsed, so it costs one extra walk rather than a second parse.
+        var declarationHashes = incremental is null
+            ? null
+            : PhaseTimings.Measure("hash declaration surface", () => IncrementalPlan.DeclarationHashes(compilation.SyntaxTrees, incremental));
+
+        // An incremental build only rescans and re-diagnoses the files whose text changed: a method
+        // body cannot produce a diagnostic in another file, and the plan is only ever populated when
+        // the declaration surface of every file is unchanged (see IncrementalPlan).
+        var changedTrees = incremental is null
+            ? null
+            : compilation.SyntaxTrees.Where(incremental.IsChanged).ToList();
 
         var diagnostics = new List<Diagnostic>();
 
@@ -109,7 +123,7 @@ public sealed class RoslynTranslator
         // missing symbols), but an unexpected throw must never lose the Roslyn errors.
         CompileProgress.Report("scanning for unsupported features");
         IReadOnlyList<Diagnostic> unsupported;
-        try { unsupported = PhaseTimings.Measure("scan unsupported features", () => UnsupportedFeatureScanner.Scan(compilation, models)); }
+        try { unsupported = PhaseTimings.Measure("scan unsupported features", () => UnsupportedFeatureScanner.Scan(compilation, models, changedTrees, incremental)); }
         catch { unsupported = System.Array.Empty<Diagnostic>(); }
 
         // Binding the whole compilation is the single most expensive thing a build does, and
@@ -123,7 +137,16 @@ public sealed class RoslynTranslator
         byte[]? assemblyBytes = null;
         List<Diagnostic> roslynErrors;
 
-        if (emitAssembly)
+        // A metadata-only assembly is a function of the declarations alone (it has no method bodies at
+        // all — see ResolvedProject.MetadataOnlyAssembly), so an incremental build over a body-only
+        // edit reuses the previous one byte for byte and skips the single most expensive Roslyn call a
+        // build makes. The caller only ever supplies these bytes for a metadata-only emit.
+        if (emitAssembly && incremental?.AssemblyBytes is { } reusedAssembly)
+        {
+            assemblyBytes = reusedAssembly;
+            roslynErrors = new List<Diagnostic>();
+        }
+        else if (emitAssembly)
         {
             var asmCompilation = compilation.WithOptions(
                 compilation.Options.WithOutputKind(OutputKind.DynamicallyLinkedLibrary));
@@ -185,7 +208,7 @@ public sealed class RoslynTranslator
         TranslationException? emitterFailure = null;
         try
         {
-            var emitter = new Emitter(compilation, assemblyName, models)
+            var emitter = new Emitter(compilation, assemblyName, models, incremental)
             {
                 ReflectionEnabled = reflectionEnabled,
                 MetadataTarget = metadataTarget,
@@ -211,7 +234,10 @@ public sealed class RoslynTranslator
             var bodyErrors = PhaseTimings.Measure("body diagnostics (semantic models)", () =>
             {
                 var found = new System.Collections.Concurrent.ConcurrentBag<Diagnostic>();
-                Parallel.ForEach(compilation.SyntaxTrees, tree =>
+                // On an incremental build only the changed files' bodies can have new diagnostics: an
+                // unchanged body binds against an unchanged declaration surface, so its verdict from
+                // the cached build still stands (and that build succeeded, or nothing was cached).
+                Parallel.ForEach(changedTrees ?? (IEnumerable<SyntaxTree>)compilation.SyntaxTrees, tree =>
                 {
                     foreach (var d in models.SemanticModelFor(tree).GetDiagnostics())
                         if (d.Severity == DiagnosticSeverity.Error && !BenignForJs.Contains(d.Id))
@@ -234,7 +260,10 @@ public sealed class RoslynTranslator
             return new AssemblyBuildResult(null, null, null, diagnostics);
         }
 
-        return new AssemblyBuildResult(js, metadataJs, assemblyBytes, diagnostics);
+        return new AssemblyBuildResult(js, metadataJs, assemblyBytes, diagnostics)
+        {
+            DeclarationHashes = declarationHashes,
+        };
     }
 
     /// <summary>

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -60,14 +60,19 @@ public sealed partial class Emitter
     /// script (a full Transpose.assembly wrapper) produced by the last <see cref="Emit"/>; else null.</summary>
     public string? MetadataScript { get; private set; }
 
+    /// <summary>What this build may reuse from the previous one (null = emit everything). Only the
+    /// top-level emitter consults it; the per-type clones never see it.</summary>
+    private IncrementalPlan? _plan;
+
     /// <param name="models">A semantic-model cache to reuse. Passing the one the
     /// unsupported-feature scan already populated means every member that scan bound is bound
     /// once for the whole build instead of twice.</param>
-    internal Emitter(CSharpCompilation compilation, string assemblyName, TreeModel? models)
+    internal Emitter(CSharpCompilation compilation, string assemblyName, TreeModel? models, IncrementalPlan? plan = null)
     {
         _compilation = compilation;
         _assemblyName = assemblyName;
         _model = models ?? new TreeModel(compilation);
+        _plan = plan;
     }
 
     public Emitter(CSharpCompilation compilation, string assemblyName = CompilationBuilder.DefaultAssemblyName)
@@ -113,7 +118,7 @@ public sealed partial class Emitter
             long done = 0;
 
 #pragma warning disable RS1024 // Symbols should be compared for equality - we don't the symbol comparer here as we want the actual object to define the order, not the "kind" of symbol
-            var results = new ConcurrentDictionary<INamedTypeSymbol, JsWriter>();
+            var results = new ConcurrentDictionary<INamedTypeSymbol, string>();
 #pragma warning restore RS1024 // Symbols should be compared for equality
 
             // Parallel.ForEach aggregates any thrown exception into an AggregateException. The
@@ -126,7 +131,19 @@ public sealed partial class Emitter
                 PhaseTimings.Measure("  ├ emit type bodies (parallel)", () =>
                     Parallel.ForEach(types, type =>
                     {
-                        results[type] = EmitOnlyType(this, type);
+                        // An incremental build splices in the previous build's JavaScript for every
+                        // type none of whose declaring files changed. The text is reused verbatim, so
+                        // the bundle is byte-identical to the one a full build would have produced.
+                        if (_plan?.TryReuse(type) is { } cached)
+                        {
+                            results[type] = cached;
+                            _plan.RecordReused();
+                        }
+                        else
+                        {
+                            results[type] = EmitOnlyType(this, type).ToString();
+                            _plan?.RecordReemitted();
+                        }
                         var count = Interlocked.Increment(ref done);
                         CompileProgress.ReportStep("emitting JavaScript", count, types.Count);
                     }));
@@ -140,8 +157,15 @@ public sealed partial class Emitter
             {
                 foreach (var type in types)
                 {
-                    _w.Write(results[type]);
+                    var js = results[type];
+                    _w.WriteRaw(js);
                     _w.WriteLine();
+                    if (_plan is not null)
+                    {
+                        var key = IncrementalPlan.TypeKey(type);
+                        _plan.FinalTypeJs[key] = js;
+                        _plan.FinalOrder.Add(key);
+                    }
                 }
             });
 
@@ -157,11 +181,30 @@ public sealed partial class Emitter
             //    CompileProgress.ReportStep("emitting JavaScript", ++done, types.Count);
             //}
 
-            if (inlineMeta) PhaseTimings.Measure("  ├ reflection metadata (inline)", () => EmitReflectionMetadata(types));
+            // The reflection metadata describes declarations only — types, members, signatures and
+            // attributes — so an incremental build over a body-only edit reuses it wholesale. That is
+            // worth having: on a large project building the metadata block is ~12% of a build.
+            if (inlineMeta)
+            {
+                if (_plan?.InlineMetadata is { } cachedInline)
+                {
+                    _w.WriteRaw(cachedInline);
+                    if (_plan is not null) _plan.FinalInlineMetadata = cachedInline;
+                }
+                else
+                {
+                    var block = PhaseTimings.Measure("  ├ reflection metadata (inline)",
+                        () => CaptureAtCurrentIndent(() => EmitReflectionMetadata(types)));
+                    _w.WriteRaw(block);
+                    if (_plan is not null) _plan.FinalInlineMetadata = block;
+                }
+            }
         });
         _w.WriteLine(");");
 
-        MetadataScript = fileMeta ? PhaseTimings.Measure("  └ reflection metadata (file)", () => BuildMetadataFile(types)) : null;
+        MetadataScript = fileMeta
+            ? _plan?.MetadataScript ?? PhaseTimings.Measure("  └ reflection metadata (file)", () => BuildMetadataFile(types))
+            : null;
         return _w.ToString();
     }
 
@@ -230,6 +273,27 @@ public sealed partial class Emitter
         parts.AddRange(containing);
         parts.Add(type.Name);
         return string.Join("/", parts) + ".js";
+    }
+
+    /// <summary>
+    /// Runs <paramref name="emit"/> against a temporary writer that starts at the *current*
+    /// indentation depth, and returns its text. Splicing the result back with
+    /// <see cref="JsWriter.WriteRaw"/> then reproduces exactly what emitting in place would have
+    /// written — which is what lets the block be cached and restored verbatim.
+    /// </summary>
+    private string CaptureAtCurrentIndent(Action emit)
+    {
+        var saved = _w;
+        _w = new JsWriter(saved.IndentLevel);
+        try
+        {
+            emit();
+            return _w.ToString();
+        }
+        finally
+        {
+            _w = saved;
+        }
     }
 
     /// <summary>Runs <paramref name="emit"/> against a temporary writer and returns its text.</summary>

--- a/Transpose/Transpose.Translator/Emit/JsWriter.cs
+++ b/Transpose/Transpose.Translator/Emit/JsWriter.cs
@@ -41,6 +41,27 @@ public sealed class JsWriter
         return this;
     }
 
+    /// <summary>
+    /// Appends already-formatted JavaScript verbatim — no indentation is inserted and the
+    /// line-start state is left alone, exactly as appending another writer's buffer does. This is how
+    /// a block that was written by a nested writer (a per-type emit, or one restored from the
+    /// incremental cache) is spliced in without disturbing its own indentation.
+    /// </summary>
+    internal JsWriter WriteRaw(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return this;
+        _sb.Append(text);
+        return this;
+    }
+
+    /// <summary>The current indentation depth, so a capture buffer can start at the same level and
+    /// produce text that splices back in unchanged.</summary>
+    internal int IndentLevel => _indent;
+
+    public JsWriter() { }
+
+    internal JsWriter(int indent) => _indent = indent;
+
 
     public JsWriter Write(string text)
     {

--- a/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
+++ b/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
@@ -64,6 +64,13 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
         models ??= new TreeModel(compilation);
 
         var allDiagnostics = new List<List<Diagnostic>>();
+        // Measured separately from the enclosing phase, because the two are wildly different things and
+        // the difference is the most useful number in an incremental build's timing table: this walk is
+        // proportional to the files actually being scanned (a few ms for one file), while whatever is
+        // left over in the parent phase is Roslyn building the compilation's symbol tables and importing
+        // the reference metadata — a fixed per-process cost that lands on whichever phase binds first,
+        // and the floor no on-disk cache can get under. See TODO.incremental.md.
+        PhaseTimings.Measure("  ├ walk files", () =>
         Parallel.ForEach(trees ?? compilation.SyntaxTrees, tree =>
         {
             var diagnostics = new List<Diagnostic>();
@@ -79,7 +86,7 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
                     allDiagnostics.Add(diagnostics);
                 }
             }
-        });
+        }));
         return allDiagnostics.SelectMany(d => d).ToArray();
     }
 

--- a/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
+++ b/Transpose/Transpose.Translator/Support/UnsupportedFeatureScanner.cs
@@ -48,13 +48,23 @@ internal sealed class UnsupportedFeatureScanner : CSharpSyntaxWalker
     /// resolve, say, the inferred type of a <c>var</c>) is already bound when the emitter reaches it.
     /// Pass null to scan against throw-away models — only useful when there is no emit to follow.
     /// </summary>
-    public static IReadOnlyList<Diagnostic> Scan(CSharpCompilation compilation, TreeModel? models = null)
+    /// <param name="trees">The trees to scan; null scans the whole compilation. An incremental build
+    /// passes only the files whose text changed — an unsupported construct is a property of the file it
+    /// appears in, so an unchanged file's verdict from the cached build still holds.</param>
+    /// <param name="incremental">The build's incremental plan, if any: supplies the cached
+    /// denied-name filter (whose inputs — the references and the declaration surface — are fixed on a
+    /// body-only edit) and receives the one this build used, for the next build to reuse.</param>
+    public static IReadOnlyList<Diagnostic> Scan(CSharpCompilation compilation, TreeModel? models = null,
+        IEnumerable<SyntaxTree>? trees = null, IncrementalPlan? incremental = null)
     {
-        var deniedSimpleNames = CollectDeniedSimpleNames(compilation);
+        var deniedSimpleNames = incremental?.DeniedSimpleNames is { } cachedNames
+            ? new HashSet<string>(cachedNames, StringComparer.Ordinal)
+            : PhaseTimings.Measure("  ├ collect denied type names", () => CollectDeniedSimpleNames(compilation));
+        if (incremental is not null) incremental.FinalDeniedSimpleNames = deniedSimpleNames;
         models ??= new TreeModel(compilation);
 
         var allDiagnostics = new List<List<Diagnostic>>();
-        Parallel.ForEach(compilation.SyntaxTrees, tree =>
+        Parallel.ForEach(trees ?? compilation.SyntaxTrees, tree =>
         {
             var diagnostics = new List<Diagnostic>();
 


### PR DESCRIPTION
`tps` recompiles a project from scratch on every invocation. About half of a
clean tesserae build is work the previous build already did, and when nothing
changed at all it is 100%. This adds an on-disk build cache behind
`--incremental` (off by default) with three verdicts:

  * nothing changed and the outputs are intact -> compile nothing (20x)
  * only method/accessor bodies changed -> keep the cached JavaScript of every
    untouched type, the reflection metadata, the scanner's denied-name filter
    and, in a metadata-only configuration, the .NET assembly (~2x)
  * anything else -> full build, fresh cache (~1% slower than today)

Emitted output is byte-identical either way, verified over seven edit shapes
with the new scripts/verify-incremental.sh gate.

The reuse policy and the soundness argument live in BuildCache; the translator
holds no cache and does no file I/O, it just consults an IncrementalPlan.
IncrementalPlan.DeclarationHash establishes the body-only precondition by
hashing each file's text with the executable bodies cut out — it over-reports
(reformatting a declaration forces a rebuild) and never under-reports.

A referenced package contributes two separable things: metadata, which a
consumer binds against, and embedded JavaScript, which it copies through. So
the cache carries two keys, and a package build writes a `.tpsmeta` sidecar
holding the hash of the assembly Roslyn emitted. Without that split, a
body-only edit in a library would force a full rebuild of everything
referencing it, because Mono.Cecil restamps the DLL's MVID on every embed.

TODO.incremental.md has the design, the measurements, and what is left —
notably that the residual cost of an incremental build is almost entirely
Roslyn re-importing Transpose.dll's metadata in a fresh process, which is the
size of the prize a compilation server would collect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016gysZqZ7Wi6ZTkqUDZuN4Q