### PR TITLE
Add tps --watch: rebuild on change and serve via Kestrel with live reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,11 @@ property is not guessed at: such an import or item is skipped, which is why SDK-
 `--incremental` / `--no-incremental` / `--cache-dir <dir>` (reuse the previous build; off by default),
 `--timing` (per-phase time + allocations), `--timing-json <file>`,
 `--metadata-only-assembly` / `--no-metadata-only-assembly`,
-`--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line).
+`--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line),
+`--watch` / `--watch-port <n>` (rebuild a site on every source change — root project and every
+referenced project — and serve it over Kestrel on localhost; the served index.html carries an
+injected script that reconnects over a websocket and reloads the page after each rebuild; see
+`Transpose.Compiler/WatchMode.cs`).
 
 ### Diagnostics are in MSBuild's canonical format
 
@@ -328,6 +332,19 @@ The short version:
   a consumer actually binds against. Output is byte-identical either way, gated in CI over eight edit
   shapes. The `tps` CLI still defaults to off; the SDK opts in. Remaining: re-emitting only the
   *dependent* types when a declaration changes. See **`TODO.incremental.md`**.
+- **Watch mode (done).** `tps --watch` (`Transpose.Compiler/WatchMode.cs`) rebuilds a site whenever a
+  source file changes — the root project's own sources and every project it transitively references
+  (via `ProjectResolver.ReferencedProjectsInBuildOrder`), debounced so one save triggers one rebuild —
+  and serves the assembled site over a Kestrel dev server (`--watch-port`, default 4300) started with
+  `Microsoft.AspNetCore.App` as a `FrameworkReference` (no `Sdk.Web` switch needed). `OutputBuilder`
+  gets an optional `liveReloadScript` inlined before `</body>`; it opens a websocket to
+  `/__tps-livereload` and reloads on any message, and a monotonic build version embedded in the script
+  lets a reconnecting client (e.g. one whose reload navigation overlapped a second rebuild) catch up
+  immediately instead of waiting on a broadcast it could otherwise miss. `Program.RunOnce` is the
+  extracted single-build path both a plain invocation and every watch rebuild call. Covered end to end
+  by `WatchModeTests` (a real `tps --watch` subprocess + headless Chromium via Playwright, editing both
+  the root and a referenced project and asserting the page reloads itself — never calling
+  `page.ReloadAsync()`).
 
 A compilation server is still intentionally **out of scope** — though the measurements in
 `TODO.incremental.md` say what it would be worth (the residual cost of an incremental build is almost

--- a/Transpose/Transpose.Compiler/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler/MsBuildDiagnostic.cs
@@ -54,10 +54,12 @@ internal static class MsBuildDiagnostic
     public const string CodeInternalError          = "TPS0004";
     public const string CodeDependencyBuildFailed  = "TPS0005";
     public const string CodeAssemblyEmitFailed     = "TPS0006";
+    public const string CodeWatchRequiresSiteBuild = "TPS0007";
     public const string CodeReferenceNotFound      = "TPS0100";
     public const string CodeMissingRuntimeBundle   = "TPS0101";
     public const string CodeTimingJsonNotWritten   = "TPS0102";
     public const string CodeCacheNotWritten        = "TPS0103";
+    public const string CodeWatchServerFailed      = "TPS0104";
 
     /// <summary>Formats a Roslyn diagnostic, pointing at its source location when it has one.</summary>
     public static string Format(Diagnostic d)

--- a/Transpose/Transpose.Compiler/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler/OutputBuilder.cs
@@ -59,7 +59,7 @@ internal static class OutputBuilder
     /// stale.</summary>
     public readonly record struct SiteBuildResult(string OutputDir, IReadOnlyList<string> RemovedStaleFiles);
 
-    public static SiteBuildResult Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, string configuration, string? metadataJavascript = null)
+    public static SiteBuildResult Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, string configuration, string? metadataJavascript = null, string? liveReloadScript = null)
     {
         Directory.CreateDirectory(outputDir);
 
@@ -205,7 +205,7 @@ internal static class OutputBuilder
 
         // 4. index.html (and index.min.html when both variants exist).
         if (!config.HtmlDisabled)
-            WriteHtml(project, config, outputDir, jsOuts, cssLinks, configuration, utf8, written);
+            WriteHtml(project, config, outputDir, jsOuts, cssLinks, configuration, utf8, written, liveReloadScript);
 
         // 5. Prune only files THIS project authored in an earlier build and no longer writes — read
         //    from its own manifest — then persist the current file list as the next manifest. Files
@@ -670,7 +670,8 @@ internal static class OutputBuilder
     /// </summary>
     private static void WriteHtml(
         ResolvedProject project, TransposeJson config, string outputDir,
-        List<JsOut> jsOuts, List<string> cssLinks, string configuration, UTF8Encoding utf8, HashSet<string> written)
+        List<JsOut> jsOuts, List<string> cssLinks, string configuration, UTF8Encoding utf8, HashSet<string> written,
+        string? liveReloadScript = null)
     {
         var css = new StringBuilder();
         foreach (var link in cssLinks)
@@ -717,13 +718,21 @@ internal static class OutputBuilder
             if (htmlMinName is not null && htmlName is not null) htmlMinName = null;
         }
 
