### PR TITLE
Watch mode: skip the compile for a CSS-only change, and share the engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,14 @@ Transpose/                     # The compiler toolchain
 │   ├── Support/               #   TransposeNaming, NameMangler, UnsupportedFeatureScanner
 │   └── Runtime/tps.shim.js    #   embedded TransposeR shim (language helpers over the tps.js runtime)
 ├── Transpose.Compiler/        # The CLI compiler.  AssemblyName + tool command: `tps`
-│   ├── Program.cs             #   arg parsing, orchestration, output modes
-│   └── WatchMode.cs           #   `tps --watch`: rebuild on change, serve over Kestrel + live reload
+│   ├── Program.cs             #   arg parsing -> BuildOptions, the --timing report, watch-mode entry
+│   └── WatchMode.cs           #   `tps --watch`'s dev server only: Kestrel static files + the reload socket
 ├── Transpose.Compiler.Core/   # Shared engine behind the CLI and Transpose.Compiler.Library — not itself
 │   │                          #   packaged, like Transpose.Translator above. Namespace Transpose.Compiler.
+│   ├── ProjectBuild.cs        #   one build of one project, end to end (everything `tps` does after parsing
+│   │                          #   its command line): BuildOptions -> BuildOutcome, plus BuildLog
+│   ├── WatchSession.cs        #   the watch engine: file watchers + debounce, the rebuild-vs-CSS-only
+│   │                          #   decision, ReloadHub (websocket) and the injected live-reload script
 │   ├── ProjectResolver.cs     #   reads the .csproj (raw XML), globs sources, resolves references
 │   ├── ProjectXml.cs          #   csproj + <Import> flattening (shared projects' .projitems)
 │   ├── OutputBuilder.cs       #   site build (runtime + bundle + resources + index.html) + stale-output prune
@@ -52,8 +56,13 @@ Transpose/                     # The compiler toolchain
 ├── Transpose.Compiler.Library/# Compiler-as-a-library. Package id + AssemblyName Transpose.Compiler.Library
 │   ├── CompilationRequest.cs  #   fluent request: in-memory sources, package/reference assemblies, settings
 │   ├── CompilationResult.cs   #   JS/assembly bytes + diagnostics on success, formatted errors on failure
-│   └── TransposeCompilerLibrary.cs # Compile/CompileAsync — serialized (CompileProgress/PhaseTimings are
-│                              #   process-wide mutable state, so concurrent compiles are queued, not parallel)
+│   ├── ProjectBuildRequest.cs #   build a real on-disk .csproj (the library form of `tps --project`)
+│   ├── ProjectBuildResult.cs  #   exit code + site directory + formatted errors/warnings + captured output
+│   ├── TransposeWatcher.cs    #   watch mode for a host that runs its own web server: Start/BeginWatching +
+│   │                          #   HandleWebSocketAsync. Used by `curiosity-cli serve --watch` (mosaik repo)
+│   └── TransposeCompilerLibrary.cs # Compile/BuildProject (+Async) — serialized (CompileProgress/PhaseTimings
+│                              #   and the diagnostic sink are process-wide mutable state, so concurrent
+│                              #   compiles are queued, not parallel)
 ├── Transpose.Bench/           # Benchmark harness. AssemblyName + tool command: `tps-bench`
 │   ├── MachineInfo.cs         #   CPU model / cores / RAM / SIMD-ISA detection
 │   ├── CpuScore.cs            #   short deterministic CPU+memory benchmark -> normalisation score
