### PR TITLE
Add a `load` flag to tps.json resource groups

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -110,6 +110,27 @@ the same (`output`, `fileName`, `html`, `reflection`, `resources`,
 A per-configuration overlay is supported: `tps.Release.json` (or
 `tps.<Configuration>.json`) is merged on top of `tps.json` for that build.
 
+### Resources you load yourself
+
+h5 marked a resource that must be copied but *not* referenced from `index.html`
+by suffixing its name: `"name": "lazy-module.js.dontload"`. Transpose still
+honours that suffix, and adds a plain flag on the group — use whichever you
+prefer (either one alone suppresses the injection):
+
+```jsonc
+{
+    "resources": [
+        { "name": "lazy-module.js", "files": [ "tps/assets/js/lazy-module.js" ], "load": false },
+        { "name": "theme-dark.css", "files": [ "tps/assets/css/dark.css" ],      "load": false }
+    ]
+}
+```
+
+It applies to every resource kind the generated HTML can load — scripts and
+stylesheets — and it survives packaging: the flag is recorded in the resource
+manifest embedded in the package DLL, so a project referencing the library
+extracts the file without auto-loading it either.
+
 ### Cleaning the output folder
 
 h5's `cleanOutputFolderBeforeBuild` / `cleanOutputFolderBeforeBuildPattern`

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -277,9 +277,11 @@ internal static class OutputBuilder
 
         foreach (var group in config.Resources)
         {
-            // Parse the "module#file" grouping and ".dontload" flag so a referencing project extracts
-            // the resource under its real name and knows whether to inject it into index.html.
-            var (name, load) = ParseResourceName(group.Name ?? "");
+            // Resolve the "module#file" grouping and the load flag ("load": false / a ".dontload"
+            // name) so a referencing project extracts the resource under its real name and knows
+            // whether to inject it into index.html. The flag travels in the DLL's resource manifest,
+            // which is how it survives packing.
+            var (name, load) = ResolveResource(group);
             var destSub = string.IsNullOrEmpty(group.Output) ? null : group.Output!.Replace('\\', '/');
 
             var isBundle = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
@@ -460,6 +462,27 @@ internal static class OutputBuilder
     }
 
     /// <summary>
+    /// What a <c>tps.json</c> resource group produces: the output file name, and whether the generated
+    /// <c>index.html</c> references it (a <c>&lt;script&gt;</c> for JavaScript, a
+    /// <c>&lt;link rel=stylesheet&gt;</c> for CSS — the only two resource kinds the HTML can load).
+    /// Either way the file is written to the output and embedded into a package DLL; a
+    /// non-loaded resource is simply left for the application to fetch itself.
+    ///
+    /// Two spellings say "don't load", and they are AND-ed so either one alone suppresses the
+    /// injection: the declarative <c>"load": false</c> on the group, and the legacy <c>.dontload</c>
+    /// suffix on its <c>name</c> (see <see cref="ParseResourceName"/>). The single place both are
+    /// resolved, so the site build (<see cref="ProcessResourceGroup"/>) and the package embed
+    /// (<see cref="CollectEmbeddableItems"/>) cannot disagree — which is what makes the flag survive
+    /// packing: the resolved value is what lands in the DLL's resource manifest as <c>Load</c>, and a
+    /// referencing project's site build honours it there.
+    /// </summary>
+    internal static (string fileName, bool load) ResolveResource(TransposeJson.ResourceGroup group)
+    {
+        var (name, loadFromName) = ParseResourceName(group.Name ?? "");
+        return (name, loadFromName && group.Load);
+    }
+
+    /// <summary>
     /// Parses a tps.json resource group's <c>name</c> into the output file name and whether it should
     /// be injected into index.html, mirroring the legacy compiler's conventions:
     /// <list type="bullet">
@@ -469,6 +492,8 @@ internal static class OutputBuilder
     /// the output but NOT referenced from index.html (loaded on demand); the output name drops the
     /// suffix (<c>file.js</c>).</item>
     /// </list>
+    /// Callers that need the group's effective load flag go through <see cref="ResolveResource"/>,
+    /// which folds in the group's own <c>load</c> property.
     /// </summary>
     internal static (string fileName, bool load) ParseResourceName(string rawName)
     {
@@ -523,9 +548,10 @@ internal static class OutputBuilder
         string projectDir, string outputDir, TransposeJson.ResourceGroup group,
         List<JsOut> jsOuts, List<string> cssLinks, HashSet<string> written)
     {
-        // The group name carries the "module#file" grouping and the ".dontload" flag; parse both. A
-        // .dontload resource is written to the output but never referenced from index.html.
-        var (name, load) = ParseResourceName(group.Name ?? "");
+        // The output name (the group name minus its "module#" grouping prefix and ".dontload" suffix)
+        // plus the effective load flag: a non-loaded resource is written to the output but never
+        // referenced from index.html — neither as a <script> nor as a stylesheet <link>.
+        var (name, load) = ResolveResource(group);
         var isBundle = IsBundleName(name);
 
         foreach (var (rel, sources) in ResourceGroupOutputs(projectDir, group))
@@ -568,7 +594,7 @@ internal static class OutputBuilder
 
         string Rel(string leaf) => string.IsNullOrEmpty(destSub) ? leaf : destSub + "/" + leaf;
 
-        var (name, _) = ParseResourceName(group.Name ?? "");
+        var (name, _) = ResolveResource(group);
         if (IsBundleName(name))
         {
             outputs.Add((Rel(name), files));
@@ -623,7 +649,7 @@ internal static class OutputBuilder
             if (cfg is null) return;
             foreach (var group in cfg.Resources)
             {
-                var isBundle = IsBundleName(ParseResourceName(group.Name ?? "").fileName);
+                var isBundle = IsBundleName(ResolveResource(group).fileName);
                 foreach (var (rel, sources) in ResourceGroupOutputs(projectDir, group))
                     if (IsCss(rel)) css.Add(new CssResource(rel, sources, isBundle));
             }

--- a/Transpose/Transpose.Compiler.Core/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler.Core/TransposeJson.cs
@@ -87,6 +87,20 @@ internal sealed class TransposeJson
         public string? Name { get; init; }
         public List<string> Files { get; init; } = new();
         public string? Output { get; init; }
+
+        /// <summary>
+        /// <c>load</c> — whether the resource is referenced from the generated <c>index.html</c>
+        /// (a <c>&lt;script&gt;</c> for JavaScript, a <c>&lt;link rel=stylesheet&gt;</c> for CSS).
+        /// Defaults to <c>true</c>. <c>false</c> still copies the resource into the output — and
+        /// still embeds it into a package DLL, flagged so a *referencing* project doesn't inject it
+        /// either — but leaves loading it to the application (a lazily fetched module, a stylesheet
+        /// swapped in at runtime, …).
+        ///
+        /// The declarative form of the legacy <c>.dontload</c> name suffix, which is still honoured;
+        /// the two combine, so either one alone suppresses the injection
+        /// (see <c>OutputBuilder.ResolveResource</c>).
+        /// </summary>
+        public bool Load { get; init; } = true;
     }
 
     /// <summary>
@@ -201,7 +215,13 @@ internal sealed class TransposeJson
                 var files = new List<string>();
                 if (g.TryGetProperty("files", out var fs) && fs.ValueKind == JsonValueKind.Array)
                     files.AddRange(fs.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!));
-                resources.Add(new ResourceGroup { Name = Str(g, "name"), Files = files, Output = Str(g, "output") });
+                resources.Add(new ResourceGroup
+                {
+                    Name = Str(g, "name"),
+                    Files = files,
+                    Output = Str(g, "output"),
+                    Load = Bool(g, "load") ?? true,   // absent → loaded from index.html
+                });
             }
         }
 

