### PR TITLE
Emit a zeroed struct for an initializer-less struct local

### DIFF
--- a/Transpose/Transpose.Translator.Tests/UninitializedStructLocalTests.cs
+++ b/Transpose/Transpose.Translator.Tests/UninitializedStructLocalTests.cs
@@ -1,0 +1,107 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Regression tests for a local of struct type declared without an initializer. C# lets such a
+    /// local be definitely assigned one field at a time (`ElementCount result; result.uniqueCount = 0;`),
+    /// so emitting a bare `let result;` left it undefined and the first field write threw
+    /// "Cannot set properties of undefined". The BCL's own
+    /// HashSet&lt;T&gt;.CheckUniqueAndUnfoundElements is written that way, which took down every
+    /// SetEquals / IsSubsetOf / Overlaps call whose argument is not a same-comparer HashSet.
+    /// </summary>
+    [TestClass]
+    public class UninitializedStructLocalTests : TranslatorTestBase
+    {
+        /// <summary>Mirrors the shape of HashSet&lt;T&gt;.CheckUniqueAndUnfoundElements: a struct local
+        /// declared bare, filled in field by field on two separate paths, returned by value.</summary>
+        [TestMethod]
+        public async Task TestFieldWiseAssignmentOfUninitializedStructLocalAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public struct ElementCount
+{
+    public int uniqueCount;
+    public int unfoundCount;
+}
+
+public class Program
+{
+    private static ElementCount CheckUniqueAndUnfoundElements(int count, bool returnIfUnfound)
+    {
+        ElementCount result;
+        if (count == 0)
+        {
+            result.uniqueCount  = 0;
+            result.unfoundCount = returnIfUnfound ? 1 : 0;
+            return result;
+        }
+        result.uniqueCount  = count;
+        result.unfoundCount = count - 1;
+        return result;
+    }
+
+    public static void Main()
+    {
+        var a = CheckUniqueAndUnfoundElements(0, true);
+        var b = CheckUniqueAndUnfoundElements(3, false);
+        Console.WriteLine(a.uniqueCount + "","" + a.unfoundCount);
+        Console.WriteLine(b.uniqueCount + "","" + b.unfoundCount);
+    }
+}
+                ");
+        }
+
+        /// <summary>A bare struct local must be a fresh zeroed value each time its declaration runs, and
+        /// a nested struct field must itself be an object so `o.Nested.Value = …` has somewhere to write.
+        /// Non-struct and primitive locals keep their bare declaration — they are covered here only to
+        /// show the change did not disturb them.</summary>
+        [TestMethod]
+        public async Task TestUninitializedStructLocalIsZeroedPerDeclarationAsync()
+        {
+            await RunTest(
+                @"
+using System;
+
+public struct Inner
+{
+    public int Value;
+}
+
+public struct Outer
+{
+    public Inner  Nested;
+    public string Name;
+    public int    Count;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            Outer o;
+            o.Count        = i;
+            o.Name         = ""set"";
+            o.Nested.Value = i * 2;
+            Console.WriteLine(o.Nested.Value + "","" + o.Name + "","" + o.Count);
+        }
+
+        int    n;
+        string s;
+        DateTime d;
+        n = 5;
+        s = ""hi"";
+        d = new DateTime(2020, 1, 2);
+        Console.WriteLine(n + "","" + s + "","" + d.Year);
+    }
+}
+                ");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -401,8 +401,33 @@ public sealed partial class Emitter
                 _w.Write(" = ");
                 EmitExpressionConverted(variable.Initializer.Value, _model.GetTypeInfo(variable.Initializer.Value).ConvertedType);
             }
+            else if (UninitializedLocalStructType(variable) is { } structType)
+            {
+                _w.Write(" = ");
+                _w.Write(DefaultValueLiteral(structType));
+            }
             _w.WriteLine(";");
         }
+    }
+
+    /// <summary>
+    /// The struct type of an initializer-less local that must still be emitted as a zeroed struct
+    /// instance, or null when a bare declaration is fine. C# lets `SomeStruct s;` be definitely
+    /// assigned field by field (`s.a = 1; s.b = 2;`) — the BCL's own
+    /// <c>HashSet&lt;T&gt;.CheckUniqueAndUnfoundElements</c> does exactly that — so emitting a bare
+    /// `let s;` leaves `s` undefined and the first field write throws "Cannot set properties of
+    /// undefined". Primitives, enums and reference types are excluded: definite assignment means
+    /// they are always written before they are read, so the extra initializer would be dead weight.
+    /// Nullable&lt;T&gt; is excluded for the same reason (its default is a bare `null`), and a ref
+    /// struct is left alone — it has its own emit path and never reaches JS as a plain object.
+    /// </summary>
+    private ITypeSymbol? UninitializedLocalStructType(VariableDeclaratorSyntax variable)
+    {
+        if (_model.GetDeclaredSymbol(variable) is not ILocalSymbol { Type: { } type }) return null;
+        if (type.TypeKind != TypeKind.Struct || type.IsRefLikeType) return null;
+        if (IsPrimitiveNumericOrBool(type)) return null;
+        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T) return null;
+        return type;
     }
 
     private void EmitIf(IfStatementSyntax ifStmt)


### PR DESCRIPTION
C# allows a struct local to be definitely assigned one field at a time:

    ElementCount result;
    result.uniqueCount  = 0;
    result.unfoundCount = n;

The emitter wrote that declaration as a bare `let result;`, so the local was `undefined` in JS and the first field write threw

    TypeError: Cannot set properties of undefined (setting 'uniqueCount')

The BCL's own HashSet<T>.CheckUniqueAndUnfoundElements (and the SortedSet<T> copy) is written exactly that way, so every SetEquals / IsSubsetOf / IsProperSubsetOf / IsSupersetOf / IsProperSupersetOf / Overlaps call that falls to the slow path — i.e. whose argument is not a HashSet<T> with the same comparer — crashed at runtime. A List<T>, a Dictionary.KeyCollection or a LINQ sequence hits that path every time.

A local of non-primitive struct type declared without an initializer now emits its zeroed value (`let result = Transpose.getDefaultValue(ElementCount);`). Primitives, enums, Nullable<T>, ref structs and reference types keep the bare declaration: definite assignment guarantees they are written before they are read, so an initializer there would be dead weight.


Claude-Session: https://claude.ai/code/session_01YZxzCLG8bR7E7wbx2GK74d