-        string Render(string scripts) => HtmlTemplate
-            .Replace("{META}", config.HtmlMeta)
-            .Replace("{TITLE}", config.HtmlTitle ?? project.AssemblyName)
-            .Replace("{CSS}", css.ToString().TrimStart())
-            .Replace("{SCRIPT}", scripts.TrimStart())
-            .Replace("{HEAD}", config.HtmlHead)
-            .Replace("{BODY}", config.HtmlBody);
+        // Watch mode (--watch) passes a small inline script that opens a websocket back to the tps
+        // dev server and reloads the page when a rebuild completes. Appended right before </body> so
+        // it runs after everything else on the page, and left out entirely for a normal build (the
+        // parameter is null), so ordinary output is unaffected.
+        string Render(string scripts)
+        {
+            var html = HtmlTemplate
+                .Replace("{META}", config.HtmlMeta)
+                .Replace("{TITLE}", config.HtmlTitle ?? project.AssemblyName)
+                .Replace("{CSS}", css.ToString().TrimStart())
+                .Replace("{SCRIPT}", scripts.TrimStart())
+                .Replace("{HEAD}", config.HtmlHead)
+                .Replace("{BODY}", config.HtmlBody);
+            return liveReloadScript is null ? html : html.Replace("</body>", liveReloadScript + "\n</body>");
+        }
 
         if (htmlName is not null)
         {

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -3,6 +3,13 @@ using Microsoft.CodeAnalysis;
 
 namespace Transpose.Compiler;
 
+/// <summary>The outcome of one build pass (<see cref="Program.RunOnce"/>): the process exit code, plus
+/// — only for a successful site build — the directory it was written to and whether index.html
+/// generation is disabled. <see cref="OutDir"/> is null for every other outcome (a failure, or a
+/// package/bundle/runtime build with nothing to serve), which is what <see cref="WatchMode"/> uses to
+/// tell "this build resolves to a servable site" from "there is nothing here to watch".</summary>
+internal readonly record struct BuildRunResult(int ExitCode, string? OutDir, bool HtmlDisabled);
+
 /// <summary>
 /// A small command-line front-end for the Roslyn-only C# → JavaScript translator, in the
 /// spirit of the existing <c>tps</c> compiler: point it at a project and it resolves the
@@ -42,6 +49,8 @@ public static class Program
         // than a failed one. TRANSPOSE_INCREMENTAL=1 turns it on for a whole session.
         var incremental = Environment.GetEnvironmentVariable("TRANSPOSE_INCREMENTAL") is "1" or "true";
         string? cacheDir = null;
+        var watch = false;
+        var watchPort = 4300;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -63,6 +72,8 @@ public static class Program
                 case "--incremental": incremental = true; break;
                 case "--no-incremental": incremental = false; break;
                 case "--cache-dir": cacheDir = args[++i]; incremental = true; break;
+                case "--watch": watch = true; break;
+                case "--watch-port": watchPort = int.Parse(args[++i]); break;
                 case "--metadata-only-assembly": metadataOnlyAssembly = true; break;
                 case "--no-metadata-only-assembly": metadataOnlyAssembly = false; break;
                 case "--assembly-version": assemblyVersion = args[++i]; break;
@@ -116,6 +127,44 @@ public static class Program
             separateAssemblies = true;
         }
 
+        // --watch rebuilds this same project over and over as its sources change, serving the result
+        // from a directory it can keep pointing a browser at — only a site build (a tps.json project,
+        // no --emit-package/--build-runtime/--out) produces that. Reject the combination up front
+        // rather than starting a server for a build that will never populate an outDir.
+        if (watch && (emitPackage || buildRuntime || outPath is not null))
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeWatchRequiresSiteBuild,
+                "--watch requires a site build: the project must have a tps.json and not use --emit-package, --build-runtime, or --out.");
+            return 1;
+        }
+
+        if (watch)
+        {
+            return WatchMode.Run(csproj, watchPort, liveReloadScript => RunOnce(
+                csproj, outPath, siteDir, configuration, withRuntime, quiet, maxErrors, emitPackage,
+                separateAssemblies, buildRuntime, extraReferences, extraDefines, assemblyVersion,
+                metadataOnlyAssembly, incremental, cacheDir, liveReloadScript));
+        }
+
+        return RunOnce(csproj, outPath, siteDir, configuration, withRuntime, quiet, maxErrors, emitPackage,
+            separateAssemblies, buildRuntime, extraReferences, extraDefines, assemblyVersion,
+            metadataOnlyAssembly, incremental, cacheDir, liveReloadScript: null).ExitCode;
+    }
+
+    /// <summary>
+    /// Runs one build of <paramref name="csproj"/> end to end — resolve, translate, write outputs —
+    /// exactly what a plain <c>tps</c> invocation always did. Watch mode calls this repeatedly (once
+    /// per detected change) with a fresh <see cref="BuildRunResult"/> each time; a normal invocation
+    /// calls it once. <paramref name="liveReloadScript"/>, when not null, is inlined into the generated
+    /// index.html right before <c>&lt;/body&gt;</c> so the served page reconnects to the watch server
+    /// and reloads after each rebuild — a normal build always passes null, so its output is unaffected.
+    /// </summary>
+    private static BuildRunResult RunOnce(
+        string csproj, string? outPath, string? siteDir, string configuration, bool withRuntime, bool quiet,
+        int maxErrors, bool emitPackage, bool separateAssemblies, bool buildRuntime, List<string> extraReferences,
+        List<string> extraDefines, string? assemblyVersion, bool? metadataOnlyAssembly, bool incremental,
+        string? cacheDir, string? liveReloadScript)
+    {
         Console.WriteLine($"tps: compiling {Path.GetFileName(csproj)}");
         // Surface the translator's phase/step progress (binding, scanning, JS emit) so the long
         // silent phases show visible movement. Quiet mode suppresses it.
@@ -132,7 +181,7 @@ public static class Program
         {
             MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
                 $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
-            return 1;
+            return new BuildRunResult(1, null, false);
         }
 
         // Extra references (--reference) and defines (--define) from the command line. --reference
@@ -181,7 +230,7 @@ public static class Program
             string.Equals(Path.GetFileNameWithoutExtension(p), "Transpose", StringComparison.OrdinalIgnoreCase));
         if (buildRuntime
             || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && !referencesTransposeBcl))
