### PR TITLE
Bump Transpose.BCL package reference to 26.7.3055

### DIFF
--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3027" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3027" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
     <PackageReference Include="Transpose.Core" Version="26.7.2950" />
   </ItemGroup>
 

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3027" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
     <PackageReference Include="Transpose.Core" Version="26.7.2950" />
   </ItemGroup>
 

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3027" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3027" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
     <PackageReference Include="Transpose.Core" Version="26.7.2950" />
   </ItemGroup>
 

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3027" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
     <PackageReference Include="Transpose.Core" Version="26.7.2950" />
   </ItemGroup>
 

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
+        <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
         <PackageReference Include="Transpose.Core" Version="26.7.2920" />
         <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2921" />
         <PackageReference Include="Tesserae" Version="2026.7.68468" />


### PR DESCRIPTION
## Summary
- Bump the pinned `Transpose.BCL` `PackageReference` version to `26.7.3055` (the latest version published on NuGet) across every csproj that references it: `Transpose.Core`, all `Packages/*` binding libraries (`Transpose.Howler`, `Transpose.HttpClient`, `Transpose.Newtonsoft.Json`, `Transpose.P2`, `Transpose.WebGL2`), and the `dotnet new` template project.
- `README.md`/`MIGRATION.md` already use a floating `Version="*"` for `Transpose.BCL` in their sample snippets, so no change was needed there.

## Test plan
- No tests run per request (version-bump only, no code changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtEaHxDqd3byHHVYzjjRYF)_