--- a/Transpose/Transpose.Translator.Tests/ResourceLoadFlagTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ResourceLoadFlagTests.cs
@@ -1,0 +1,300 @@
+using System.Text.Json;
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers the <c>tps.json</c> resource <c>load</c> flag: a resource group declaring
+/// <c>"load": false</c> is copied into the output (and embedded into the package DLL) but never
+/// referenced from the generated <c>index.html</c> — for every resource kind the HTML can load, i.e.
+/// scripts and stylesheets alike.
+///
+/// It is the declarative form of the legacy <c>.dontload</c> name suffix, which keeps working; both
+/// resolve in one place (<see cref="OutputBuilder.ResolveResource"/>) and AND together. Crucially the
+/// resolved flag is what gets written into the package DLL's <c>Transpose.Resources.json</c> manifest,
+/// so it survives packing: a project *referencing* the package extracts the file but does not inject
+/// it into its own index.html either.
+/// </summary>
+[TestClass]
+public sealed class ResourceLoadFlagTests
+{
+    private string _root = "";
+    private string _projectDir = "";
+    private string _outputDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-load-" + Guid.NewGuid().ToString("N"));
+        _projectDir = Path.Combine(_root, "proj");
+        _outputDir = Path.Combine(_root, "site");
+        Directory.CreateDirectory(_projectDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private string Asset(string rel, string content)
+    {
+        var full = Path.Combine(_projectDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    private TransposeJson Config(string tpsJson)
+    {
+        File.WriteAllText(Path.Combine(_projectDir, "tps.json"), tpsJson);
+        var config = TransposeJson.TryLoad(_projectDir, "Debug");
+        Assert.IsNotNull(config, "tps.json must load");
+        return config!;
+    }
+
+    private ResolvedProject Project(params string[] referencePaths) => new()
+    {
+        CsprojPath = Path.Combine(_projectDir, "App.csproj"),
+        ProjectDir = _projectDir,
+        AssemblyName = "App",
+        TargetFramework = "netstandard2.0",
+        Sources = new List<(string, string)>(),
+        ReferencePaths = referencePaths.ToList(),
+        DefineConstants = new List<string>(),
+        LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+        ProjectDirs = new List<string> { _projectDir },
+    };
+
+    /// <summary>Assembles the site for <paramref name="config"/> and returns the generated
+    /// index.html.</summary>
+    private string BuildSite(TransposeJson config, ResolvedProject? project = null)
+    {
+        OutputBuilder.Build(project ?? Project(), config, "var app = 1;", _outputDir, "Debug");
+        var html = Path.Combine(_outputDir, "index.html");
+        Assert.IsTrue(File.Exists(html), "the build must generate index.html");
+        return File.ReadAllText(html);
+    }
+
+    private void AssertInOutput(string rel, string because)
+        => Assert.IsTrue(File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))), because);
+
+    // ---------------------------------------------------------------- parsing
+
+    [TestMethod]
+    public void TheLoadFlagIsReadFromTpsJsonAndDefaultsToTrue()
+    {
+        var config = Config(@"{
+            ""resources"": [
+                { ""name"": ""loaded.js"",  ""files"": [ ""a.js"" ] },
+                { ""name"": ""quiet.js"",   ""files"": [ ""a.js"" ], ""load"": false },
+                { ""name"": ""spelled.js"", ""files"": [ ""a.js"" ], ""load"": true }
+            ]
+        }");
+
+        Assert.IsTrue(config.Resources[0].Load, "an absent load flag must default to true");
+        Assert.IsFalse(config.Resources[1].Load);
+        Assert.IsTrue(config.Resources[2].Load);
+    }
+
+    [TestMethod]
+    public void ResolveResourceCombinesTheFlagWithTheLegacyDontloadSuffix()
+    {
+        // Either spelling alone suppresses the injection, and they compose; the output name never
+        // carries the suffix or the "module#" grouping prefix.
+        Assert.AreEqual(("x.js", true), Resolve("x.js", load: true));
+        Assert.AreEqual(("x.js", false), Resolve("x.js", load: false));
+        Assert.AreEqual(("x.js", false), Resolve("x.js.dontload", load: true));
+        Assert.AreEqual(("x.js", false), Resolve("x.js.dontload", load: false));
+        Assert.AreEqual(("x.js", false), Resolve("mod#x.js", load: false));
+
+        static (string, bool) Resolve(string name, bool load)
+            => OutputBuilder.ResolveResource(new TransposeJson.ResourceGroup { Name = name, Load = load });
+    }
+
+    // ---------------------------------------------------------------- site build
+
+    [TestMethod]
+    public void ANonLoadedScriptIsWrittenToTheOutputButNotReferencedFromIndexHtml()
+    {
+        Asset("assets/lazy.js", "// lazy module");
+        Asset("assets/eager.js", "// eager module");
+
+        var html = BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""eager.js"", ""files"": [ ""assets/eager.js"" ] },
+                { ""name"": ""lazy.js"",  ""files"": [ ""assets/lazy.js"" ], ""load"": false }
+            ]
+        }"));
+
+        AssertInOutput("lazy.js", "a non-loaded resource must still be copied to the output");
+        AssertInOutput("eager.js", "a loaded resource must be copied to the output");
+        StringAssert.Contains(html, "src=\"eager.js\"", "a loaded script must be injected");
+        Assert.IsFalse(html.Contains("lazy.js"), "a non-loaded script must not appear in index.html");
+    }
+
+    [TestMethod]
+    public void ANonLoadedStylesheetIsWrittenToTheOutputButNotLinkedFromIndexHtml()
+    {
+        Asset("assets/theme-dark.css", "body { color: #fff }");
+        Asset("assets/site.css", "body { color: #000 }");
+
+        var html = BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""site.css"",       ""files"": [ ""assets/site.css"" ] },
+                { ""name"": ""theme-dark.css"", ""files"": [ ""assets/theme-dark.css"" ], ""load"": false }
+            ]
+        }"));
+
+        AssertInOutput("theme-dark.css", "a non-loaded stylesheet must still be copied to the output");
+        StringAssert.Contains(html, "href=\"site.css\"", "a loaded stylesheet must be linked");
+        Assert.IsFalse(html.Contains("theme-dark.css"), "a non-loaded stylesheet must not be linked from index.html");
+    }
+
+    [TestMethod]
+    public void ANonLoadedCopyThroughGroupCopiesEveryFileWithoutReferencingAny()
+    {
+        // A group whose name is not a bundle name copies each matched file under its own name — the
+        // shape used for globbed assets. The flag has to hold for every file the glob produced,
+        // whatever its type.
+        Asset("vendor/one.js", "// one");
+        Asset("vendor/two.css", ".two { }");
+
+        var html = BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""vendor"", ""files"": [ ""vendor/*.js"", ""vendor/*.css"" ], ""output"": ""vendor"", ""load"": false }
+            ]
+        }"));
+
+        AssertInOutput("vendor/one.js", "a non-loaded copy-through file must still be copied");
+        AssertInOutput("vendor/two.css", "a non-loaded copy-through file must still be copied");
+        Assert.IsFalse(html.Contains("one.js"), "a non-loaded script must not appear in index.html");
+        Assert.IsFalse(html.Contains("two.css"), "a non-loaded stylesheet must not appear in index.html");
+    }
+
+    [TestMethod]
+    public void TheLegacyDontloadSuffixStillSuppressesTheInjection()
+    {
+        Asset("assets/lazy.js", "// lazy module");
+
+        var html = BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""lazy.js.dontload"", ""files"": [ ""assets/lazy.js"" ] }
+            ]
+        }"));
+
+        AssertInOutput("lazy.js", "the .dontload suffix must be stripped from the output name");
+        Assert.IsFalse(html.Contains("lazy.js"), "a .dontload script must not appear in index.html");
+    }
+
+    // ---------------------------------------------------------------- packing
+
+    [TestMethod]
+    public void TheFlagIsRecordedInTheEmbeddedResourceManifest()
+    {
+        Asset("assets/lazy.js", "// lazy module");
+        Asset("assets/site.css", "body { }");
+
+        var config = Config(@"{
+            ""fileName"": ""Lib.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""site.css"", ""files"": [ ""assets/site.css"" ] },
+                { ""name"": ""lazy.js"",  ""files"": [ ""assets/lazy.js"" ], ""load"": false }
+            ]
+        }");
+
+        var items = OutputBuilder.CollectEmbeddableItems(_projectDir, config, "Lib.js", "var lib = 1;", null);
+
+        Assert.IsFalse(items.Single(i => i.Name == "lazy.js").Load, "the flag must reach the embedded item");
+        Assert.IsTrue(items.Single(i => i.Name == "site.css").Load);
+        Assert.IsTrue(items.Single(i => i.Name == "Lib.js").Load, "the compiled bundle itself is always loaded");
+
+        // …and out the other side, in the manifest a consumer reads.
+        var dll = PackageDll("Lib", items);
+        var manifest = ManifestEntries(dll);
+        Assert.IsFalse(manifest["lazy.js"], "the manifest must record Load: false");
+        Assert.IsTrue(manifest["site.css"]);
+    }
+
+    [TestMethod]
+    public void AReferencingSiteBuildExtractsANonLoadedPackageResourceWithoutReferencingIt()
+    {
+        // The end of the chain: the library's tps.json says load: false, the package DLL carries that,
+        // and a *different* project referencing the package copies the files into its site but leaves
+        // them out of its own index.html — for a script and a stylesheet alike.
+        Asset("assets/lazy.js", "// lazy module");
+        Asset("assets/theme-dark.css", "body { color: #fff }");
+        Asset("assets/site.css", "body { color: #000 }");
+
+        var libConfig = Config(@"{
+            ""fileName"": ""Lib.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""site.css"",       ""files"": [ ""assets/site.css"" ] },
+                { ""name"": ""lazy.js"",        ""files"": [ ""assets/lazy.js"" ], ""load"": false },
+                { ""name"": ""theme-dark.css"", ""files"": [ ""assets/theme-dark.css"" ], ""load"": false }
+            ]
+        }");
+
+        var dll = PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(_projectDir, libConfig, "Lib.js", "var lib = 1;", null));
+
+        // The consuming project has no resources of its own — everything below comes from the package.
+        var appConfig = Config(@"{ ""fileName"": ""app.js"", ""outputFormatting"": ""Formatted"" }");
+        var html = BuildSite(appConfig, Project(dll));
+
+        AssertInOutput("lazy.js", "a non-loaded package script must still be extracted");
+        AssertInOutput("theme-dark.css", "a non-loaded package stylesheet must still be extracted");
+        AssertInOutput("site.css", "a loaded package stylesheet must be extracted");
+
+        StringAssert.Contains(html, "src=\"Lib.js\"", "the package's compiled bundle must load");
+        StringAssert.Contains(html, "href=\"site.css\"", "a loaded package stylesheet must be linked");
+        Assert.IsFalse(html.Contains("lazy.js"), "a non-loaded package script must not appear in index.html");
+        Assert.IsFalse(html.Contains("theme-dark.css"), "a non-loaded package stylesheet must not be linked");
+    }
+
+    /// <summary>Embeds <paramref name="items"/> into an assembly through the real
+    /// <see cref="ResourceEmbedder"/> — the same call <c>tps --emit-package</c> makes — and returns the
+    /// package DLL's path. The assembly itself is an empty one built here rather than a compiled
+    /// snippet: what is under test is the resource manifest, so the test stays independent of a
+    /// bootstrapped <c>Transpose.dll</c>.</summary>
+    private string PackageDll(string assemblyName, IReadOnlyList<EmbeddedItem> items)
+    {
+        byte[] bytes;
+        using (var asm = AssemblyDefinition.CreateAssembly(
+                   new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)), assemblyName, ModuleKind.Dll))
+        using (var ms = new MemoryStream())
+        {
+            asm.Write(ms);
+            bytes = ms.ToArray();
+        }
+
+        var path = Path.Combine(_root, "packages", assemblyName + ".dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        ResourceEmbedder.Embed(path, bytes, items);
+        return path;
+    }
+
+    /// <summary>The package's <c>Transpose.Resources.json</c> manifest, as file name → Load.</summary>
+    private static Dictionary<string, bool> ManifestEntries(string dllPath)
+    {
+        using var asm = AssemblyDefinition.ReadAssembly(dllPath);
+        var manifest = asm.MainModule.Resources.OfType<EmbeddedResource>().Single(r => r.Name == "Transpose.Resources.json");
+        using var doc = JsonDocument.Parse(manifest.GetResourceData());
+        return doc.RootElement.EnumerateArray().ToDictionary(
+            e => e.GetProperty("FileName").GetString()!,
+            e => e.GetProperty("Load").GetBoolean());
+    }
+}

--- a/docs/compiler-config.md
+++ b/docs/compiler-config.md
@@ -44,6 +44,11 @@ H5 can manage and bundle external assets (JS, CSS, fonts) using the `resources` 
       "name": "styles.css",
       "files": [ "assets/css/*.css" ],
       "output": "css"
+    },
+    {
+      "name": "lazy-module.js",
+      "files": [ "assets/js/lazy-module.js" ],
+      "load": false
     }
   ]
 }
@@ -52,6 +57,17 @@ H5 can manage and bundle external assets (JS, CSS, fonts) using the `resources` 
 - **`name`**: The name of the bundled file.
 - **`files`**: A list of files or wildcards to include.
 - **`output`**: The sub-directory in the output folder where the bundle will be placed.
+- **`load`**: `true` (default) injects the resource into `index.html` — a `<script>` for
+  JavaScript, a `<link rel="stylesheet">` for CSS. `false` still copies the resource into
+  the output folder (and still embeds it when the project is packaged) but leaves loading
+  it to your code: a module you fetch on demand, a theme you swap in at runtime, an asset
+  another file references. This is the declarative form of h5's `.dontload` name suffix
+  (`"name": "lazy-module.js.dontload"`), which is still honoured; either spelling alone
+  suppresses the injection.
+
+The flag survives packaging. When a library declares `"load": false`, that is recorded in
+the resource manifest embedded in its DLL, so a project *referencing* the library also
+extracts the file into its site without referencing it from its own `index.html`.
 
 ### Output Folder Cleanup
 


### PR DESCRIPTION
`.dontload` on a resource group's `name` was the only way to say "copy this
resource but don't reference it from index.html" — an h5-era encoding of a
boolean into a file name. Add the declarative form:

    { "name": "lazy-module.js", "files": [ ... ], "load": false }

Both spellings are resolved in one place (`OutputBuilder.ResolveResource`) and
AND together, so the suffix keeps working and either one alone suppresses the
injection. It applies to every resource kind the generated HTML can load —
`<script>` for JavaScript, `<link rel=stylesheet>` for CSS — for bundle groups
and globbed copy-through groups alike.

The flag survives packing: the resolved value is what `CollectEmbeddableItems`
writes into the package DLL's Transpose.Resources.json manifest as `Load`, which
a referencing project's site build already honours, so a consumer extracts the
file without auto-loading it either.

Covered by ResourceLoadFlagTests: parsing and the default, the combination with
`.dontload`, a site build for scripts/stylesheets/copy-through groups, the
manifest a real embed produces, and a referencing build consuming that package.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015bY3tDewTYH9n7s5YzFa36