@@ -270,8 +279,9 @@ property is not guessed at: such an import or item is skipped, which is why SDK-
 `--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line),
 `--watch` / `--watch-port <n>` (rebuild a site on every source change — root project and every
 referenced project — and serve it over Kestrel on localhost; the served index.html carries an
-injected script that reconnects over a websocket and reloads the page after each rebuild; see
-`Transpose.Compiler/WatchMode.cs`).
+injected script that reconnects over a websocket and reloads the page after each rebuild, or swaps
+the page's stylesheets in place when only CSS changed; see `Transpose.Compiler.Core/WatchSession.cs`
+for the engine and `Transpose.Compiler/WatchMode.cs` for the dev server).
 
 ### Diagnostics are in MSBuild's canonical format
 
@@ -405,19 +415,45 @@ The short version:
   a consumer actually binds against. Output is byte-identical either way, gated in CI over eight edit
   shapes. The `tps` CLI still defaults to off; the SDK opts in. Remaining: re-emitting only the
   *dependent* types when a declaration changes. See **`TODO.incremental.md`**.
-- **Watch mode (done).** `tps --watch` (`Transpose.Compiler/WatchMode.cs`) rebuilds a site whenever a
-  source file changes — the root project's own sources and every project it transitively references
-  (via `ProjectResolver.ReferencedProjectsInBuildOrder`), debounced so one save triggers one rebuild —
-  and serves the assembled site over a Kestrel dev server (`--watch-port`, default 4300) started with
+- **Watch mode (done).** `tps --watch` rebuilds a site whenever a source file changes — the root
+  project's own sources and every project it transitively references (via
+  `ProjectResolver.ReferencedProjectsInBuildOrder`), debounced so one save triggers one rebuild — and
+  serves the assembled site over a Kestrel dev server (`--watch-port`, default 4300) started with
   `Microsoft.AspNetCore.App` as a `FrameworkReference` (no `Sdk.Web` switch needed). `OutputBuilder`
   gets an optional `liveReloadScript` inlined before `</body>`; it opens a websocket to
-  `/__tps-livereload` and reloads on any message, and a monotonic build version embedded in the script
-  lets a reconnecting client (e.g. one whose reload navigation overlapped a second rebuild) catch up
-  immediately instead of waiting on a broadcast it could otherwise miss. `Program.RunOnce` is the
-  extracted single-build path both a plain invocation and every watch rebuild call. Covered end to end
-  by `WatchModeTests` in its own **`Transpose.WatchMode.Tests`** project (a real `tps --watch` subprocess
-  + headless Chromium via Playwright, editing both the root and a referenced project and asserting the
-  page reloads itself — never calling `page.ReloadAsync()`).
+  `/__tps-livereload` and acts on the message (`reload` → reload the page, `css` → re-fetch the
+  stylesheets), and a monotonic build version embedded in the script lets a reconnecting client (e.g. one
+  whose reload navigation overlapped a second rebuild) catch up immediately instead of waiting on a
+  broadcast it could otherwise miss.
+
+  The split is deliberate: `WatchSession` (`Transpose.Compiler.Core`) is the whole engine — watchers,
+  debounce, the change classification, the reload hub and the injected script — and
+  `Transpose.Compiler/WatchMode.cs` is *only* the dev server (static files + the websocket endpoint), so
+  a host with its own web server drives the identical loop through `TransposeWatcher`
+  (`Transpose.Compiler.Library`). `curiosity-cli serve --watch` in the **mosaik** repo is that host.
+
+  **A CSS-only change skips the compiler.** When every file in a debounced batch is a source of a
+  stylesheet the last successful build already produced from disk (a `tps.json` `resources` group, in the
+  root project or in any project it references), the site's CSS is re-copied — byte for byte what a full
+  build would have written, via `OutputBuilder.CssResources`/`WriteCssResources` — and the page is told
+  `css` rather than `reload`, so the running app keeps its state. Anything else is a real build: a new
+  stylesheet adds a `<link>` to index.html, a deleted one has to remove it, and a `.cs`/`.csproj`/tps.json
+  edit obviously needs compiling. The build version deliberately does **not** advance for a CSS update,
+  because index.html was not rewritten.
+
+  Covered end to end by `WatchModeTests` in its own **`Transpose.WatchMode.Tests`** project (a real
+  `tps --watch` subprocess + headless Chromium via Playwright): editing both the root and a referenced
+  project and asserting the page reloads itself — never calling `page.ReloadAsync()` — and editing a
+  stylesheet and asserting the computed style changes while a value set on `window` survives, i.e. the
+  page was *not* reloaded and `app.js` was not even rewritten.
+
+- **Reading a package's embedded resources never loads it (`OutputBuilder.AssemblyResources`).** The site
+  build reads each reference's embedded JS/CSS through Mono.Cecil, not `Assembly.LoadFrom`. Loading an
+  assembly to read its resources is fine for a one-shot CLI and broken for anything long-running: the
+  file stays locked for the process's lifetime, so the *next* rebuild of a referenced project fails to
+  write its DLL (`IOException`, which is exactly what watch mode used to do on its second rebuild of a
+  multi-project app), and resolution is by assembly identity, so a re-read of a rebuilt DLL silently
+  returns the copy loaded the first time.
 
 A compilation server is still intentionally **out of scope** — though the measurements in
 `TODO.incremental.md` say what it would be worth (the residual cost of an incremental build is almost

--- a/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
@@ -95,14 +95,32 @@ internal static class MsBuildDiagnostic
         return $"{origin}: {category} {code}: {(message.Length == 0 ? "(no message)" : message)}";
     }
 
+    /// <summary>
+    /// Where a diagnostic line is written: the line, and whether it is an error. Null — the default —
+    /// means the console, which is what <c>tps</c> wants (errors on stderr, warnings on stdout; MSBuild
+    /// parses both streams alike). <c>Transpose.Compiler.Library</c> redirects this for the duration of
+    /// one build so a hosting application can collect the diagnostics instead of finding them on its own
+    /// console. Process-wide mutable state, exactly like <c>Transpose.Translator.CompileProgress.Sink</c>
+    /// — which is why the library serializes its builds.
+    /// </summary>
+    public static Action<string, bool>? Sink;
+
     /// <summary>Writes an error for a failure that is not tied to a source file.</summary>
     public static void WriteError(string code, string text)
-        => Console.Error.WriteLine(Format("error", code, text));
+        => Write(Format("error", code, text), isError: true);
 
-    /// <summary>Writes a warning for a condition that is not tied to a source file. Warnings go to
-    /// stdout — they are not failures, and MSBuild parses both streams alike.</summary>
+    /// <summary>Writes a warning for a condition that is not tied to a source file.</summary>
     public static void WriteWarning(string code, string text)
-        => Console.WriteLine(Format("warning", code, text));
+        => Write(Format("warning", code, text), isError: false);
+
+    /// <summary>Writes an already-formatted diagnostic line to <see cref="Sink"/> (or the console).</summary>
+    public static void Write(string line, bool isError)
+    {
+        var sink = Sink;
+        if (sink is not null) sink(line, isError);
+        else if (isError) Console.Error.WriteLine(line);
+        else Console.WriteLine(line);
+    }
 
     /// <summary>
     /// Collapses a message to a single line: MSBuild parses line by line, so a newline in the middle

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 
@@ -58,6 +57,20 @@ internal static class OutputBuilder
     /// re-produce). <see cref="RemovedStaleFiles"/> is empty when cleaning is disabled or nothing was
     /// stale.</summary>
     public readonly record struct SiteBuildResult(string OutputDir, IReadOnlyList<string> RemovedStaleFiles);
+
+    /// <summary>
+    /// One stylesheet a site build produces <em>from files on disk</em> — a <c>tps.json</c> resource
+    /// group of the root project or of any project in its closure — recorded as the output-relative
+    /// path it is written to plus the source files that produce it. <see cref="Concatenated"/>
+    /// distinguishes a named bundle group (every source file joined into the one output, e.g.
+    /// Tesserae's <c>tss.css</c>) from a copy-through group (each source copied under its own name).
+    ///
+    /// This is what makes a CSS-only rebuild possible: watch mode can reproduce exactly these files,
+    /// byte for byte, without recompiling anything (see <see cref="WriteCssResources"/>). CSS a
+    /// referenced <em>package</em> embeds is deliberately not here — changing that means rebuilding
+    /// the package, which is a real build.
+    /// </summary>
+    public readonly record struct CssResource(string OutputRelativePath, IReadOnlyList<string> SourceFiles, bool Concatenated);
 
     public static SiteBuildResult Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, string configuration, string? metadataJavascript = null, string? liveReloadScript = null)
     {
@@ -335,6 +348,52 @@ internal static class OutputBuilder
     private readonly record struct EmbeddedJs(string FileName, string Rel, string Text, bool Load = true);
 
     /// <summary>
+    /// Read-only access to one assembly's embedded resources, opened and closed around the extraction —
+    /// deliberately <em>not</em> via <c>Assembly.LoadFrom</c>.
+    ///
+    /// Loading an assembly to read its resources has two consequences a build cannot live with, both of
+    /// which only show up in a long-running process (i.e. <c>tps --watch</c>, or a host embedding the
+    /// compiler): the file stays locked for the lifetime of the process, so the *next* rebuild of that
+    /// referenced project fails to write its DLL; and the runtime resolves by assembly identity, so a
+    /// second read of a rebuilt DLL silently returns the copy loaded the first time. Reading the metadata
+    /// with Mono.Cecil — already how <see cref="TopologicalOrder"/> inspects these same assemblies — has
+    /// neither problem: nothing is loaded into the process, and the handle is released on Dispose.
+    /// </summary>
+    private sealed class AssemblyResources : IDisposable
+    {
+        private readonly Mono.Cecil.AssemblyDefinition _assembly;
+        private readonly Dictionary<string, Mono.Cecil.EmbeddedResource> _byName;
+
+        private AssemblyResources(Mono.Cecil.AssemblyDefinition assembly)
+        {
+            _assembly = assembly;
+            _byName = new Dictionary<string, Mono.Cecil.EmbeddedResource>(StringComparer.Ordinal);
+            var names = new List<string>();
+            foreach (var resource in assembly.MainModule.Resources.OfType<Mono.Cecil.EmbeddedResource>())
+            {
+                if (_byName.TryAdd(resource.Name, resource)) names.Add(resource.Name);
+            }
+            Names = names;
+        }
+
+        /// <summary>Opens <paramref name="dllPath"/> for reading, or returns null if it is not a readable
+        /// assembly — a missing or half-written DLL is a condition the site build reports by simply
+        /// contributing nothing, exactly as it did before.</summary>
+        public static AssemblyResources? TryOpen(string dllPath)
+        {
+            try { return new AssemblyResources(Mono.Cecil.AssemblyDefinition.ReadAssembly(dllPath)); }
+            catch { return null; }
+        }
+
+        /// <summary>Every embedded resource's name, in metadata order.</summary>
+        public IReadOnlyList<string> Names { get; }
+
+        public Stream Open(string name) => _byName[name].GetResourceStream();
+
+        public void Dispose() => _assembly.Dispose();
+    }
+
+    /// <summary>
     /// Extracts a referenced project assembly's embedded resources (listed in its
     /// Transpose.Resources.json manifest) into the output folder: CSS is written and linked here,
     /// and the JS resources are returned for <c>RoutePackageJs</c> to place (which picks the
@@ -346,15 +405,15 @@ internal static class OutputBuilder
     {
         var jsFiles = new List<EmbeddedJs>();
         if (!File.Exists(dllPath)) return jsFiles;
-        Assembly asm;
-        try { asm = Assembly.LoadFrom(dllPath); } catch { return jsFiles; }
+        using var asm = AssemblyResources.TryOpen(dllPath);
+        if (asm is null) return jsFiles;
 
-        var names = asm.GetManifestResourceNames();
+        var names = asm.Names;
         var manifestName = names.FirstOrDefault(n => n.EndsWith("Transpose.Resources.json", StringComparison.OrdinalIgnoreCase));
         if (manifestName is null) return jsFiles;
 
         List<(string fileName, string? path, bool load)> entries;
-        using (var ms = asm.GetManifestResourceStream(manifestName)!)
+        using (var ms = asm.Open(manifestName))
         using (var sr = new StreamReader(ms))
         using (var doc = JsonDocument.Parse(sr.ReadToEnd(), new JsonDocumentOptions { AllowTrailingCommas = true }))
         {
@@ -381,7 +440,7 @@ internal static class OutputBuilder
 
             if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
             {
-                using var s = asm.GetManifestResourceStream(resName)!;
+                using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
                 jsFiles.Add(new EmbeddedJs(fileName, rel, reader.ReadToEnd(), load));
             }
@@ -390,7 +449,7 @@ internal static class OutputBuilder
                 // CSS and copy-through resources (images, fonts): write to disk now.
                 var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                using (var s = asm.GetManifestResourceStream(resName)!)
+                using (var s = asm.Open(resName))
                 using (var fs = File.Create(dest))
                     s.CopyTo(fs);
                 written.Add(Path.GetFullPath(dest));
@@ -464,52 +523,132 @@ internal static class OutputBuilder
         string projectDir, string outputDir, TransposeJson.ResourceGroup group,
         List<JsOut> jsOuts, List<string> cssLinks, HashSet<string> written)
     {
-        var destSub = (group.Output ?? "").Replace('\\', '/').TrimEnd('/');
-        var files = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
-        if (files.Count == 0) return;
-
         // The group name carries the "module#file" grouping and the ".dontload" flag; parse both. A
         // .dontload resource is written to the output but never referenced from index.html.
         var (name, load) = ParseResourceName(group.Name ?? "");
-        var isBundle = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
-                       || name.EndsWith(".css", StringComparison.OrdinalIgnoreCase);
+        var isBundle = IsBundleName(name);
 
-        void RouteJs(string rel)
+        foreach (var (rel, sources) in ResourceGroupOutputs(projectDir, group))
         {
-            if (!load) return;   // copied to disk already; not injected into index.html
+            WriteResource(outputDir, rel, sources, concatenate: isBundle, written);
+            if (!load) continue;   // written to disk already; not injected into index.html
+
+            if (IsCss(rel)) cssLinks.Add(rel);
             // Resource JS is taken as authored (never re-minified): a .min.js links only from
             // index.min.html; a plain .js links only from index.html — matching the legacy compiler.
-            if (IsMinifiedName(rel)) jsOuts.Add(new JsOut { Path = rel, IsMinified = true });
-            else jsOuts.Add(new JsOut { Path = rel });
+            else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+                jsOuts.Add(new JsOut { Path = rel, IsMinified = IsMinifiedName(rel) });
         }
+    }
 
-        void LinkCss(string rel) { if (load) cssLinks.Add(rel); }
+    /// <summary>Whether a resource group's <c>name</c> makes it a <em>bundle</em> group — every file it
+    /// lists is concatenated into that one named output — rather than a copy-through group, where each
+    /// listed file is copied under its own file name.</summary>
+    private static bool IsBundleName(string name)
+        => name.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
+           || name.EndsWith(".css", StringComparison.OrdinalIgnoreCase);
 
-        if (isBundle)
+    /// <summary>
+    /// What one <c>tps.json</c> resource group resolves to on disk: the output-relative path of each
+    /// file it produces, and the source file(s) behind it. A bundle group yields exactly one output
+    /// (its declared name, fed by every file it lists); a copy-through group yields one output per
+    /// file. Empty when the group's globs match nothing.
+    ///
+    /// The single place that maps a group to its outputs, so the site build
+    /// (<see cref="ProcessResourceGroup"/>) and the CSS-only rebuild path
+    /// (<see cref="CssResources"/>) can never disagree about where a file lands.
+    /// </summary>
+    private static List<(string rel, List<string> sources)> ResourceGroupOutputs(
+        string projectDir, TransposeJson.ResourceGroup group)
+    {
+        var outputs = new List<(string, List<string>)>();
+        var destSub = (group.Output ?? "").Replace('\\', '/').TrimEnd('/');
+        var files = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
+        if (files.Count == 0) return outputs;
+
+        string Rel(string leaf) => string.IsNullOrEmpty(destSub) ? leaf : destSub + "/" + leaf;
+
+        var (name, _) = ParseResourceName(group.Name ?? "");
+        if (IsBundleName(name))
         {
-            // Concatenate the group's files into a single named output (e.g. tss-dep.js).
-            var rel = string.IsNullOrEmpty(destSub) ? name : destSub + "/" + name;
-            var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
-            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-            File.WriteAllText(dest, string.Join("\n", files.Select(File.ReadAllText)));
-            written.Add(Path.GetFullPath(dest));
-            if (name.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) LinkCss(rel);
-            else RouteJs(rel);
+            outputs.Add((Rel(name), files));
         }
         else
         {
-            // Copy each file through (images, or JS/CSS referenced by their own file name).
             foreach (var src in files)
+                outputs.Add((Rel(Path.GetFileName(src)), new List<string> { src }));
+        }
+        return outputs;
+    }
+
+    /// <summary>Writes one resource-group output: a bundle group's files joined with newlines, or a
+    /// single file copied through byte for byte. <paramref name="written"/> is null for a CSS-only
+    /// rebuild, which rewrites files the last full build already recorded in its manifest.</summary>
+    private static void WriteResource(
+        string outputDir, string rel, IReadOnlyList<string> sources, bool concatenate, HashSet<string>? written)
+    {
+        var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+        if (concatenate) File.WriteAllText(dest, string.Join("\n", sources.Select(File.ReadAllText)));
+        else File.Copy(sources[0], dest, overwrite: true);
+        written?.Add(Path.GetFullPath(dest));
+    }
+
+    /// <summary>
+    /// Every stylesheet this project's site build produces from files on disk, across the whole project
+    /// closure. Two sources contribute, and both resolve a group to the same output path:
+    ///
+    /// <list type="bullet">
+    /// <item>the projects whose <c>tps.json</c> resources <see cref="Build"/> reads directly
+    /// (<see cref="ResolvedProject.ProjectDirs"/> — in separate-assembly mode, just the root);</item>
+    /// <item>every project the root <em>references</em>, whose stylesheets reach the site as resources
+    /// embedded in its package DLL. The embedded copy is a byte-for-byte concatenation of the same files
+    /// under the same group name and <c>output</c> directory, so re-copying from disk lands the same
+    /// bytes at the same path that a full rebuild (recompiling that dependency, re-embedding, and
+    /// re-extracting) would have.</item>
+    /// </list>
+    ///
+    /// Watch mode captures this after each successful build so it can tell a change to a CSS source it
+    /// already knows about from one that needs a real rebuild.
+    /// </summary>
+    public static List<CssResource> CssResources(ResolvedProject project, TransposeJson config, string configuration)
+    {
+        var css = new List<CssResource>();
+        var seen = new HashSet<string>(PathComparer);
+
+        void Scan(string projectDir)
+        {
+            if (!seen.Add(Path.GetFullPath(projectDir))) return;
+            var cfg = projectDir == project.ProjectDir ? config : TransposeJson.TryLoad(projectDir, configuration);
+            if (cfg is null) return;
+            foreach (var group in cfg.Resources)
             {
-                var rel = string.IsNullOrEmpty(destSub) ? Path.GetFileName(src) : destSub + "/" + Path.GetFileName(src);
-                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
-                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                File.Copy(src, dest, overwrite: true);
-                written.Add(Path.GetFullPath(dest));
-                if (rel.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) LinkCss(rel);
-                else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) RouteJs(rel);
+                var isBundle = IsBundleName(ParseResourceName(group.Name ?? "").fileName);
+                foreach (var (rel, sources) in ResourceGroupOutputs(projectDir, group))
+                    if (IsCss(rel)) css.Add(new CssResource(rel, sources, isBundle));
             }
         }
+
+        // Referenced projects first, then the project's own dirs with the root last — the precedence
+        // Build applies (a package's extracted resources are written before the root's own, and the
+        // root's tps.json wins a collision).
+        foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(project.CsprojPath))
+            if (Path.GetDirectoryName(dep) is { } dir) Scan(dir);
+        foreach (var projectDir in Enumerable.Reverse(project.ProjectDirs))
+            Scan(projectDir);
+
+        return css;
+    }
+
+    /// <summary>Rewrites the given stylesheets into an already-assembled site, exactly as
+    /// <see cref="Build"/> would have — same concatenation, same encoding, same destination — so a
+    /// CSS-only update leaves the site byte-identical to what a full rebuild would have produced.
+    /// Nothing else in the output is touched, and no manifest entry changes (these paths were already
+    /// recorded by the build that produced them).</summary>
+    public static void WriteCssResources(string outputDir, IEnumerable<CssResource> resources)
+    {
+        foreach (var resource in resources)
+            WriteResource(outputDir, resource.OutputRelativePath, resource.SourceFiles, resource.Concatenated, written: null);
     }
 
     /// <summary>
@@ -581,11 +720,10 @@ internal static class OutputBuilder
     private static IReadOnlyList<EmbeddedJs> ExtractEmbeddedJs(string dllPath, string outputDir, List<string> cssLinks, HashSet<string> written)
     {
         var jsFiles = new List<EmbeddedJs>();
-        Assembly asm;
-        try { asm = Assembly.LoadFrom(dllPath); }
-        catch { return jsFiles; }
+        using var asm = AssemblyResources.TryOpen(dllPath);
+        if (asm is null) return jsFiles;
 
-        var resourceNames = asm.GetManifestResourceNames();
+        var resourceNames = asm.Names;
         var manifest = resourceNames.FirstOrDefault(n => n.EndsWith("Transpose.Resources.json", StringComparison.OrdinalIgnoreCase));
 
         // Each entry: the resource's FileName (manifest key), the output subdirectory it extracts to
@@ -595,7 +733,7 @@ internal static class OutputBuilder
         List<(string fileName, string? path, bool load)> entries;
         if (manifest is not null)
         {
-            using var ms = asm.GetManifestResourceStream(manifest)!;
+            using var ms = asm.Open(manifest);
             using var sr = new StreamReader(ms);
             using var doc = JsonDocument.Parse(sr.ReadToEnd(), new JsonDocumentOptions { AllowTrailingCommas = true });
             entries = doc.RootElement.EnumerateArray()
@@ -630,7 +768,7 @@ internal static class OutputBuilder
 
             if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
             {
-                using var s = asm.GetManifestResourceStream(resName)!;
+                using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
                 jsFiles.Add(new EmbeddedJs(leaf, rel, reader.ReadToEnd(), load));   // JS: placed/minified by RoutePackageJs
             }
@@ -640,7 +778,7 @@ internal static class OutputBuilder
                 // assets stay intact, and link stylesheets. These must never reach the JS minifier.
                 var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                using (var s = asm.GetManifestResourceStream(resName)!)
+                using (var s = asm.Open(resName))
                 using (var fs = File.Create(dest))
                     s.CopyTo(fs);
                 written.Add(Path.GetFullPath(dest));

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -1,0 +1,924 @@
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// Where a build's human-readable progress goes. Defaults to the console — what the <c>tps</c> CLI
+/// wants — and is overridden by a hosting application (via <c>Transpose.Compiler.Library</c>) that would
+/// rather collect the lines than have them appear on its own console. Only ordinary progress output goes
+/// here; diagnostics keep their canonical MSBuild form and their own sink
+/// (<see cref="MsBuildDiagnostic.Sink"/>), because a build tool's errors are a contract, not chatter.
+/// </summary>
+internal class BuildLog
+{
+    /// <summary>The default log: progress on stdout, failures on stderr.</summary>
+    public static readonly BuildLog Console = new();
+
+    /// <summary>A log that discards everything.</summary>
+    public static readonly BuildLog Silent = new SilentLog();
+
+    public virtual void Info(string message) => System.Console.WriteLine(message);
+    public virtual void Error(string message) => System.Console.Error.WriteLine(message);
+
+    private sealed class SilentLog : BuildLog
+    {
+        public override void Info(string message) { }
+        public override void Error(string message) { }
+    }
+}
+
+/// <summary>
+/// Everything one build of one project needs to know: which project, which configuration, and the
+/// output shape. Mirrors the <c>tps</c> command line one-to-one — the CLI parses arguments into this and
+/// nothing else — so a library caller has exactly the same knobs as the tool.
+/// </summary>
+internal sealed record BuildOptions
+{
+    /// <summary>Absolute path to the <c>.csproj</c> to build.</summary>
+    public required string CsprojPath { get; init; }
+
+    /// <summary>Write a single JavaScript bundle to this path instead of assembling a site or a package
+    /// (<c>--out</c>). Null for the normal site/package build.</summary>
+    public string? OutPath { get; init; }
+
+    /// <summary>Override the site output directory tps.json's <c>output</c> would resolve to
+    /// (<c>--site-dir</c>).</summary>
+    public string? SiteDir { get; init; }
+
+    public string Configuration { get; init; } = "Debug";
+
+    /// <summary>Prepend the tps.js runtime to a <see cref="OutPath"/> bundle (<c>--with-runtime</c>).</summary>
+    public bool WithRuntime { get; init; }
+
+    /// <summary>Suppress warning output (<c>--quiet</c>).</summary>
+    public bool Quiet { get; init; }
+
+    /// <summary>Cap on how many individual errors are reported; 0 — the default — reports every one.</summary>
+    public int MaxErrors { get; init; }
+
+    /// <summary>Compile the project as a distributable package assembly (<c>--emit-package</c>).</summary>
+    public bool EmitPackage { get; init; }
+
+    /// <summary>Consume referenced projects as their built DLLs rather than recompiling their sources.</summary>
+    public bool SeparateAssemblies { get; init; }
+
+    /// <summary>Build the base runtime package (<c>--build-runtime</c>): only the BCL does this.</summary>
+    public bool BuildRuntime { get; init; }
+
+    /// <summary>Extra reference assemblies outside the NuGet cache (<c>--reference</c>).</summary>
+    public IReadOnlyList<string> ExtraReferences { get; init; } = Array.Empty<string>();
+
+    /// <summary>Extra preprocessor symbols (<c>--define</c>).</summary>
+    public IReadOnlyList<string> ExtraDefines { get; init; } = Array.Empty<string>();
+
+    public string? AssemblyVersion { get; init; }
+
+    /// <summary>Force the emitted .NET assembly to be metadata-only, or real IL. Null leaves the
+    /// decision to the csproj property and then the configuration default.</summary>
+    public bool? MetadataOnlyAssembly { get; init; }
+
+    /// <summary>Reuse the previous build of this project where its inputs are unchanged.</summary>
+    public bool Incremental { get; init; }
+
+    /// <summary>Where the incremental cache lives; null means the project's <c>obj/</c>.</summary>
+    public string? CacheDir { get; init; }
+
+    /// <summary>A script inlined into the generated index.html right before <c>&lt;/body&gt;</c>. Watch
+    /// mode passes its live-reload script here; every other build passes null, leaving the output
+    /// untouched.</summary>
+    public string? LiveReloadScript { get; init; }
+}
+
+/// <summary>
+/// The outcome of one build. <see cref="OutDir"/> is set only for a successful <em>site</em> build —
+/// which is what makes it the test for "this build produced something servable" that watch mode needs;
+/// a failure, or a package/bundle/runtime build, leaves it null. <see cref="CssResources"/> lists the
+/// stylesheets that site assembled from files on disk, so a watcher can rewrite one without recompiling
+/// (see <see cref="OutputBuilder.CssResource"/>).
+/// </summary>
+internal readonly record struct BuildOutcome(
+    int ExitCode,
+    string? OutDir,
+    bool HtmlDisabled,
+    IReadOnlyList<Diagnostic> Diagnostics,
+    IReadOnlyList<OutputBuilder.CssResource> CssResources)
+{
+    public bool Success => ExitCode == 0;
+
+    /// <summary>An outcome with no servable site: every failure, and every successful build whose shape
+    /// is a package DLL, the runtime assembly or a single <c>--out</c> bundle.</summary>
+    public static BuildOutcome NoSite(int exitCode, IReadOnlyList<Diagnostic>? diagnostics = null)
+        => new(exitCode, null, false, diagnostics ?? Array.Empty<Diagnostic>(), Array.Empty<OutputBuilder.CssResource>());
+}
+
+/// <summary>
+/// One build of one project, end to end: resolve the csproj, chain its referenced projects, translate,
+/// and write the outputs (a site, a package DLL, the runtime assembly, or a single bundle).
+///
+/// This is the whole of what <c>tps</c> does after parsing its command line, and it lives here rather
+/// than in the CLI so <c>Transpose.Compiler.Library</c> can run exactly the same build in-process — a
+/// hosting application (the Curiosity CLI's watch-mode dev server, for one) needs a real project build,
+/// not just the in-memory source compilation the library started out offering. The CLI keeps argument
+/// parsing, the timing report and its watch-mode server; everything else is here.
+/// </summary>
+internal static class ProjectBuild
+{
+    /// <summary>
+    /// Fills in the output shape the project implies, the way the <c>tps</c> command line always has —
+    /// so a caller that only says "build this project" gets the same decision the CLI makes.
+    ///
+    /// When the Transpose SDK invokes <c>tps --project</c> for a library — no explicit <c>--out</c> and
+    /// not the <c>--build-runtime</c> corlib — the build must produce the distributable package
+    /// assembly, exactly as <c>--emit-package</c> does: the .NET DLL (with the compiled JS +
+    /// Transpose.Resources.json manifest embedded) that <c>dotnet pack</c> wraps into
+    /// <c>lib/&lt;tfm&gt;/&lt;Assembly&gt;.dll</c>. Without this the SDK build emits only a stray .js (or a
+    /// runnable site folder) and <c>dotnet pack</c> fails with NU5026 (&lt;Assembly&gt;.dll not found).
+    ///
+    /// A binding library needs this even when it carries a tps.json (which only configures its JS
+    /// layout / embedded resources): tps.json presence alone does not make it a site app. Only a
+    /// *non-packable* project with a tps.json builds a runnable site; a packable one is a library.
+    /// Projects that pass <c>--out</c> (bootstrap, tooling) keep writing a single .js bundle unchanged.
+    ///
+    /// A site build additionally consumes each referenced project's already-built package DLL —
+    /// extracting its compiled JS — instead of recompiling that project's sources into this bundle. A
+    /// dependency is therefore compiled once and reused: editing the app re-transpiles only the app's
+    /// own files, not the whole referenced library. (With no project references this is equivalent to
+    /// the old bundle build.)
+    /// </summary>
+    public static BuildOptions ResolveOutputMode(BuildOptions options)
+    {
+        if (options.EmitPackage || options.BuildRuntime || options.OutPath is not null) return options;
+
+        var hasTpsJson = TransposeJson.TryLoad(Path.GetDirectoryName(Path.GetFullPath(options.CsprojPath))!) is not null;
+        if (ProjectResolver.IsPackable(options.CsprojPath) || !hasTpsJson)
+            return options with { EmitPackage = true, SeparateAssemblies = true };
+
+        return options with { SeparateAssemblies = true };
+    }
+
+    /// <summary>Whether these (already <see cref="ResolveOutputMode"/>d) options describe a build that
+    /// assembles a runnable site — the only shape watch mode can serve.</summary>
+    public static bool IsSiteBuild(BuildOptions options)
+        => !options.EmitPackage && !options.BuildRuntime && options.OutPath is null
+           && TransposeJson.TryLoad(Path.GetDirectoryName(Path.GetFullPath(options.CsprojPath))!, options.Configuration) is not null;
+
+    /// <summary>
+    /// Runs one build of <paramref name="options"/> end to end. Watch mode calls this repeatedly (once
+    /// per detected change) with a fresh <see cref="BuildOutcome"/> each time; a normal invocation calls
+    /// it once. Never throws for a build failure — a crash in the translator or the write phase is
+    /// reported as a diagnostic and returned as a non-zero exit code, so a long-running host (a watch
+    /// server) can keep going.
+    /// </summary>
+    public static BuildOutcome Run(BuildOptions options, BuildLog? log = null)
+    {
+        log ??= BuildLog.Console;
+        var csproj = options.CsprojPath;
+        var configuration = options.Configuration;
+
+        log.Info($"tps: compiling {Path.GetFileName(csproj)}");
+        // Surface the translator's phase/step progress (binding, scanning, JS emit) so the long
+        // silent phases show visible movement. Quiet mode suppresses it. Always assigned (rather than
+        // only when not quiet): the sink is process-wide, so a quiet build must clear a previous build's
+        // sink rather than keep reporting into it.
+        CompileProgress.Sink = options.Quiet ? null : msg => log.Info($"  {msg}");
+        var sw = Stopwatch.StartNew();
+
+        ResolvedProject project;
+        try
+        {
+            project = PhaseTimings.Measure("resolve project (csproj + globs + references)",
+                () => ProjectResolver.Resolve(csproj, configuration, options.SeparateAssemblies));
+        }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
+                $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
+            return BuildOutcome.NoSite(1);
+        }
+
+        // Extra references (--reference) and defines (--define) from the command line. --reference
+        // lets a build reference assemblies that are not in the NuGet cache (e.g. locally-built
+        // tps.core during bootstrap, or a <Reference HintPath> assembly).
+        foreach (var r in options.ExtraReferences)
+        {
+            var full = Path.GetFullPath(r);
+            if (File.Exists(full) && !project.ReferencePaths.Contains(full)) project.ReferencePaths.Add(full);
+            else if (!File.Exists(full))
+                MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeReferenceNotFound,
+                    $"--reference not found: {full}");
+        }
+        foreach (var d in options.ExtraDefines)
+            if (!project.DefineConstants.Contains(d)) project.DefineConstants.Add(d);
+
+        log.Info($"  sources:    {project.Sources.Count} file(s){(options.SeparateAssemblies ? " (own sources only)" : "")}");
+        log.Info($"  references: {project.ReferencePaths.Count} assembly(ies) — {string.Join(", ", project.ReferencePaths.Select(Path.GetFileNameWithoutExtension))}");
+        if (project.ReferencedProjectDlls.Count > 0)
+            log.Info($"  projects:   {string.Join(", ", project.ReferencedProjectDlls.Select(Path.GetFileName))}");
+        log.Info($"  defines:    {string.Join(";", project.DefineConstants)}");
+        log.Info($"  config:     {configuration}");
+        log.Info($"  lang:       {project.LanguageVersion}");
+
+        // Command line beats the csproj property, which beats the per-configuration default. Printed,
+        // because "why is my DLL half the size in Debug?" should be answerable from the build log.
+        var metadataOnly = options.MetadataOnlyAssembly
+                           ?? project.MetadataOnlyAssembly
+                           ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration);
+        log.Info($"  assembly:   {(metadataOnly ? "metadata only (throw-null bodies, not packable)" : "full IL")}");
+
+        // The project's tps.json drives runtime-package detection and reflection settings. A
+        // tps.<Configuration>.json overlay (e.g. tps.Release.json) is merged on top when present.
+        var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
+
+        // Base runtime package build: compile Transpose.BCL self-contained, transpile it with
+        // outputBy: ClassPath, stitch the per-class files with the hand-written Resources primitives
+        // into tps.js per the project's tps.json, and embed tps.js + tps.meta.js into Transpose.dll.
+        //
+        // This path is ONLY for the base library, which *defines* the BCL and therefore references no
+        // Transpose.dll of its own. A binding library (Transpose.Newtonsoft.Json, Transpose.WebGL2, …)
+        // may also declare outputBy: ClassPath for its JS layout, but it references the Transpose BCL
+        // and must bind against it — compiling it self-contained would leave System.Object and every
+        // other predefined type undefined (CS0518 ×N). Such libraries fall through to the package path.
+        var referencesTransposeBcl = project.ReferencePaths.Any(p =>
+            string.Equals(Path.GetFileNameWithoutExtension(p), "Transpose", StringComparison.OrdinalIgnoreCase));
+        if (options.BuildRuntime
+            || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && !referencesTransposeBcl))
+            return BuildOutcome.NoSite(BuildRuntimePackage(project, configuration, sw, options, log));
+
+        // Refuse to compile against assemblies built by a newer Transpose than this one (see
+        // BuildStamp). Checked before anything is compiled — and before the incremental cache can
+        // declare the project up to date — so the answer never depends on how much of a previous
+        // build survives. The base library is checked too: it is injected by the translator rather
+        // than listed as a project reference, and it is the assembly most likely to be ahead of the
+        // compiler in a NuGet cache.
+        if (!CompilerIsNewEnough(project.ReferencePaths, log)) return BuildOutcome.NoSite(1);
+
+        // Reflection settings come from the project's tps.json (target inline vs a .meta.js file).
+        var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
+
+        // Chain the referenced projects first (like the MSBuild-driven compiler): in
+        // separate-assembly / package mode this project binds against its dependencies' built DLLs
+        // and extracts their embedded JS, so each must be compiled — in dependency order — before
+        // this one. Up-to-date packages are skipped.
+        if (options.SeparateAssemblies && !EnsureReferencedProjectsBuilt(csproj, options, log))
+        {
+            log.Error("\nFAILED building referenced projects.");
+            return BuildOutcome.NoSite(1);
+        }
+
+        // A site build still emits the .NET assembly: the Transpose.Build.Target SDK declares the
+        // project's <Assembly>.dll as its build output, and MSBuild copies it for any project that
+        // references this one. Emitting the DLL (with the compiled JS embedded, like a package) means
+        // every project — app or library — produces the DLL the SDK/consumers expect.
+        var isSiteBuild = !options.EmitPackage && !options.BuildRuntime && options.OutPath is null && tpscfg is not null;
+
+        // Incremental build (--incremental): consult the cache written by the previous build of this
+        // project. This happens *after* the referenced projects were rebuilt above, so a dependency's
+        // freshly written DLL is part of what gets fingerprinted.
+        BuildCache? cache = null;
+        var verdict = BuildCache.Verdict.FullBuild;
+        var changedSources = new List<string>();
+        if (options.Incremental)
+        {
+            cache = BuildCache.Open(project, configuration,
+                OutputMode(options.EmitPackage, isSiteBuild),
+                // "watch={..}" so switching --watch on/off across builds sharing a cache dir invalidates
+                // it — the injected live-reload script changes the written index.html even when nothing
+                // else about the build did, and an "up to date" verdict skips writing it altogether.
+                BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
+                    metadataOnly, options.EmitPackage, isSiteBuild, options.SeparateAssemblies, options.WithRuntime,
+                    options.OutPath, options.SiteDir, options.AssemblyVersion)
+                    .Append($"watch={options.LiveReloadScript is not null}"),
+                BuildContentFingerprint(project),
+                options.CacheDir);
+            (verdict, changedSources, var reason) = cache.Decide();
+
+            if (verdict == BuildCache.Verdict.UpToDate)
+            {
+                log.Info($"\nOK — everything up to date, nothing to compile ({sw.ElapsedMilliseconds} ms).");
+                foreach (var output in cache.PreviousOutputs.Take(4)) log.Info($"  output:   {output}");
+                if (cache.PreviousOutputs.Count > 4)
+                    log.Info($"            … and {cache.PreviousOutputs.Count - 4} more");
+                // An up-to-date site is still a servable site: report where it is (and which
+                // stylesheets it assembled) so a watch host does not mistake "nothing to do" for
+                // "nothing to serve".
+                return isSiteBuild
+                    ? new BuildOutcome(0, SiteDirectory(options, tpscfg!, project), tpscfg!.HtmlDisabled,
+                        Array.Empty<Diagnostic>(), OutputBuilder.CssResources(project, tpscfg, configuration))
+                    : BuildOutcome.NoSite(0);
+            }
+            log.Info(verdict == BuildCache.Verdict.BodyOnlyChange
+                ? $"  cache:      {changedSources.Count} file(s) changed, method bodies only — reusing cached declarations"
+                : $"  cache:      full build ({reason})");
+        }
+        // Nothing in this project changed — only a referenced package's content did (its declarations
+        // are identical). The compilation would reproduce the cached bundle byte for byte, so skip it
+        // and go straight to writing the outputs, which do have to be rewritten.
+        var replayed = options.Incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
+            ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)
+            : null;
+        if (replayed is not null)
+            log.Info("  cache:      reusing the previous compilation in full — writing outputs only");
+
+        var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
+
+        var translator = new RoslynTranslator();
+        AssemblyBuildResult result;
+        try
+        {
+            result = replayed ?? translator.BuildAssembly(
+                project.Sources,
+                project.AssemblyName,
+                project.ReferencePaths,
+                project.DefineConstants,
+                project.LanguageVersion,
+                reflectionEnabled,
+                metadataTarget,
+                emitAssembly: options.EmitPackage || isSiteBuild,
+                assemblyVersion: options.AssemblyVersion,
+                emitDebugInformation: project.EmitDebugInformation,
+                metadataOnlyAssembly: metadataOnly,
+                incremental: plan);
+        }
+        catch (Exception ex)
+        {
+            ReportCrash("Translator", ex, log);
+            return BuildOutcome.NoSite(2);
+        }
+
+        // The stopwatch keeps running: writing the package (minifying the embedded JS, the Cecil
+        // resource embed) and assembling the site are a real part of a build's cost, and the
+        // reported total should include them rather than stopping at the translator's last phase.
+        if (!result.Success)
+        {
+            ReportDiagnostics(result.Diagnostics, options.MaxErrors, log);
+            log.Error($"\nFAILED in {sw.ElapsedMilliseconds} ms.");
+            return BuildOutcome.NoSite(1, result.Diagnostics);
+        }
+
+        var js = result.Javascript!;
+        if (!options.Quiet) ReportDiagnostics(result.Diagnostics, options.MaxErrors, log); // surface warnings
+        var config = tpscfg;
+
+        // Package mode: compile this project as a distributable assembly — emit the .NET DLL and
+        // embed its JS (+ tps.json resources) so another project can reference it and extract them.
+        if (options.EmitPackage)
+        {
+            var written = TryWritePackage(project, config, configuration, result, log);
+            if (written is null) return BuildOutcome.NoSite(2, result.Diagnostics);
+
+            var (dllPath, items) = written.Value;
+            SaveCache(cache, plan, result, new[] { dllPath });
+            log.Info($"\nOK — built package {project.AssemblyName}.dll ({result.AssemblyBytes!.Length:N0} bytes) with {items.Count} embedded resource(s) in {sw.ElapsedMilliseconds} ms.");
+            log.Info($"  dll:      {dllPath}");
+            log.Info($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
+            return BuildOutcome.NoSite(0, result.Diagnostics);
+        }
+
+        // Site build: when the project has an tps.json and no single-file --out was requested,
+        // assemble a runnable output folder (runtime JS + bundle + resources + index.html),
+        // exactly like the existing tps compiler.
+        if (config is not null && options.OutPath is null)
+        {
+            // Also emit the package DLL (with JS embedded), so referencing projects can consume this
+            // one and the SDK finds the <Assembly>.dll it declares as the build output.
+            string? dllPath = null;
+            if (result.AssemblyBytes is not null)
+            {
+                var package = TryWritePackage(project, config, configuration, result, log);
+                if (package is null) return BuildOutcome.NoSite(2, result.Diagnostics);
+                dllPath = package.Value.dllPath;
+            }
+
+            var outDir = SiteDirectory(options, config, project);
+            var siteResult = PhaseTimings.Measure("write site (minify + resources + html)", () =>
+                OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript, options.LiveReloadScript));
+            // Every file in the site counts as an output: a rebuild must notice if any of them was
+            // deleted or edited, otherwise "up to date" would leave a broken site in place.
+            SaveCache(cache, plan, result, SiteOutputs(outDir, dllPath));
+            log.Info($"\nOK — built site in {outDir} ({js.Length:N0} bytes of {config.FileName}) in {sw.ElapsedMilliseconds} ms.");
+            log.Info($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
+            if (dllPath is not null) log.Info($"  dll:        {dllPath}");
+            if (siteResult.RemovedStaleFiles.Count > 0)
+            {
+                var stale = siteResult.RemovedStaleFiles;
+                log.Info($"  cleaned:    {stale.Count} stale file(s) from a previous build");
+                foreach (var f in stale.Take(10)) log.Info($"                - {Path.GetRelativePath(outDir, f)}");
+                if (stale.Count > 10) log.Info($"                … and {stale.Count - 10} more");
+            }
+            return new BuildOutcome(0, outDir, config.HtmlDisabled, result.Diagnostics,
+                OutputBuilder.CssResources(project, config, configuration));
+        }
+
+        if (options.WithRuntime) js = RoslynTranslator.LoadRuntime() + "\n" + js;
+        var outPath = options.OutPath ?? Path.Combine(project.ProjectDir, "bin", project.AssemblyName + ".js");
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outPath))!);
+        File.WriteAllText(outPath, js);
+        SaveCache(cache, plan, result, new[] { Path.GetFullPath(outPath) });
+        log.Info($"\nOK — wrote {js.Length:N0} bytes to {outPath} in {sw.ElapsedMilliseconds} ms.");
+        return BuildOutcome.NoSite(0, result.Diagnostics);
+    }
+
+    /// <summary>The directory a site build writes to: <c>--site-dir</c> when given, otherwise the path
+    /// tps.json's <c>output</c> resolves to.</summary>
+    private static string SiteDirectory(BuildOptions options, TransposeJson config, ResolvedProject project)
+        => options.SiteDir ?? ResolveOutputDir(config, project.ProjectDir, options.Configuration);
+
+    /// <summary>
+    /// Whether this compiler is new enough for everything the project binds against — every referenced
+    /// assembly plus the injected base library (<c>Transpose.dll</c>). Reports the diagnostic and
+    /// returns false when it is not; see <see cref="BuildStamp"/> for what is being compared and
+    /// <see cref="CompilerVersion.EnforceMinimum"/> for when the check applies at all (never in a dev
+    /// build of the compiler, which carries no version).
+    /// </summary>
+    private static bool CompilerIsNewEnough(IEnumerable<string> referencePaths, BuildLog log)
+    {
+        if (!CompilerVersion.EnforceMinimum) return true;
+
+        var toCheck = new List<string>(referencePaths);
+        // Discovering the base library can itself fail (no NuGet cache, no TRANSPOSE_DLL_PATH); that is
+        // the translator's error to report, not this check's.
+        try { toCheck.Add(TransposeAssemblies.TransposeDllPath); } catch { }
+
+        var outdated = BuildStamp.CheckReferences(toCheck);
+        if (outdated is null) return true;
+
+        log.Error("");
+        MsBuildDiagnostic.Write(MsBuildDiagnostic.Format(outdated), isError: true);
+        return false;
+    }
+
+    /// <summary>
+    /// Persists the cache after a successful build. A build that reused the previous compilation whole
+    /// (no plan) has nothing new to record but its new output files; any other build writes the lot.
+    /// </summary>
+    private static void SaveCache(BuildCache? cache, IncrementalPlan? plan, AssemblyBuildResult result,
+        IEnumerable<string> outputs)
+    {
+        if (cache is null) return;
+        if (plan is null) cache.SaveOutputsOnly(outputs);
+        else cache.Save(plan, result, outputs);
+    }
+
+    /// <summary>Every file under the assembled site, plus the emitted DLL — the outputs an incremental
+    /// build has to find unchanged before it may declare the project up to date.</summary>
+    private static IEnumerable<string> SiteOutputs(string outDir, string? dllPath)
+    {
+        if (dllPath is not null) yield return dllPath;
+        if (!Directory.Exists(outDir)) yield break;
+        foreach (var file in Directory.EnumerateFiles(outDir, "*", SearchOption.AllDirectories))
+            yield return file;
+    }
+
+    /// <summary>
+    /// Everything about a build other than its source files: the settings, the output shape, and a
+    /// fingerprint of every referenced assembly and config file. A change to any of these can change
+    /// every byte of the output, so it invalidates the whole cache rather than any part of it.
+    ///
+    /// Anything the compiler starts to read in future has to be added here. That is the one
+    /// maintenance obligation the cache imposes: an input nobody fingerprints is an input whose change
+    /// goes unnoticed.
+    /// </summary>
+    private static IEnumerable<string> BuildSettingsFingerprint(
+        ResolvedProject project, string configuration, TransposeJson? tpscfg, bool reflectionEnabled,
+        MetadataTarget metadataTarget, bool metadataOnly, bool emitPackage, bool isSiteBuild,
+        bool separateAssemblies, bool withRuntime, string? outPath, string? siteDir, string? assemblyVersion)
+    {
+        yield return $"configuration={configuration}";
+        yield return $"assembly={project.AssemblyName}";
+        yield return $"tfm={project.TargetFramework}";
+        yield return $"lang={project.LanguageVersion}";
+        yield return $"defines={string.Join(";", project.DefineConstants)}";
+        yield return $"reflection={reflectionEnabled}/{metadataTarget}";
+        yield return $"metadataOnly={metadataOnly}";
+        yield return $"debugInfo={project.EmitDebugInformation}";
+        yield return $"minifyLocals={project.MinifyLocalVariables}";
+        yield return $"assemblyVersion={assemblyVersion}";
+        yield return $"mode={OutputMode(emitPackage, isSiteBuild)}";
+        yield return $"separate={separateAssemblies};runtime={withRuntime}";
+        yield return $"out={outPath};siteDir={siteDir}";
+        yield return $"tpsjson={tpscfg is null}";
+
+        // The project file and its tps.json (plus the per-configuration overlay) by content: they
+        // decide which files compile, what gets embedded and how the site is laid out.
+        yield return "csproj=" + BuildCache.FileContentFingerprint(project.CsprojPath);
+        yield return "tps.json=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, "tps.json"));
+        yield return $"tps.{configuration}.json="
+            + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, $"tps.{configuration}.json"));
+
+        // Every referenced assembly, by the part of it this project's output depends on: its metadata.
+        // A package upgrade or a dependency whose declarations moved changes emitted names (overload
+        // numbering counts the reference's full member set), so it is a full-rebuild input; a dependency
+        // rebuilt from a body-only edit of its own is not (see ReferenceMetadataFingerprint).
+        foreach (var reference in project.ReferencePaths.OrderBy(p => p, StringComparer.Ordinal))
+            yield return "ref=" + BuildCache.ReferenceMetadataFingerprint(reference);
+
+        // The Transpose base assembly and the JS runtime it carries are injected by the translator, not
+        // by the project, so they have to be fingerprinted explicitly.
+        yield return "bcl=" + BuildCache.ReferenceFingerprint(TransposeAssemblies.TransposeDllPath);
+
+        // Resources the site/package build reads straight from disk (tps.json `resources`): tps.json's
+        // own hash covers *which* files are listed, but not what is in them.
+        if (tpscfg is not null)
+            foreach (var file in tpscfg.Resources.SelectMany(g => g.Files).OrderBy(n => n, StringComparer.Ordinal))
+                yield return "res=" + file + "=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, file));
+    }
+
+    /// <summary>What shape of output this build produces — the distributable package DLL, a runnable
+    /// site, or a single .js bundle. Each gets its own cache.</summary>
+    private static string OutputMode(bool emitPackage, bool isSiteBuild)
+        => emitPackage ? "package" : isSiteBuild ? "site" : "bundle";
+
+    /// <summary>
+    /// The inputs that cannot change a byte this project *emits*, but do change what it has to *write*:
+    /// the full content of every referenced assembly, whose embedded JavaScript and resources are copied
+    /// into the site and re-embedded into this project's own DLL. A change here means "rebuild the
+    /// outputs, keep the compilation" — see <see cref="BuildCache.Open"/>.
+    /// </summary>
+    private static IEnumerable<string> BuildContentFingerprint(ResolvedProject project)
+    {
+        foreach (var reference in project.ReferencePaths.OrderBy(p => p, StringComparer.Ordinal))
+            yield return "refbytes=" + BuildCache.ReferenceFingerprint(reference);
+    }
+
+    /// <summary>
+    /// Builds the base runtime package (Transpose.BCL → the `tps` NuGet package): compiles the BCL
+    /// self-contained, transpiles it with outputBy: ClassPath into Resources/.generated/, stitches
+    /// those with the hand-written Resources/*.js primitives into tps.js (and the reflection block
+    /// into tps.meta.js) per the project's tps.json, and embeds both into Transpose.dll.
+    /// </summary>
+    private static int BuildRuntimePackage(ResolvedProject project, string configuration, Stopwatch sw,
+        BuildOptions options, BuildLog log)
+    {
+        var cfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
+        var reflectionEnabled = !(cfg?.ReflectionDisabled ?? false);
+
+        RuntimePackageResult result;
+        try
+        {
+            result = new RoslynTranslator().BuildRuntimePackage(
+                project.Sources, project.AssemblyName, project.DefineConstants,
+                project.LanguageVersion, reflectionEnabled);
+        }
+        catch (Exception ex) { ReportCrash("Runtime build", ex, log); return 2; }
+
+        if (!result.Success)
+        {
+            ReportDiagnostics(result.Diagnostics, options.MaxErrors, log);
+            log.Error($"\nFAILED building runtime in {sw.ElapsedMilliseconds} ms.");
+            return 1;
+        }
+
+        // Write the ClassPath per-class files + reflection metadata under Resources/.generated/.
+        var genRoot = Path.Combine(project.ProjectDir, "Resources", ".generated");
+        PhaseTimings.Measure("write ClassPath files", () =>
+        {
+        if (Directory.Exists(genRoot)) Directory.Delete(genRoot, recursive: true);
+        Directory.CreateDirectory(genRoot);
+        // Group types that share a ClassPath file (same simple name across generic arities, e.g.
+        // ValueTuple + ValueTuple$1..$8, or all the nested Enumerator types) so they are concatenated
+        // into one file rather than overwriting each other.
+        foreach (var grp in result.ClassPath!.Files.GroupBy(f => f.relPath))
+        {
+            var dest = Path.Combine(genRoot, grp.Key.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            File.WriteAllText(dest, string.Join("\n", grp.Select(g => g.js)));
+        }
+        if (result.ClassPath.MetaBlock is not null)
+            File.WriteAllText(Path.Combine(genRoot, project.AssemblyName + ".meta.js"), result.ClassPath.MetaBlock);
+        });
+        log.Info($"  emitted:    {result.ClassPath!.Files.Count} ClassPath file(s) into Resources/.generated");
+        if (result.ClassPath.Skipped.Count > 0)
+        {
+            log.Info($"  skipped:    {result.ClassPath.Skipped.Count} type(s) the emitter could not translate:");
+            foreach (var (t, why) in result.ClassPath.Skipped.Take(20)) log.Info($"                - {t}: {why}");
+        }
+
+        // Assemble the resource bundles (tps.js, tps.meta.js, …) declared in tps.json, then add a
+        // pre-minified variant of each next to it. Embedding the .min.js in the runtime package
+        // means a referencing build never re-minifies the (large) runtime — it just picks the
+        // variant its configuration wants, exactly as it does for the formatted/minified pair.
+        var bundles = PhaseTimings.Measure("assemble runtime bundles (tps.js)",
+            () => RuntimeAssembler.Assemble(project.ProjectDir));
+        var minBundles = PhaseTimings.Measure("minify runtime bundles", () =>
+        {
+        var mins = new List<(string name, byte[] bytes)>();
+        foreach (var (name, bytes) in bundles)
+        {
+            var minName = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && !name.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
+                ? name.Substring(0, name.Length - ".js".Length) + ".min.js"
+                : null;
+            if (minName is null) continue;
+            var minText = JsMinifier.Minify(System.Text.Encoding.UTF8.GetString(bytes), name, project.MinifyLocalVariables);
+            mins.Add((minName, System.Text.Encoding.UTF8.GetBytes(minText)));
+        }
+        return mins;
+        });
+        bundles = bundles.Concat(minBundles).ToList();
+        // Write the assembly to bin/<config>/<tfm>/, matching the SDK's output path so `dotnet pack`
+        // finds it (the Transpose.Build.Target SDK forces netstandard2.0, so that is the effective tfm).
+        var dllPath = options.OutPath ?? Path.Combine(project.ProjectDir, "bin", configuration, project.TargetFramework, project.AssemblyName + ".dll");
+        var outDir = Path.GetDirectoryName(Path.GetFullPath(dllPath))!;
+        Directory.CreateDirectory(outDir);
+        foreach (var (name, bytes) in bundles)
+        {
+            File.WriteAllBytes(Path.Combine(outDir, name), bytes); // write bundles next to the DLL for reuse
+            log.Info($"  assembled:  {name} ({bytes.Length:N0} bytes)");
+        }
+
+        // Emit the reference assembly with the JS bundles embedded as manifest resources, via
+        // Roslyn (not a Mono.Cecil post-process) so the DLL stays a clean core library — Cecil's
+        // writer injects an mscorlib reference, which stops Roslyn from treating the runtime as the
+        // corlib when compiling user code against it (every type would fail with CS0518).
+        //
+        // The base library gets the same minimum-compiler-version stamp as every other assembly tps
+        // builds — it is the reference every Transpose project binds against, so it is the one whose
+        // "you need a newer tps" is most worth saying. Appended here rather than to `bundles`: the
+        // bundles are also written to disk next to the DLL for reuse, and this belongs only inside it.
+        var embedded = bundles.Append((BuildStamp.ResourceName, BuildStamp.ForCurrentCompiler().ToJsonBytes())).ToList();
+
+        byte[] assemblyBytes;
+        try { assemblyBytes = result.EmitAssembly!(embedded); }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeAssemblyEmitFailed,
+                $"Runtime assembly emit failed: {ex.Message}");
+            return 2;
+        }
+        File.WriteAllBytes(dllPath, assemblyBytes);
+
+        log.Info($"\nOK — built runtime {Path.GetFileName(dllPath)} with {bundles.Count} embedded bundle(s) in {sw.ElapsedMilliseconds} ms.");
+        log.Info($"  dll:      {dllPath}");
+        log.Info($"  bundles:  written to {outDir}");
+        return 0;
+    }
+
+    private static (bool reflectionEnabled, MetadataTarget target) ReflectionSettings(TransposeJson? tpscfg)
+    {
+        var reflectionEnabled = !(tpscfg?.ReflectionDisabled ?? false);
+        var metadataTarget = (tpscfg?.ReflectionTarget ?? "file").ToLowerInvariant() switch
+        {
+            "inline" => MetadataTarget.Inline,
+            "type" => MetadataTarget.Type,
+            "assembly" => MetadataTarget.Assembly,
+            _ => MetadataTarget.File,
+        };
+        return (reflectionEnabled, metadataTarget);
+    }
+
+    /// <summary>
+    /// Builds every referenced project of <paramref name="rootCsproj"/> in dependency order,
+    /// skipping any whose package DLL is already up-to-date. Mirrors the MSBuild-driven compiler,
+    /// which builds project references (each producing a DLL with its JS embedded) before the
+    /// project that consumes them.
+    /// </summary>
+    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, BuildOptions options, BuildLog log)
+    {
+        foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
+        {
+            var name = Path.GetFileNameWithoutExtension(dep);
+            // Without the cache, a dependency's freshness is judged by timestamps. With it, that
+            // question is answered better inside BuildPackage — by hashing the content — so the
+            // timestamp screen is skipped rather than layered on top: it can only disagree by calling a
+            // project dirty when it is not (a touched file, a checkout that moved an mtime backwards),
+            // and the cache then resolves that to "nothing to do" for the price of hashing the sources.
+            // Two mechanisms answering the same question, weaker one first, is how a build ends up
+            // rebuilding for reasons nobody can explain.
+            if (!options.Incremental && ProjectResolver.IsPackageUpToDate(dep, options.Configuration))
+            {
+                log.Info($"  dependency up-to-date: {name}");
+                continue;
+            }
+            log.Info($"  building dependency: {name}");
+            if (!BuildPackage(dep, options, log))
+            {
+                MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeDependencyBuildFailed,
+                    $"Failed to build referenced project '{name}'.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>Compiles one project into its Transpose package DLL (the .NET assembly with the compiled JS
+    /// and tps.json resources embedded). Its own project references are consumed as their built DLLs,
+    /// so they must already have been built (this is called in dependency order).</summary>
+    private static bool BuildPackage(string csproj, BuildOptions options, BuildLog log)
+    {
+        var configuration = options.Configuration;
+
+        ResolvedProject project;
+        try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
+                $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
+            return false;
+        }
+
+        // A dependency can reference a package the root project does not, so it gets its own check.
+        if (!CompilerIsNewEnough(project.ReferencePaths, log)) return false;
+
+        var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
+        var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
+        var assemblyVersion = ProjectResolver.ReadAssemblyVersion(csproj);
+        // Each dependency reads its own csproj property, but a command-line override applies to the
+        // whole invocation.
+        var metadataOnly = options.MetadataOnlyAssembly
+                           ?? project.MetadataOnlyAssembly
+                           ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration);
+
+        // A dependency gets the same treatment as the root project: its own cache, in its own obj/.
+        // Without this, editing a method body in a referenced library — the common case in a
+        // solution — would still cost that library a full rebuild.
+        BuildCache? cache = null;
+        var verdict = BuildCache.Verdict.FullBuild;
+        var changedSources = new List<string>();
+        if (options.Incremental)
+        {
+            cache = BuildCache.Open(project, configuration,
+                OutputMode(emitPackage: true, isSiteBuild: false),
+                BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
+                    metadataOnly, emitPackage: true, isSiteBuild: false, separateAssemblies: true,
+                    withRuntime: false, outPath: null, siteDir: null, assemblyVersion: assemblyVersion),
+                BuildContentFingerprint(project),
+                options.CacheDir);
+            (verdict, changedSources, var reason) = cache.Decide();
+            if (verdict == BuildCache.Verdict.UpToDate)
+            {
+                // Every input and output of the dependency is unchanged, so its package DLL is already
+                // the one this build wants. This is the incremental replacement for the timestamp screen
+                // in EnsureReferencedProjectsBuilt, and it is cheaper than the replay path below
+                // because it does not even rewrite the DLL.
+                log.Info("    cache: up to date, nothing to do");
+                return true;
+            }
+            log.Info(verdict == BuildCache.Verdict.FullBuild
+                ? $"    cache: full build ({reason})"
+                : $"    cache: {changedSources.Count} file(s) changed, method bodies only");
+        }
+        var replayed = options.Incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
+            ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)
+            : null;
+        var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
+
+        AssemblyBuildResult result;
+        try
+        {
+            result = replayed ?? new RoslynTranslator().BuildAssembly(
+                project.Sources, project.AssemblyName, project.ReferencePaths,
+                project.DefineConstants, project.LanguageVersion,
+                reflectionEnabled, metadataTarget, emitAssembly: true,
+                assemblyVersion: assemblyVersion,
+                emitDebugInformation: project.EmitDebugInformation,
+                metadataOnlyAssembly: metadataOnly,
+                incremental: plan);
+        }
+        catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex, log); return false; }
+
+        if (!result.Success)
+        {
+            ReportDiagnostics(result.Diagnostics, options.MaxErrors, log);
+            return false;
+        }
+
+        var written = TryWritePackage(project, tpscfg, configuration, result, log);
+        if (written is null) return false;
+        SaveCache(cache, plan, result, new[] { written.Value.dllPath });
+        return true;
+    }
+
+    /// <summary>Writes a project's package DLL, turning a failure into a reported diagnostic (rather
+    /// than an unhandled exception) and a null result. Embedding the resources re-serializes the
+    /// assembly's metadata through Mono.Cecil, which resolves referenced assemblies as it goes — a
+    /// step that can fail on its own, after a clean compile.</summary>
+    private static (string dllPath, List<EmbeddedItem> items)? TryWritePackage(
+        ResolvedProject project, TransposeJson? config, string configuration, AssemblyBuildResult result, BuildLog log)
+    {
+        try { return WritePackage(project, config, configuration, result); }
+        catch (Exception ex)
+        {
+            ReportCrash($"Writing the package for '{Path.GetFileName(project.CsprojPath)}'", ex, log);
+            return null;
+        }
+    }
+
+    /// <summary>Writes a project's emitted assembly and embeds its JS + resources, returning the DLL
+    /// path and the embedded items. The DLL path is the one the resolver references for this
+    /// project, so a consumer finds it.</summary>
+    private static (string dllPath, List<EmbeddedItem> items) WritePackage(
+        ResolvedProject project, TransposeJson? config, string configuration, AssemblyBuildResult result)
+    {
+        var mainJsName = config?.ExplicitFileName ?? project.AssemblyName + ".js";
+        var dllPath = ProjectResolver.OutputDll(project.CsprojPath, configuration)!;
+        Directory.CreateDirectory(Path.GetDirectoryName(dllPath)!);
+
+        var items = PhaseTimings.Measure("collect package resources (minify + read files)", () => config is not null
+            ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables)
+            : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) });
+        // Cecil re-serializes the assembly's metadata when embedding the resources; encoding a
+        // parameter's default value whose type lives in a referenced assembly (e.g. a Tesserae enum)
+        // makes it resolve that assembly. Seed the resolver with the reference directories so those
+        // types are found (the referenced DLLs live in the NuGet cache / sibling bin folders, not
+        // next to this DLL).
+        // Writes the DLL — the emitted assembly plus the embedded resources — in one pass.
+        PhaseTimings.Measure("embed resources into DLL (Cecil)",
+            () => ResourceEmbedder.Embed(dllPath, result.AssemblyBytes!, items, project.ReferencePaths));
+        // Record what a consumer's compilation actually depends on — this assembly's metadata — so a
+        // rebuild of this project does not force a rebuild of everything referencing it when only its
+        // method bodies moved. Cecil restamps the DLL's MVID on every embed, so its bytes cannot serve.
+        BuildCache.WriteMetadataSidecar(dllPath, result.AssemblyBytes);
+        return (dllPath, items);
+    }
+
+    /// <summary>Resolves tps.json's output path, expanding the $(OutDir) MSBuild token.</summary>
+    internal static string ResolveOutputDir(TransposeJson config, string projectDir, string configuration)
+    {
+        var raw = (config.Output ?? "$(OutDir)/tps/").Replace("$(OutDir)", ResolveBinDir(projectDir, configuration)).Replace('\\', '/');
+        return Path.GetFullPath(raw);
+    }
+
+    /// <summary>The project's build output directory (bin/&lt;config&gt;/netstandard2.0), where the
+    /// emitted assembly and tps output land — matching the Transpose SDK's default output path.</summary>
+    private static string ResolveBinDir(string projectDir, string configuration)
+        => Path.Combine(projectDir, "bin", configuration, "netstandard2.0");
+
+    /// <summary>
+    /// The errors to report, in the order to report them: by file, then line, then column — the order
+    /// you would fix them in — rather than by the phase that produced them (the unsupported-feature
+    /// scan runs before Roslyn's diagnostics, and its parallel per-file walk has no inherent order).
+    /// Nothing is filtered out here; truncation, if any, is the caller's decision.
+    /// </summary>
+    internal static List<Diagnostic> OrderErrorsForReport(IReadOnlyList<Diagnostic> diagnostics)
+        => diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)
+            .OrderBy(d => d.Location.SourceTree?.FilePath ?? "", StringComparer.OrdinalIgnoreCase)
+            .ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Line)
+            .ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Character)
+            .ThenBy(d => d.Id, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// Prints the build's diagnostics. **Every** error is printed by default: a truncated list makes a
+    /// broken build take several compile cycles to fix, and the caller has no way to know whether the
+    /// errors it cannot see are the same problem or a different one. <paramref name="maxErrors"/> caps
+    /// the list only when a caller explicitly asked for a cap (<c>--max-errors</c>).
+    ///
+    /// Ordering comes from <see cref="OrderErrorsForReport"/>.
+    /// </summary>
+    private static void ReportDiagnostics(IReadOnlyList<Diagnostic> diagnostics, int maxErrors, BuildLog log)
+    {
+        var errors = OrderErrorsForReport(diagnostics);
+        var warnings = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToList();
+
+        if (errors.Count > 0)
+        {
+            // The summary lines are deliberately not in diagnostic form, and must stay that way: any
+            // line MSBuild can parse becomes a build error, so a summary could otherwise conjure an
+            // error nobody wrote. See MsBuildDiagnostic for the shape to avoid — writing the count as
+            // "N error(s), by id: …" rather than "N error(s):" keeps a colon from ever landing where
+            // the parser expects one.
+            var byId = errors.GroupBy(d => d.Id).OrderByDescending(g => g.Count());
+            log.Error("");
+            log.Error($"{errors.Count} error(s), by id: "
+                + string.Join(", ", byId.Select(g => $"{g.Key}×{g.Count()}")));
+            log.Error("");
+            var shown = maxErrors > 0 ? errors.Take(maxErrors) : errors;
+            foreach (var d in shown)
+                MsBuildDiagnostic.Write(MsBuildDiagnostic.Format(d), isError: true);
+            if (maxErrors > 0 && errors.Count > maxErrors)
+                log.Error($"… and {errors.Count - maxErrors} more (raise or drop --max-errors to see them)");
+        }
+
+        // Warnings are printed in full too, not just counted: in canonical form they reach the IDE's
+        // task list, where a count on the console never would.
+        foreach (var d in warnings)
+            MsBuildDiagnostic.Write(MsBuildDiagnostic.Format(d), isError: false);
+        if (warnings.Count > 0)
+            log.Info($"{warnings.Count} warning(s) total");
+    }
+
+    /// <summary>
+    /// Reports an unhandled exception from the translator as a single diagnostic — a crash is a build
+    /// failure the caller must see, and MSBuild only sees a line it can parse. The messages of the
+    /// whole exception chain go into that one line; the stack frames follow as plain text, since they
+    /// are what makes a crash actionable but cannot fit on one line.
+    ///
+    /// The frames are printed on their own rather than via <c>ex.ToString()</c> deliberately: an
+    /// exception message that happens to read like "... error: ..." would be parsed as a *second*
+    /// diagnostic, and frames alone can never match.
+    /// </summary>
+    internal static void ReportCrash(string what, Exception ex, BuildLog log)
+    {
+        var chain = new List<string>();
+        for (var e = ex; e is not null; e = e.InnerException)
+            chain.Add($"{e.GetType().Name}: {e.Message}");
+        MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInternalError,
+            $"{what} threw {string.Join(" ---> ", chain)}");
+
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (!ReferenceEquals(e, ex)) log.Error($"--- inner {e.GetType().FullName}");
+            log.Error(e.StackTrace ?? "");
+        }
+    }
+}

--- a/Transpose/Transpose.Compiler.Core/WatchSession.cs
+++ b/Transpose/Transpose.Compiler.Core/WatchSession.cs
@@ -1,0 +1,475 @@
+using System.Net.WebSockets;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// The watch-mode engine: decides <em>when</em> to rebuild a project, <em>what kind</em> of rebuild a
+/// change needs, and <em>what to tell the browser</em> afterwards. Everything except the HTTP server —
+/// so both the <c>tps --watch</c> dev server and a hosting application that already runs its own Kestrel
+/// (the Curiosity CLI's <c>serve --watch</c>, via <c>Transpose.Compiler.Library</c>) drive the exact same
+/// logic instead of each reimplementing the debounce, the change classification and the reload protocol.
+///
+/// The host's only obligations are to serve <see cref="BuildOutcome.OutDir"/> as static files and to map
+/// a websocket endpoint at <see cref="ReloadHub.Path"/> (under its own base path, if it has one) to
+/// <see cref="Hub"/>.
+/// </summary>
+internal sealed class WatchSession : IDisposable
+{
+    /// <summary>How long to wait after the last file-system event before acting — coalesces the burst of
+    /// Created/Changed/Renamed events a single save produces (editors commonly write a temp file and
+    /// rename it, or write-then-touch), so one save triggers exactly one rebuild.</summary>
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(300);
+
+    private readonly string _rootCsproj;
+    private readonly Func<string, BuildOutcome> _build;
+    private readonly Action<BuildOutcome, bool>? _afterUpdate;
+    private readonly BuildLog _log;
+    private readonly string _reloadPath;
+    private readonly Debouncer _debouncer;
+    private readonly List<FileSystemWatcher> _watchers = new();
+
+    private readonly object _gate = new();
+    private bool _running;
+    private List<string> _pending = new();
+
+    /// <summary>Every successful build gets a version number, embedded in that build's own index.html. A
+    /// client compares its embedded version against the server's current one when it (re)connects (see
+    /// <see cref="ReloadHub.HandleAsync"/>) and catches up immediately if they differ — without this, a
+    /// client whose reload navigation is still in flight when a second rebuild lands could miss that
+    /// rebuild's broadcast entirely (its socket isn't open yet to receive it) and be stuck showing stale
+    /// content until another edit happens to trigger a further broadcast.</summary>
+    private long _version;
+
+    private string? _outDir;
+    private IReadOnlyList<OutputBuilder.CssResource> _cssResources = Array.Empty<OutputBuilder.CssResource>();
+    private BuildOutcome _lastOutcome;
+
+    /// <param name="rootCsproj">The project being watched; its own directory and every directory of a
+    /// project it transitively references are watched.</param>
+    /// <param name="build">Runs one build, given the live-reload script to inline into index.html.</param>
+    /// <param name="reloadPath">The URL path the host maps to <see cref="Hub"/>, as the browser sees it
+    /// — <see cref="ReloadHub.Path"/> prefixed with the host's base path, if any.</param>
+    /// <param name="afterUpdate">Runs after each successful update (the flag says whether it was the
+    /// CSS-only path) and <em>before</em> the browser is told, so a host that post-processes the site —
+    /// rewriting the generated index.html, say — does so on output the page has not loaded yet.</param>
+    public WatchSession(string rootCsproj, Func<string, BuildOutcome> build, BuildLog? log = null,
+                        string? reloadPath = null, Action<BuildOutcome, bool>? afterUpdate = null)
+    {
+        _rootCsproj = Path.GetFullPath(rootCsproj);
+        _build = build;
+        _afterUpdate = afterUpdate;
+        _log = log ?? BuildLog.Console;
+        _reloadPath = reloadPath ?? ReloadHub.Path;
+        _debouncer = new Debouncer(DebounceDelay, OnChanges);
+    }
+
+    public ReloadHub Hub { get; } = new();
+
+    /// <summary>The directories being watched — available after <see cref="Start"/>.</summary>
+    public IReadOnlyList<string> WatchedDirectories { get; private set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Runs the first build. On success the session remembers where the site went and which stylesheets
+    /// it assembled from disk, which is what later lets a CSS-only change skip the compiler. The caller
+    /// decides what to do with a failure — there is nothing to serve, so it is not this class's call.
+    /// </summary>
+    public BuildOutcome Start()
+    {
+        var outcome = _build(LiveReloadScript(_version));
+        if (outcome.Success && outcome.OutDir is not null) Remember(outcome);
+        return outcome;
+    }
+
+    /// <summary>Starts watching for changes. Call once the host is actually serving the initial build, so
+    /// the first rebuild cannot broadcast to a server that is not up yet.</summary>
+    public void BeginWatching()
+    {
+        if (_outDir is null) throw new InvalidOperationException("Start() must succeed before watching begins.");
+
+        WatchedDirectories = WatchDirectories(_rootCsproj);
+        foreach (var dir in WatchedDirectories)
+        {
+            var watcher = CreateWatcher(dir, _outDir);
+            if (watcher is not null) _watchers.Add(watcher);
+        }
+    }
+
+    /// <summary>
+    /// The inline script for the *current* build, for a host that generates its index.html itself rather
+    /// than letting <see cref="OutputBuilder"/> inline it.
+    /// </summary>
+    public string CurrentLiveReloadScript() => LiveReloadScript(Interlocked.Read(ref _version));
+
+    private void Remember(BuildOutcome outcome)
+    {
+        _outDir = outcome.OutDir;
+        _cssResources = outcome.CssResources;
+        _lastOutcome = outcome;
+    }
+
+    /// <summary>
+    /// Handles one debounced batch of file-system changes, serialized against itself: a change that
+    /// arrives while a rebuild is running is folded into the next batch rather than dropped, and two
+    /// rebuilds never overlap (they would write the same output files).
+    /// </summary>
+    private void OnChanges(IReadOnlyList<string> changed)
+    {
+        lock (_gate)
+        {
+            _pending.AddRange(changed);
+            if (_running) return;
+            _running = true;
+        }
+
+        while (true)
+        {
+            List<string> batch;
+            lock (_gate) { batch = _pending; _pending = new List<string>(); }
+
+            try
+            {
+                Process(batch);
+            }
+            catch (Exception ex)
+            {
+                // Process() already turns a compile failure into a clean exit code without ever reaching
+                // OutputBuilder, so the site on disk is untouched for that, the common, case. This catch
+                // is for the uncommon one — a genuine exception from the write phase itself (a locked
+                // file, a full disk, a directory raced out from under it) — which would otherwise be
+                // unhandled on this thread-pool thread and take the whole watch server down with it.
+                // Report, keep whatever the previous successful build left on disk, and keep watching.
+                MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInternalError, $"rebuild crashed: {ex.Message}");
+                _log.Error(ex.StackTrace ?? "");
+            }
+
+            lock (_gate)
+            {
+                if (_pending.Count == 0) { _running = false; return; }
+            }
+        }
+    }
+
+    private void Process(IReadOnlyList<string> changed)
+    {
+        // A change confined to stylesheets this site copies straight from disk cannot change a single byte
+        // of the compiled JavaScript or of index.html, so there is nothing for the compiler to do: re-copy
+        // exactly the files the site build would have written and let the page swap them in. That turns a
+        // CSS tweak from a full recompile of the project closure into a file copy.
+        var css = CssOnlyUpdate(changed);
+        if (css is not null)
+        {
+            _log.Info($"\ntps: {Describe(changed)} changed (stylesheets only) — updating CSS without rebuilding");
+            OutputBuilder.WriteCssResources(_outDir!, css);
+            foreach (var resource in css) _log.Info($"  css:        {resource.OutputRelativePath}");
+            // The build version deliberately does NOT move: index.html was not rewritten, so every
+            // connected page is still the current build and must not be told it is behind.
+            _afterUpdate?.Invoke(_lastOutcome, true);
+            _ = Hub.BroadcastAsync(ReloadHub.Message.Css);
+            return;
+        }
+
+        _log.Info("\ntps: change detected, rebuilding...");
+        var nextVersion = Interlocked.Increment(ref _version);
+        var outcome = _build(LiveReloadScript(nextVersion));
+
+        if (outcome.Success)
+        {
+            if (outcome.OutDir is not null) Remember(outcome);
+            _log.Info("tps: rebuilt — reloading browser");
+            Hub.SetVersion(nextVersion);
+            _afterUpdate?.Invoke(outcome, false);
+            _ = Hub.BroadcastAsync(ReloadHub.Message.Reload);
+        }
+        else
+        {
+            // The failed build never reached OutputBuilder, so the site on disk still embeds the previous
+            // (successful) version's script — roll the counter back to match, or the next successful
+            // build's embedded version would skip ahead of what a client still on the old page believes
+            // is current.
+            Interlocked.Decrement(ref _version);
+            _log.Error("tps: rebuild failed — keeping the previous build (see errors above)");
+        }
+    }
+
+    /// <summary>
+    /// The stylesheets to re-copy for <paramref name="changed"/>, or null when this batch needs a real
+    /// build. A batch qualifies only when <em>every</em> changed path is a source file of a stylesheet the
+    /// last successful build already produced — which is exactly the case where the fast path is provably
+    /// equivalent to a full one:
+    ///
+    /// <list type="bullet">
+    /// <item>a changed <c>.cs</c>/<c>.csproj</c>/<c>tps.json</c> obviously needs the compiler;</item>
+    /// <item>a <em>new</em> stylesheet (one no resource group resolved to last time, or one that a glob
+    /// has only now started matching) adds a <c>&lt;link&gt;</c> to index.html, which only the site build
+    /// writes;</item>
+    /// <item>a deleted stylesheet has to remove that link and prune the stale output.</item>
+    /// </list>
+    /// </summary>
+    private IReadOnlyList<OutputBuilder.CssResource>? CssOnlyUpdate(IReadOnlyList<string> changed)
+    {
+        if (_outDir is null || changed.Count == 0) return null;
+
+        var known = _cssResources;
+        if (known.Count == 0) return null;
+
+        var affected = new List<OutputBuilder.CssResource>();
+        foreach (var path in changed.Distinct(OutputBuilder.PathComparer))
+        {
+            if (!path.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) return null;
+            if (!File.Exists(path)) return null;   // deleted or renamed away: index.html has to change
+
+            var matches = known.Where(r => r.SourceFiles.Contains(path, OutputBuilder.PathComparer)).ToList();
+            if (matches.Count == 0) return null;   // not (yet) part of the site: a full build decides
+
+            foreach (var match in matches)
+                if (!affected.Contains(match)) affected.Add(match);
+        }
+        return affected;
+    }
+
+    private static string Describe(IReadOnlyList<string> changed)
+    {
+        var names = changed.Distinct(OutputBuilder.PathComparer).Select(Path.GetFileName).ToList();
+        return names.Count <= 3
+            ? string.Join(", ", names)
+            : $"{string.Join(", ", names.Take(3))} and {names.Count - 3} more";
+    }
+
+    /// <summary>Every directory to watch: the root project's, then every project it references
+    /// (transitively), in whatever order <see cref="ProjectResolver.ReferencedProjectsInBuildOrder"/>
+    /// returns them. A change under any of these can change the compiled output — the root project's
+    /// own sources, or a library it depends on — so all of them feed the same trigger.</summary>
+    public static List<string> WatchDirectories(string rootCsproj)
+    {
+        var dirs = new List<string> { Path.GetDirectoryName(Path.GetFullPath(rootCsproj))! };
+        foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
+        {
+            var dir = Path.GetDirectoryName(dep);
+            if (dir is not null) dirs.Add(dir);
+        }
+        return dirs.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>Watches one project directory for changes to the files a rebuild cares about
+    /// (<c>.cs</c>, <c>.csproj</c>, <c>tps*.json</c>, <c>.css</c>), signalling the debouncer for each
+    /// relevant event. Skips <c>bin/</c>/<c>obj/</c> (build output, never a source) and anything under
+    /// <paramref name="outDir"/> itself — without that exclusion the site build's own writes would
+    /// retrigger the watcher that is serving it, rebuilding forever.</summary>
+    private FileSystemWatcher? CreateWatcher(string dir, string outDir)
+    {
+        if (!Directory.Exists(dir)) return null;
+        var fullOutDir = Path.GetFullPath(outDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        var watcher = new FileSystemWatcher(dir)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Size,
+        };
+
+        void OnEvent(object sender, FileSystemEventArgs e)
+        {
+            if (!IsRelevant(e.FullPath, dir, fullOutDir)) return;
+            _debouncer.Signal(Path.GetFullPath(e.FullPath));
+        }
+
+        watcher.Changed += OnEvent;
+        watcher.Created += OnEvent;
+        watcher.Deleted += OnEvent;
+        watcher.Renamed += (s, e) => OnEvent(s, e);
+        watcher.Error += (_, e) =>
+            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeWatchServerFailed,
+                $"File watcher for '{dir}' failed: {e.GetException().Message}");
+        watcher.EnableRaisingEvents = true;
+        return watcher;
+    }
+
+    internal static bool IsRelevant(string path, string projectDir, string fullOutDir)
+    {
+        var full = Path.GetFullPath(path);
+        // Never watch the site's own output — every rebuild writes there, which would otherwise
+        // retrigger itself. Comparing full paths (not just a prefix string) avoids a false match on a
+        // sibling directory that merely shares the outDir's name as a prefix (e.g. "bin-tools").
+        if (full.Equals(fullOutDir, StringComparison.OrdinalIgnoreCase)
+            || full.StartsWith(fullOutDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var rel = Path.GetRelativePath(projectDir, full).Replace('\\', '/');
+        if (rel.StartsWith("bin/", StringComparison.Ordinal) || rel.Contains("/bin/", StringComparison.Ordinal)
+            || rel.StartsWith("obj/", StringComparison.Ordinal) || rel.Contains("/obj/", StringComparison.Ordinal))
+            return false;
+
+        var name = Path.GetFileName(full);
+        if (name.StartsWith('.') || name.EndsWith('~')) return false; // editor swap/backup files
+
+        return name.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+            // Stylesheets: a tps.json `resources` group copies these into the site, so editing one
+            // changes what the browser loads even though no C# moved (see CssOnlyUpdate).
+            || name.EndsWith(".css", StringComparison.OrdinalIgnoreCase)
+            || (name.StartsWith("tps", StringComparison.OrdinalIgnoreCase) && name.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>The inline script injected into index.html: connects to the reload endpoint, tagged with
+    /// the version of the build this exact page came from, and either swaps the page's stylesheets (a
+    /// CSS-only update) or reloads (anything else). Reconnects with a short fixed backoff if the socket
+    /// drops (e.g. the server is mid-rebuild), so a page left open survives more than one reload — and
+    /// the version tag lets the server detect, right at (re)connect time, a client that is already
+    /// behind (see <see cref="ReloadHub.HandleAsync"/>).
+    ///
+    /// The websocket URL is derived from the page's own <c>location</c> rather than baked in, so the
+    /// script works unchanged behind a base path and over https (<c>wss:</c>) — a hosting application's
+    /// dev server, not just tps's own <c>http://localhost:port/</c>.</summary>
+    private string LiveReloadScript(long version) => $$"""
+        <script>
+        (function tpsLiveReload() {
+            var url = (location.protocol === "https:" ? "wss://" : "ws://") + location.host + "{{_reloadPath}}?v={{version}}";
+            function swapStylesheets() {
+                var links = document.querySelectorAll('link[rel="stylesheet"]');
+                for (var i = 0; i < links.length; i++) {
+                    var href = links[i].getAttribute("href");
+                    if (href) links[i].setAttribute("href", href.split("?")[0] + "?tps=" + Date.now());
+                }
+            }
+            function connect() {
+                var ws = new WebSocket(url);
+                ws.onmessage = function (e) {
+                    if (e.data === "{{ReloadHub.Message.Css}}") swapStylesheets();
+                    else location.reload();
+                };
+                ws.onclose = function () { setTimeout(connect, 1000); };
+                ws.onerror = function () { ws.close(); };
+            }
+            connect();
+        })();
+        </script>
+        """;
+
+    public void Dispose()
+    {
+        _debouncer.Dispose();
+        foreach (var w in _watchers) w.Dispose();
+        _watchers.Clear();
+    }
+}
+
+/// <summary>Tracks the currently-connected live-reload websockets and tells all of them what happened
+/// after a successful build. The payload is one of <see cref="Message"/>: a full page reload, or — for a
+/// change that only touched stylesheets — a request to re-fetch them in place, which keeps the running
+/// app's state. A client that fails to send (already gone) is dropped rather than failing the broadcast
+/// for everyone else.</summary>
+internal sealed class ReloadHub
+{
+    public const string Path = "/__tps-livereload";
+
+    /// <summary>What the server tells a connected page. Plain strings, because the client side of this
+    /// protocol is the few lines of JavaScript in <see cref="WatchSession"/>'s injected script.</summary>
+    public static class Message
+    {
+        /// <summary>The build changed; reload the page.</summary>
+        public const string Reload = "reload";
+
+        /// <summary>Only stylesheets changed; re-fetch them without reloading.</summary>
+        public const string Css = "css";
+    }
+
+    private readonly List<WebSocket> _sockets = new();
+    private readonly object _gate = new();
+    private long _version;
+
+    /// <summary>The version of the most recent successful build. Set once that build's outputs (and
+    /// the index.html embedding that same version) have actually been written to disk.</summary>
+    public void SetVersion(long version) => Interlocked.Exchange(ref _version, version);
+
+    public async Task HandleAsync(WebSocket socket, long clientVersion, CancellationToken cancellationToken)
+    {
+        lock (_gate) _sockets.Add(socket);
+        try
+        {
+            // The page this socket was opened from was generated by build `clientVersion`. If a newer
+            // build has already completed — e.g. two edits landed back to back while this client was
+            // navigating during a previous reload, so it missed that build's broadcast entirely — catch
+            // it up right away instead of leaving it stuck on stale content until the next edit.
+            if (Interlocked.Read(ref _version) > clientVersion && socket.State == WebSocketState.Open)
+                await SendAsync(socket, Message.Reload, cancellationToken);
+
+            var buffer = new byte[16];
+            // The client never sends anything meaningful; this just blocks until it disconnects
+            // (browser navigation/close), which is what a receive on a closed socket reports.
+            while (socket.State == WebSocketState.Open)
+            {
+                var result = await socket.ReceiveAsync(buffer, cancellationToken);
+                if (result.MessageType == WebSocketMessageType.Close) break;
+            }
+        }
+        catch (OperationCanceledException) { /* server shutting down */ }
+        catch (WebSocketException) { /* client dropped mid-read */ }
+        finally
+        {
+            lock (_gate) _sockets.Remove(socket);
+        }
+    }
+
+    public async Task BroadcastAsync(string message)
+    {
+        List<WebSocket> targets;
+        lock (_gate) targets = new List<WebSocket>(_sockets);
+
+        foreach (var socket in targets)
+        {
+            try
+            {
+                if (socket.State == WebSocketState.Open) await SendAsync(socket, message, CancellationToken.None);
+            }
+            catch (WebSocketException) { /* client dropped; it will be removed by HandleAsync's own loop */ }
+        }
+    }
+
+    private static Task SendAsync(WebSocket socket, string message, CancellationToken cancellationToken)
+        => socket.SendAsync(System.Text.Encoding.UTF8.GetBytes(message), WebSocketMessageType.Text,
+                            endOfMessage: true, cancellationToken);
+}
+
+/// <summary>Coalesces a burst of file-system events into a single call to <c>action</c>, fired
+/// <c>delay</c> after the last <see cref="Signal"/>, passing every path signalled since the previous
+/// call. The paths matter: they are what lets the watcher tell a stylesheet edit (no compile needed)
+/// from a source edit.</summary>
+internal sealed class Debouncer : IDisposable
+{
+    private readonly TimeSpan _delay;
+    private readonly Action<IReadOnlyList<string>> _action;
+    private readonly object _gate = new();
+    private readonly List<string> _paths = new();
+    private Timer? _timer;
+
+    public Debouncer(TimeSpan delay, Action<IReadOnlyList<string>> action)
+    {
+        _delay = delay;
+        _action = action;
+    }
+
+    public void Signal(string path)
+    {
+        lock (_gate)
+        {
+            _paths.Add(path);
+            _timer?.Dispose();
+            _timer = new Timer(_ => Fire(), null, _delay, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private void Fire()
+    {
+        List<string> batch;
+        lock (_gate)
+        {
+            batch = new List<string>(_paths);
+            _paths.Clear();
+        }
+        _action(batch);
+    }
+
+    public void Dispose()
+    {
+        lock (_gate) _timer?.Dispose();
+    }
+}

--- a/Transpose/Transpose.Compiler.Library/ProjectBuildRequest.cs
+++ b/Transpose/Transpose.Compiler.Library/ProjectBuildRequest.cs
@@ -1,0 +1,78 @@
+namespace Transpose.Compiler.Library;
+
+/// <summary>
+/// A request to build a real, on-disk Transpose project — the library form of a <c>tps --project …</c>
+/// invocation, for an application that wants to run the compiler in-process rather than shell out to the
+/// <c>tps</c> tool. Where <see cref="CompilationRequest"/> compiles source held in memory,
+/// this resolves the <c>.csproj</c>, chains its project references, and writes the same outputs the CLI
+/// writes (a runnable site, or the project's package DLL).
+///
+/// <code>
+/// var result = TransposeCompilerLibrary.BuildProject(
+///     new ProjectBuildRequest("/src/App/App.csproj") { Configuration = "Debug", Incremental = true });
+///
+/// if (result.Success) Console.WriteLine($"site at {result.SiteDirectory}");
+/// else foreach (var error in result.Errors) Console.Error.WriteLine(error);
+/// </code>
+///
+/// The defaults match the CLI's: the output shape is inferred from the project (a non-packable project
+/// with a <c>tps.json</c> assembles a site, anything else produces its package DLL), and the incremental
+/// cache is off unless asked for.
+/// </summary>
+public sealed class ProjectBuildRequest
+{
+    /// <summary>The project to build. A directory is accepted too, as long as it holds exactly one
+    /// <c>.csproj</c> — the same rule <c>tps</c> applies to its project argument.</summary>
+    public string ProjectPath { get; }
+
+    public ProjectBuildRequest(string projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath))
+            throw new ArgumentException("A project path must be provided.", nameof(projectPath));
+        ProjectPath = projectPath;
+    }
+
+    /// <summary>Build configuration — <c>Debug</c> (the default) or <c>Release</c>. Release selects the
+    /// minified resource variants and emits a full-IL assembly.</summary>
+    public string Configuration { get; set; } = "Debug";
+
+    /// <summary>Where a site build writes its output. Null uses the directory the project's
+    /// <c>tps.json</c> <c>output</c> resolves to — normally <c>bin/&lt;config&gt;/netstandard2.0/tps/</c>.</summary>
+    public string? SiteDirectory { get; set; }
+
+    /// <summary>Reuse the previous build of this project where its inputs are unchanged. Off by default,
+    /// matching the CLI; a dev-loop host (a watch server) wants it on.</summary>
+    public bool Incremental { get; set; }
+
+    /// <summary>Where the incremental cache lives. Null puts it in the project's <c>obj/</c>.</summary>
+    public string? CacheDirectory { get; set; }
+
+    /// <summary>The <c>AssemblyVersion</c> baked into the bundle via <c>Transpose.assemblyVersion(...)</c>
+    /// and into the emitted assembly. Null reads it from the project.</summary>
+    public string? AssemblyVersion { get; set; }
+
+    /// <summary>Reference assemblies that are not resolvable from the NuGet cache (the CLI's
+    /// <c>--reference</c>).</summary>
+    public IList<string> ExtraReferences { get; } = new List<string>();
+
+    /// <summary>Extra preprocessor symbols for the build (the CLI's <c>--define</c>).</summary>
+    public IList<string> ExtraDefines { get; } = new List<string>();
+
+    /// <summary>Cap on how many individual errors <see cref="ProjectBuildResult.Errors"/> carries; 0 —
+    /// the default — reports every one.</summary>
+    public int MaxErrors { get; set; }
+
+    /// <summary>Suppress warnings from the reported output.</summary>
+    public bool Quiet { get; set; }
+
+    /// <summary>
+    /// A script inlined into the generated index.html immediately before <c>&lt;/body&gt;</c>. This is how a
+    /// watch host injects its live-reload client; leave it null (the default) and the generated HTML is
+    /// exactly what an ordinary build produces. <see cref="TransposeWatcher"/> fills this in for you.
+    /// </summary>
+    public string? InjectedHtmlScript { get; set; }
+
+    /// <summary>Where the build's progress output goes — the lines <c>tps</c> would print to its console.
+    /// Null discards them; the diagnostics are returned on the result either way.</summary>
+    public Action<string>? OnProgress { get; set; }
+}

--- a/Transpose/Transpose.Compiler.Library/ProjectBuildResult.cs
+++ b/Transpose/Transpose.Compiler.Library/ProjectBuildResult.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis;
+
+namespace Transpose.Compiler.Library;
+
+/// <summary>
+/// The outcome of a <see cref="ProjectBuildRequest"/>. <see cref="SiteDirectory"/> is set only when the
+/// build assembled a runnable site (the shape a dev server can serve); a package build succeeds with it
+/// null. <see cref="Errors"/>/<see cref="Warnings"/> are pre-formatted in the canonical
+/// <c>file(line,column): error CS0000: message</c> shape <c>tps</c> prints, so a host can surface them
+/// without knowing anything about Roslyn.
+/// </summary>
+public sealed class ProjectBuildResult
+{
+    private readonly IReadOnlyList<OutputBuilder.CssResource> _cssResources;
+
+    internal ProjectBuildResult(BuildOutcome outcome, IReadOnlyList<string> output)
+    {
+        ExitCode = outcome.ExitCode;
+        SiteDirectory = outcome.OutDir;
+        HtmlDisabled = outcome.HtmlDisabled;
+        Diagnostics = outcome.Diagnostics;
+        _cssResources = outcome.CssResources;
+        Output = output;
+        Errors = outcome.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(MsBuildDiagnostic.Format).ToList();
+        Warnings = outcome.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).Select(MsBuildDiagnostic.Format).ToList();
+    }
+
+    /// <summary>True when the build completed without errors.</summary>
+    public bool Success => ExitCode == 0;
+
+    /// <summary>The process exit code <c>tps</c> would have returned for this build: 0 on success, 1 for a
+    /// build failure, 2 for a crash while translating or writing the output.</summary>
+    public int ExitCode { get; }
+
+    /// <summary>The assembled site's directory, for a successful site build; null for a failure or for a
+    /// project whose build shape is a package DLL.</summary>
+    public string? SiteDirectory { get; }
+
+    /// <summary>Whether the project's <c>tps.json</c> disables index.html generation — a host that wants
+    /// to inject into the page needs to know there is no generated page to inject into.</summary>
+    public bool HtmlDisabled { get; }
+
+    /// <summary>Every diagnostic the build reported, errors and warnings alike.</summary>
+    public IReadOnlyList<Diagnostic> Diagnostics { get; }
+
+    /// <summary>The build errors, formatted one per line — empty when <see cref="Success"/> is true.</summary>
+    public IReadOnlyList<string> Errors { get; }
+
+    /// <summary>The build warnings, formatted one per line. Populated whether or not the build succeeded.</summary>
+    public IReadOnlyList<string> Warnings { get; }
+
+    /// <summary>Every line the build printed — its progress output plus its formatted diagnostics, in the
+    /// order <c>tps</c> would have written them. Collected regardless of
+    /// <see cref="ProjectBuildRequest.OnProgress"/>, so a failure can be reported in full after the fact.</summary>
+    public IReadOnlyList<string> Output { get; }
+
+    /// <summary>The stylesheets this site build copied from disk (its own <c>tps.json</c> resources and
+    /// those of every project it references). Opaque to callers — it is what
+    /// <see cref="TransposeWatcher"/> uses to update CSS without recompiling.</summary>
+    internal IReadOnlyList<OutputBuilder.CssResource> CssResources => _cssResources;
+}

--- a/Transpose/Transpose.Compiler.Library/TransposeCompilerLibrary.cs
+++ b/Transpose/Transpose.Compiler.Library/TransposeCompilerLibrary.cs
@@ -50,6 +50,111 @@ public static class TransposeCompilerLibrary
         return Task.Run(() => Compile(request), cancellationToken);
     }
 
+    /// <summary>
+    /// Builds a real, on-disk project — the library form of <c>tps --project …</c>: resolves the csproj,
+    /// builds every project it references, translates, and writes the site (or the package DLL). Serialized
+    /// against every other compilation in this process, for the reasons in the type-level remarks.
+    /// </summary>
+    public static ProjectBuildResult BuildProject(ProjectBuildRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        lock (Gate)
+        {
+            var (outcome, output) = RunProjectBuild(request, request.InjectedHtmlScript);
+            return new ProjectBuildResult(outcome, output);
+        }
+    }
+
+    /// <summary>Runs <paramref name="request"/> on a thread-pool thread, still serialized against any other
+    /// compilation in this process.</summary>
+    public static Task<ProjectBuildResult> BuildProjectAsync(ProjectBuildRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return Task.Run(() => BuildProject(request), cancellationToken);
+    }
+
+    /// <summary>
+    /// The shared build path behind <see cref="BuildProject"/> and <see cref="TransposeWatcher"/>: turns the
+    /// request into the CLI's own <see cref="BuildOptions"/>, redirects the build's console output into
+    /// <paramref name="output"/> (and the request's progress callback), and runs it.
+    ///
+    /// Not locked here — <see cref="BuildProject"/> takes the gate, and the watcher's builds are already
+    /// serialized by its own single-threaded update loop — but it does install process-wide sinks
+    /// (<see cref="MsBuildDiagnostic.Sink"/>, <c>CompileProgress.Sink</c>) for the duration of the build,
+    /// which is why nothing else may be compiling at the same time.
+    /// </summary>
+    internal static (BuildOutcome Outcome, IReadOnlyList<string> Output) RunProjectBuild(
+        ProjectBuildRequest request, string? injectedHtmlScript)
+    {
+        var lines = new List<string>();
+        var log = new CollectingLog(lines, request.OnProgress);
+
+        var options = ProjectBuild.ResolveOutputMode(new BuildOptions
+        {
+            CsprojPath = LocateProject(request.ProjectPath),
+            SiteDir = request.SiteDirectory,
+            Configuration = request.Configuration,
+            Quiet = request.Quiet,
+            MaxErrors = request.MaxErrors,
+            ExtraReferences = request.ExtraReferences.ToList(),
+            ExtraDefines = request.ExtraDefines.ToList(),
+            AssemblyVersion = request.AssemblyVersion,
+            Incremental = request.Incremental,
+            CacheDir = request.CacheDirectory,
+            LiveReloadScript = injectedHtmlScript,
+        });
+
+        var previousSink = MsBuildDiagnostic.Sink;
+        try
+        {
+            MsBuildDiagnostic.Sink = (line, _) => log.Info(line);
+            return (ProjectBuild.Run(options, log), lines);
+        }
+        finally
+        {
+            MsBuildDiagnostic.Sink = previousSink;
+        }
+    }
+
+    /// <summary>Resolves a project argument the way the <c>tps</c> CLI does: a <c>.csproj</c> path as given,
+    /// or the single <c>.csproj</c> in a directory.</summary>
+    internal static string LocateProject(string projectPath)
+    {
+        var full = Path.GetFullPath(projectPath);
+        if (File.Exists(full) && full.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) return full;
+        if (Directory.Exists(full))
+        {
+            var found = Directory.GetFiles(full, "*.csproj", SearchOption.TopDirectoryOnly);
+            if (found.Length == 1) return Path.GetFullPath(found[0]);
+            if (found.Length > 1)
+                throw new ArgumentException($"'{full}' holds {found.Length} .csproj files; name the one to build.", nameof(projectPath));
+        }
+        throw new FileNotFoundException($"No .csproj found at '{projectPath}'.", full);
+    }
+
+    /// <summary>Collects the build's output so a failure can be reported in full afterwards, forwarding each
+    /// line to the request's progress callback as it happens.</summary>
+    private sealed class CollectingLog : BuildLog
+    {
+        private readonly List<string> _lines;
+        private readonly Action<string>? _forward;
+
+        public CollectingLog(List<string> lines, Action<string>? forward)
+        {
+            _lines = lines;
+            _forward = forward;
+        }
+
+        public override void Info(string message) => Add(message);
+        public override void Error(string message) => Add(message);
+
+        private void Add(string message)
+        {
+            lock (_lines) _lines.Add(message);
+            _forward?.Invoke(message);
+        }
+    }
+
     private static CompilationResult CompileCore(CompilationRequest request)
     {
         // The same gate the `tps` CLI applies: a reference built by a newer Transpose than this one

--- a/Transpose/Transpose.Compiler.Library/TransposeWatcher.cs
+++ b/Transpose/Transpose.Compiler.Library/TransposeWatcher.cs
@@ -1,0 +1,112 @@
+using System.Net.WebSockets;
+
+namespace Transpose.Compiler.Library;
+
+/// <summary>
+/// Watch mode as a library: rebuilds a Transpose project whenever its sources change — the project's own
+/// files and those of every project it transitively references — and tells connected browsers to update.
+/// This is the same engine behind <c>tps --watch</c>; the difference is that the HTTP server is yours.
+///
+/// A host has three obligations:
+/// <list type="number">
+/// <item>call <see cref="Start"/> and serve the resulting <see cref="ProjectBuildResult.SiteDirectory"/>
+/// as static files;</item>
+/// <item>accept websockets at <see cref="ReloadEndpointPath"/> (prefixed with the host's own base path,
+/// which it must then pass as <c>reloadEndpointPath</c>) and hand each one to
+/// <see cref="HandleWebSocketAsync"/>;</item>
+/// <item>call <see cref="BeginWatching"/> once the server is actually serving.</item>
+/// </list>
+///
+/// The live-reload client is injected into the generated index.html automatically — the watcher supplies
+/// it to each build — so nothing else is needed to make the page track the compiler. Two kinds of update
+/// are distinguished: an ordinary rebuild reloads the page, while a change confined to stylesheets the
+/// site copies from disk skips the compiler entirely and swaps the page's <c>&lt;link&gt;</c> hrefs in
+/// place, leaving the running application's state alone.
+///
+/// <code>
+/// var watcher = new TransposeWatcher(new ProjectBuildRequest(csproj) { Incremental = true });
+/// var initial = watcher.Start();
+/// if (!initial.Success) return 1;
+/// // ... start a web server on initial.SiteDirectory, mapping TransposeWatcher.ReloadEndpointPath ...
+/// watcher.BeginWatching();
+/// </code>
+/// </summary>
+public sealed class TransposeWatcher : IDisposable
+{
+    /// <summary>The URL path a host must map to <see cref="HandleWebSocketAsync"/>. A host serving under a
+    /// base path maps <c>&lt;base&gt; + ReloadEndpointPath</c> and passes that whole path to the
+    /// constructor, so the injected client connects to the right place.</summary>
+    public const string ReloadEndpointPath = ReloadHub.Path;
+
+    private readonly ProjectBuildRequest _request;
+    private readonly WatchSession _session;
+
+    /// <summary>The output of the most recent build, kept so <see cref="Start"/> (and the update callback)
+    /// can report it — the watch engine itself only deals in outcomes.</summary>
+    private IReadOnlyList<string> _lastOutput = Array.Empty<string>();
+
+    /// <param name="request">How to build the project on every change. Its
+    /// <see cref="ProjectBuildRequest.InjectedHtmlScript"/> is set by the watcher and must not be set by
+    /// the caller. Setting <see cref="ProjectBuildRequest.Incremental"/> is strongly recommended: a watch
+    /// loop rebuilds the same project over and over, which is exactly what the cache is for.</param>
+    /// <param name="reloadEndpointPath">The path, as the browser sees it, that the host maps to
+    /// <see cref="HandleWebSocketAsync"/>. Defaults to <see cref="ReloadEndpointPath"/>.</param>
+    /// <param name="onUpdated">Runs after each successful update and before the browser is told about it;
+    /// the flag says whether only stylesheets changed. This is the hook for a host that post-processes the
+    /// generated site (rewriting index.html, for instance) — doing it here means the page never loads the
+    /// un-processed output.</param>
+    public TransposeWatcher(
+        ProjectBuildRequest request,
+        string? reloadEndpointPath = null,
+        Action<ProjectBuildResult, bool>? onUpdated = null)
+    {
+        _request = request ?? throw new ArgumentNullException(nameof(request));
+        if (request.InjectedHtmlScript is not null)
+            throw new ArgumentException("InjectedHtmlScript is set by the watcher itself.", nameof(request));
+
+        ProjectPath = TransposeCompilerLibrary.LocateProject(request.ProjectPath);
+        _session = new WatchSession(
+            ProjectPath,
+            Build,
+            reloadPath: reloadEndpointPath,
+            afterUpdate: onUpdated is null
+                ? null
+                : (outcome, cssOnly) => onUpdated(new ProjectBuildResult(outcome, _lastOutput), cssOnly));
+    }
+
+    /// <summary>The resolved <c>.csproj</c> being watched.</summary>
+    public string ProjectPath { get; }
+
+    private BuildOutcome Build(string liveReloadScript)
+    {
+        var (outcome, output) = TransposeCompilerLibrary.RunProjectBuild(_request, liveReloadScript);
+        _lastOutput = output;
+        return outcome;
+    }
+
+    /// <summary>The project directories being watched — available after <see cref="BeginWatching"/>.</summary>
+    public IReadOnlyList<string> WatchedDirectories => _session.WatchedDirectories;
+
+    /// <summary>
+    /// Runs the initial build. The host serves <see cref="ProjectBuildResult.SiteDirectory"/> from here on;
+    /// a result with no site directory (a failed build, or a project whose shape is a package rather than a
+    /// site) means there is nothing to watch and the host should report the errors and stop.
+    /// </summary>
+    public ProjectBuildResult Start() => new(_session.Start(), _lastOutput);
+
+    /// <summary>Starts watching for changes. Call once the host is serving the initial build, so a rebuild
+    /// can never broadcast to a server that is not up yet. Throws if <see cref="Start"/> did not produce a
+    /// site.</summary>
+    public void BeginWatching() => _session.BeginWatching();
+
+    /// <summary>
+    /// Serves one live-reload websocket until the browser disconnects. <paramref name="clientVersion"/> is
+    /// the <c>v</c> query-string value the injected client sends: the build the page it is running came
+    /// from. A client that reconnects already behind the current build is brought up to date immediately,
+    /// which is what keeps a page whose reload overlapped a second rebuild from getting stuck.
+    /// </summary>
+    public Task HandleWebSocketAsync(WebSocket socket, long clientVersion, CancellationToken cancellationToken = default)
+        => _session.Hub.HandleAsync(socket, clientVersion, cancellationToken);
+
+    public void Dispose() => _session.Dispose();
+}

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -1,14 +1,6 @@
 using System.Diagnostics;
-using Microsoft.CodeAnalysis;
 
 namespace Transpose.Compiler;
-
-/// <summary>The outcome of one build pass (<see cref="Program.RunOnce"/>): the process exit code, plus
-/// — only for a successful site build — the directory it was written to and whether index.html
-/// generation is disabled. <see cref="OutDir"/> is null for every other outcome (a failure, or a
-/// package/bundle/runtime build with nothing to serve), which is what <see cref="WatchMode"/> uses to
-/// tell "this build resolves to a servable site" from "there is nothing here to watch".</summary>
-internal readonly record struct BuildRunResult(int ExitCode, string? OutDir, bool HtmlDisabled);
 
 /// <summary>
 /// A small command-line front-end for the Roslyn-only C# → JavaScript translator, in the
@@ -16,6 +8,10 @@ internal readonly record struct BuildRunResult(int ExitCode, string? OutDir, boo
 /// sources and package references, runs the translator, and writes the JavaScript bundle.
 ///
 ///   tps &lt;project.csproj|dir&gt; [--out &lt;file.js&gt;] [--with-runtime] [--quiet]
+///
+/// The build itself lives in <see cref="ProjectBuild"/> (Transpose.Compiler.Core), shared with the
+/// <c>Transpose.Compiler.Library</c> package; this file is argument parsing, the timing report and
+/// watch mode's dev server.
 /// </summary>
 public static class Program
 {
@@ -99,536 +95,50 @@ public static class Program
             return 1;
         }
 
-        // When the Transpose SDK invokes `tps --project` for a library — no explicit `--out` and not
-        // the `--build-runtime` corlib — produce the distributable package assembly, exactly as
-        // `--emit-package` does: the .NET DLL (with the compiled JS + Transpose.Resources.json manifest
-        // embedded) that `dotnet pack` wraps into `lib/<tfm>/<Assembly>.dll`. Without this the SDK
-        // build emits only a stray .js (or a runnable site folder) and `dotnet pack` fails with
-        // NU5026 (<Assembly>.dll not found).
-        //
-        // A binding library needs this even when it carries a tps.json (which only configures its JS
-        // layout / embedded resources): tps.json presence alone does not make it a site app. Only a
-        // *non-packable* project with a tps.json builds a runnable site; a packable one is a library.
-        // Projects that pass `--out` (bootstrap, tooling) keep writing a single .js bundle unchanged.
-        var hasTpsJson = TransposeJson.TryLoad(Path.GetDirectoryName(csproj)!) is not null;
-        if (!emitPackage && !buildRuntime && outPath is null
-            && (ProjectResolver.IsPackable(csproj) || !hasTpsJson))
+        var options = ProjectBuild.ResolveOutputMode(new BuildOptions
         {
-            emitPackage = true;
-            separateAssemblies = true;
-        }
-        // A site build (a non-packable project with a tps.json) consumes each referenced project's
-        // already-built package DLL — extracting its compiled JS — instead of recompiling that
-        // project's sources into this bundle. A dependency is therefore compiled once and reused:
-        // editing the app re-transpiles only the app's own files, not the whole referenced library.
-        // (With no project references this is equivalent to the old bundle build.)
-        else if (!emitPackage && !buildRuntime && outPath is null && hasTpsJson)
-        {
-            separateAssemblies = true;
-        }
+            CsprojPath = csproj,
+            OutPath = outPath,
+            SiteDir = siteDir,
+            Configuration = configuration,
+            WithRuntime = withRuntime,
+            Quiet = quiet,
+            MaxErrors = maxErrors,
+            EmitPackage = emitPackage,
+            SeparateAssemblies = separateAssemblies,
+            BuildRuntime = buildRuntime,
+            ExtraReferences = extraReferences,
+            ExtraDefines = extraDefines,
+            AssemblyVersion = assemblyVersion,
+            MetadataOnlyAssembly = metadataOnlyAssembly,
+            Incremental = incremental,
+            CacheDir = cacheDir,
+        });
 
         // --watch rebuilds this same project over and over as its sources change, serving the result
         // from a directory it can keep pointing a browser at — only a site build (a tps.json project,
         // no --emit-package/--build-runtime/--out) produces that. Reject the combination up front
         // rather than starting a server for a build that will never populate an outDir.
-        if (watch && (emitPackage || buildRuntime || outPath is not null))
+        if (watch && !ProjectBuild.IsSiteBuild(options))
         {
             MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeWatchRequiresSiteBuild,
                 "--watch requires a site build: the project must have a tps.json and not use --emit-package, --build-runtime, or --out.");
             return 1;
         }
 
+        var sw = Stopwatch.StartNew();
         if (watch)
         {
-            return WatchMode.Run(csproj, watchPort, liveReloadScript => RunOnce(
-                csproj, outPath, siteDir, configuration, withRuntime, quiet, maxErrors, emitPackage,
-                separateAssemblies, buildRuntime, extraReferences, extraDefines, assemblyVersion,
-                metadataOnlyAssembly, incremental, cacheDir, liveReloadScript));
+            // Every rebuild re-times its own phases, and the timing report is a whole-invocation
+            // summary — a running watch server has no "the build" to report on, so the report is
+            // simply not printed between rebuilds.
+            return WatchMode.Run(csproj, watchPort,
+                liveReloadScript => ProjectBuild.Run(options with { LiveReloadScript = liveReloadScript }));
         }
 
-        return RunOnce(csproj, outPath, siteDir, configuration, withRuntime, quiet, maxErrors, emitPackage,
-            separateAssemblies, buildRuntime, extraReferences, extraDefines, assemblyVersion,
-            metadataOnlyAssembly, incremental, cacheDir, liveReloadScript: null).ExitCode;
-    }
-
-    /// <summary>
-    /// Runs one build of <paramref name="csproj"/> end to end — resolve, translate, write outputs —
-    /// exactly what a plain <c>tps</c> invocation always did. Watch mode calls this repeatedly (once
-    /// per detected change) with a fresh <see cref="BuildRunResult"/> each time; a normal invocation
-    /// calls it once. <paramref name="liveReloadScript"/>, when not null, is inlined into the generated
-    /// index.html right before <c>&lt;/body&gt;</c> so the served page reconnects to the watch server
-    /// and reloads after each rebuild — a normal build always passes null, so its output is unaffected.
-    /// </summary>
-    private static BuildRunResult RunOnce(
-        string csproj, string? outPath, string? siteDir, string configuration, bool withRuntime, bool quiet,
-        int maxErrors, bool emitPackage, bool separateAssemblies, bool buildRuntime, List<string> extraReferences,
-        List<string> extraDefines, string? assemblyVersion, bool? metadataOnlyAssembly, bool incremental,
-        string? cacheDir, string? liveReloadScript)
-    {
-        Console.WriteLine($"tps: compiling {Path.GetFileName(csproj)}");
-        // Surface the translator's phase/step progress (binding, scanning, JS emit) so the long
-        // silent phases show visible movement. Quiet mode suppresses it.
-        if (!quiet) CompileProgress.Sink = msg => Console.WriteLine($"  {msg}");
-        var sw = Stopwatch.StartNew();
-
-        ResolvedProject project;
-        try
-        {
-            project = PhaseTimings.Measure("resolve project (csproj + globs + references)",
-                () => ProjectResolver.Resolve(csproj, configuration, separateAssemblies));
-        }
-        catch (Exception ex)
-        {
-            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
-                $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
-            return new BuildRunResult(1, null, false);
-        }
-
-        // Extra references (--reference) and defines (--define) from the command line. --reference
-        // lets a build reference assemblies that are not in the NuGet cache (e.g. locally-built
-        // tps.core during bootstrap, or a <Reference HintPath> assembly).
-        foreach (var r in extraReferences)
-        {
-            var full = Path.GetFullPath(r);
-            if (File.Exists(full) && !project.ReferencePaths.Contains(full)) project.ReferencePaths.Add(full);
-            else if (!File.Exists(full))
-                MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeReferenceNotFound,
-                    $"--reference not found: {full}");
-        }
-        foreach (var d in extraDefines)
-            if (!project.DefineConstants.Contains(d)) project.DefineConstants.Add(d);
-
-        Console.WriteLine($"  sources:    {project.Sources.Count} file(s){(separateAssemblies ? " (own sources only)" : "")}");
-        Console.WriteLine($"  references: {project.ReferencePaths.Count} assembly(ies) — {string.Join(", ", project.ReferencePaths.Select(Path.GetFileNameWithoutExtension))}");
-        if (project.ReferencedProjectDlls.Count > 0)
-            Console.WriteLine($"  projects:   {string.Join(", ", project.ReferencedProjectDlls.Select(Path.GetFileName))}");
-        Console.WriteLine($"  defines:    {string.Join(";", project.DefineConstants)}");
-        Console.WriteLine($"  config:     {configuration}");
-        Console.WriteLine($"  lang:       {project.LanguageVersion}");
-
-        // Command line beats the csproj property, which beats the per-configuration default. Printed,
-        // because "why is my DLL half the size in Debug?" should be answerable from the build log.
-        var metadataOnly = metadataOnlyAssembly
-                           ?? project.MetadataOnlyAssembly
-                           ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration);
-        Console.WriteLine($"  assembly:   {(metadataOnly ? "metadata only (throw-null bodies, not packable)" : "full IL")}");
-
-        // The project's tps.json drives runtime-package detection and reflection settings. A
-        // tps.<Configuration>.json overlay (e.g. tps.Release.json) is merged on top when present.
-        var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
-
-        // Base runtime package build: compile Transpose.BCL self-contained, transpile it with
-        // outputBy: ClassPath, stitch the per-class files with the hand-written Resources primitives
-        // into tps.js per the project's tps.json, and embed tps.js + tps.meta.js into Transpose.dll.
-        //
-        // This path is ONLY for the base library, which *defines* the BCL and therefore references no
-        // Transpose.dll of its own. A binding library (Transpose.Newtonsoft.Json, Transpose.WebGL2, …)
-        // may also declare outputBy: ClassPath for its JS layout, but it references the Transpose BCL
-        // and must bind against it — compiling it self-contained would leave System.Object and every
-        // other predefined type undefined (CS0518 ×N). Such libraries fall through to the package path.
-        var referencesTransposeBcl = project.ReferencePaths.Any(p =>
-            string.Equals(Path.GetFileNameWithoutExtension(p), "Transpose", StringComparison.OrdinalIgnoreCase));
-        if (buildRuntime
-            || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && !referencesTransposeBcl))
-            return new BuildRunResult(BuildRuntime(project, configuration, sw, outPath, maxErrors), null, false);
-
-        // Refuse to compile against assemblies built by a newer Transpose than this one (see
-        // BuildStamp). Checked before anything is compiled — and before the incremental cache can
-        // declare the project up to date — so the answer never depends on how much of a previous
-        // build survives. The base library is checked too: it is injected by the translator rather
-        // than listed as a project reference, and it is the assembly most likely to be ahead of the
-        // compiler in a NuGet cache.
-        if (!CompilerIsNewEnough(project.ReferencePaths)) return new BuildRunResult(1, null, false);
-
-        // Reflection settings come from the project's tps.json (target inline vs a .meta.js file).
-        var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
-
-        // Chain the referenced projects first (like the MSBuild-driven compiler): in
-        // separate-assembly / package mode this project binds against its dependencies' built DLLs
-        // and extracts their embedded JS, so each must be compiled — in dependency order — before
-        // this one. Up-to-date packages are skipped.
-        if (separateAssemblies && !EnsureReferencedProjectsBuilt(csproj, configuration, maxErrors, metadataOnlyAssembly, incremental, cacheDir))
-        {
-            Console.Error.WriteLine("\nFAILED building referenced projects.");
-            return new BuildRunResult(1, null, false);
-        }
-
-        // A site build still emits the .NET assembly: the Transpose.Build.Target SDK declares the
-        // project's <Assembly>.dll as its build output, and MSBuild copies it for any project that
-        // references this one. Emitting the DLL (with the compiled JS embedded, like a package) means
-        // every project — app or library — produces the DLL the SDK/consumers expect.
-        var isSiteBuild = !emitPackage && !buildRuntime && outPath is null && tpscfg is not null;
-
-        // Incremental build (--incremental): consult the cache written by the previous build of this
-        // project. This happens *after* the referenced projects were rebuilt above, so a dependency's
-        // freshly written DLL is part of what gets fingerprinted.
-        BuildCache? cache = null;
-        var verdict = BuildCache.Verdict.FullBuild;
-        var changedSources = new List<string>();
-        if (incremental)
-        {
-            cache = BuildCache.Open(project, configuration,
-                OutputMode(emitPackage, isSiteBuild),
-                // "watch={..}" so switching --watch on/off across builds sharing a cache dir invalidates
-                // it — the injected live-reload script changes the written index.html even when nothing
-                // else about the build did, and an "up to date" verdict skips writing it altogether.
-                BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
-                    metadataOnly, emitPackage, isSiteBuild, separateAssemblies, withRuntime, outPath, siteDir,
-                    assemblyVersion).Append($"watch={liveReloadScript is not null}"),
-                BuildContentFingerprint(project),
-                cacheDir);
-            (verdict, changedSources, var reason) = cache.Decide();
-
-            if (verdict == BuildCache.Verdict.UpToDate)
-            {
-                Console.WriteLine($"\nOK — everything up to date, nothing to compile ({sw.ElapsedMilliseconds} ms).");
-                foreach (var output in cache.PreviousOutputs.Take(4)) Console.WriteLine($"  output:   {output}");
-                if (cache.PreviousOutputs.Count > 4)
-                    Console.WriteLine($"            … and {cache.PreviousOutputs.Count - 4} more");
-                PrintTimings(sw.ElapsedMilliseconds);
-                return new BuildRunResult(0, null, false);
-            }
-            Console.WriteLine(verdict == BuildCache.Verdict.BodyOnlyChange
-                ? $"  cache:      {changedSources.Count} file(s) changed, method bodies only — reusing cached declarations"
-                : $"  cache:      full build ({reason})");
-        }
-        // Nothing in this project changed — only a referenced package's content did (its declarations
-        // are identical). The compilation would reproduce the cached bundle byte for byte, so skip it
-        // and go straight to writing the outputs, which do have to be rewritten.
-        var replayed = incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
-            ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)
-            : null;
-        if (replayed is not null)
-            Console.WriteLine("  cache:      reusing the previous compilation in full — writing outputs only");
-
-        var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
-
-        var translator = new RoslynTranslator();
-        AssemblyBuildResult result;
-        try
-        {
-            result = replayed ?? translator.BuildAssembly(
-                project.Sources,
-                project.AssemblyName,
-                project.ReferencePaths,
-                project.DefineConstants,
-                project.LanguageVersion,
-                reflectionEnabled,
-                metadataTarget,
-                emitAssembly: emitPackage || isSiteBuild,
-                assemblyVersion: assemblyVersion,
-                emitDebugInformation: project.EmitDebugInformation,
-                metadataOnlyAssembly: metadataOnly,
-                incremental: plan);
-        }
-        catch (Exception ex)
-        {
-            ReportCrash("Translator", ex);
-            return new BuildRunResult(2, null, false);
-        }
-
-        // The stopwatch keeps running: writing the package (minifying the embedded JS, the Cecil
-        // resource embed) and assembling the site are a real part of a build's cost, and the
-        // reported total should include them rather than stopping at the translator's last phase.
-        if (!result.Success)
-        {
-            ReportDiagnostics(result.Diagnostics, maxErrors);
-            Console.Error.WriteLine($"\nFAILED in {sw.ElapsedMilliseconds} ms.");
-            return new BuildRunResult(1, null, false);
-        }
-
-        var js = result.Javascript!;
-        if (!quiet) ReportDiagnostics(result.Diagnostics, maxErrors); // surface warnings
-        var config = tpscfg;
-
-        // Package mode: compile this project as a distributable assembly — emit the .NET DLL and
-        // embed its JS (+ tps.json resources) so another project can reference it and extract them.
-        if (emitPackage)
-        {
-            var written = TryWritePackage(project, config, configuration, result);
-            if (written is null) return new BuildRunResult(2, null, false);
-
-            var (dllPath, items) = written.Value;
-            SaveCache(cache, plan, result, new[] { dllPath });
-            Console.WriteLine($"\nOK — built package {project.AssemblyName}.dll ({result.AssemblyBytes!.Length:N0} bytes) with {items.Count} embedded resource(s) in {sw.ElapsedMilliseconds} ms.");
-            Console.WriteLine($"  dll:      {dllPath}");
-            Console.WriteLine($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
-            PrintTimings(sw.ElapsedMilliseconds);
-            return new BuildRunResult(0, null, false);
-        }
-
-        // Site build: when the project has an tps.json and no single-file --out was requested,
-        // assemble a runnable output folder (runtime JS + bundle + resources + index.html),
-        // exactly like the existing tps compiler.
-        if (config is not null && outPath is null)
-        {
-            // Also emit the package DLL (with JS embedded), so referencing projects can consume this
-            // one and the SDK finds the <Assembly>.dll it declares as the build output.
-            string? dllPath = null;
-            if (result.AssemblyBytes is not null)
-            {
-                var package = TryWritePackage(project, config, configuration, result);
-                if (package is null) return new BuildRunResult(2, null, false);
-                dllPath = package.Value.dllPath;
-            }
-
-            var outDir = siteDir ?? ResolveOutputDir(config, project.ProjectDir, configuration);
-            var siteResult = PhaseTimings.Measure("write site (minify + resources + html)", () =>
-                OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript, liveReloadScript));
-            // Every file in the site counts as an output: a rebuild must notice if any of them was
-            // deleted or edited, otherwise "up to date" would leave a broken site in place.
-            SaveCache(cache, plan, result, SiteOutputs(outDir, dllPath));
-            Console.WriteLine($"\nOK — built site in {outDir} ({js.Length:N0} bytes of {config.FileName}) in {sw.ElapsedMilliseconds} ms.");
-            Console.WriteLine($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
-            if (dllPath is not null) Console.WriteLine($"  dll:        {dllPath}");
-            if (siteResult.RemovedStaleFiles.Count > 0)
-            {
-                var stale = siteResult.RemovedStaleFiles;
-                Console.WriteLine($"  cleaned:    {stale.Count} stale file(s) from a previous build");
-                foreach (var f in stale.Take(10)) Console.WriteLine($"                - {Path.GetRelativePath(outDir, f)}");
-                if (stale.Count > 10) Console.WriteLine($"                … and {stale.Count - 10} more");
-            }
-            PrintTimings(sw.ElapsedMilliseconds);
-            return new BuildRunResult(0, outDir, config.HtmlDisabled);
-        }
-
-        if (withRuntime) js = RoslynTranslator.LoadRuntime() + "\n" + js;
-        outPath ??= Path.Combine(project.ProjectDir, "bin", project.AssemblyName + ".js");
-        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outPath))!);
-        File.WriteAllText(outPath, js);
-        SaveCache(cache, plan, result, new[] { Path.GetFullPath(outPath) });
-        Console.WriteLine($"\nOK — wrote {js.Length:N0} bytes to {outPath} in {sw.ElapsedMilliseconds} ms.");
+        var outcome = ProjectBuild.Run(options);
         PrintTimings(sw.ElapsedMilliseconds);
-        return new BuildRunResult(0, null, false);
-    }
-
-    /// <summary>
-    /// Whether this compiler is new enough for everything the project binds against — every referenced
-    /// assembly plus the injected base library (<c>Transpose.dll</c>). Reports the diagnostic and
-    /// returns false when it is not; see <see cref="BuildStamp"/> for what is being compared and
-    /// <see cref="CompilerVersion.EnforceMinimum"/> for when the check applies at all (never in a dev
-    /// build of the compiler, which carries no version).
-    /// </summary>
-    private static bool CompilerIsNewEnough(IEnumerable<string> referencePaths)
-    {
-        if (!CompilerVersion.EnforceMinimum) return true;
-
-        var toCheck = new List<string>(referencePaths);
-        // Discovering the base library can itself fail (no NuGet cache, no TRANSPOSE_DLL_PATH); that is
-        // the translator's error to report, not this check's.
-        try { toCheck.Add(TransposeAssemblies.TransposeDllPath); } catch { }
-
-        var outdated = BuildStamp.CheckReferences(toCheck);
-        if (outdated is null) return true;
-
-        Console.Error.WriteLine();
-        Console.Error.WriteLine(MsBuildDiagnostic.Format(outdated));
-        return false;
-    }
-
-    /// <summary>
-    /// Persists the cache after a successful build. A build that reused the previous compilation whole
-    /// (no plan) has nothing new to record but its new output files; any other build writes the lot.
-    /// </summary>
-    private static void SaveCache(BuildCache? cache, IncrementalPlan? plan, AssemblyBuildResult result,
-        IEnumerable<string> outputs)
-    {
-        if (cache is null) return;
-        if (plan is null) cache.SaveOutputsOnly(outputs);
-        else cache.Save(plan, result, outputs);
-    }
-
-    /// <summary>Every file under the assembled site, plus the emitted DLL — the outputs an incremental
-    /// build has to find unchanged before it may declare the project up to date.</summary>
-    private static IEnumerable<string> SiteOutputs(string outDir, string? dllPath)
-    {
-        if (dllPath is not null) yield return dllPath;
-        if (!Directory.Exists(outDir)) yield break;
-        foreach (var file in Directory.EnumerateFiles(outDir, "*", SearchOption.AllDirectories))
-            yield return file;
-    }
-
-    /// <summary>
-    /// Everything about a build other than its source files: the settings, the output shape, and a
-    /// fingerprint of every referenced assembly and config file. A change to any of these can change
-    /// every byte of the output, so it invalidates the whole cache rather than any part of it.
-    ///
-    /// Anything the compiler starts to read in future has to be added here. That is the one
-    /// maintenance obligation the cache imposes: an input nobody fingerprints is an input whose change
-    /// goes unnoticed.
-    /// </summary>
-    private static IEnumerable<string> BuildSettingsFingerprint(
-        ResolvedProject project, string configuration, TransposeJson? tpscfg, bool reflectionEnabled,
-        MetadataTarget metadataTarget, bool metadataOnly, bool emitPackage, bool isSiteBuild,
-        bool separateAssemblies, bool withRuntime, string? outPath, string? siteDir, string? assemblyVersion)
-    {
-        yield return $"configuration={configuration}";
-        yield return $"assembly={project.AssemblyName}";
-        yield return $"tfm={project.TargetFramework}";
-        yield return $"lang={project.LanguageVersion}";
-        yield return $"defines={string.Join(";", project.DefineConstants)}";
-        yield return $"reflection={reflectionEnabled}/{metadataTarget}";
-        yield return $"metadataOnly={metadataOnly}";
-        yield return $"debugInfo={project.EmitDebugInformation}";
-        yield return $"minifyLocals={project.MinifyLocalVariables}";
-        yield return $"assemblyVersion={assemblyVersion}";
-        yield return $"mode={OutputMode(emitPackage, isSiteBuild)}";
-        yield return $"separate={separateAssemblies};runtime={withRuntime}";
-        yield return $"out={outPath};siteDir={siteDir}";
-        yield return $"tpsjson={tpscfg is null}";
-
-        // The project file and its tps.json (plus the per-configuration overlay) by content: they
-        // decide which files compile, what gets embedded and how the site is laid out.
-        yield return "csproj=" + BuildCache.FileContentFingerprint(project.CsprojPath);
-        yield return "tps.json=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, "tps.json"));
-        yield return $"tps.{configuration}.json="
-            + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, $"tps.{configuration}.json"));
-
-        // Every referenced assembly, by the part of it this project's output depends on: its metadata.
-        // A package upgrade or a dependency whose declarations moved changes emitted names (overload
-        // numbering counts the reference's full member set), so it is a full-rebuild input; a dependency
-        // rebuilt from a body-only edit of its own is not (see ReferenceMetadataFingerprint).
-        foreach (var reference in project.ReferencePaths.OrderBy(p => p, StringComparer.Ordinal))
-            yield return "ref=" + BuildCache.ReferenceMetadataFingerprint(reference);
-
-        // The Transpose base assembly and the JS runtime it carries are injected by the translator, not
-        // by the project, so they have to be fingerprinted explicitly.
-        yield return "bcl=" + BuildCache.ReferenceFingerprint(TransposeAssemblies.TransposeDllPath);
-
-        // Resources the site/package build reads straight from disk (tps.json `resources`): tps.json's
-        // own hash covers *which* files are listed, but not what is in them.
-        if (tpscfg is not null)
-            foreach (var file in tpscfg.Resources.SelectMany(g => g.Files).OrderBy(n => n, StringComparer.Ordinal))
-                yield return "res=" + file + "=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, file));
-    }
-
-    /// <summary>What shape of output this build produces — the distributable package DLL, a runnable
-    /// site, or a single .js bundle. Each gets its own cache.</summary>
-    private static string OutputMode(bool emitPackage, bool isSiteBuild)
-        => emitPackage ? "package" : isSiteBuild ? "site" : "bundle";
-
-    /// <summary>
-    /// The inputs that cannot change a byte this project *emits*, but do change what it has to *write*:
-    /// the full content of every referenced assembly, whose embedded JavaScript and resources are copied
-    /// into the site and re-embedded into this project's own DLL. A change here means "rebuild the
-    /// outputs, keep the compilation" — see <see cref="BuildCache.Open"/>.
-    /// </summary>
-    private static IEnumerable<string> BuildContentFingerprint(ResolvedProject project)
-    {
-        foreach (var reference in project.ReferencePaths.OrderBy(p => p, StringComparer.Ordinal))
-            yield return "refbytes=" + BuildCache.ReferenceFingerprint(reference);
-    }
-
-    /// <summary>
-    /// Builds the base runtime package (Transpose.BCL → the `tps` NuGet package): compiles the BCL
-    /// self-contained, transpiles it with outputBy: ClassPath into Resources/.generated/, stitches
-    /// those with the hand-written Resources/*.js primitives into tps.js (and the reflection block
-    /// into tps.meta.js) per the project's tps.json, and embeds both into Transpose.dll.
-    /// </summary>
-    private static int BuildRuntime(ResolvedProject project, string configuration, Stopwatch sw, string? outPath, int maxErrors)
-    {
-        var cfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
-        var reflectionEnabled = !(cfg?.ReflectionDisabled ?? false);
-
-        RuntimePackageResult result;
-        try
-        {
-            result = new RoslynTranslator().BuildRuntimePackage(
-                project.Sources, project.AssemblyName, project.DefineConstants,
-                project.LanguageVersion, reflectionEnabled);
-        }
-        catch (Exception ex) { ReportCrash("Runtime build", ex); return 2; }
-
-        if (!result.Success)
-        {
-            ReportDiagnostics(result.Diagnostics, maxErrors);
-            Console.Error.WriteLine($"\nFAILED building runtime in {sw.ElapsedMilliseconds} ms.");
-            return 1;
-        }
-
-        // Write the ClassPath per-class files + reflection metadata under Resources/.generated/.
-        var genRoot = Path.Combine(project.ProjectDir, "Resources", ".generated");
-        PhaseTimings.Measure("write ClassPath files", () =>
-        {
-        if (Directory.Exists(genRoot)) Directory.Delete(genRoot, recursive: true);
-        Directory.CreateDirectory(genRoot);
-        // Group types that share a ClassPath file (same simple name across generic arities, e.g.
-        // ValueTuple + ValueTuple$1..$8, or all the nested Enumerator types) so they are concatenated
-        // into one file rather than overwriting each other.
-        foreach (var grp in result.ClassPath!.Files.GroupBy(f => f.relPath))
-        {
-            var dest = Path.Combine(genRoot, grp.Key.Replace('/', Path.DirectorySeparatorChar));
-            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-            File.WriteAllText(dest, string.Join("\n", grp.Select(g => g.js)));
-        }
-        if (result.ClassPath.MetaBlock is not null)
-            File.WriteAllText(Path.Combine(genRoot, project.AssemblyName + ".meta.js"), result.ClassPath.MetaBlock);
-        });
-        Console.WriteLine($"  emitted:    {result.ClassPath.Files.Count} ClassPath file(s) into Resources/.generated");
-        if (result.ClassPath.Skipped.Count > 0)
-        {
-            Console.WriteLine($"  skipped:    {result.ClassPath.Skipped.Count} type(s) the emitter could not translate:");
-            foreach (var (t, why) in result.ClassPath.Skipped.Take(20)) Console.WriteLine($"                - {t}: {why}");
-        }
-
-        // Assemble the resource bundles (tps.js, tps.meta.js, …) declared in tps.json, then add a
-        // pre-minified variant of each next to it. Embedding the .min.js in the runtime package
-        // means a referencing build never re-minifies the (large) runtime — it just picks the
-        // variant its configuration wants, exactly as it does for the formatted/minified pair.
-        var bundles = PhaseTimings.Measure("assemble runtime bundles (tps.js)",
-            () => RuntimeAssembler.Assemble(project.ProjectDir));
-        var minBundles = PhaseTimings.Measure("minify runtime bundles", () =>
-        {
-        var mins = new List<(string name, byte[] bytes)>();
-        foreach (var (name, bytes) in bundles)
-        {
-            var minName = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && !name.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
-                ? name.Substring(0, name.Length - ".js".Length) + ".min.js"
-                : null;
-            if (minName is null) continue;
-            var minText = JsMinifier.Minify(System.Text.Encoding.UTF8.GetString(bytes), name, project.MinifyLocalVariables);
-            mins.Add((minName, System.Text.Encoding.UTF8.GetBytes(minText)));
-        }
-        return mins;
-        });
-        bundles = bundles.Concat(minBundles).ToList();
-        // Write the assembly to bin/<config>/<tfm>/, matching the SDK's output path so `dotnet pack`
-        // finds it (the Transpose.Build.Target SDK forces netstandard2.0, so that is the effective tfm).
-        var dllPath = outPath ?? Path.Combine(project.ProjectDir, "bin", configuration, project.TargetFramework, project.AssemblyName + ".dll");
-        var outDir = Path.GetDirectoryName(Path.GetFullPath(dllPath))!;
-        Directory.CreateDirectory(outDir);
-        foreach (var (name, bytes) in bundles)
-        {
-            File.WriteAllBytes(Path.Combine(outDir, name), bytes); // write bundles next to the DLL for reuse
-            Console.WriteLine($"  assembled:  {name} ({bytes.Length:N0} bytes)");
-        }
-
-        // Emit the reference assembly with the JS bundles embedded as manifest resources, via
-        // Roslyn (not a Mono.Cecil post-process) so the DLL stays a clean core library — Cecil's
-        // writer injects an mscorlib reference, which stops Roslyn from treating the runtime as the
-        // corlib when compiling user code against it (every type would fail with CS0518).
-        //
-        // The base library gets the same minimum-compiler-version stamp as every other assembly tps
-        // builds — it is the reference every Transpose project binds against, so it is the one whose
-        // "you need a newer tps" is most worth saying. Appended here rather than to `bundles`: the
-        // bundles are also written to disk next to the DLL for reuse, and this belongs only inside it.
-        var embedded = bundles.Append((BuildStamp.ResourceName, BuildStamp.ForCurrentCompiler().ToJsonBytes())).ToList();
-
-        byte[] assemblyBytes;
-        try { assemblyBytes = result.EmitAssembly!(embedded); }
-        catch (Exception ex)
-        {
-            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeAssemblyEmitFailed,
-                $"Runtime assembly emit failed: {ex.Message}");
-            return 2;
-        }
-        File.WriteAllBytes(dllPath, assemblyBytes);
-
-        Console.WriteLine($"\nOK — built runtime {Path.GetFileName(dllPath)} with {bundles.Count} embedded bundle(s) in {sw.ElapsedMilliseconds} ms.");
-        Console.WriteLine($"  dll:      {dllPath}");
-        Console.WriteLine($"  bundles:  written to {outDir}");
-        PrintTimings(sw.ElapsedMilliseconds);
-        return 0;
+        return outcome.ExitCode;
     }
 
     /// <summary>Prints the per-phase timing breakdown gathered when <c>--timing</c> (or
@@ -710,196 +220,6 @@ public static class Program
         return sb.Append('"').ToString();
     }
 
-    private static (bool reflectionEnabled, MetadataTarget target) ReflectionSettings(TransposeJson? tpscfg)
-    {
-        var reflectionEnabled = !(tpscfg?.ReflectionDisabled ?? false);
-        var metadataTarget = (tpscfg?.ReflectionTarget ?? "file").ToLowerInvariant() switch
-        {
-            "inline" => MetadataTarget.Inline,
-            "type" => MetadataTarget.Type,
-            "assembly" => MetadataTarget.Assembly,
-            _ => MetadataTarget.File,
-        };
-        return (reflectionEnabled, metadataTarget);
-    }
-
-    /// <summary>
-    /// Builds every referenced project of <paramref name="rootCsproj"/> in dependency order,
-    /// skipping any whose package DLL is already up-to-date. Mirrors the MSBuild-driven compiler,
-    /// which builds project references (each producing a DLL with its JS embedded) before the
-    /// project that consumes them.
-    /// </summary>
-    private static bool EnsureReferencedProjectsBuilt(string rootCsproj, string configuration, int maxErrors,
-        bool? metadataOnlyAssembly, bool incremental, string? cacheDir)
-    {
-        foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
-        {
-            var name = Path.GetFileNameWithoutExtension(dep);
-            // Without the cache, a dependency's freshness is judged by timestamps. With it, that
-            // question is answered better inside BuildPackage — by hashing the content — so the
-            // timestamp screen is skipped rather than layered on top: it can only disagree by calling a
-            // project dirty when it is not (a touched file, a checkout that moved an mtime backwards),
-            // and the cache then resolves that to "nothing to do" for the price of hashing the sources.
-            // Two mechanisms answering the same question, weaker one first, is how a build ends up
-            // rebuilding for reasons nobody can explain.
-            if (!incremental && ProjectResolver.IsPackageUpToDate(dep, configuration))
-            {
-                Console.WriteLine($"  dependency up-to-date: {name}");
-                continue;
-            }
-            Console.WriteLine($"  building dependency: {name}");
-            if (!BuildPackage(dep, configuration, maxErrors, metadataOnlyAssembly, incremental, cacheDir))
-            {
-                MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeDependencyBuildFailed,
-                    $"Failed to build referenced project '{name}'.");
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /// <summary>Compiles one project into its Transpose package DLL (the .NET assembly with the compiled JS
-    /// and tps.json resources embedded). Its own project references are consumed as their built DLLs,
-    /// so they must already have been built (this is called in dependency order).</summary>
-    private static bool BuildPackage(string csproj, string configuration, int maxErrors, bool? metadataOnlyAssembly,
-        bool incremental, string? cacheDir)
-    {
-        ResolvedProject project;
-        try { project = ProjectResolver.Resolve(csproj, configuration, separateAssemblies: true); }
-        catch (Exception ex)
-        {
-            MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeProjectResolveFailed,
-                $"Failed to resolve project '{Path.GetFileName(csproj)}': {ex.Message}");
-            return false;
-        }
-
-        // A dependency can reference a package the root project does not, so it gets its own check.
-        if (!CompilerIsNewEnough(project.ReferencePaths)) return false;
-
-        var tpscfg = TransposeJson.TryLoad(project.ProjectDir, configuration);
-        var (reflectionEnabled, metadataTarget) = ReflectionSettings(tpscfg);
-        var assemblyVersion = ProjectResolver.ReadAssemblyVersion(csproj);
-        // Each dependency reads its own csproj property, but a command-line override applies to the
-        // whole invocation.
-        var metadataOnly = metadataOnlyAssembly
-                           ?? project.MetadataOnlyAssembly
-                           ?? ResolvedProject.MetadataOnlyAssemblyDefault(configuration);
-
-        // A dependency gets the same treatment as the root project: its own cache, in its own obj/.
-        // Without this, editing a method body in a referenced library — the common case in a
-        // solution — would still cost that library a full rebuild.
-        BuildCache? cache = null;
-        var verdict = BuildCache.Verdict.FullBuild;
-        var changedSources = new List<string>();
-        if (incremental)
-        {
-            cache = BuildCache.Open(project, configuration,
-                OutputMode(emitPackage: true, isSiteBuild: false),
-                BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
-                    metadataOnly, emitPackage: true, isSiteBuild: false, separateAssemblies: true,
-                    withRuntime: false, outPath: null, siteDir: null, assemblyVersion: assemblyVersion),
-                BuildContentFingerprint(project),
-                cacheDir);
-            (verdict, changedSources, var reason) = cache.Decide();
-            if (verdict == BuildCache.Verdict.UpToDate)
-            {
-                // Every input and output of the dependency is unchanged, so its package DLL is already
-                // the one this build wants. This is the incremental replacement for the timestamp screen
-                // in EnsureReferencedProjectsBuilt, and it is cheaper than the replay path below
-                // because it does not even rewrite the DLL.
-                Console.WriteLine("    cache: up to date, nothing to do");
-                return true;
-            }
-            Console.WriteLine(verdict == BuildCache.Verdict.FullBuild
-                ? $"    cache: full build ({reason})"
-                : $"    cache: {changedSources.Count} file(s) changed, method bodies only");
-        }
-        var replayed = incremental && verdict == BuildCache.Verdict.BodyOnlyChange && changedSources.Count == 0
-            ? cache!.TryReplayCompilation(canReuseAssembly: metadataOnly)
-            : null;
-        var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
-
-        AssemblyBuildResult result;
-        try
-        {
-            result = replayed ?? new RoslynTranslator().BuildAssembly(
-                project.Sources, project.AssemblyName, project.ReferencePaths,
-                project.DefineConstants, project.LanguageVersion,
-                reflectionEnabled, metadataTarget, emitAssembly: true,
-                assemblyVersion: assemblyVersion,
-                emitDebugInformation: project.EmitDebugInformation,
-                metadataOnlyAssembly: metadataOnly,
-                incremental: plan);
-        }
-        catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex); return false; }
-
-        if (!result.Success)
-        {
-            ReportDiagnostics(result.Diagnostics, maxErrors);
-            return false;
-        }
-
-        var written = TryWritePackage(project, tpscfg, configuration, result);
-        if (written is null) return false;
-        SaveCache(cache, plan, result, new[] { written.Value.dllPath });
-        return true;
-    }
-
-    /// <summary>Writes a project's package DLL, turning a failure into a reported diagnostic (rather
-    /// than an unhandled exception) and a null result. Embedding the resources re-serializes the
-    /// assembly's metadata through Mono.Cecil, which resolves referenced assemblies as it goes — a
-    /// step that can fail on its own, after a clean compile.</summary>
-    private static (string dllPath, List<EmbeddedItem> items)? TryWritePackage(
-        ResolvedProject project, TransposeJson? config, string configuration, AssemblyBuildResult result)
-    {
-        try { return WritePackage(project, config, configuration, result); }
-        catch (Exception ex)
-        {
-            ReportCrash($"Writing the package for '{Path.GetFileName(project.CsprojPath)}'", ex);
-            return null;
-        }
-    }
-
-    /// <summary>Writes a project's emitted assembly and embeds its JS + resources, returning the DLL
-    /// path and the embedded items. The DLL path is the one the resolver references for this
-    /// project, so a consumer finds it.</summary>
-    private static (string dllPath, List<EmbeddedItem> items) WritePackage(
-        ResolvedProject project, TransposeJson? config, string configuration, AssemblyBuildResult result)
-    {
-        var mainJsName = config?.ExplicitFileName ?? project.AssemblyName + ".js";
-        var dllPath = ProjectResolver.OutputDll(project.CsprojPath, configuration)!;
-        Directory.CreateDirectory(Path.GetDirectoryName(dllPath)!);
-
-        var items = PhaseTimings.Measure("collect package resources (minify + read files)", () => config is not null
-            ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables)
-            : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) });
-        // Cecil re-serializes the assembly's metadata when embedding the resources; encoding a
-        // parameter's default value whose type lives in a referenced assembly (e.g. a Tesserae enum)
-        // makes it resolve that assembly. Seed the resolver with the reference directories so those
-        // types are found (the referenced DLLs live in the NuGet cache / sibling bin folders, not
-        // next to this DLL).
-        // Writes the DLL — the emitted assembly plus the embedded resources — in one pass.
-        PhaseTimings.Measure("embed resources into DLL (Cecil)",
-            () => ResourceEmbedder.Embed(dllPath, result.AssemblyBytes!, items, project.ReferencePaths));
-        // Record what a consumer's compilation actually depends on — this assembly's metadata — so a
-        // rebuild of this project does not force a rebuild of everything referencing it when only its
-        // method bodies moved. Cecil restamps the DLL's MVID on every embed, so its bytes cannot serve.
-        BuildCache.WriteMetadataSidecar(dllPath, result.AssemblyBytes);
-        return (dllPath, items);
-    }
-
-    /// <summary>Resolves tps.json's output path, expanding the $(OutDir) MSBuild token.</summary>
-    private static string ResolveOutputDir(TransposeJson config, string projectDir, string configuration)
-    {
-        var raw = (config.Output ?? "$(OutDir)/tps/").Replace("$(OutDir)", ResolveBinDir(projectDir, configuration)).Replace('\\', '/');
-        return Path.GetFullPath(raw);
-    }
-
-    /// <summary>The project's build output directory (bin/&lt;config&gt;/netstandard2.0), where the
-    /// emitted assembly and tps output land — matching the Transpose SDK's default output path.</summary>
-    private static string ResolveBinDir(string projectDir, string configuration)
-        => Path.Combine(projectDir, "bin", configuration, "netstandard2.0");
-
     private static string? LocateProject(string? arg)
     {
         if (string.IsNullOrWhiteSpace(arg)) arg = Directory.GetCurrentDirectory();
@@ -916,85 +236,6 @@ public static class Program
             }
         }
         return null;
-    }
-
-    /// <summary>
-    /// Prints the build's diagnostics. **Every** error is printed by default: a truncated list makes a
-    /// broken build take several compile cycles to fix, and the caller has no way to know whether the
-    /// errors it cannot see are the same problem or a different one. <paramref name="maxErrors"/> caps
-    /// the list only when a caller explicitly asked for a cap (<c>--max-errors</c>).
-    ///
-    /// Ordering comes from <see cref="OrderErrorsForReport"/>.
-    /// </summary>
-    /// <summary>
-    /// The errors to report, in the order to report them: by file, then line, then column — the order
-    /// you would fix them in — rather than by the phase that produced them (the unsupported-feature
-    /// scan runs before Roslyn's diagnostics, and its parallel per-file walk has no inherent order).
-    /// Nothing is filtered out here; truncation, if any, is the caller's decision.
-    /// </summary>
-    internal static List<Diagnostic> OrderErrorsForReport(IReadOnlyList<Diagnostic> diagnostics)
-        => diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)
-            .OrderBy(d => d.Location.SourceTree?.FilePath ?? "", StringComparer.OrdinalIgnoreCase)
-            .ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Line)
-            .ThenBy(d => d.Location.GetLineSpan().StartLinePosition.Character)
-            .ThenBy(d => d.Id, StringComparer.Ordinal)
-            .ToList();
-
-    private static void ReportDiagnostics(IReadOnlyList<Diagnostic> diagnostics, int maxErrors)
-    {
-        var errors = OrderErrorsForReport(diagnostics);
-        var warnings = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToList();
-
-        if (errors.Count > 0)
-        {
-            // The summary lines are deliberately not in diagnostic form, and must stay that way: any
-            // line MSBuild can parse becomes a build error, so a summary could otherwise conjure an
-            // error nobody wrote. See MsBuildDiagnostic for the shape to avoid — writing the count as
-            // "N error(s), by id: …" rather than "N error(s):" keeps a colon from ever landing where
-            // the parser expects one.
-            var byId = errors.GroupBy(d => d.Id).OrderByDescending(g => g.Count());
-            Console.Error.WriteLine();
-            Console.Error.WriteLine($"{errors.Count} error(s), by id: "
-                + string.Join(", ", byId.Select(g => $"{g.Key}×{g.Count()}")));
-            Console.Error.WriteLine();
-            var shown = maxErrors > 0 ? errors.Take(maxErrors) : errors;
-            foreach (var d in shown)
-                Console.Error.WriteLine(MsBuildDiagnostic.Format(d));
-            if (maxErrors > 0 && errors.Count > maxErrors)
-                Console.Error.WriteLine($"… and {errors.Count - maxErrors} more (raise or drop --max-errors to see them)");
-        }
-
-        // Warnings are printed in full too, not just counted: in canonical form they reach the IDE's
-        // task list, where a count on the console never would.
-        foreach (var d in warnings)
-            Console.WriteLine(MsBuildDiagnostic.Format(d));
-        if (warnings.Count > 0)
-            Console.WriteLine($"{warnings.Count} warning(s) total");
-    }
-
-    /// <summary>
-    /// Reports an unhandled exception from the translator as a single diagnostic — a crash is a build
-    /// failure the caller must see, and MSBuild only sees a line it can parse. The messages of the
-    /// whole exception chain go into that one line; the stack frames follow as plain text, since they
-    /// are what makes a crash actionable but cannot fit on one line.
-    ///
-    /// The frames are printed on their own rather than via <c>ex.ToString()</c> deliberately: an
-    /// exception message that happens to read like "... error: ..." would be parsed as a *second*
-    /// diagnostic, and frames alone can never match.
-    /// </summary>
-    private static void ReportCrash(string what, Exception ex)
-    {
-        var chain = new List<string>();
-        for (var e = ex; e is not null; e = e.InnerException)
-            chain.Add($"{e.GetType().Name}: {e.Message}");
-        MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInternalError,
-            $"{what} threw {string.Join(" ---> ", chain)}");
-
-        for (var e = ex; e is not null; e = e.InnerException)
-        {
-            if (!ReferenceEquals(e, ex)) Console.Error.WriteLine($"--- inner {e.GetType().FullName}");
-            Console.Error.WriteLine(e.StackTrace);
-        }
     }
 
     private static void ShowHelp()
@@ -1047,8 +288,11 @@ public static class Program
                                     every referenced project's — and serve the assembled site over
                                     HTTP on localhost. The served index.html carries a small injected
                                     script that reconnects over a websocket and reloads the page after
-                                    each successful rebuild. Requires a site build (a project with
-                                    tps.json; incompatible with --emit-package, --build-runtime, --out).
+                                    each successful rebuild. A change confined to stylesheets the site
+                                    copies from disk (tps.json `resources`) skips the compile entirely:
+                                    the CSS is re-copied and the page swaps it in without reloading.
+                                    Requires a site build (a project with tps.json; incompatible with
+                                    --emit-package, --build-runtime, --out).
               --watch-port <n>      Port for --watch's HTTP server and websocket (default 4300)
               --timing              Print a per-phase timing/allocation breakdown of the build
               --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON

--- a/Transpose/Transpose.Compiler/WatchMode.cs
+++ b/Transpose/Transpose.Compiler/WatchMode.cs
@@ -1,5 +1,3 @@
-using System.Net.WebSockets;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -9,39 +7,23 @@ using Microsoft.Extensions.Logging;
 namespace Transpose.Compiler;
 
 /// <summary>
-/// <c>--watch</c>: rebuilds a site whenever a source file changes — the root project's own sources
-/// and every project it references, transitively — and serves the assembled output over a local
-/// Kestrel server. The served index.html carries a small inline script (see
-/// <see cref="LiveReloadScript"/>) that opens a websocket back to this server and reloads the page
-/// once a rebuild completes, so the browser tracks the compiled output without a manual refresh.
-///
-/// The server and the file watchers are independent of <see cref="Program.RunOnce"/>: this class
-/// only decides *when* to rebuild and *how to tell the browser*; the actual compile is the same
-/// build a plain <c>tps</c> invocation runs, passed in as <paramref name="build"/> so this file has
-/// no dependency on the translator/output pipeline's internals.
+/// <c>--watch</c>: serves the assembled site over a local Kestrel server and keeps it in step with the
+/// sources. Everything about <em>when</em> to rebuild, <em>what kind</em> of update a change needs and
+/// <em>what to tell the browser</em> lives in <see cref="WatchSession"/> (Transpose.Compiler.Core), which
+/// the <c>Transpose.Compiler.Library</c> package exposes so a hosting application can run the same watch
+/// loop behind its own web server. This file is only the dev server: static files plus the websocket
+/// endpoint the injected live-reload script connects to.
 /// </summary>
 internal static class WatchMode
 {
-    /// <summary>How long to wait after the last file-system event before rebuilding — coalesces the
-    /// burst of Created/Changed/Renamed events a single save produces (editors commonly write a temp
-    /// file and rename it, or write-then-touch), so one save triggers exactly one rebuild.</summary>
-    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(300);
-
-    public static int Run(string rootCsproj, int port, Func<string?, BuildRunResult> build)
+    public static int Run(string rootCsproj, int port, Func<string, BuildOutcome> build)
     {
-        // Every successful build gets a version number, embedded in that build's own index.html.
-        // A client compares its embedded version against the server's current one when it (re)connects
-        // (see ReloadHub.HandleAsync) and catches up immediately if they differ — without this, a
-        // client whose reload navigation is still in flight when a second rebuild lands could miss
-        // that rebuild's broadcast entirely (its socket isn't open yet to receive it) and be stuck
-        // showing stale content until another edit happens to trigger a further broadcast.
-        var version = 0L;
-        var hub = new ReloadHub();
+        using var session = new WatchSession(rootCsproj, build);
 
-        var initial = build(LiveReloadScript(port, version));
+        var initial = session.Start();
         if (initial.OutDir is null)
         {
-            // A failure on the very first build leaves nothing to serve, and RunOnce already printed
+            // A failure on the very first build leaves nothing to serve, and the build already printed
             // why. A non-site project (package/bundle/runtime) is rejected earlier in Main, so
             // reaching here with a null OutDir on exit code 0 should not happen — guarded anyway.
             if (initial.ExitCode == 0)
@@ -55,7 +37,7 @@ internal static class WatchMode
         WebApplication app;
         try
         {
-            app = StartServer(initial.OutDir, port, hub);
+            app = StartServer(initial.OutDir, port, session.Hub);
         }
         catch (Exception ex)
         {
@@ -64,73 +46,10 @@ internal static class WatchMode
             return 1;
         }
 
-        var watchDirs = WatchDirectories(rootCsproj);
+        session.BeginWatching();
 
-        var rebuilding = false;
-        var rebuildQueued = false;
-        var rebuildGate = new object();
-
-        void Rebuild()
-        {
-            lock (rebuildGate)
-            {
-                if (rebuilding) { rebuildQueued = true; return; }
-                rebuilding = true;
-            }
-            try
-            {
-                Console.WriteLine("\ntps: change detected, rebuilding...");
-                var nextVersion = Interlocked.Increment(ref version);
-                BuildRunResult result;
-                try
-                {
-                    result = build(LiveReloadScript(port, nextVersion));
-                }
-                catch (Exception ex)
-                {
-                    // build() (RunOnce) already turns a compile failure into a clean exit code without
-                    // ever reaching OutputBuilder, so the site on disk is untouched for that, the common,
-                    // case. This catch is for the uncommon one — a genuine exception from the write phase
-                    // itself (a locked file, a full disk, a directory raced out from under it) — which
-                    // would otherwise be unhandled on this Timer callback's thread pool thread and take
-                    // the whole watch server down with it. Treat it exactly like a failed build: report,
-                    // keep whatever the previous successful build left on disk, and keep watching.
-                    MsBuildDiagnostic.WriteError(MsBuildDiagnostic.CodeInternalError, $"rebuild crashed: {ex.Message}");
-                    Console.Error.WriteLine(ex.StackTrace);
-                    result = new BuildRunResult(2, null, false);
-                }
-                if (result.ExitCode == 0)
-                {
-                    Console.WriteLine("tps: rebuilt — reloading browser");
-                    hub.SetVersion(nextVersion);
-                    _ = hub.BroadcastReloadAsync();
-                }
-                else
-                {
-                    // The failed build never reached OutputBuilder, so the site on disk still embeds
-                    // the previous (successful) version's script — roll the counter back to match, or
-                    // the next successful build's embedded version would skip ahead of what a client
-                    // still on the old page believes is current.
-                    Interlocked.Decrement(ref version);
-                    Console.Error.WriteLine("tps: rebuild failed — keeping the previous build (see errors above)");
-                }
-            }
-            finally
-            {
-                bool again;
-                lock (rebuildGate) { rebuilding = false; again = rebuildQueued; rebuildQueued = false; }
-                if (again) Rebuild();
-            }
-        }
-
-        using var debouncer = new Debouncer(DebounceDelay, Rebuild);
-        var watchers = watchDirs
-            .Select(dir => CreateWatcher(dir, initial.OutDir, debouncer))
-            .Where(w => w is not null)
-            .Cast<FileSystemWatcher>()
-            .ToList();
-
-        Console.WriteLine($"\ntps: watching {watchDirs.Count} director{(watchDirs.Count == 1 ? "y" : "ies")} for changes");
+        var dirs = session.WatchedDirectories.Count;
+        Console.WriteLine($"\ntps: watching {dirs} director{(dirs == 1 ? "y" : "ies")} for changes");
         Console.WriteLine($"tps: serving http://localhost:{port}/  (Ctrl+C to stop)");
 
         var exit = new ManualResetEventSlim();
@@ -143,81 +62,9 @@ internal static class WatchMode
         finally
         {
             Console.CancelKeyPress -= onCancel;
-            foreach (var w in watchers) w.Dispose();
             app.StopAsync().GetAwaiter().GetResult();
         }
         return 0;
-    }
-
-    /// <summary>Every directory to watch: the root project's, then every project it references
-    /// (transitively), in whatever order <see cref="ProjectResolver.ReferencedProjectsInBuildOrder"/>
-    /// returns them. A change under any of these can change the compiled output — the root project's
-    /// own sources, or a library it depends on — so all of them feed the same rebuild trigger.</summary>
-    private static List<string> WatchDirectories(string rootCsproj)
-    {
-        var dirs = new List<string> { Path.GetDirectoryName(Path.GetFullPath(rootCsproj))! };
-        foreach (var dep in ProjectResolver.ReferencedProjectsInBuildOrder(rootCsproj))
-        {
-            var dir = Path.GetDirectoryName(dep);
-            if (dir is not null) dirs.Add(dir);
-        }
-        return dirs.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-    }
-
-    /// <summary>Watches one project directory for changes to the files a rebuild cares about
-    /// (<c>.cs</c>, <c>.csproj</c>, <c>tps*.json</c>), signalling <paramref name="debouncer"/> for
-    /// each relevant event. Skips <c>bin/</c>/<c>obj/</c> (build output, never a source) and anything
-    /// under <paramref name="outDir"/> itself — without that exclusion the site build's own writes
-    /// would retrigger the watcher that is serving it, rebuilding forever.</summary>
-    private static FileSystemWatcher? CreateWatcher(string dir, string outDir, Debouncer debouncer)
-    {
-        if (!Directory.Exists(dir)) return null;
-        var fullOutDir = Path.GetFullPath(outDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        var watcher = new FileSystemWatcher(dir)
-        {
-            IncludeSubdirectories = true,
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Size,
-        };
-
-        void OnEvent(object sender, FileSystemEventArgs e)
-        {
-            if (!IsRelevant(e.FullPath, dir, fullOutDir)) return;
-            debouncer.Signal();
-        }
-
-        watcher.Changed += OnEvent;
-        watcher.Created += OnEvent;
-        watcher.Deleted += OnEvent;
-        watcher.Renamed += (s, e) => OnEvent(s, e);
-        watcher.Error += (_, e) =>
-            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeWatchServerFailed,
-                $"File watcher for '{dir}' failed: {e.GetException().Message}");
-        watcher.EnableRaisingEvents = true;
-        return watcher;
-    }
-
-    private static bool IsRelevant(string path, string projectDir, string fullOutDir)
-    {
-        var full = Path.GetFullPath(path);
-        // Never watch the site's own output — every rebuild writes there, which would otherwise
-        // retrigger itself. Comparing full paths (not just a prefix string) avoids a false match on a
-        // sibling directory that merely shares the outDir's name as a prefix (e.g. "bin-tools").
-        if (full.Equals(fullOutDir, StringComparison.OrdinalIgnoreCase)
-            || full.StartsWith(fullOutDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        var rel = Path.GetRelativePath(projectDir, full).Replace('\\', '/');
-        if (rel.StartsWith("bin/", StringComparison.Ordinal) || rel.Contains("/bin/", StringComparison.Ordinal)
-            || rel.StartsWith("obj/", StringComparison.Ordinal) || rel.Contains("/obj/", StringComparison.Ordinal))
-            return false;
-
-        var name = Path.GetFileName(full);
-        if (name.StartsWith('.') || name.EndsWith('~')) return false; // editor swap/backup files
-
-        return name.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
-            || name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
-            || (name.StartsWith("tps", StringComparison.OrdinalIgnoreCase) && name.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>Starts Kestrel serving <paramref name="outDir"/> as static content, plus a websocket
@@ -252,121 +99,5 @@ internal static class WatchMode
 
         app.StartAsync().GetAwaiter().GetResult();
         return app;
-    }
-
-    /// <summary>The inline script injected into index.html: connects to <see cref="ReloadHub.Path"/>,
-    /// tagged with the version of the build this exact page came from, and reloads on any message.
-    /// Reconnects with a short fixed backoff if the socket drops (e.g. the server is mid-rebuild), so
-    /// a page left open survives more than one reload — and the version tag lets the server detect,
-    /// right at (re)connect time, a client that is already behind (see <see cref="ReloadHub.HandleAsync"/>).</summary>
-    private static string LiveReloadScript(int port, long version) => $$"""
-        <script>
-        (function tpsLiveReload() {
-            var url = "ws://localhost:{{port}}{{ReloadHub.Path}}?v={{version}}";
-            function connect() {
-                var ws = new WebSocket(url);
-                ws.onmessage = function () { location.reload(); };
-                ws.onclose = function () { setTimeout(connect, 1000); };
-                ws.onerror = function () { ws.close(); };
-            }
-            connect();
-        })();
-        </script>
-        """;
-}
-
-/// <summary>Tracks the currently-connected live-reload websockets and broadcasts a reload notification
-/// to all of them after a successful rebuild. Content-free by design — the browser always does a full
-/// page reload, so the message itself carries no payload; a client that fails to send (already gone)
-/// is dropped rather than failing the broadcast for everyone else.</summary>
-internal sealed class ReloadHub
-{
-    public const string Path = "/__tps-livereload";
-
-    private static readonly byte[] ReloadMessage = System.Text.Encoding.UTF8.GetBytes("reload");
-
-    private readonly List<WebSocket> _sockets = new();
-    private readonly object _gate = new();
-    private long _version;
-
-    /// <summary>The version of the most recent successful build. Set once that build's outputs (and
-    /// the index.html embedding that same version) have actually been written to disk.</summary>
-    public void SetVersion(long version) => Interlocked.Exchange(ref _version, version);
-
-    public async Task HandleAsync(WebSocket socket, long clientVersion, CancellationToken cancellationToken)
-    {
-        lock (_gate) _sockets.Add(socket);
-        try
-        {
-            // The page this socket was opened from was generated by build `clientVersion`. If a newer
-            // build has already completed — e.g. two edits landed back to back while this client was
-            // navigating during a previous reload, so it missed that build's broadcast entirely — catch
-            // it up right away instead of leaving it stuck on stale content until the next edit.
-            if (Interlocked.Read(ref _version) > clientVersion && socket.State == WebSocketState.Open)
-                await socket.SendAsync(ReloadMessage, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
-
-            var buffer = new byte[16];
-            // The client never sends anything meaningful; this just blocks until it disconnects
-            // (browser navigation/close), which is what a receive on a closed socket reports.
-            while (socket.State == WebSocketState.Open)
-            {
-                var result = await socket.ReceiveAsync(buffer, cancellationToken);
-                if (result.MessageType == WebSocketMessageType.Close) break;
-            }
-        }
-        catch (OperationCanceledException) { /* server shutting down */ }
-        catch (WebSocketException) { /* client dropped mid-read */ }
-        finally
-        {
-            lock (_gate) _sockets.Remove(socket);
-        }
-    }
-
-    public async Task BroadcastReloadAsync()
-    {
-        List<WebSocket> targets;
-        lock (_gate) targets = new List<WebSocket>(_sockets);
-
-        foreach (var socket in targets)
-        {
-            try
-            {
-                if (socket.State == WebSocketState.Open)
-                    await socket.SendAsync(ReloadMessage, WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
-            }
-            catch (WebSocketException) { /* client dropped; it will be removed by HandleAsync's own loop */ }
-        }
-    }
-}
-
-/// <summary>Coalesces a burst of file-system events into a single call to <paramref name="action"/>,
-/// fired <paramref name="delay"/> after the last <see cref="Signal"/>. If a signal arrives while
-/// <paramref name="action"/> is still running, one more run is queued for when it finishes — so a
-/// change made during a rebuild is never silently dropped, but concurrent rebuilds never overlap.</summary>
-internal sealed class Debouncer : IDisposable
-{
-    private readonly TimeSpan _delay;
-    private readonly Action _action;
-    private readonly object _gate = new();
-    private Timer? _timer;
-
-    public Debouncer(TimeSpan delay, Action action)
-    {
-        _delay = delay;
-        _action = action;
-    }
-
-    public void Signal()
-    {
-        lock (_gate)
-        {
-            _timer?.Dispose();
-            _timer = new Timer(_ => _action(), null, _delay, Timeout.InfiniteTimeSpan);
-        }
-    }
-
-    public void Dispose()
-    {
-        lock (_gate) _timer?.Dispose();
     }
 }

--- a/Transpose/Transpose.Translator.Tests/MsBuildDiagnosticFormatTests.cs
+++ b/Transpose/Transpose.Translator.Tests/MsBuildDiagnosticFormatTests.cs
@@ -111,7 +111,7 @@ public sealed class MsBuildDiagnosticFormatTests
     {
         // The whole error list, not just a sample: ordering and truncation must not produce a line the
         // build cannot read.
-        var errors = Program.OrderErrorsForReport(
+        var errors = ProjectBuild.OrderErrorsForReport(
             new RoslynTranslator().Translate(new[]
             {
                 ("A.cs", "public class A { public int M() { return X(); } }"),

--- a/Transpose/Transpose.Translator.Tests/ProjectImportTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ProjectImportTests.cs
@@ -221,7 +221,7 @@ public sealed class ErrorReportingTests
     {
         // 60 per file = 120 total: comfortably past the 40-error cap the compiler used to apply.
         const int perFile = 60;
-        var errors = Program.OrderErrorsForReport(Errors(perFile));
+        var errors = ProjectBuild.OrderErrorsForReport(Errors(perFile));
         Assert.AreEqual(perFile * 2, errors.Count(d => d.Id == "CS0103"),
             "every error from both files must survive to the report");
     }
@@ -229,7 +229,7 @@ public sealed class ErrorReportingTests
     [TestMethod]
     public void ErrorsAreOrderedByFileThenPosition()
     {
-        var errors = Program.OrderErrorsForReport(Errors(5));
+        var errors = ProjectBuild.OrderErrorsForReport(Errors(5));
 
         var files = errors.Select(d => Path.GetFileName(d.Location.SourceTree?.FilePath ?? "")).ToList();
         CollectionAssert.AreEqual(files.OrderBy(f => f, StringComparer.OrdinalIgnoreCase).ToArray(), files.ToArray(),

--- a/Transpose/Transpose.WatchMode.Tests/WatchModeTests.cs
+++ b/Transpose/Transpose.WatchMode.Tests/WatchModeTests.cs
@@ -186,6 +186,99 @@ public sealed class WatchModeTests
     }
 
     [TestMethod]
+    [Timeout(300_000)]
+    public async Task EditingOnlyCssUpdatesTheStylesheetWithoutRebuildingOrReloading()
+    {
+        Write("App/App.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>netstandard2.0</TargetFramework>
+                <AssemblyName>App</AssemblyName>
+              </PropertyGroup>
+            </Project>
+            """);
+        // A tps.json `resources` group whose name is a .css file: the site build concatenates the group's
+        // files into that one stylesheet and links it from index.html. This is the shape watch mode can
+        // update without the compiler.
+        Write("App/tps.json", """
+            {
+              "fileName": "app.js",
+              "resources": [ { "name": "app.css", "files": [ "css/app.css" ] } ]
+            }
+            """);
+        var cssPath = Write("App/css/app.css", "body { background-color: rgb(1, 2, 3); }");
+        Write("App/Program.cs", """
+            using Transpose;
+
+            public class Program
+            {
+                [Script("document.body.innerHTML = html;")]
+                public static extern void SetBody(string html);
+
+                public static void Main()
+                {
+                    SetBody("styled");
+                }
+            }
+            """);
+        var appCsproj = Path.Combine(_root, "App", "App.csproj");
+        var siteDir = Path.Combine(_root, "site");
+
+        var port = GetFreePort();
+        _watchProcess = StartWatch(appCsproj, siteDir, port);
+        await WaitForLogAsync(msg => msg.Contains("tps: serving http://localhost:"), TimeSpan.FromSeconds(60));
+
+        var appJsPath = Path.Combine(siteDir, "app.js");
+        var appJsBefore = File.ReadAllText(appJsPath);
+        var appJsStampBefore = File.GetLastWriteTimeUtc(appJsPath);
+
+        var page = await Browser!.NewPageAsync();
+        try
+        {
+            await page.GotoAsync($"http://localhost:{port}/", new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+            await page.WaitForFunctionAsync(
+                "() => getComputedStyle(document.body).backgroundColor === 'rgb(1, 2, 3)'",
+                null, new PageWaitForFunctionOptions { Timeout = 60_000 });
+
+            // A value that only survives if the page is never reloaded — the whole point of the CSS path is
+            // that the running application keeps its state while the stylesheet is swapped underneath it.
+            await page.EvaluateAsync("() => { window.__survivesCssUpdate = 'kept'; }");
+
+            File.WriteAllText(cssPath, "body { background-color: rgb(9, 8, 7); }");
+
+            try
+            {
+                await page.WaitForFunctionAsync(
+                    "() => getComputedStyle(document.body).backgroundColor === 'rgb(9, 8, 7)'",
+                    null, new PageWaitForFunctionOptions { Timeout = 90_000 });
+            }
+            catch (TimeoutException)
+            {
+                Assert.Fail("Timed out waiting for the edited stylesheet to reach the page."
+                    + $"\n--- tps --watch log ---\n{string.Join('\n', SnapshotLog())}");
+            }
+
+            Assert.AreEqual("kept", await page.EvaluateAsync<string?>("() => window.__survivesCssUpdate"),
+                "a CSS-only change must swap the stylesheet in place, not reload the page.\n"
+                + string.Join('\n', SnapshotLog()));
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+
+        Assert.IsTrue(SnapshotLog().Any(l => l.Contains("stylesheets only")),
+            "the change should have taken the CSS-only path.\n" + string.Join('\n', SnapshotLog()));
+        Assert.IsFalse(SnapshotLog().Any(l => l.Contains("change detected, rebuilding")),
+            "a stylesheet edit must not trigger a rebuild.\n" + string.Join('\n', SnapshotLog()));
+
+        // Nothing the compiler produces may have been rewritten — that is what "without rebuilding" means.
+        Assert.AreEqual(appJsBefore, File.ReadAllText(appJsPath), "app.js must not be re-emitted");
+        Assert.AreEqual(appJsStampBefore, File.GetLastWriteTimeUtc(appJsPath), "app.js must not even be rewritten");
+        Assert.AreEqual("body { background-color: rgb(9, 8, 7); }", File.ReadAllText(Path.Combine(siteDir, "app.css")));
+    }
+
+    [TestMethod]
     [Timeout(60_000)]
     public async Task RebuildExceptionDoesNotCorruptOutputOrCrashTheWatchProcess()
     {


### PR DESCRIPTION
`tps --watch` now recognises a change that only touches stylesheets the site
copies from disk (a tps.json `resources` group, in the root project or in any
project it references) and skips the compiler entirely: the CSS is re-copied —
byte for byte what a full build would have written — and the page is told to
re-fetch its stylesheets instead of reloading, so the running app keeps its
state. Anything else is still a real build, including a new or deleted
stylesheet (both change index.html's `<link>` list, which only the site build
writes). The build version deliberately does not advance for a CSS update.

To make that reachable from a host with its own web server, the watch engine and
the project build moved into Transpose.Compiler.Core:

- `ProjectBuild` is everything `tps` does after parsing its command line
  (BuildOptions -> BuildOutcome), with progress going through a `BuildLog` sink
  rather than straight to the console.
- `WatchSession` is the whole watch loop: watchers, debounce, the
  rebuild-vs-CSS-only decision, the reload hub and the injected client script.
  `Transpose.Compiler/WatchMode.cs` is now only the Kestrel dev server.
- `Transpose.Compiler.Library` exposes both as public API —
  `TransposeCompilerLibrary.BuildProject` and `TransposeWatcher` — so an
  application can run the identical build and watch loop in process.

The injected script now derives its websocket URL from the page's own
`location`, so it works behind a base path and over https rather than only at
`http://localhost:<port>/`.

Also fixes a watch-mode bug this exposed: the site build read a reference's
embedded JS/CSS via `Assembly.LoadFrom`, which locks the file for the process's
lifetime and resolves by assembly identity. In a long-running watch process the
second rebuild of a referenced project therefore failed to write its DLL
(IOException) or silently re-read the copy loaded the first time, losing that
package's extracted resources from the site. Reading the metadata with
Mono.Cecil — as `TopologicalOrder` already did for these same assemblies — has
neither problem.

Validated against the tesserae repo: a clean site build is byte-identical to the
previous compiler's (`diff -r`), a stylesheet edit in either Tesserae or
Tesserae.Tests takes the fast path without rewriting app.js or index.html, and a
C# edit still rebuilds the dependency chain with every extracted resource
intact. 666 translator tests and 3 watch-mode tests pass; the new watch-mode
test asserts the computed style changes while a value set on `window` survives.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ru6EzN1tWYSUVDtphiWcd8