-            return BuildRuntime(project, configuration, sw, outPath, maxErrors);
+            return new BuildRunResult(BuildRuntime(project, configuration, sw, outPath, maxErrors), null, false);
 
         // Reflection settings come from the project's tps.json (target inline vs a .meta.js file).
         var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
@@ -193,7 +242,7 @@ public static class Program
         if (separateAssemblies && !EnsureReferencedProjectsBuilt(csproj, configuration, maxErrors, metadataOnlyAssembly, incremental, cacheDir))
         {
             Console.Error.WriteLine("\nFAILED building referenced projects.");
-            return 1;
+            return new BuildRunResult(1, null, false);
         }
 
         // A site build still emits the .NET assembly: the Transpose.Build.Target SDK declares the
@@ -212,9 +261,12 @@ public static class Program
         {
             cache = BuildCache.Open(project, configuration,
                 OutputMode(emitPackage, isSiteBuild),
+                // "watch={..}" so switching --watch on/off across builds sharing a cache dir invalidates
+                // it — the injected live-reload script changes the written index.html even when nothing
+                // else about the build did, and an "up to date" verdict skips writing it altogether.
                 BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
                     metadataOnly, emitPackage, isSiteBuild, separateAssemblies, withRuntime, outPath, siteDir,
-                    assemblyVersion),
+                    assemblyVersion).Append($"watch={liveReloadScript is not null}"),
                 BuildContentFingerprint(project),
                 cacheDir);
             (verdict, changedSources, var reason) = cache.Decide();
@@ -226,7 +278,7 @@ public static class Program
                 if (cache.PreviousOutputs.Count > 4)
                     Console.WriteLine($"            … and {cache.PreviousOutputs.Count - 4} more");
                 PrintTimings(sw.ElapsedMilliseconds);
-                return 0;
+                return new BuildRunResult(0, null, false);
             }
             Console.WriteLine(verdict == BuildCache.Verdict.BodyOnlyChange
                 ? $"  cache:      {changedSources.Count} file(s) changed, method bodies only — reusing cached declarations"
@@ -264,7 +316,7 @@ public static class Program
         catch (Exception ex)
         {
             ReportCrash("Translator", ex);
-            return 2;
+            return new BuildRunResult(2, null, false);
         }
 
         // The stopwatch keeps running: writing the package (minifying the embedded JS, the Cecil
@@ -274,7 +326,7 @@ public static class Program
         {
             ReportDiagnostics(result.Diagnostics, maxErrors);
             Console.Error.WriteLine($"\nFAILED in {sw.ElapsedMilliseconds} ms.");
-            return 1;
+            return new BuildRunResult(1, null, false);
         }
 
         var js = result.Javascript!;
@@ -286,7 +338,7 @@ public static class Program
         if (emitPackage)
         {
             var written = TryWritePackage(project, config, configuration, result);
-            if (written is null) return 2;
+            if (written is null) return new BuildRunResult(2, null, false);
 
             var (dllPath, items) = written.Value;
             SaveCache(cache, plan, result, new[] { dllPath });
@@ -294,7 +346,7 @@ public static class Program
             Console.WriteLine($"  dll:      {dllPath}");
             Console.WriteLine($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
             PrintTimings(sw.ElapsedMilliseconds);
-            return 0;
+            return new BuildRunResult(0, null, false);
         }
 
         // Site build: when the project has an tps.json and no single-file --out was requested,
@@ -308,13 +360,13 @@ public static class Program
             if (result.AssemblyBytes is not null)
             {
                 var package = TryWritePackage(project, config, configuration, result);
-                if (package is null) return 2;
+                if (package is null) return new BuildRunResult(2, null, false);
                 dllPath = package.Value.dllPath;
             }
 
             var outDir = siteDir ?? ResolveOutputDir(config, project.ProjectDir, configuration);
             var siteResult = PhaseTimings.Measure("write site (minify + resources + html)", () =>
-                OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript));
+                OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript, liveReloadScript));
             // Every file in the site counts as an output: a rebuild must notice if any of them was
             // deleted or edited, otherwise "up to date" would leave a broken site in place.
             SaveCache(cache, plan, result, SiteOutputs(outDir, dllPath));
@@ -329,7 +381,7 @@ public static class Program
                 if (stale.Count > 10) Console.WriteLine($"                … and {stale.Count - 10} more");
             }
             PrintTimings(sw.ElapsedMilliseconds);
-            return 0;
+            return new BuildRunResult(0, outDir, config.HtmlDisabled);
         }
 
         if (withRuntime) js = RoslynTranslator.LoadRuntime() + "\n" + js;
@@ -339,7 +391,7 @@ public static class Program
         SaveCache(cache, plan, result, new[] { Path.GetFullPath(outPath) });
         Console.WriteLine($"\nOK — wrote {js.Length:N0} bytes to {outPath} in {sw.ElapsedMilliseconds} ms.");
         PrintTimings(sw.ElapsedMilliseconds);
-        return 0;
+        return new BuildRunResult(0, null, false);
     }
 
     /// <summary>
@@ -949,6 +1001,13 @@ public static class Program
               --cache-dir <dir>     Put the incremental cache under <dir> instead of the project's
                                     obj/ (implies --incremental). A temp directory is fine — losing
                                     the cache only costs a full build.
+              --watch               Rebuild whenever a source file changes — the root project's and
+                                    every referenced project's — and serve the assembled site over
+                                    HTTP on localhost. The served index.html carries a small injected
+                                    script that reconnects over a websocket and reloads the page after
+                                    each successful rebuild. Requires a site build (a project with
+                                    tps.json; incompatible with --emit-package, --build-runtime, --out).
+              --watch-port <n>      Port for --watch's HTTP server and websocket (default 4300)
               --timing              Print a per-phase timing/allocation breakdown of the build
               --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON
               -q, --quiet           Suppress warning output

