### PR TITLE
Resolve the newest cached Transpose.BCL by version; isolate the watch-mode suite and run tests in CI

### DIFF
--- a/.devops/build-transpose-compiler.yml
+++ b/.devops/build-transpose-compiler.yml
@@ -1,6 +1,10 @@
 variables:
   compiler: '$(Build.SourcesDirectory)/Transpose/Transpose.Compiler/Transpose.Compiler.csproj'
   bench: '$(Build.SourcesDirectory)/Transpose/Transpose.Bench/Transpose.Bench.csproj'
+  translatorTests: '$(Build.SourcesDirectory)/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj'
+  watchModeTests: '$(Build.SourcesDirectory)/Transpose/Transpose.WatchMode.Tests/Transpose.WatchMode.Tests.csproj'
+  bcl: '$(Build.SourcesDirectory)/BCL/Transpose.BCL/Transpose.BCL.csproj'
+  bclRuntimeDll: '$(Build.SourcesDirectory)/BCL/Transpose.BCL/bin/Release/netstandard2.0/Transpose.dll'
   buildConfiguration: 'Release'
   targetVersion: yy.M.$(build.buildId)
 
@@ -34,6 +38,8 @@ trigger:
     - Transpose/Transpose.Compiler/*
     - Transpose/Transpose.Translator/*
     - Transpose/Transpose.Bench/*
+    - Transpose/Transpose.Translator.Tests/*
+    - Transpose/Transpose.WatchMode.Tests/*
     - .devops/build-transpose-compiler.yml
 
 pr: none
@@ -82,6 +88,67 @@ steps:
     projects: '$(compiler)'
     arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)'
 
+# --- tests ------------------------------------------------------------------------------------
+# Everything below runs before the pack/push, so a red test never reaches nuget.org.
+#
+# Two suites, both needing something the compiler build alone does not provide:
+#   * Transpose.Translator.Tests transpiles snippets and runs them on Node, diffing the output against
+#     the same C# executed natively — so it needs Node, and a Transpose.dll to compile against.
+#   * Transpose.WatchMode.Tests drives a real headless Chromium against a real `tps --watch` server —
+#     so it needs the Playwright browser installed.
+
+- task: NodeTool@0
+  displayName: 'Use Node 22 (the translator tests run emitted JS on it)'
+  inputs:
+    versionSpec: '22.x'
+
+# Every compilation gets Transpose.dll as its sole BCL reference, and nothing in this pipeline restores
+# the published Transpose.BCL package. Build it here with the compiler just built, and point the tests
+# at it via TRANSPOSE_DLL_PATH: that both makes them runnable and means they exercise *this commit's*
+# BCL and runtime rather than whatever was last released.
+- script: |
+    set -euo pipefail
+    dotnet "$(Build.SourcesDirectory)/Transpose/Transpose.Compiler/bin/$(buildConfiguration)/net10.0/tps.dll" \
+      --project "$(bcl)" --build-runtime -c $(buildConfiguration) -o "$(bclRuntimeDll)"
+    test -f "$(bclRuntimeDll)"
+    echo "##vso[task.setvariable variable=TRANSPOSE_DLL_PATH;]$(bclRuntimeDll)"
+  displayName: 'build the Transpose.dll runtime the tests compile against'
+
+- task: DotNetCoreCLI@2
+  displayName: 'test translator'
+  inputs:
+    command: 'test'
+    projects: '$(translatorTests)'
+    arguments: '-c $(buildConfiguration)'
+
+# Built as its own step so the Playwright install script below exists before the tests run; the test
+# step then uses --no-build.
+- task: DotNetCoreCLI@2
+  displayName: 'build watch-mode tests'
+  inputs:
+    command: 'build'
+    projects: '$(watchModeTests)'
+    arguments: '-c $(buildConfiguration)'
+
+# playwright.ps1 ships in the test project's build output (Microsoft.Playwright) and is the supported
+# way to install browsers for the .NET binding. `--with-deps` also pulls the shared libraries headless
+# Chromium needs on a Linux agent. Run through PowerShell@2/pwsh, as the CalVer step above already does.
+- task: PowerShell@2
+  displayName: 'install the Chromium the watch-mode tests drive'
+  inputs:
+    targetType: 'filePath'
+    pwsh: true
+    filePath: '$(Build.SourcesDirectory)/Transpose/Transpose.WatchMode.Tests/bin/$(buildConfiguration)/net10.0/playwright.ps1'
+    arguments: 'install chromium --with-deps'
+
+- task: DotNetCoreCLI@2
+  displayName: 'test watch mode'
+  inputs:
+    command: 'test'
+    projects: '$(watchModeTests)'
+    arguments: '-c $(buildConfiguration) --no-build'
+
+# --- pack and push ----------------------------------------------------------------------------
 # One pack produces the outer selector package plus one ReadyToRun package per RID (~15 MB each).
 - task: DotNetCoreCLI@2
   displayName: 'pack nuget compiler (ReadyToRun, per RID)'

--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,11 @@ Transpose/                     # The compiler toolchain
 │   └── ab.sh                  #   interleaved A/B of two tps binaries on one project
 ├── Transpose.Build.Target/    # MSBuild SDK (package id Transpose.Build.Target) that invokes `tps`
 ├── Transpose.Template/        # `dotnet new` template (package id Transpose.Template)
-└── Transpose.Translator.Tests/# MSTest suite; transpiles snippets and diffs vs native .NET via Playwright
+├── Transpose.Translator.Tests/# MSTest suite; transpiles snippets and diffs vs native .NET on Node
+└── Transpose.WatchMode.Tests/ # MSTest suite for `tps --watch`: a real tps subprocess + headless
+                               #   Chromium (Playwright). Separate project on purpose — it waits on
+                               #   wall-clock events, so sharing a host with the Roslyn-heavy suite
+                               #   above starved the browser and timed the waits out spuriously.
 
 BCL/                           # The base runtime libraries
 ├── Transpose.BCL/             # Base library. AssemblyName Transpose, package id `Transpose.BCL`, namespace Transpose
@@ -86,7 +90,9 @@ Packages/                      # Additional binding libraries (all [assembly: Ex
 
 benchmarks/tesserae/           # git submodule: the benchmark corpus (see Performance below)
 docs/perf/                     # recorded tps-bench reports (baseline + current)
-.devops/                       # Azure DevOps pipelines (one per package, plus the benchmark)
+.devops/                       # Azure DevOps pipelines (one per package, plus the benchmark).
+                               #   Two of them run tests before publishing: build-transpose-compiler
+                               #   (the translator + watch-mode suites) and build-transpose-json.
 
 docs/, logo/, lib/, External-less # docs, brand assets (see below), misc
 ```
@@ -370,9 +376,9 @@ The short version:
   lets a reconnecting client (e.g. one whose reload navigation overlapped a second rebuild) catch up
   immediately instead of waiting on a broadcast it could otherwise miss. `Program.RunOnce` is the
   extracted single-build path both a plain invocation and every watch rebuild call. Covered end to end
-  by `WatchModeTests` (a real `tps --watch` subprocess + headless Chromium via Playwright, editing both
-  the root and a referenced project and asserting the page reloads itself — never calling
-  `page.ReloadAsync()`).
+  by `WatchModeTests` in its own **`Transpose.WatchMode.Tests`** project (a real `tps --watch` subprocess
+  + headless Chromium via Playwright, editing both the root and a referenced project and asserting the
+  page reloads itself — never calling `page.ReloadAsync()`).
 
 A compilation server is still intentionally **out of scope** — though the measurements in
 `TODO.incremental.md` say what it would be worth (the residual cost of an incremental build is almost

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3060" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3106" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3060" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3106" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Newtonsoft.Json.Tests/BclTypeTests.cs
+++ b/Packages/Transpose.Newtonsoft.Json.Tests/BclTypeTests.cs
@@ -96,8 +96,10 @@ public class App
         {
             Assert.Inconclusive(
                 "The resolved Transpose runtime predates the DateTime fractional-seconds fix " +
-                "(BCL/Transpose.BCL/Resources/Date.js). Rebuild it (tps --project BCL/Transpose.BCL) " +
-                "and point TRANSPOSE_DLL_PATH at the result, or wait for the next Transpose.BCL release.");
+                "(BCL/Transpose.BCL/Resources/Date.js, shipped in Transpose.BCL 26.7.3064): " +
+                $"'{TransposeAssemblies.TransposeDllPath}'. Point TRANSPOSE_DLL_PATH at a newer " +
+                "Transpose.dll — a released one, or one rebuilt from this repo with " +
+                "`tps --project BCL/Transpose.BCL/Transpose.BCL.csproj --build-runtime`.");
         }
 
         await RunAndCompare(code);

--- a/Packages/Transpose.Newtonsoft.Json.Tests/README.md
+++ b/Packages/Transpose.Newtonsoft.Json.Tests/README.md
@@ -69,4 +69,9 @@ Each is asserted by the test named beside it, so this list stays true.
 
 `FractionalSecondsRoundTrip` reports **inconclusive** against a runtime that predates the
 `fractionToMilliseconds` fix in `BCL/Transpose.BCL/Resources/Date.js` (a `.25` fraction read as 25 ms
-instead of 250 ms) — that fix ships with the runtime, not with this package.
+instead of 250 ms) — that fix ships with the runtime, not with this package, and reached NuGet in
+**`Transpose.BCL 26.7.3064`**. So it is the one test here that can come out non-green without anything
+being wrong with the package: it means the resolved `Transpose.dll` is stale, not that the bug is back.
+Which runtime gets resolved is `TRANSPOSE_DLL_PATH` if set, else the **highest-versioned**
+`Transpose.BCL` in the NuGet cache — so an old cached package is enough to trigger it, and the
+inconclusive message names the DLL it actually used.

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3060" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3106" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3060" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3106" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpose.slnx
+++ b/Transpose.slnx
@@ -14,6 +14,9 @@
     <Project Path="Transpose/Transpose.Template/Transpose.Template.csproj" />
     <Project Path="Transpose/Transpose.Translator/Transpose.Translator.csproj" />
     <Project Path="Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj" />
+    <!-- The browser-driven watch-mode suite, kept out of Transpose.Translator.Tests so its
+         wall-clock waits do not compete with that suite's Roslyn compiles (see its csproj). -->
+    <Project Path="Transpose/Transpose.WatchMode.Tests/Transpose.WatchMode.Tests.csproj" />
   </Folder>
   <Folder Name="/BCL/">
     <Project Path="BCL/Transpose.BCL/Transpose.BCL.csproj" />

--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.3055" />
-        <PackageReference Include="Transpose.Core" Version="26.7.3056" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2921" />
+        <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
+        <PackageReference Include="Transpose.Core" Version="26.7.3106" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.3066" />
         <PackageReference Include="Tesserae" Version="2026.7.68468" />
     </ItemGroup>
 </Project>

--- a/Transpose/Transpose.Translator.Tests/RuntimeAssemblyVersionOrderTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RuntimeAssemblyVersionOrderTests.cs
@@ -1,0 +1,59 @@
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers which <c>Transpose.BCL</c> version <c>TransposeAssemblies.Discover</c> picks out of the NuGet
+/// cache when several are extracted there — i.e. which JavaScript runtime every compile without
+/// <c>TRANSPOSE_DLL_PATH</c> binds against.
+///
+/// The version folders are CalVer (<c>yy.M.buildId</c>), and the resolver used to sort them as plain
+/// strings, which silently prefers the *older* runtime as soon as a component's digit count changes:
+/// ordinally <c>26.7.999</c> &gt; <c>26.7.3104</c> and <c>26.7.x</c> &gt; <c>26.10.x</c>. A stale runtime
+/// does not fail the build — it compiles clean and only misbehaves in Node, which is how a fixed BCL bug
+/// appears to still be there (the JSON suite's <c>FractionalSecondsRoundTrip</c> reporting inconclusive
+/// against a runtime that predates the <c>Date.js</c> fractional-seconds fix is exactly that symptom).
+/// </summary>
+[TestClass]
+public sealed class RuntimeAssemblyVersionOrderTests
+{
+    private static string Newest(params string[] versions) =>
+        versions.OrderBy(v => v, TransposeAssemblies.PackageVersionOrder.Instance).Last();
+
+    [TestMethod]
+    public void MoreDigitsInABuildIdIsANewerVersion()
+    {
+        Assert.AreEqual("26.7.3104", Newest("26.7.999", "26.7.3104"));
+        Assert.AreEqual("26.7.10001", Newest("26.7.3104", "26.7.10001"));
+    }
+
+    [TestMethod]
+    public void ATwoDigitMonthIsNewerThanASingleDigitOne()
+    {
+        Assert.AreEqual("26.10.1", Newest("26.7.3104", "26.10.1"));
+        Assert.AreEqual("27.1.1", Newest("26.12.9999", "27.1.1"));
+    }
+
+    [TestMethod]
+    public void TheNewestOfAFullCacheWins()
+    {
+        Assert.AreEqual(
+            "26.7.3104",
+            Newest("26.7.2749", "26.7.2947", "26.7.3001", "26.7.3055", "26.7.3064", "26.7.3104"));
+    }
+
+    [TestMethod]
+    public void AReleaseOutranksAPrereleaseOfTheSameVersion()
+    {
+        Assert.AreEqual("26.7.3104", Newest("26.7.3104-beta", "26.7.3104"));
+        Assert.AreEqual("26.7.3105-alpha", Newest("26.7.3104", "26.7.3105-alpha"));
+        Assert.AreEqual("26.7.3104-beta2", Newest("26.7.3104-beta2", "26.7.3104-beta1"));
+    }
+
+    [TestMethod]
+    public void MissingSegmentsCountAsZeroAndJunkSortsLowest()
+    {
+        Assert.AreEqual("26.7.1", Newest("26.7", "26.7.1"));
+        Assert.AreEqual("26.7.0", Newest("26.7", "26.7.0"));            // equal: the later one is kept
+        Assert.AreEqual("26.7.3104", Newest("not-a-version", "26.7.3104"));
+        Assert.AreEqual("26.7.3104", Newest("26.7.3104", "not-a-version"));
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj
+++ b/Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj
@@ -13,10 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="MSTest" Version="4.3.2" />
-    <!-- Drives a real browser against tps's watch-mode served site (WatchModeTests.cs). Pinned to
-         match the Chromium revision already installed in dev/CI images, so the test suite never
-         needs its own browser download. -->
-    <PackageReference Include="Microsoft.Playwright" Version="1.56.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,8 +21,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Transpose.Translator\Transpose.Translator.csproj" />
-    <!-- tps.dll (AssemblyName of Transpose.Compiler) is copied next to the test binary for
-         WatchModeTests, which spawns a real tps watch-mode process. -->
+    <!-- For the CLI's own internals (Program.OrderErrorsForReport — see its InternalsVisibleTo).
+         The browser-driven watch-mode suite that used to spawn tps.dll from here now lives in
+         Transpose.WatchMode.Tests. -->
     <ProjectReference Include="..\Transpose.Compiler\Transpose.Compiler.csproj" />
     <!-- ProjectResolver/TransposeJson/OutputBuilder/BuildCache/ResourceEmbedder/JsMinifier/… now live
          here (see Transpose.Compiler.Core), shared with Transpose.Compiler.Library. -->

--- a/Transpose/Transpose.Translator/Compilation/TransposeAssemblies.cs
+++ b/Transpose/Transpose.Translator/Compilation/TransposeAssemblies.cs
@@ -48,16 +48,66 @@ public static class TransposeAssemblies
             from versionDir in Directory.GetDirectories(pkg)
             let dll = Path.Combine(versionDir, "lib", "netstandard2.0", "Transpose.dll")
             where File.Exists(dll)
-            orderby Path.GetFileName(versionDir)
-            select dll;
+            select (version: Path.GetFileName(versionDir), dll);
 
-        var found = candidates.LastOrDefault();
+        // Newest wins — by version, not by folder name. The versions are CalVer (yy.M.buildId), so an
+        // ordinal sort of the folder names silently prefers a *stale* runtime as soon as a component's
+        // digit count changes ("26.7.999" over "26.7.3104", "26.7.x" over "26.10.x"). A stale runtime
+        // does not fail loudly: it compiles fine and only misbehaves at runtime.
+        var found = candidates
+            .OrderBy(c => c.version, PackageVersionOrder.Instance)
+            .Select(c => c.dll)
+            .LastOrDefault();
         if (found is null)
         {
             throw new InvalidOperationException(
                 "Could not locate Transpose.dll in the NuGet packages cache. Set the TRANSPOSE_DLL_PATH environment variable.");
         }
         return found;
+    }
+
+    /// <summary>
+    /// Orders NuGet version-folder names by their numeric segments, with a release ranking above any
+    /// prerelease of the same segments (<c>1.0.0</c> &gt; <c>1.0.0-beta</c>) — enough to pick between
+    /// the versions of one package in the cache, like <c>ProjectResolver.CompareVersions</c> does for
+    /// package references (a full NuGet.Versioning dependency would buy nothing here). A folder name
+    /// that is not a version sorts below every real one.
+    /// </summary>
+    internal sealed class PackageVersionOrder : IComparer<string>
+    {
+        public static readonly PackageVersionOrder Instance = new();
+
+        public int Compare(string? x, string? y)
+        {
+            var (left,  leftPre)  = Parse(x);
+            var (right, rightPre) = Parse(y);
+
+            for (var i = 0; i < Math.Max(left.Length, right.Length); i++)
+            {
+                var a = i < left.Length  ? left[i]  : 0;
+                var b = i < right.Length ? right[i] : 0;
+                if (a != b) return a.CompareTo(b);
+            }
+
+            if (leftPre.Length == 0 && rightPre.Length == 0) return 0;
+            if (leftPre.Length == 0) return 1;   // release > prerelease
+            if (rightPre.Length == 0) return -1;
+            return string.CompareOrdinal(leftPre, rightPre);
+        }
+
+        private static (int[] segments, string prerelease) Parse(string? version)
+        {
+            if (string.IsNullOrWhiteSpace(version)) return (Array.Empty<int>(), "");
+
+            var core = version!.Trim().Split('+')[0];          // drop build metadata
+            var dash = core.IndexOf('-');
+            var prerelease = dash < 0 ? "" : core.Substring(dash + 1);
+            if (dash >= 0) core = core.Substring(0, dash);
+
+            // A non-numeric segment yields -1, so a junk folder name sorts below any real version.
+            var segments = core.Split('.').Select(s => int.TryParse(s, out var n) ? n : -1).ToArray();
+            return (segments, prerelease);
+        }
     }
 
     /// <summary>

--- a/Transpose/Transpose.Translator/Transpose.Translator.csproj
+++ b/Transpose/Transpose.Translator/Transpose.Translator.csproj
@@ -19,4 +19,9 @@
     <EmbeddedResource Include="Runtime\tps.shim.js" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- So the test suite can exercise internals directly, e.g. TransposeAssemblies.PackageVersionOrder. -->
+    <InternalsVisibleTo Include="Transpose.Translator.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/Transpose/Transpose.WatchMode.Tests/Transpose.WatchMode.Tests.csproj
+++ b/Transpose/Transpose.WatchMode.Tests/Transpose.WatchMode.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Watch mode's end-to-end coverage lives in its own project rather than in
+       Transpose.Translator.Tests. It is the only suite here that drives a real browser against a real
+       tps watch-mode subprocess, so it waits on wall-clock events (a rebuild, a websocket broadcast, a
+       page reload) instead of computing an answer. Sharing a test host with several hundred
+       Roslyn-heavy compile/diff tests starved the headless Chromium of CPU often enough to time out a
+       wait that takes ~2s when the box is idle: a failure with nothing actually wrong.
+       [DoNotParallelize] only orders the classes within one host; a separate project gets its own. -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <InvariantTimezone>true</InvariantTimezone>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="4.3.2" />
+    <!-- Drives a real browser against tps's watch-mode served site. Pinned to match the Chromium
+         revision already installed in dev/CI images, so the suite never needs its own browser
+         download. -->
+    <PackageReference Include="Microsoft.Playwright" Version="1.56.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- tps.dll (the AssemblyName of Transpose.Compiler) is copied next to the test binary: the tests
+         spawn a real tps process in watch mode, so no separate build or publish step is needed. -->
+    <ProjectReference Include="..\Transpose.Compiler\Transpose.Compiler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Transpose/Transpose.WatchMode.Tests/WatchModeTests.cs
+++ b/Transpose/Transpose.WatchMode.Tests/WatchModeTests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using Microsoft.Playwright;
 
-namespace Transpose.Translator.Tests;
+namespace Transpose.WatchMode.Tests;
 
 /// <summary>
 /// End-to-end coverage of <c>tps --watch</c>: a real <c>tps</c> process compiles a small fixture (a
@@ -17,13 +17,12 @@ namespace Transpose.Translator.Tests;
 /// separate project it references (<c>ProjectReference</c>) — the "referenced projects being
 /// imported" half of watch mode that a root-only glob would miss.
 ///
-/// <c>DoNotParallelize</c>: MSTest runs test classes in parallel by default, and every other class
-/// in this suite is a CPU-heavy Roslyn compile/diff. A real browser waiting on a real subprocess's
-/// websocket message is latency-sensitive in a way those aren't — under that contention the rebuild
-/// itself is still fast, but the headless Chromium process can be too CPU-starved to receive and act
-/// on the reload message within the wait window, which reads as a hang with nothing actually wrong.
-/// Running this class alone removes that contention instead of just papering over it with a longer
-/// timeout.
+/// This lives in its own test project, not in <c>Transpose.Translator.Tests</c>, because it is the one
+/// suite that waits on wall-clock events (a rebuild, a websocket broadcast, a page reload) rather than
+/// computing an answer. Sharing a test host with several hundred CPU-heavy Roslyn compile/diff tests
+/// starved the headless Chromium often enough to time out a wait that takes ~2s on an idle box, which
+/// reads as a hang with nothing actually wrong. <c>DoNotParallelize</c> only orders the classes inside
+/// one host, so it did not remove that contention; a separate project does.
 /// </summary>
 [TestClass]
 [DoNotParallelize]
@@ -280,13 +279,39 @@ public sealed class WatchModeTests
         }
         catch (TimeoutException)
         {
-            var actual = await page.EvaluateAsync<string>("() => document.body.innerHTML");
             Assert.Fail($"Timed out waiting for the browser to auto-reload with '{expected}' ({because}). "
-                + $"Last body content: '{actual}'.\n--- tps --watch log ---\n{string.Join('\n', SnapshotLog())}");
+                + $"Last body content: '{await ReadBodyAsync(page) ?? "<unreadable: the page was navigating>"}'."
+                + $"\n--- tps --watch log ---\n{string.Join('\n', SnapshotLog())}");
         }
 
-        var text = await page.EvaluateAsync<string>("() => document.body.innerHTML");
-        Assert.IsTrue(text.Contains(expected), $"expected '{expected}' in body ({because}), got '{text}'");
+        // WaitForFunctionAsync already observed the content, so this re-read only exists to quote the
+        // body if it somehow does not match. An unreadable body means another reload was in flight —
+        // that is the behaviour under test, not a failure, so let the wait's success stand.
+        var text = await ReadBodyAsync(page);
+        Assert.IsTrue(text is null || text.Contains(expected),
+            $"expected '{expected}' in body ({because}), got '{text}'");
+    }
+
+    /// <summary>
+    /// The page's body HTML, or null if it could not be read because the page was navigating. Reading
+    /// it races with the live reload this test is about: an evaluate that a reload interrupts throws
+    /// "Execution context was destroyed", which — thrown from the timeout handler above — used to
+    /// replace the real diagnostic (the body plus the watch log) with an opaque Playwright error.
+    /// </summary>
+    private static async Task<string?> ReadBodyAsync(IPage page)
+    {
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                return await page.EvaluateAsync<string>("() => document.body.innerHTML");
+            }
+            catch (PlaywrightException)
+            {
+                await Task.Delay(250);
+            }
+        }
+        return null;
     }
 
     private Process StartWatch(string appCsproj, string siteDir, int port)


### PR DESCRIPTION
## What started this

"Why is a test not passing on the JSON package?" — **nothing in the JSON package is broken.** All 131 tests pass: Debug, Release, against the repo-built runtime, and against the published `Transpose.BCL` (26.7.3064 and 26.7.3104), with `Skipped: 0` every time. All six binding libraries transpile cleanly.

The one test that can come out non-green is `BclTypeTests.FractionalSecondsRoundTrip`, and it does not fail — it calls `Assert.Inconclusive`, which `dotnet test` prints as *Skipped* and Test Explorer shows as not-passed. It bails out when the resolved `Transpose.dll` predates the `fractionToMilliseconds` fix in `BCL/Transpose.BCL/Resources/Date.js` (a `.25` fraction read as 25 ms instead of 250 ms). Confirmed both sides of that boundary: inconclusive against `Transpose.BCL 26.7.3055`, passing from **26.7.3064** on. So that result means *the runtime is stale*, not that the bug is back.

## Why a stale runtime got picked (the actual bug)

Without `TRANSPOSE_DLL_PATH`, `TransposeAssemblies.Discover` takes the highest-versioned `Transpose.BCL` in the NuGet cache — but it ordered the version folders as **plain strings**. The versions are CalVer (`yy.M.buildId`), so an ordinal sort silently prefers the *older* runtime as soon as a component's digit count changes: `26.7.999` outranks `26.7.3104`, and every `26.7.x` outranks `26.10.x` — which would hit everyone this October. It fails silently: the build is clean and only the emitted JavaScript misbehaves, which reads as a fixed BCL bug still being there.

Now ordered by numeric segments (release above prerelease, a non-version folder below every real one), mirroring what `ProjectResolver.CompareVersions` already does for package references. Verified end to end: with an old runtime planted at `26.10.1` beside `26.7.3104`, the resolver now picks `26.10.1` where it previously took `26.7.3104`.

The inconclusive message now also names the DLL it actually used and which release carries the fix, so the diagnosis is in the failure itself.

## Watch-mode suite moved to its own project

While verifying, the full translator suite failed on `WatchModeTests.EditingRootOrReferencedProjectAutoReloadsTheBrowser`. It is the only test here that waits on wall-clock events (a rebuild, a websocket broadcast, a page reload) instead of computing an answer, and sharing a test host with several hundred CPU-heavy Roslyn compile/diff tests starved the headless Chromium enough to time out a wait that takes ~2s on an idle box — it passed in 9s on its own. `[DoNotParallelize]` only orders classes within one host, so it never removed that contention; **`Transpose.WatchMode.Tests`** does. The translator suite also drops ~2 minutes (6m14 → 3m57) and no longer needs Playwright.

Its timeout diagnostic was self-defeating too: the `catch (TimeoutException)` handler evaluated on a page the live reload may be navigating, so it threw `Execution context was destroyed` and replaced the useful message (last body content + the `tps --watch` log) with an opaque Playwright error — which is exactly what hid the timeout above. Reading the body now tolerates a navigation, and an unreadable body no longer fails a wait that already succeeded. Verified by forcing the timeout: the intended diagnostic prints.

## Tests now run in CI

`build-transpose-compiler.yml` only built and pushed the compiler, so nothing ran these tests. It now runs both suites **before** the pack/push, so a red test cannot reach nuget.org. Each needs something the compiler build does not provide, so the pipeline:

- pins **Node 22** (the translator suite runs emitted JS on it),
- builds `Transpose.dll` with the compiler it just built — which also means the tests exercise *this commit's* BCL rather than the last released one,
- installs Chromium via the `playwright.ps1` that ships in the test project's output (through `PowerShell@2`/`pwsh`, as the CalVer step already does).

Both test projects are added to the trigger paths. Both new steps were rehearsed locally; the YAML parses and the two artifact paths it references exist in a real build output.

## Package references

Every project now uses the latest published `Transpose.BCL 26.7.3104`, `Transpose.Core 26.7.3106` and `Transpose.Newtonsoft.Json 26.7.3066` (Core, Howler, P2, WebGL2, HttpClient, Newtonsoft.Json, and the `dotnet new` template). `Transpose.Build.Target/26.7.3049` was already the latest, so the SDK line is unchanged.

## Verification

| suite | result |
| --- | --- |
| `Transpose.Newtonsoft.Json.Tests` | 131 passed, 0 failed, 0 skipped — five runs (Debug, Release, repo-built runtime, published BCL 26.7.3064 and 26.7.3104) |
| `Transpose.Translator.Tests` | 656 passed, 0 failed, 17 skipped (browser-API tests, skipped by design) |
| `Transpose.WatchMode.Tests` | 2 passed, 0 failed |
| `RuntimeAssemblyVersionOrderTests` (new) | 5 passed — digit-count changes, two-digit months, release vs prerelease, junk folder names |
| binding libraries | all six transpile against the bumped packages |
| toolchain projects | all build clean in Release |

`dotnet build Transpose.slnx` still reports the documented `tps`-not-on-PATH failures (exit 127) for the BCL/Packages projects — unchanged by this branch; use `./bootstrap.sh` for those.

## One thing I did not change

`build-transpose-compiler.yml`'s trigger paths omit `Transpose/Transpose.Compiler.Core/*`, so edits to `ProjectResolver`/`OutputBuilder`/`BuildCache` never publish a compiler. That looks like a real gap, but fixing it changes when the pipeline *releases*, which felt like your call rather than a side effect of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdSaMySFuuMRsMnkhSUNpy)_