--- a/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
+++ b/Transpose/Transpose.Compiler/Transpose.Compiler.csproj
@@ -101,6 +101,13 @@
     <InternalsVisibleTo Include="Transpose.Translator.Tests" />
   </ItemGroup>
 
+  <!-- Kestrel + minimal-hosting APIs for the watch-mode local dev server (WatchMode.cs). A
+       FrameworkReference under the plain Sdk keeps this a normal console app / packable dotnet
+       tool — switching to Microsoft.NET.Sdk.Web would change far more than watch mode needs. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Transpose.Translator\Transpose.Translator.csproj" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />

--- a/Transpose/Transpose.Compiler/WatchMode.cs
+++ b/Transpose/Transpose.Compiler/WatchMode.cs
@@ -1,0 +1,355 @@
+using System.Net.WebSockets;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// <c>--watch</c>: rebuilds a site whenever a source file changes — the root project's own sources
+/// and every project it references, transitively — and serves the assembled output over a local
+/// Kestrel server. The served index.html carries a small inline script (see
+/// <see cref="LiveReloadScript"/>) that opens a websocket back to this server and reloads the page
+/// once a rebuild completes, so the browser tracks the compiled output without a manual refresh.
+///
+/// The server and the file watchers are independent of <see cref="Program.RunOnce"/>: this class
+/// only decides *when* to rebuild and *how to tell the browser*; the actual compile is the same
+/// build a plain <c>tps</c> invocation runs, passed in as <paramref name="build"/> so this file has
+/// no dependency on the translator/output pipeline's internals.
+/// </summary>
+internal static class WatchMode
+{
+    /// <summary>How long to wait after the last file-system event before rebuilding — coalesces the
+    /// burst of Created/Changed/Renamed events a single save produces (editors commonly write a temp
+    /// file and rename it, or write-then-touch), so one save triggers exactly one rebuild.</summary>
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(300);
+
+    public static int Run(string rootCsproj, int port, Func<string?, BuildRunResult> build)
+    {
+        // Every successful build gets a version number, embedded in that build's own index.html.
+        // A client compares its embedded version against the server's current one when it (re)connects
+        // (see ReloadHub.HandleAsync) and catches up immediately if they differ — without this, a
+        // client whose reload navigation is still in flight when a second rebuild lands could miss
+        // that rebuild's broadcast entirely (its socket isn't open yet to receive it) and be stuck
+        // showing stale content until another edit happens to trigger a further broadcast.
+        var version = 0L;
+        var hub = new ReloadHub();
+
+        var initial = build(LiveReloadScript(port, version));
+        if (initial.OutDir is null)
+        {
+            // A failure on the very first build leaves nothing to serve, and RunOnce already printed
+            // why. A non-site project (package/bundle/runtime) is rejected earlier in Main, so
+            // reaching here with a null OutDir on exit code 0 should not happen — guarded anyway.
+            if (initial.ExitCode == 0)
+                MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeWatchRequiresSiteBuild,
+                    "--watch requires a site build, but this build produced nothing to serve.");
+            else
+                Console.Error.WriteLine("\ntps: --watch could not complete an initial build; fix the error above and re-run.");
+            return initial.ExitCode == 0 ? 1 : initial.ExitCode;
+        }
+
+        WebApplication app;
+        try
+        {
+            app = StartServer(initial.OutDir, port, hub);
+        }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeWatchServerFailed,
+                $"Could not start the watch server on port {port}: {ex.Message}");
+            return 1;
+        }
+
+        var watchDirs = WatchDirectories(rootCsproj);
+
+        var rebuilding = false;
+        var rebuildQueued = false;
+        var rebuildGate = new object();
+
+        void Rebuild()
+        {
+            lock (rebuildGate)
+            {
+                if (rebuilding) { rebuildQueued = true; return; }
+                rebuilding = true;
+            }
+            try
+            {
+                Console.WriteLine("\ntps: change detected, rebuilding...");
+                var nextVersion = Interlocked.Increment(ref version);
+                var result = build(LiveReloadScript(port, nextVersion));
+                if (result.ExitCode == 0)
+                {
+                    Console.WriteLine("tps: rebuilt — reloading browser");
+                    hub.SetVersion(nextVersion);
+                    _ = hub.BroadcastReloadAsync();
+                }
+                else
+                {
+                    // The failed build never reached OutputBuilder, so the site on disk still embeds
+                    // the previous (successful) version's script — roll the counter back to match, or
+                    // the next successful build's embedded version would skip ahead of what a client
+                    // still on the old page believes is current.
+                    Interlocked.Decrement(ref version);
+                    Console.Error.WriteLine("tps: rebuild failed — keeping the previous build (see errors above)");
+                }
+            }
+            finally
+            {
+                bool again;
+                lock (rebuildGate) { rebuilding = false; again = rebuildQueued; rebuildQueued = false; }
+                if (again) Rebuild();
+            }
+        }
+
+        using var debouncer = new Debouncer(DebounceDelay, Rebuild);
+        var watchers = watchDirs
+            .Select(dir => CreateWatcher(dir, initial.OutDir, debouncer))
+            .Where(w => w is not null)
+            .Cast<FileSystemWatcher>()
+            .ToList();
+
+        Console.WriteLine($"\ntps: watching {watchDirs.Count} director{(watchDirs.Count == 1 ? "y" : "ies")} for changes");
+        Console.WriteLine($"tps: serving http://localhost:{port}/  (Ctrl+C to stop)");
+
+        var exit = new ManualResetEventSlim();
+        ConsoleCancelEventHandler onCancel = (_, e) => { e.Cancel = true; exit.Set(); };
+        Console.CancelKeyPress += onCancel;
+        try
+        {
+            exit.Wait();
+        }
+        finally
+        {
+            Console.CancelKeyPress -= onCancel;
+            foreach (var w in watchers) w.Dispose();
+            app.StopAsync().GetAwaiter().GetResult();
+        }
+        return 0;
+    }
+
+    /// <summary>Every directory to watch: the root project's, then every project it references
+    /// (transitively), in whatever order <see cref="ProjectResolver.ReferencedProjectsInBuildOrder"/>
+    /// returns them. A change under any of these can change the compiled output — the root project's
+    /// own sources, or a library it depends on — so all of them feed the same rebuild trigger.</summary>
+    private static List<string> WatchDirectories(string rootCsproj)
+    {
+        var dirs = new List<string> { Path.GetDirectoryName(Path.GetFullPath(rootCsproj))! };
+        foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
+        {
+            var dir = Path.GetDirectoryName(dep);
+            if (dir is not null) dirs.Add(dir);
+        }
+        return dirs.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>Watches one project directory for changes to the files a rebuild cares about
+    /// (<c>.cs</c>, <c>.csproj</c>, <c>tps*.json</c>), signalling <paramref name="debouncer"/> for
+    /// each relevant event. Skips <c>bin/</c>/<c>obj/</c> (build output, never a source) and anything
+    /// under <paramref name="outDir"/> itself — without that exclusion the site build's own writes
+    /// would retrigger the watcher that is serving it, rebuilding forever.</summary>
+    private static FileSystemWatcher? CreateWatcher(string dir, string outDir, Debouncer debouncer)
+    {
+        if (!Directory.Exists(dir)) return null;
+        var fullOutDir = Path.GetFullPath(outDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        var watcher = new FileSystemWatcher(dir)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Size,
+        };
+
+        void OnEvent(object sender, FileSystemEventArgs e)
+        {
+            if (!IsRelevant(e.FullPath, dir, fullOutDir)) return;
+            debouncer.Signal();
+        }
+
+        watcher.Changed += OnEvent;
+        watcher.Created += OnEvent;
+        watcher.Deleted += OnEvent;
+        watcher.Renamed += (s, e) => OnEvent(s, e);
+        watcher.Error += (_, e) =>
+            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeWatchServerFailed,
+                $"File watcher for '{dir}' failed: {e.GetException().Message}");
+        watcher.EnableRaisingEvents = true;
+        return watcher;
+    }
+
+    private static bool IsRelevant(string path, string projectDir, string fullOutDir)
+    {
+        var full = Path.GetFullPath(path);
+        // Never watch the site's own output — every rebuild writes there, which would otherwise
+        // retrigger itself. Comparing full paths (not just a prefix string) avoids a false match on a
+        // sibling directory that merely shares the outDir's name as a prefix (e.g. "bin-tools").
+        if (full.Equals(fullOutDir, StringComparison.OrdinalIgnoreCase)
+            || full.StartsWith(fullOutDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var rel = Path.GetRelativePath(projectDir, full).Replace('\\', '/');
+        if (rel.StartsWith("bin/", StringComparison.Ordinal) || rel.Contains("/bin/", StringComparison.Ordinal)
+            || rel.StartsWith("obj/", StringComparison.Ordinal) || rel.Contains("/obj/", StringComparison.Ordinal))
+            return false;
+
+        var name = Path.GetFileName(full);
+        if (name.StartsWith('.') || name.EndsWith('~')) return false; // editor swap/backup files
+
+        return name.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+            || (name.StartsWith("tps", StringComparison.OrdinalIgnoreCase) && name.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Starts Kestrel serving <paramref name="outDir"/> as static content, plus a websocket
+    /// endpoint the live-reload script connects to. Logging is disabled entirely — tps's own
+    /// Console.WriteLine progress lines are the only intended console output, and ASP.NET Core's
+    /// default per-request logging would otherwise clutter it (and risk a stray "warning:"/"error:"
+    /// line that MsBuildDiagnostic's contract requires tps itself to control — see MsBuildDiagnostic).</summary>
+    private static WebApplication StartServer(string outDir, int port, ReloadHub hub)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = Array.Empty<string>() });
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://localhost:{port}");
+
+        var app = builder.Build();
+        app.UseWebSockets();
+
+        app.Map(ReloadHub.Path, async context =>
+        {
+            if (!context.WebSockets.IsWebSocketRequest)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return;
+            }
+            var clientVersion = long.TryParse(context.Request.Query["v"], out var v) ? v : 0L;
+            using var socket = await context.WebSockets.AcceptWebSocketAsync();
+            await hub.HandleAsync(socket, clientVersion, context.RequestAborted);
+        });
+
+        var files = new PhysicalFileProvider(Path.GetFullPath(outDir));
+        app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = files });
+        app.UseStaticFiles(new StaticFileOptions { FileProvider = files });
+
+        app.StartAsync().GetAwaiter().GetResult();
+        return app;
+    }
+
+    /// <summary>The inline script injected into index.html: connects to <see cref="ReloadHub.Path"/>,
+    /// tagged with the version of the build this exact page came from, and reloads on any message.
+    /// Reconnects with a short fixed backoff if the socket drops (e.g. the server is mid-rebuild), so
+    /// a page left open survives more than one reload — and the version tag lets the server detect,
+    /// right at (re)connect time, a client that is already behind (see <see cref="ReloadHub.HandleAsync"/>).</summary>
+    private static string LiveReloadScript(int port, long version) => $$"""
+        <script>
+        (function tpsLiveReload() {
+            var url = "ws://localhost:{{port}}{{ReloadHub.Path}}?v={{version}}";
+            function connect() {
+                var ws = new WebSocket(url);
+                ws.onmessage = function () { location.reload(); };
+                ws.onclose = function () { setTimeout(connect, 1000); };
+                ws.onerror = function () { ws.close(); };
+            }
+            connect();
+        })();
+        </script>
+        """;
+}
+
+/// <summary>Tracks the currently-connected live-reload websockets and broadcasts a reload notification
+/// to all of them after a successful rebuild. Content-free by design — the browser always does a full
+/// page reload, so the message itself carries no payload; a client that fails to send (already gone)
+/// is dropped rather than failing the broadcast for everyone else.</summary>
+internal sealed class ReloadHub
+{
+    public const string Path = "/__tps-livereload";
+
+    private static readonly byte[] ReloadMessage = System.Text.Encoding.UTF8.GetBytes("reload");
+
+    private readonly List<WebSocket> _sockets = new();
+    private readonly object _gate = new();
+    private long _version;
+
+    /// <summary>The version of the most recent successful build. Set once that build's outputs (and
+    /// the index.html embedding that same version) have actually been written to disk.</summary>
+    public void SetVersion(long version) => Interlocked.Exchange(ref _version, version);
+
+    public async Task HandleAsync(WebSocket socket, long clientVersion, CancellationToken cancellationToken)
+    {
+        lock (_gate) _sockets.Add(socket);
+        try
+        {
+            // The page this socket was opened from was generated by build `clientVersion`. If a newer
+            // build has already completed — e.g. two edits landed back to back while this client was
+            // navigating during a previous reload, so it missed that build's broadcast entirely — catch
+            // it up right away instead of leaving it stuck on stale content until the next edit.
+            if (Interlocked.Read(ref _version) > clientVersion && socket.State == WebSocketState.Open)
+                await socket.SendAsync(ReloadMessage, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
+
+            var buffer = new byte[16];
+            // The client never sends anything meaningful; this just blocks until it disconnects
+            // (browser navigation/close), which is what a receive on a closed socket reports.
+            while (socket.State == WebSocketState.Open)
+            {
+                var result = await socket.ReceiveAsync(buffer, cancellationToken);
+                if (result.MessageType == WebSocketMessageType.Close) break;
+            }
+        }
+        catch (OperationCanceledException) { /* server shutting down */ }
+        catch (WebSocketException) { /* client dropped mid-read */ }
+        finally
+        {
+            lock (_gate) _sockets.Remove(socket);
+        }
+    }
+
+    public async Task BroadcastReloadAsync()
+    {
+        List<WebSocket> targets;
+        lock (_gate) targets = new List<WebSocket>(_sockets);
+
+        foreach (var socket in targets)
+        {
+            try
+            {
+                if (socket.State == WebSocketState.Open)
+                    await socket.SendAsync(ReloadMessage, WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
+            }
+            catch (WebSocketException) { /* client dropped; it will be removed by HandleAsync's own loop */ }
+        }
+    }
+}
+
+/// <summary>Coalesces a burst of file-system events into a single call to <paramref name="action"/>,
+/// fired <paramref name="delay"/> after the last <see cref="Signal"/>. If a signal arrives while
+/// <paramref name="action"/> is still running, one more run is queued for when it finishes — so a
+/// change made during a rebuild is never silently dropped, but concurrent rebuilds never overlap.</summary>
+internal sealed class Debouncer : IDisposable
+{
+    private readonly TimeSpan _delay;
+    private readonly Action _action;
+    private readonly object _gate = new();
+    private Timer? _timer;
+
+    public Debouncer(TimeSpan delay, Action action)
+    {
+        _delay = delay;
+        _action = action;
+    }
+
+    public void Signal()
+    {
+        lock (_gate)
+        {
+            _timer?.Dispose();
+            _timer = new Timer(_ => _action(), null, _delay, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate) _timer?.Dispose();
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/LiveReloadScriptInjectionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/LiveReloadScriptInjectionTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers <c>OutputBuilder.Build</c>'s <c>liveReloadScript</c> parameter (used by <c>--watch</c>,
+/// see WatchMode.cs): a normal build passes <c>null</c> and must produce byte-for-byte the same
+/// index.html it always did, while watch mode's inline reconnect-and-reload script is appended
+/// right before <c>&lt;/body&gt;</c> when one is supplied. The end-to-end websocket/rebuild
+/// behaviour itself is covered by WatchModeTests (a real server + browser); this only checks the
+/// HTML generation is wired correctly and does not regress an ordinary build.
+/// </summary>
+[TestClass]
+public sealed class LiveReloadScriptInjectionTests
+{
+    private string _dir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "tps-livereload-html-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static ResolvedProject MakeProject(string dir) => new()
+    {
+        CsprojPath = Path.Combine(dir, "App.csproj"),
+        ProjectDir = dir,
+        AssemblyName = "App",
+        TargetFramework = "netstandard2.0",
+        Sources = new List<(string, string)>(),
+        ReferencePaths = new List<string>(),
+        DefineConstants = new List<string>(),
+        LanguageVersion = LanguageVersion.Latest,
+        ProjectDirs = new List<string> { dir },
+    };
+
+    [TestMethod]
+    public void OrdinaryBuildInjectsNoLiveReloadScript()
+    {
+        var project = MakeProject(_dir);
+        var config = new TransposeJson { FileName = "app.js" };
+
+        OutputBuilder.Build(project, config, "console.log('hi');", _dir, "Debug", liveReloadScript: null);
+
+        var html = File.ReadAllText(Path.Combine(_dir, "index.html"));
+        Assert.IsFalse(html.Contains("tps-livereload"), "a normal build must not carry the watch-mode script");
+    }
+
+    [TestMethod]
+    public void WatchBuildInjectsTheLiveReloadScriptBeforeClosingBody()
+    {
+        var project = MakeProject(_dir);
+        var config = new TransposeJson { FileName = "app.js" };
+        const string script = "<script>/* tps-livereload marker */</script>";
+
+        OutputBuilder.Build(project, config, "console.log('hi');", _dir, "Debug", liveReloadScript: script);
+
+        var html = File.ReadAllText(Path.Combine(_dir, "index.html"));
+        Assert.IsTrue(html.Contains(script), "the live-reload script must be present in the generated HTML");
+
+        var bodyClose = html.IndexOf("</body>", StringComparison.Ordinal);
+        var scriptIndex = html.IndexOf(script, StringComparison.Ordinal);
+        Assert.IsTrue(scriptIndex >= 0 && scriptIndex < bodyClose, "the script must be injected before </body>");
+    }
+
+    [TestMethod]
+    public void HtmlDisabledSkipsGenerationEvenInWatchMode()
+    {
+        var project = MakeProject(_dir);
+        var config = new TransposeJson { FileName = "app.js", HtmlDisabled = true };
+
+        OutputBuilder.Build(project, config, "console.log('hi');", _dir, "Debug", liveReloadScript: "<script>x</script>");
+
+        Assert.IsFalse(File.Exists(Path.Combine(_dir, "index.html")), "html.disabled must still suppress index.html under --watch");
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj
+++ b/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj
@@ -13,6 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="MSTest" Version="4.3.2" />
+    <!-- Drives a real browser against tps's watch-mode served site (WatchModeTests.cs). Pinned to
+         match the Chromium revision already installed in dev/CI images, so the test suite never
+         needs its own browser download. -->
+    <PackageReference Include="Microsoft.Playwright" Version="1.56.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpose/Transpose.Translator.Tests/WatchModeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/WatchModeTests.cs
@@ -1,0 +1,268 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Playwright;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// End-to-end coverage of <c>tps --watch</c>: a real <c>tps</c> process compiles a small fixture (a
+/// root site project plus a project it references), serves it over its Kestrel dev server, and a
+/// real headless Chromium (via Playwright) loads the page and is left running while the fixture's
+/// source is edited on disk. The assertions never call <c>page.ReloadAsync()</c> themselves — the
+/// whole point is that the page reloads on its own, driven by the websocket script <c>WatchMode</c>
+/// injects into index.html, once a rebuild completes.
+///
+/// Both watched inputs are exercised: editing the root project's own source, and editing the
+/// separate project it references (<c>ProjectReference</c>) — the "referenced projects being
+/// imported" half of watch mode that a root-only glob would miss.
+/// </summary>
+[TestClass]
+public sealed class WatchModeTests
+{
+    private static string RepoRoot = "";
+    private static string TpsDllPath = "";
+    private static string TransposeDllPath = "";
+    private static IPlaywright? PlaywrightDriver;
+    private static IBrowser? Browser;
+
+    private string _root = "";
+    private Process? _watchProcess;
+    private readonly List<string> _log = new();
+
+    [ClassInitialize]
+    public static void ClassSetup(TestContext _)
+    {
+        RepoRoot = FindRepoRoot();
+
+        // The test project references Transpose.Compiler (ProjectReference), so its build output —
+        // including tps.dll, the AssemblyName of Transpose.Compiler — is copied right next to this
+        // test assembly; no separate build/publish step is needed to get a runnable tps.
+        TpsDllPath = Path.Combine(AppContext.BaseDirectory, "tps.dll");
+        Assert.IsTrue(File.Exists(TpsDllPath), $"tps.dll was not found next to the test binary at {TpsDllPath}");
+
+        // A site build always needs the Transpose.dll runtime (the sole BCL reference every
+        // compilation gets). Build it once, self-contained, exactly like
+        // transpose-debugging/scripts/setup-toolkit.sh does, if a previous run hasn't already.
+        TransposeDllPath = Path.Combine(RepoRoot, "BCL", "Transpose.BCL", "bin", "Debug", "netstandard2.0", "Transpose.dll");
+        if (!File.Exists(TransposeDllPath))
+        {
+            var bclCsproj = Path.Combine(RepoRoot, "BCL", "Transpose.BCL", "Transpose.BCL.csproj");
+            var psi = new ProcessStartInfo("dotnet") { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false };
+            psi.ArgumentList.Add(TpsDllPath);
+            psi.ArgumentList.Add(bclCsproj);
+            psi.ArgumentList.Add("--build-runtime");
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            Assert.AreEqual(0, proc.ExitCode, $"Failed to build the Transpose runtime before running watch-mode tests.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+            Assert.IsTrue(File.Exists(TransposeDllPath), "Transpose.dll still missing after --build-runtime");
+        }
+
+        PlaywrightDriver = Microsoft.Playwright.Playwright.CreateAsync().GetAwaiter().GetResult();
+        Browser = PlaywrightDriver.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true }).GetAwaiter().GetResult();
+    }
+
+    [ClassCleanup]
+    public static void ClassTeardown()
+    {
+        try { Browser?.CloseAsync().GetAwaiter().GetResult(); } catch { /* best-effort */ }
+        PlaywrightDriver?.Dispose();
+    }
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-watch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { _watchProcess?.Kill(entireProcessTree: true); } catch { /* already gone */ }
+        _watchProcess?.Dispose();
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private string Write(string rel, string content)
+    {
+        var full = Path.Combine(_root, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    [TestMethod]
+    [Timeout(120_000)]
+    public async Task EditingRootOrReferencedProjectAutoReloadsTheBrowser()
+    {
+        // Lib: the referenced project. App: the root site project (ProjectReference to Lib, a
+        // tps.json, and no DOM bindings package — it renders by replacing the whole page body via
+        // Transpose's [Script] escape hatch, which needs nothing beyond the base runtime).
+        Write("Lib/Lib.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>netstandard2.0</TargetFramework>
+                <AssemblyName>Lib</AssemblyName>
+              </PropertyGroup>
+            </Project>
+            """);
+        Write("Lib/Greeter.cs", """
+            namespace Lib
+            {
+                public static class Greeter
+                {
+                    public const string Message = "v1";
+                }
+            }
+            """);
+
+        Write("App/App.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>netstandard2.0</TargetFramework>
+                <AssemblyName>App</AssemblyName>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Lib/Lib.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        Write("App/tps.json", """{ "fileName": "app.js" }""");
+        var programPath = Write("App/Program.cs", """
+            using Transpose;
+            using Lib;
+
+            public class Program
+            {
+                private const string Suffix = "-r1";
+
+                [Script("document.body.innerHTML = html;")]
+                public static extern void SetBody(string html);
+
+                public static void Main()
+                {
+                    SetBody(Greeter.Message + Suffix);
+                }
+            }
+            """);
+        var greeterPath = Path.Combine(_root, "Lib", "Greeter.cs");
+        var appCsproj = Path.Combine(_root, "App", "App.csproj");
+        var siteDir = Path.Combine(_root, "site");
+
+        var port = GetFreePort();
+        _watchProcess = StartWatch(appCsproj, siteDir, port);
+        await WaitForLogAsync(msg => msg.Contains("tps: serving http://localhost:"), TimeSpan.FromSeconds(60));
+
+        var page = await Browser!.NewPageAsync();
+        try
+        {
+            await page.GotoAsync($"http://localhost:{port}/", new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+            await AssertBodyEventuallyContainsAsync(page, "v1-r1", "the initial build");
+
+            // Edit the REFERENCED project (Lib) — proves watch mode follows ProjectReferences, not
+            // just the root project's own glob.
+            File.WriteAllText(greeterPath, File.ReadAllText(greeterPath).Replace("v1", "v2"));
+            await AssertBodyEventuallyContainsAsync(page, "v2-r1", "after editing the referenced project (Lib)");
+
+            // Edit the ROOT project's own source.
+            File.WriteAllText(programPath, File.ReadAllText(programPath).Replace("-r1", "-r2"));
+            await AssertBodyEventuallyContainsAsync(page, "v2-r2", "after editing the root project (App)");
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+    }
+
+    /// <summary>Waits for the page's own auto-reload (never calls ReloadAsync) to bring the body's
+    /// content in line with a rebuild — the reload is driven entirely by the websocket message
+    /// WatchMode's ReloadHub broadcasts once the rebuild it triggered completes.</summary>
+    private async Task AssertBodyEventuallyContainsAsync(IPage page, string expected, string because)
+    {
+        try
+        {
+            await page.WaitForFunctionAsync(
+                "expected => document.body.innerHTML.includes(expected)", expected,
+                new PageWaitForFunctionOptions { Timeout = 30_000 });
+        }
+        catch (TimeoutException)
+        {
+            var actual = await page.EvaluateAsync<string>("() => document.body.innerHTML");
+            Assert.Fail($"Timed out waiting for the browser to auto-reload with '{expected}' ({because}). "
+                + $"Last body content: '{actual}'.\n--- tps --watch log ---\n{string.Join('\n', SnapshotLog())}");
+        }
+
+        var text = await page.EvaluateAsync<string>("() => document.body.innerHTML");
+        Assert.IsTrue(text.Contains(expected), $"expected '{expected}' in body ({because}), got '{text}'");
+    }
+
+    private Process StartWatch(string appCsproj, string siteDir, int port)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = Path.GetDirectoryName(appCsproj)!,
+        };
+        psi.ArgumentList.Add(TpsDllPath);
+        psi.ArgumentList.Add(appCsproj);
+        psi.ArgumentList.Add("--watch");
+        psi.ArgumentList.Add("--watch-port");
+        psi.ArgumentList.Add(port.ToString());
+        psi.ArgumentList.Add("--site-dir");
+        psi.ArgumentList.Add(siteDir);
+        // The fixture has no PackageReference that would resolve Transpose.dll into
+        // ResolvedProject.ReferencePaths (a real project gets one from its Transpose.BCL/Transpose.Core
+        // package references) — without it, OutputBuilder never finds the runtime assembly to extract
+        // tps.js/tps.shim.js from, and the page would load with no Transpose runtime at all. --reference
+        // is exactly the escape hatch for an assembly outside the NuGet cache (see --reference's help
+        // text), so use it to add the runtime the same way a real project's package reference would.
+        psi.ArgumentList.Add("--reference");
+        psi.ArgumentList.Add(TransposeDllPath);
+        psi.Environment["TRANSPOSE_DLL_PATH"] = TransposeDllPath;
+
+        var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) lock (_log) _log.Add(e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) lock (_log) _log.Add("[stderr] " + e.Data); };
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        return process;
+    }
+
+    private List<string> SnapshotLog() { lock (_log) return new List<string>(_log); }
+
+    private async Task WaitForLogAsync(Func<string, bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (SnapshotLog().Any(predicate)) return;
+            if (_watchProcess!.HasExited)
+                Assert.Fail("tps --watch exited before becoming ready.\n" + string.Join('\n', SnapshotLog()));
+            await Task.Delay(100);
+        }
+        Assert.Fail("Timed out waiting for tps --watch to report readiness.\n" + string.Join('\n', SnapshotLog()));
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static string FindRepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+            if (File.Exists(Path.Combine(dir.FullName, "Transpose.slnx"))) return dir.FullName;
+        throw new InvalidOperationException("Could not locate the repo root (Transpose.slnx) above " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Watches the root project and every project it transitively references
(ProjectReferences), debounces file-system events, and rebuilds the site
through the same Program.RunOnce path a plain build uses. The rebuilt
site is served over a local Kestrel server; the generated index.html
carries a small injected script that reconnects over a websocket
(/__tps-livereload) and reloads the page after each successful rebuild.
A monotonic build version embedded in that script lets a reconnecting
client catch up immediately if it missed a broadcast (e.g. two edits
landing back to back), instead of waiting on an already-open socket
that was never there to receive it.

Covered by a real end-to-end test: a tps --watch subprocess plus a
headless Chromium (Playwright) that loads the served page and is left
running while both the root project and a referenced project are
edited on disk, asserting the page reloads itself.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018iLUZKBPnnGQAqGFypVkcv