### PR TITLE
Make C# records emit correct value semantics, and let one declare a JS object literal

### DIFF
--- a/BCL/Transpose.BCL/Resources/Core.js
+++ b/BCL/Transpose.BCL/Resources/Core.js
@@ -27,10 +27,48 @@
                 return System.Boolean.toString(instance);
             }
 
+            // Array.ToString() is object.ToString() in .NET — the array TYPE's name, not its
+            // elements. JS's Array.prototype.toString joins the elements, and it is not
+            // Object.prototype.toString, so the check below would let it through ("1,2" for an
+            // int[2]). System.Array.init tags every array it creates with its $type; a raw array
+            // arriving from interop carries none, and then System.Array is all that is known.
+            if (Transpose.isArray(instance)) {
+                return instance.$type
+                    ? Transpose.Reflection.getTypeDisplayName(instance.$type)
+                    : "System.Array";
+            }
+
+            // A DateTime is backed by a native Date, whose toString() is the JS date form
+            // ("Thu Jan 02 2020 00:00:00 GMT+0000 (…)"); .NET's is the culture's general pattern.
+            if (instance instanceof Date) {
+                return System.DateTime.format(instance);
+            }
+
+            // A Transpose type is a JS constructor function, so Function.prototype.toString would
+            // hand back the constructor's SOURCE TEXT; .NET's is Type.ToString(). Recognised by
+            // $$name rather than by being a function, because a delegate is a bare function too.
+            if (typeof instance === "function" && (instance.$$name !== undefined || instance.$isArray)) {
+                return Transpose.Reflection.getTypeDisplayName(instance);
+            }
+
             var guardItem = Transpose.$toStringGuard[Transpose.$toStringGuard.length - 1];
 
             if (instance.toString === Object.prototype.toString || guardItem && guardItem === instance) {
-                return Transpose.Reflection.getTypeFullName(instance);
+                // object.ToString() is GetType().ToString(), i.e. the type's DISPLAY name — which
+                // names generic arguments plainly (List`1[System.Int32]). $$fullname, which
+                // getTypeFullName reads off the instance, holds the assembly-qualified FullName
+                // shape instead (List`1[[System.Int32, mscorlib]]).
+                var instanceType = null;
+
+                try {
+                    instanceType = Transpose.getType(instance);
+                } catch (ex) {
+                    instanceType = null;
+                }
+
+                return instanceType
+                    ? Transpose.Reflection.getTypeDisplayName(instanceType)
+                    : Transpose.Reflection.getTypeFullName(instance);
             }
 
             Transpose.$toStringGuard.push(instance);

--- a/BCL/Transpose.BCL/Resources/Reflection.js
+++ b/BCL/Transpose.BCL/Resources/Reflection.js
@@ -243,6 +243,28 @@
             return "System.Object";
         },
 
+        /// The Type.ToString() form of a type, which is also what object.ToString() reports. It is
+        /// the full name with each generic argument named by ITS display name — plainly, without the
+        /// assembly qualification FullName carries: List`1[System.Int32], not
+        /// List`1[[System.Int32, mscorlib]] (the shape $$fullname holds).
+        getTypeDisplayName: function (type) {
+            if (type == null) {
+                return "";
+            }
+
+            if (type.$genericTypeDefinition && type.$typeArguments) {
+                var result = Transpose.Reflection.getTypeFullName(type.$genericTypeDefinition);
+
+                for (var i = 0; i < type.$typeArguments.length; i++) {
+                    result += (i === 0 ? "[" : ",") + Transpose.Reflection.getTypeDisplayName(type.$typeArguments[i]);
+                }
+
+                return result + "]";
+            }
+
+            return Transpose.Reflection.getTypeFullName(type);
+        },
+
         _makeQName: function (name, asm) {
             return name + (asm ? ", " + asm.name : "");
         },

--- a/BCL/Transpose.BCL/System/DateTime.cs
+++ b/BCL/Transpose.BCL/System/DateTime.cs
@@ -184,7 +184,11 @@ namespace System
         [Transpose.Template("System.DateTime.ToFileTimeUtc({this})")]
         public extern long ToFileTimeUtc();
 
-        [Transpose.Template(Fn = "System.DateTime.format")]
+        // The direct form is needed as well as Fn: with only the delegate template, a plain
+        // `d.ToString()` had no template to apply and fell through to a member call on the backing
+        // native Date, whose toString() is the JS date form ("Thu Jan 02 2020 00:00:00 GMT+0000 (…)")
+        // rather than the culture's general date/time pattern.
+        [Transpose.Template("System.DateTime.format({this})", Fn = "System.DateTime.format")]
         public override extern string ToString();
 
         [Transpose.Template("System.DateTime.format({this}, {0})")]

--- a/BCL/Transpose.BCL/System/Type.cs
+++ b/BCL/Transpose.BCL/System/Type.cs
@@ -429,7 +429,10 @@ namespace System
         [Transpose.Template("{left} !== {right}")]
         public static extern bool operator !=(Type left, Type right);
 
-        [Transpose.Template("Transpose.getTypeName({this})")]
+        // Type.ToString() is the full name with each generic argument named plainly
+        // (List`1[System.Int32]); FullName assembly-qualifies them, which is what
+        // Transpose.getTypeName / getTypeFullName return.
+        [Transpose.Template("Transpose.Reflection.getTypeDisplayName({this})")]
         public override extern string ToString();
 
         public extern bool IsValueType

--- a/BCL/Transpose.BCL/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/BCL/Transpose.BCL/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The nullable-analysis annotations. They carry no runtime behaviour — Roslyn reads them to refine
+// its flow analysis — but code that uses one failed to compile at all without a definition here
+// ("The type or namespace name 'AllowNullAttribute' does not exist in the namespace
+// 'System.Diagnostics.CodeAnalysis'"), so they are declared for source compatibility.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    public sealed class AllowNullAttribute : Attribute
+    {
+    }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    public sealed class DisallowNullAttribute : Attribute
+    {
+    }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    public sealed class MaybeNullAttribute : Attribute
+    {
+    }
+
+    /// <summary>Specifies that an output is not null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    public sealed class NotNullAttribute : Attribute
+    {
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null
+    /// even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) { ReturnValue = returnValue; }
+
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter is not null
+    /// even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) { ReturnValue = returnValue; }
+
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output is not null if the named parameter is not null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    public sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) { ParameterName = parameterName; }
+
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+
+    /// <summary>Specifies that the method will not return if the parameter has the given value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) { ParameterValue = parameterValue; }
+
+        public bool ParameterValue { get; }
+    }
+
+    /// <summary>Specifies that the listed members are not null when the method returns.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public sealed class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) { Members = new[] { member }; }
+
+        public MemberNotNullAttribute(params string[] members) { Members = members; }
+
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the listed members are not null when the method returns
+    /// <see cref="ReturnValue"/>.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        public bool ReturnValue { get; }
+
+        public string[] Members { get; }
+    }
+}

--- a/BCL/Transpose.BCL/shared/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
+++ b/BCL/Transpose.BCL/shared/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Marks a constructor as initializing every required member of its type, so callers need not set
+    /// them. Roslyn treats this as a compiler-required member: as soon as a type has a `required`
+    /// member it emits the attribute on the constructors that satisfy it — for a record, that is the
+    /// synthesized copy constructor `with` uses — so without a definition here any `required` member
+    /// failed to compile with "Missing compiler required member
+    /// 'System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute..ctor'".
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed class SetsRequiredMembersAttribute : Attribute
+    {
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,19 @@ The short version:
   type with a hand-written `Deconstruct(out …)` still reads `Item1`/`Item2` (see
   `PositionalPatternMemberNames`), because a pattern test is emitted as a single JS expression and
   cannot call `Deconstruct` with out-holders.
+- **An overriding auto-property shares the base's slot.** .NET gives `public override int P { get; set; }`
+  its *own* backing field, so the base and the override hold separate values and the base's getter is
+  reached only through virtual dispatch. Transpose emits an auto-property AS its slot and only suffixes a
+  `new`-hiding member (`HidingIndex`), so both write `this.P` and the later initializer wins: with
+  initializers on both, `new D().P` reads the base's value. General, not record-specific — but a record
+  makes it visible in ToString/equality too, because its constructor runs the derived initializers
+  before the base call (which is C#'s order).
+- **An identifier may shadow a type reference.** A type is referenced by its bare emitted name, so a
+  parameter or local of that same name shadows it: `record RD(int A, int B) : RB(A)` where the base is
+  literally named `B` emits `B.ctor.call(this, A)` inside `function (A, B)` and throws. This is not
+  specific to records — `class D : B { D(int A, int B) : base(A) }` fails identically — and the fix is
+  general (mangling locals/parameters against the in-scope type names), so it is tracked here rather
+  than in the record emitter.
 - **Reference resolution beyond the NuGet cache** — `<Reference HintPath>` and `tps.json`
   `references`/`referencesPath` (partially covered by `--reference`).
 - **MSBuild evaluation** stays deliberately shallow: `<Import>` is followed (see above) but

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,16 @@ Every other project is a JavaScript binding library that `tps` transpiles, bindi
 
 All six binding libraries currently transpile successfully.
 
+Which path `tps` takes for a project is decided by its **assembly name**, not by its resolved
+references: `outputBy: ClassPath` selects the runtime build only for the base library (assembly name
+`Transpose`). A binding library may declare `ClassPath` for its own JS layout — `Transpose.Newtonsoft.Json`
+does — and must still take the package path, because it *binds against* the BCL rather than defining it.
+Keying that off a resolved reference to `Transpose.dll` does not work: the translator **injects** the base
+library instead of taking it from the project's references, so in a dev tree (where the
+`Transpose.BCL` PackageReference is not in the NuGet cache) such a project resolves zero references and
+looked like the base library — which compiled it self-contained and failed with `CS0518` on every
+predefined type.
+
 ### 3. How a normal project builds
 
 A user project references the `Transpose.Build.Target` SDK, which runs `tps` once per project:
@@ -391,19 +401,6 @@ The short version:
   type with a hand-written `Deconstruct(out …)` still reads `Item1`/`Item2` (see
   `PositionalPatternMemberNames`), because a pattern test is emitted as a single JS expression and
   cannot call `Deconstruct` with out-holders.
-- **An overriding auto-property shares the base's slot.** .NET gives `public override int P { get; set; }`
-  its *own* backing field, so the base and the override hold separate values and the base's getter is
-  reached only through virtual dispatch. Transpose emits an auto-property AS its slot and only suffixes a
-  `new`-hiding member (`HidingIndex`), so both write `this.P` and the later initializer wins: with
-  initializers on both, `new D().P` reads the base's value. General, not record-specific — but a record
-  makes it visible in ToString/equality too, because its constructor runs the derived initializers
-  before the base call (which is C#'s order).
-- **An identifier may shadow a type reference.** A type is referenced by its bare emitted name, so a
-  parameter or local of that same name shadows it: `record RD(int A, int B) : RB(A)` where the base is
-  literally named `B` emits `B.ctor.call(this, A)` inside `function (A, B)` and throws. This is not
-  specific to records — `class D : B { D(int A, int B) : base(A) }` fails identically — and the fix is
-  general (mangling locals/parameters against the in-scope type names), so it is tracked here rather
-  than in the record emitter.
 - **Reference resolution beyond the NuGet cache** — `<Reference HintPath>` and `tps.json`
   `references`/`referencesPath` (partially covered by `--reference`).
 - **MSBuild evaluation** stays deliberately shallow: `<Import>` is followed (see above) but

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -221,15 +221,21 @@ public static class Program
         // outputBy: ClassPath, stitch the per-class files with the hand-written Resources primitives
         // into tps.js per the project's tps.json, and embed tps.js + tps.meta.js into Transpose.dll.
         //
-        // This path is ONLY for the base library, which *defines* the BCL and therefore references no
-        // Transpose.dll of its own. A binding library (Transpose.Newtonsoft.Json, Transpose.WebGL2, …)
-        // may also declare outputBy: ClassPath for its JS layout, but it references the Transpose BCL
-        // and must bind against it — compiling it self-contained would leave System.Object and every
-        // other predefined type undefined (CS0518 ×N). Such libraries fall through to the package path.
-        var referencesTransposeBcl = project.ReferencePaths.Any(p =>
-            string.Equals(Path.GetFileNameWithoutExtension(p), "Transpose", StringComparison.OrdinalIgnoreCase));
+        // This path is ONLY for the base library, which *defines* the BCL. A binding library
+        // (Transpose.Newtonsoft.Json, Transpose.WebGL2, …) may also declare outputBy: ClassPath for its
+        // JS layout, but it BINDS against the BCL — compiling it self-contained leaves System.Object
+        // and every other predefined type undefined (CS0518 ×N). Such libraries fall through to the
+        // package path.
+        //
+        // The base library is recognised by its assembly name, which is the one identity that always
+        // holds. Testing for a *resolved* reference to Transpose.dll instead did not: the translator
+        // injects the BCL rather than taking it from ReferencePaths, so a project whose
+        // `<PackageReference Include="Transpose.BCL" />` is absent from the NuGet cache — every fresh
+        // dev tree, which is exactly what bootstrap.sh builds — looked like it referenced nothing and
+        // took the runtime path. That is the CS0518 bootstrap.sh reported on Transpose.Newtonsoft.Json.
+        var isBaseLibrary = string.Equals(project.AssemblyName, "Transpose", StringComparison.OrdinalIgnoreCase);
         if (buildRuntime
-            || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && !referencesTransposeBcl))
+            || (string.Equals(tpscfg?.OutputBy, "ClassPath", StringComparison.OrdinalIgnoreCase) && isBaseLibrary))
             return new BuildRunResult(BuildRuntime(project, configuration, sw, outPath, maxErrors), null, false);
 
         // Refuse to compile against assemblies built by a newer Transpose than this one (see

--- a/Transpose/Transpose.Translator.Tests/ObjectToStringAndInitOrderTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ObjectToStringAndInitOrderTests.cs
@@ -1,0 +1,255 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The general-purpose behaviours that a record's synthesized ToString and constructor exposed, each
+    /// of which reproduces without records and so is fixed for every type:
+    ///
+    ///  - <b>ToString of a type-shaped value.</b> <c>object.ToString()</c> is <c>GetType().ToString()</c>,
+    ///    which names generic arguments plainly (<c>List`1[System.Int32]</c>) rather than
+    ///    assembly-qualifying them as <c>FullName</c> does; an <b>array</b>'s ToString is its type name,
+    ///    not its elements (JS's <c>Array.prototype.toString</c> joins them); a <b>DateTime</b>'s is the
+    ///    culture's general date/time pattern, not the JS <c>Date</c> string; and a <b>Type</b>'s is its
+    ///    display name, not the constructor's source text.
+    ///  - <b>Instance field initializers run before the base constructor</b>, which is C#'s order.
+    ///  - <b>A virtual auto-property has storage per declaration</b>, so an override does not share the
+    ///    base's, and a read dispatches to the most-derived accessor.
+    ///  - <b>A local binding never shadows a type reference</b>, however it is named.
+    /// </summary>
+    [TestClass]
+    public class ObjectToStringAndInitOrderTests : TranslatorTestBase
+    {
+        // ---- ToString -----------------------------------------------------------
+
+        [TestMethod]
+        public async Task ToStringOfArraysCollectionsDatesAndTypes()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public class Plain { }
+
+public class Program
+{
+    public static void Main()
+    {
+        // An array's ToString is its TYPE name; JS would join the elements ("1,2").
+        Console.WriteLine(new int[] { 1, 2 }.ToString());
+        Console.WriteLine(new string[0].ToString());
+        Console.WriteLine("A = " + new int[] { 1, 2 });
+        object boxedArray = new int[] { 1, 2 };
+        Console.WriteLine(boxedArray.ToString());
+
+        // object.ToString() falls back to GetType().ToString(), which names generic arguments
+        // plainly rather than assembly-qualifying them the way FullName does.
+        Console.WriteLine(new List<int> { 1 }.ToString());
+        Console.WriteLine(new Dictionary<string, List<int>>().ToString());
+        Console.WriteLine(new Plain().ToString());
+
+        // A DateTime's ToString is the general date/time pattern, not the JS Date string.
+        Console.WriteLine(new DateTime(2020, 1, 2).ToString());
+        Console.WriteLine(new DateTime(2020, 1, 2, 3, 4, 5).ToString());
+        Console.WriteLine("D = " + new DateTime(2020, 1, 2));
+
+        // A Type's ToString is its display name, not the JS constructor's source text.
+        Console.WriteLine(typeof(List<int>).ToString());
+        Console.WriteLine(typeof(int[]).ToString());
+        Console.WriteLine(typeof(int).ToString());
+        Console.WriteLine(typeof(Dictionary<string, List<int>>).ToString());
+        Console.WriteLine("T = " + typeof(List<int>));
+        Console.WriteLine(typeof(List<int>).Name);
+        Console.WriteLine(typeof(int[]).Name);
+    }
+}
+""");
+        }
+
+        // ---- initializer / base-constructor order -------------------------------
+
+        [TestMethod]
+        public async Task FieldInitializersRunBeforeTheBaseConstructor()
+        {
+            await RunTest("""
+using System;
+
+public class B { public B() { Console.WriteLine("B ctor"); } }
+public class D : B { public int X = Program.Log("D init"); }
+
+public class WithArgs { public WithArgs(int a) { Console.WriteLine("base " + a); } }
+public class Primary(int a) : WithArgs(a) { public int Y = Program.Log("primary init"); }
+
+public class Program
+{
+    public static int Log(string s) { Console.WriteLine(s); return 1; }
+
+    public static void Main()
+    {
+        new D();
+        Console.WriteLine("--");
+        Console.WriteLine(new Primary(2).Y);
+    }
+}
+""");
+        }
+
+        // ---- virtual auto-properties -------------------------------------------
+
+        [TestMethod]
+        public async Task AVirtualAutoPropertyHasStoragePerDeclaration()
+        {
+            await RunTest("""
+using System;
+
+public class B
+{
+    public virtual int P { get; set; } = 1;
+    public B() { Console.WriteLine("in base ctor: " + P); }
+}
+
+public class D : B
+{
+    public override int P { get; set; } = 2;
+    // The base's own storage stays reachable through base.P, and only through it.
+    public int BaseP => base.P;
+}
+
+public abstract class AbstractBase { public abstract int Q { get; set; } }
+public class Concrete : AbstractBase { public override int Q { get; set; } = 5; }
+
+public class Program
+{
+    public static void Main()
+    {
+        var d = new D();
+        Console.WriteLine(d.P);            // the override's storage
+        Console.WriteLine(((B)d).P);       // virtual dispatch reaches it too
+        Console.WriteLine(d.BaseP);        // the base's own, untouched by the override
+        d.P = 7;
+        Console.WriteLine(d.P);
+        Console.WriteLine(new B().P);      // the base still has its own
+        Console.WriteLine(new Concrete().Q);
+        AbstractBase a = new Concrete();
+        a.Q = 9;
+        Console.WriteLine(a.Q);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task AVirtualAutoPropertyOnARecord()
+        {
+            await RunTest("""
+using System;
+
+public record AutoBase(int A) { public virtual int P { get; init; } = 1; }
+public record AutoDerived(int A) : AutoBase(A) { public override int P { get; init; } = 2; }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new AutoBase(1));
+        Console.WriteLine(new AutoDerived(1));
+        Console.WriteLine(new AutoDerived(1).P);
+        Console.WriteLine(((AutoBase)new AutoDerived(1)).P);
+        Console.WriteLine(new AutoDerived(1) == new AutoDerived(1));
+        Console.WriteLine(new AutoDerived(1) with { P = 8 });
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task BaseAccessOnAnOverriddenPropertyReachesTheBaseAccessor()
+        {
+            // `base` emits as `this`, so a property read/write through it has to be routed to the base
+            // type's own accessor — a plain `this.P` runs the most-derived override, which is exactly
+            // what `base` exists to bypass.
+            await RunTest("""
+using System;
+
+public class B
+{
+    private int _v = 1;
+    public virtual int P { get { return _v; } set { _v = value; } }
+    public virtual int A { get; set; } = 10;
+}
+
+public class D : B
+{
+    private int _d = 2;
+    public override int P { get { return _d; } set { _d = value; } }
+    public override int A { get; set; } = 20;
+
+    public int BaseP => base.P;
+    public int BaseA => base.A;
+    public void SetBaseP(int v) { base.P = v; }
+    public void SetBaseA(int v) { base.A = v; }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var d = new D();
+        Console.WriteLine(d.P + " " + d.BaseP);
+        Console.WriteLine(d.A + " " + d.BaseA);
+        d.SetBaseP(7);
+        d.SetBaseA(70);
+        Console.WriteLine(d.P + " " + d.BaseP);
+        Console.WriteLine(d.A + " " + d.BaseA);
+        d.P = 8;
+        d.A = 80;
+        Console.WriteLine(d.P + " " + d.BaseP);
+        Console.WriteLine(d.A + " " + d.BaseA);
+    }
+}
+""");
+        }
+
+        // ---- type references are unshadowable ----------------------------------
+
+        [TestMethod]
+        public async Task ALocalBindingNeverShadowsATypeReference()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class B { public int A; public B(int a) { A = a; } }
+public class D : B { public int Bb; public D(int A, int B) : base(A) { Bb = B; } }
+
+public record RB(int A);
+public record RD(int A, int B) : RB(A);
+
+public class Helper { public static int Twice(int x) => x * 2; }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new D(1, 2).A);
+        Console.WriteLine(new RD(1, 2));
+
+        // A local, a foreach variable, an out var and a lambda parameter all named after a type
+        // that the same method references.
+        var Helper = 3;
+        Console.WriteLine(Helper + Program.Twice(Helper));
+        foreach (var B in new[] { 1, 2 }) Console.WriteLine(new B(B).A);
+        if (int.TryParse("4", out var Helper2)) Console.WriteLine(Helper2);
+        Func<int, int> f = B => new B(B).A;
+        Console.WriteLine(f(5));
+        Console.WriteLine(new List<int> { 1, 2 }.Select(B => new B(B).A).Sum());
+    }
+
+    static int Twice(int x) => Helper.Twice(x);
+}
+""");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/RecordTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RecordTests.cs
@@ -1,0 +1,1447 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// C# records, end to end: every test transpiles the snippet, runs it on Node and diffs the output
+    /// against the same C# executed natively, so each one pins the record's observable .NET behaviour
+    /// rather than a particular emitted shape.
+    ///
+    /// The areas are the ones a record actually synthesizes — construction (positional, bodied, mixed,
+    /// optional, extra constructors), value equality and hashing, <c>ToString</c>/<c>PrintMembers</c>,
+    /// <c>with</c>, <c>Deconstruct</c>, positional patterns and inheritance — each covered for a record
+    /// <b>class</b> and a record <b>struct</b>, and each in both the one-line positional form and the
+    /// bodied form. On top of that: what happens when the record declares one of those members itself
+    /// (its version has to win), and <c>[ObjectLiteral]</c>, where a record declares the shape of a plain
+    /// JavaScript object.
+    ///
+    /// Behaviours these tests deliberately pin down, each of which was wrong before:
+    ///  - <b>ToString prints public FIELDS too</b>, and only <b>public</b> members — C#'s PrintMembers
+    ///    walks non-static public fields and public readable properties, base record first;
+    ///  - <b>equality compares FIELDS</b>, including private ones and auto-property backing fields, and
+    ///    NOT computed properties — so a record with a get-only property that allocates
+    ///    (<c>int[] Cache =&gt; new[] { V }</c>) still compares equal;
+    ///  - a hand-written <c>ToString</c>, <c>PrintMembers</c>, <c>Equals</c>, <c>GetHashCode</c> or
+    ///    <c>Deconstruct</c> replaces the synthesized one instead of colliding with it;
+    ///  - a positional parameter is only stored when the record actually synthesized a property for it
+    ///    (a body-declared member of the same name suppresses that), and an optional one defaults;
+    ///  - a member typed <c>char</c>, an enum, a nullable enum or a type parameter renders in ToString
+    ///    the way .NET does (a character / a member name), not as its numeric representation.
+    /// </summary>
+    [TestClass]
+    public class RecordTests : TranslatorTestBase
+    {
+        // ---- declaration forms -------------------------------------------------
+
+        [TestMethod]
+        public async Task RecordClassDeclarationForms()
+        {
+            await RunTest("""
+using System;
+
+public record OneLine(int X);
+public record ClassKeyword(int X, string S);
+public sealed record Sealed(int X);
+public record NoMembers;
+public record BodyOnly { public int X { get; init; } }
+public record PositionalAndBody(int X) { public int Field = 7; public int Prop { get; init; } = 9; }
+public record EmptyParameterList() { public int A { get; init; } }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new OneLine(1));
+        Console.WriteLine(new ClassKeyword(1, "s"));
+        Console.WriteLine(new Sealed(2));
+        Console.WriteLine(new NoMembers());
+        Console.WriteLine(new BodyOnly { X = 3 });
+        Console.WriteLine(new PositionalAndBody(4));
+        Console.WriteLine(new EmptyParameterList { A = 5 });
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordStructDeclarationForms()
+        {
+            await RunTest("""
+using System;
+
+public record struct OneLine(int X);
+public readonly record struct ReadOnly(int X, string T);
+public record struct NoMembers;
+public record struct BodyOnly { public int X { get; set; } }
+public record struct PositionalAndBody(int X) { public int Y; }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new OneLine(1));
+        Console.WriteLine(new ReadOnly(1, "t"));
+        Console.WriteLine(new NoMembers());
+        Console.WriteLine(default(NoMembers));
+        Console.WriteLine(new BodyOnly { X = 2 });
+        Console.WriteLine(new PositionalAndBody(3) { Y = 4 });
+        // A record struct's default value zero-initializes every slot rather than staying undefined.
+        Console.WriteLine(default(OneLine));
+        Console.WriteLine(default(ReadOnly));
+    }
+}
+""");
+        }
+
+        // ---- construction ------------------------------------------------------
+
+        [TestMethod]
+        public async Task ExtraConstructorsChainToThePositionalOne()
+        {
+            await RunTest("""
+using System;
+
+public record R(int X, int Y)
+{
+    public R(int x) : this(x, x * 2) { }
+    public R() : this(0) { }
+    public int Sum => X + Y;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new R(1, 2));
+        Console.WriteLine(new R(3));
+        Console.WriteLine(new R());
+        Console.WriteLine(new R(3).Sum);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task OptionalPositionalParametersDefault()
+        {
+            await RunTest("""
+using System;
+
+public record Defaults(int X = 5, string S = "d");
+public record struct SDefaults(int X = 5, string S = "d");
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Defaults());
+        Console.WriteLine(new Defaults(1));
+        Console.WriteLine(new Defaults(1, "x"));
+        Console.WriteLine(new Defaults(S: "x"));
+        Console.WriteLine(new SDefaults());
+        Console.WriteLine(new SDefaults(2));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordStructHasTheImplicitParameterlessConstructor()
+        {
+            // `new S()` on a `record struct S(int X)` reaches the implicit parameterless struct
+            // constructor, not the positional one — so it zeroes the value, and does NOT apply either the
+            // positional parameters' defaults or the declared field initializers.
+            await RunTest("""
+using System;
+
+public record struct Plain(int X);
+public record struct WithDefaults(int X = 5, string S = "d");
+public record struct WithInitializer(int X) { public int Y = 1; }
+public record struct Nested(int X) { public Plain P; }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Plain());
+        Console.WriteLine(new WithDefaults());
+        Console.WriteLine(new WithDefaults(2));
+        Console.WriteLine(new WithInitializer().Y);
+        Console.WriteLine(new WithInitializer(1).Y);
+        Console.WriteLine(default(WithInitializer).Y);
+        // A struct-typed slot is still default(T) rather than null, so reading through it works.
+        Console.WriteLine(new Nested().P.X);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task PositionalParameterFlowsIntoInitializersAndDeclaredMembers()
+        {
+            await RunTest("""
+using System;
+
+// The body declares X itself, so C# does NOT synthesize a property for the parameter and does not
+// store it; the parameter is only what the initializer reads.
+public record Shadowed(int X)
+{
+    public int X { get; init; } = X * 2;
+}
+
+public record Initializers(int X)
+{
+    public int Field = X + 1;
+    public int Prop { get; } = X + 2;
+}
+
+public record FromString(string S)
+{
+    public int Len => S.Length;
+    public string Upper { get; } = S.ToUpper();
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Shadowed(3).X);
+        var i = new Initializers(1);
+        Console.WriteLine(i.Field + " " + i.Prop);
+        var f = new FromString("ab");
+        Console.WriteLine(f.Len + " " + f.Upper);
+        Console.WriteLine(f);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RequiredMembers()
+        {
+            // A `required` member makes Roslyn stamp [SetsRequiredMembersAttribute] on the constructors
+            // that satisfy it — for a record, the synthesized copy constructor `with` uses — so the
+            // attribute has to exist in the BCL or the whole compilation fails.
+            await RunTest("""
+using System;
+
+public record Req
+{
+    public required int R { get; init; }
+    public required string Name { get; init; }
+    public int O { get; init; } = 4;
+}
+
+public record struct SReq { public required int R { get; init; } }
+public record ReqPos(int X) { public required string Name { get; init; } }
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new Req { R = 1, Name = "n" };
+        Console.WriteLine(a);
+        Console.WriteLine(a with { R = 2 });
+        Console.WriteLine(a == new Req { R = 1, Name = "n" });
+        Console.WriteLine(new SReq { R = 5 });
+        Console.WriteLine(new ReqPos(1) { Name = "p" });
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordBodyMembersAreInitializedByThePositionalConstructor()
+        {
+            await RunTest("""
+using System;
+
+public struct Inner { public int V; }
+public class Ref { public int V = 3; }
+
+public record R(int X)
+{
+    public int K = 7;
+    public Ref Made = new Ref();
+    public Inner I;
+    public Ref Unset;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new R(1);
+        Console.WriteLine(r.K);
+        Console.WriteLine(r.Made.V);
+        Console.WriteLine(r.I.V);
+        Console.WriteLine(r.Unset == null);
+        r.I.V = 9;
+        Console.WriteLine(r.I.V);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task DerivedRecordInitializersRunBeforeTheBaseConstructor()
+        {
+            // C#'s order for any derived type: the derived instance initializers, then the base
+            // constructor (which runs the base's own initializers).
+            await RunTest("""
+using System;
+
+public record B(int A) { public int BX = Program.Log("base-init"); }
+public record D(int A, int C) : B(A) { public int DX = Program.Log("derived-init"); }
+
+public class Program
+{
+    public static int Log(string s) { Console.WriteLine(s); return 1; }
+    public static void Main() { Console.WriteLine(new D(1, 2)); }
+}
+""");
+        }
+
+        // ---- equality and hashing ----------------------------------------------
+
+        [TestMethod]
+        public async Task RecordClassValueEquality()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public record RC(int X, string S);
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new RC(1, "a");
+        var b = new RC(1, "a");
+        var c = new RC(2, "a");
+        Console.WriteLine(a == b);
+        Console.WriteLine(a != c);
+        Console.WriteLine(a.Equals(b));
+        Console.WriteLine(a.Equals((object)b));
+        Console.WriteLine(a.Equals((object)"nope"));
+        Console.WriteLine(a.GetHashCode() == b.GetHashCode());
+        Console.WriteLine(a.GetHashCode() == c.GetHashCode());
+        Console.WriteLine(ReferenceEquals(a, b));
+
+        var set = new HashSet<RC> { a, b, c };
+        Console.WriteLine(set.Count);
+        var d = new Dictionary<RC, int>();
+        d[a] = 1;
+        d[b] = 2;
+        Console.WriteLine(d.Count + " " + d[a]);
+
+        RC nil = null;
+        Console.WriteLine(nil == null);
+        Console.WriteLine(a == null);
+        Console.WriteLine(a.Equals(null));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordStructValueEquality()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public record struct RS(int X, string S);
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new RS(1, "a");
+        var b = new RS(1, "a");
+        var c = new RS(3, "a");
+        Console.WriteLine(a == b);
+        Console.WriteLine(a != c);
+        Console.WriteLine(a.Equals(b));
+        Console.WriteLine(a.Equals((object)b));
+        Console.WriteLine(a.GetHashCode() == b.GetHashCode());
+
+        var set = new HashSet<RS> { a, b, c };
+        Console.WriteLine(set.Count);
+
+        // Boxed: a record struct keeps its value semantics through object.
+        object boxed = a;
+        Console.WriteLine(boxed.Equals(b));
+        Console.WriteLine(boxed.GetHashCode() == b.GetHashCode());
+        Console.WriteLine(boxed.ToString());
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task EqualityAndToStringCoverPublicFieldsOfARecordBody()
+        {
+            // C# compares a record's FIELDS (so a public field participates in ==/GetHashCode) and
+            // PRINTS its public fields and public readable properties. Comparing/printing only the
+            // properties dropped `F`/`G` from both.
+            await RunTest("""
+using System;
+
+public record RC(int X) { public int F = 1; public int G; }
+public record struct RS(int X) { public int F; }
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new RC(1);
+        var b = new RC(1);
+        b.F = 99;
+        Console.WriteLine(a);
+        Console.WriteLine(b);
+        Console.WriteLine(a == b);
+        Console.WriteLine(a.GetHashCode() == b.GetHashCode());
+        // `with` copies every field, declared ones included.
+        var c = a with { X = 1 };
+        Console.WriteLine(c.F);
+        Console.WriteLine(a == c);
+
+        var s = new RS(1) { F = 5 };
+        var s2 = new RS(1) { F = 6 };
+        Console.WriteLine(s);
+        Console.WriteLine(s == s2);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task OnlyPublicMembersArePrintedAndOnlyFieldsCompared()
+        {
+            await RunTest("""
+using System;
+
+public record RC(int X)
+{
+    public int Computed => X * 2;          // public + readable: printed, but no storage to compare
+    private int _priv = 5;                 // private field: compared, never printed
+    public int Priv => _priv;
+    public void Bump() { _priv++; }
+    public static int Stat = 3;            // static: neither
+    public static int StatProp { get; set; }
+    public int WriteOnly { set { _priv = value; } }   // no getter: not printed
+    internal int Internal { get; set; }     // not public: not printed, but its field IS compared
+    private int PrivProp { get; set; }
+    public int Manual { get { return _priv; } set { _priv = value; } }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new RC(1);
+        var b = new RC(1);
+        b.Bump();
+        Console.WriteLine(a);
+        Console.WriteLine(b);
+        Console.WriteLine(a == b);         // the private field differs
+        var c = new RC(1);
+        c.Internal = 7;
+        Console.WriteLine(c);              // Internal is not printed
+        Console.WriteLine(a == c);         // but its backing field is compared
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task ComputedPropertiesDoNotParticipateInEquality()
+        {
+            // Equality compares fields, so a get-only property that allocates on every read must not
+            // make two otherwise-equal records unequal.
+            await RunTest("""
+using System;
+
+public record Node(int V)
+{
+    public int[] Cache => new int[] { V };
+    public object Fresh => new object();
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new Node(1);
+        var b = new Node(1);
+        Console.WriteLine(a == b);
+        Console.WriteLine(a.Equals(b));
+        Console.WriteLine(a.GetHashCode() == b.GetHashCode());
+    }
+}
+""");
+        }
+
+        // ---- ToString ----------------------------------------------------------
+
+        [TestMethod]
+        public async Task ToStringFormatsMemberValuesLikeDotNet()
+        {
+            await RunTest("""
+using System;
+
+public enum Color { Red, Green }
+public struct Plain { public int V; public override string ToString() => "P" + V; }
+
+public record R(char C, Color E, Color? NE, bool B, Plain P, int? NI, double D, float F, string S);
+public record G<T>(T V);
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new R('c', Color.Green, Color.Red, true, new Plain { V = 1 }, 2, 1.5, 2.5f, "s"));
+        Console.WriteLine(new R('c', Color.Green, null, false, new Plain(), null, 0, 0, null));
+        // A member typed as a type parameter renders through the type argument bound at runtime.
+        Console.WriteLine(new G<char>('x'));
+        Console.WriteLine(new G<Color>(Color.Green));
+        Console.WriteLine(new G<string>(null));
+        Console.WriteLine(new G<int>(3));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task NestedRecordsPrintRecursively()
+        {
+            await RunTest("""
+using System;
+
+public record Address(string City, string Zip);
+public record Person(string Name, Address Addr);
+public record struct SAddr(int N);
+public record struct SPerson(SAddr A, int Id);
+
+public class Program
+{
+    public static void Main()
+    {
+        var p = new Person("a", new Address("c", "z"));
+        Console.WriteLine(p);
+        Console.WriteLine(p == new Person("a", new Address("c", "z")));
+        var r = p with { Addr = p.Addr with { City = "d" } };
+        Console.WriteLine(r);
+        Console.WriteLine(p == r);
+
+        var s = new SPerson(new SAddr(1), 2);
+        Console.WriteLine(s);
+        Console.WriteLine(s == new SPerson(new SAddr(1), 2));
+    }
+}
+""");
+        }
+
+        // ---- with --------------------------------------------------------------
+
+        [TestMethod]
+        public async Task WithExpressions()
+        {
+            await RunTest("""
+using System;
+
+public record RC(int X, string S) { public int Extra { get; init; } }
+public record struct RS(int X, string S);
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new RC(1, "a") { Extra = 5 };
+        var b = a with { X = 2 };
+        Console.WriteLine(b);
+        Console.WriteLine(b.Extra);
+        var c = a with { };
+        Console.WriteLine(c == a);
+        Console.WriteLine(ReferenceEquals(c, a));
+        var d = a with { X = 9, S = "z", Extra = 8 };
+        Console.WriteLine(d);
+        Console.WriteLine(d.Extra);
+
+        // `with` on a record struct leaves the source untouched.
+        var sa = new RS(1, "a");
+        Console.WriteLine(sa with { X = 4 });
+        Console.WriteLine(sa);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task WithKeepsTheRuntimeTypeOfADerivedRecord()
+        {
+            await RunTest("""
+using System;
+
+public abstract record Base(int A);
+public record Mid(int A, int B) : Base(A);
+public record Leaf(int A, int B, int C) : Mid(A, B);
+
+public class Program
+{
+    public static void Main()
+    {
+        var l = new Leaf(1, 2, 3);
+        var withL = l with { C = 9 };
+        Console.WriteLine(withL);
+        Console.WriteLine(withL.GetType().Name);
+        // Through the base type the copy is still a Leaf, with the untouched members preserved.
+        Mid asMid = l;
+        var withMid = asMid with { B = 7 };
+        Console.WriteLine(withMid);
+        Console.WriteLine(withMid.GetType().Name);
+    }
+}
+""");
+        }
+
+        // ---- inheritance -------------------------------------------------------
+
+        [TestMethod]
+        public async Task RecordInheritanceChain()
+        {
+            await RunTest("""
+using System;
+
+public abstract record Base(int A);
+public record Mid(int A, int B) : Base(A);
+public record Leaf(int A, int B, int C) : Mid(A, B);
+public record Other(int A, int B) : Base(A);
+
+public class Program
+{
+    public static void Main()
+    {
+        var l = new Leaf(1, 2, 3);
+        Console.WriteLine(l);                       // base members first
+        Console.WriteLine(((Base)l).A);
+        Console.WriteLine(l == new Leaf(1, 2, 3));
+        // Two records of different types are never equal, however alike their members.
+        var m = new Mid(1, 2);
+        var o = new Other(1, 2);
+        Console.WriteLine(m.Equals(o));
+        Console.WriteLine(((Base)m).Equals((Base)o));
+        Console.WriteLine(typeof(Leaf).BaseType.Name);
+        Console.WriteLine(l is Mid);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task DerivedRecordsInheritDeclaredToStringAndPrintMembers()
+        {
+            await RunTest("""
+using System;
+using System.Text;
+
+// A hand-written PrintMembers on the base record is what the derived record's synthesized
+// PrintMembers chains to, so it shows through the derived ToString as well.
+public record Base(int A)
+{
+    protected virtual bool PrintMembers(StringBuilder b) { b.Append("A!"); return true; }
+}
+public record Derived(int A, int B) : Base(A);
+
+public record B2(int A);
+public record D2(int A, int B) : B2(A) { public override string ToString() => "D2!" + A + B; }
+
+public record B3(int A) { public override string ToString() => "B3!"; }
+public record D3(int A, int B) : B3(A);
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Base(1));
+        Console.WriteLine(new Derived(1, 2));
+        Console.WriteLine(new D2(1, 2));
+        Console.WriteLine(new D3(1, 2));
+        Base b = new Derived(1, 2);
+        Console.WriteLine(b.ToString());
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task DerivedRecordsPrintHiddenAndOverriddenMembersLikeDotNet()
+        {
+            // An OVERRIDE is printed once — the base record's PrintMembers prints it, and virtual
+            // dispatch there reads the override's value. A `new` member is printed twice, once from each
+            // record's own set, which is what .NET does.
+            await RunTest("""
+using System;
+
+public record Base(int A) { public int Shared => 1; public virtual int V => 1; }
+public record Derived(int A, int B) : Base(A) { public new int Shared => 2; public override int V => 2; }
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Base(1));
+        Console.WriteLine(new Derived(1, 2));
+        Console.WriteLine(new Derived(1, 2) == new Derived(1, 2));
+        Console.WriteLine(((Base)new Derived(1, 2)).V);
+    }
+}
+""");
+        }
+
+        // ---- declared members win over the synthesized ones --------------------
+
+        [TestMethod]
+        public async Task DeclaredToStringAndPrintMembersReplaceTheSynthesizedOnes()
+        {
+            await RunTest("""
+using System;
+using System.Text;
+
+public record CustomToString(int X) { public override string ToString() => "custom " + X; }
+public record SealedToString(int X) { public sealed override string ToString() => "sealed " + X; }
+
+public record CustomPrint(int X, int Y)
+{
+    protected virtual bool PrintMembers(StringBuilder b) { b.Append("only X=").Append(X); return true; }
+}
+
+// PrintMembers returning false means "nothing printed", so ToString has no inner spacing.
+public record PrintNothing(int X)
+{
+    protected virtual bool PrintMembers(StringBuilder b) => false;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new CustomToString(1));
+        Console.WriteLine(new SealedToString(2));
+        Console.WriteLine(new CustomPrint(1, 2));
+        Console.WriteLine(new PrintNothing(1));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task DeclaredEqualsAndGetHashCodeGovernEveryComparison()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public record R(int X) : IEquatable<R>
+{
+    // Two records are equal when they share a decade.
+    public virtual bool Equals(R other) => other != null && X / 10 == other.X / 10;
+    public override int GetHashCode() => X / 10;
+}
+
+public record struct SR(int X)
+{
+    public bool Equals(SR other) => true;
+    public override int GetHashCode() => 43;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new R(11) == new R(12));
+        Console.WriteLine(new R(11).Equals(new R(12)));
+        Console.WriteLine(new R(11).Equals((object)new R(12)));   // must route to the declared Equals
+        Console.WriteLine(new R(11).GetHashCode());
+        Console.WriteLine(new HashSet<R> { new R(11), new R(12) }.Count);
+
+        Console.WriteLine(new SR(1) == new SR(2));
+        Console.WriteLine(new SR(1).Equals((object)new SR(2)));
+        Console.WriteLine(new SR(1).GetHashCode());
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task ADeclaredDeconstructCoexistsWithTheSynthesizedOne()
+        {
+            // The record still synthesizes Deconstruct(out int X) for its one positional parameter, so
+            // both overloads exist and each call has to reach the right one.
+            await RunTest("""
+using System;
+
+public record R(int X)
+{
+    public void Deconstruct(out int a, out int b) { a = X; b = X * 2; }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var (a, b) = new R(5);
+        Console.WriteLine(a + " " + b);
+        new R(7).Deconstruct(out var x);
+        Console.WriteLine(x);
+        new R(7).Deconstruct(out var p, out var q);
+        Console.WriteLine(p + " " + q);
+    }
+}
+""");
+        }
+
+        // ---- deconstruction and patterns ---------------------------------------
+
+        [TestMethod]
+        public async Task Deconstruction()
+        {
+            await RunTest("""
+using System;
+
+public record RC(int X, string S);
+public record struct RS(int X, string S);
+public record Three(int A, int B, int C);
+
+public class Program
+{
+    public static void Main()
+    {
+        var (x, s) = new RC(1, "a");
+        Console.WriteLine(x + " " + s);
+        var (y, t) = new RS(2, "b");
+        Console.WriteLine(y + " " + t);
+        var (p, q, r) = new Three(1, 2, 3);
+        Console.WriteLine(p + q + r);
+
+        int a; string b;
+        (a, b) = new RC(4, "d");
+        Console.WriteLine(a + b);
+
+        new RC(5, "e").Deconstruct(out var m, out var n);
+        Console.WriteLine(m + n);
+
+        var (u, (v, w)) = (1, new RC(2, "z"));
+        Console.WriteLine(u + " " + v + " " + w);
+
+        foreach (var (k, l) in new[] { new RC(1, "a"), new RC(2, "b") })
+            Console.WriteLine(k + l);
+
+        var (_, only) = new RC(6, "f");
+        Console.WriteLine(only);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task PositionalAndPropertyPatterns()
+        {
+            await RunTest("""
+using System;
+
+public record RC(int X, string S);
+public record struct RS(int X, string S);
+public abstract record Shape;
+public record Circle(double R) : Shape;
+public record Rect(double W, double H) : Shape;
+
+public class Program
+{
+    public static void Main()
+    {
+        object o = new RC(1, "a");
+        Console.WriteLine(o is RC(1, "a"));
+        Console.WriteLine(o is RC(2, "a"));
+        Console.WriteLine(o is RC { X: 1, S: "a" });
+        Console.WriteLine(o is RC(var xx, var ss) ? xx + ss : "no");
+
+        var rs = new RS(3, "c");
+        Console.WriteLine(rs is RS(3, _));
+
+        Console.WriteLine(Describe(new Rect(2, 3)));
+        Console.WriteLine(Describe(new Circle(1)));
+        Console.WriteLine(Describe(null));
+    }
+
+    static string Describe(Shape s) => s switch
+    {
+        Circle(var r) => "circle " + r,
+        Rect(var w, var h) => "rect " + (w * h),
+        null => "none",
+        _ => "?"
+    };
+}
+""");
+        }
+
+        // ---- generics, interfaces, nesting -------------------------------------
+
+        [TestMethod]
+        public async Task GenericRecords()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public record Box<T>(T Value);
+public record Pair<TK, TV>(TK Key, TV Value) { public string Show() => Key + "=" + Value; }
+public record struct SBox<T>(T Value);
+public record Node<T>(T Value, Node<T> Next) where T : struct;
+public record Outer<T>(T V) { public record Inner(T W); }
+public class Holder<T> { public record Rec(T V); }
+
+public class Program
+{
+    public static void Main()
+    {
+        var b = new Box<int>(1);
+        Console.WriteLine(b);
+        Console.WriteLine(b == new Box<int>(1));
+        Console.WriteLine(new Box<string>("s"));
+        var p = new Pair<string, int>("a", 1);
+        Console.WriteLine(p.Show());
+        Console.WriteLine(p);
+        Console.WriteLine(new SBox<int>(2));
+        Console.WriteLine(new SBox<int>(2) == new SBox<int>(2));
+        Console.WriteLine(new Node<int>(1, new Node<int>(2, null)).Next.Value);
+        Console.WriteLine(new Box<int>(1) with { Value = 5 });
+        Console.WriteLine(new List<Box<int>> { new(1), new(2) }.Contains(new Box<int>(2)));
+        Console.WriteLine(new Outer<int>.Inner(1));
+        Console.WriteLine(new Holder<int>.Rec(2));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordsImplementingInterfaces()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public interface IHasName { string Name { get; } }
+
+public record Person(string Name, int Age) : IHasName, IComparable<Person>
+{
+    public int CompareTo(Person other) => Age.CompareTo(other.Age);
+}
+
+public record struct SPerson(string Name) : IHasName;
+
+public class Program
+{
+    public static void Main()
+    {
+        IHasName n = new Person("a", 1);
+        Console.WriteLine(n.Name);
+        var list = new List<Person> { new("c", 3), new("a", 1), new("b", 2) };
+        list.Sort();
+        foreach (var p in list) Console.WriteLine(p);
+        IHasName sn = new SPerson("s");
+        Console.WriteLine(sn.Name);
+        Console.WriteLine(((IHasName)new SPerson("q")).Name);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task NestedPartialAndStaticRecordMembers()
+        {
+            await RunTest("""
+using System;
+
+public partial record P(int X);
+public partial record P { public int Y => X + 1; }
+
+public record Nested
+{
+    public record Inner(int V);
+    public Inner I { get; init; }
+}
+
+public class Outer { public record InClass(int V); }
+
+public record WithStatics(int X)
+{
+    public static int Count;
+    static WithStatics() { Count = 10; }
+    public static WithStatics Create(int x) => new WithStatics(x);
+    public const int K = 3;
+    public event Action Ev;
+    public void Fire() => Ev?.Invoke();
+    public int Method() => X + K;
+    public int this[int i] => X + i;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new P(1).Y);
+        Console.WriteLine(new Nested { I = new Nested.Inner(7) }.I);
+        Console.WriteLine(new Outer.InClass(8));
+
+        Console.WriteLine(WithStatics.Count);
+        Console.WriteLine(WithStatics.Create(1));
+        Console.WriteLine(WithStatics.K);
+        var r = new WithStatics(1);
+        r.Ev += () => Console.WriteLine("fired");
+        r.Fire();
+        Console.WriteLine(r.Method());
+        Console.WriteLine(r[2]);
+        Console.WriteLine(r);       // an indexer/event/const is not a printed member
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordsCaptureTheirPositionalParametersInLambdas()
+        {
+            await RunTest("""
+using System;
+
+public record Cap(int X)
+{
+    public Func<int> Field = () => 7;
+    public Func<int> Make() => () => X * 2;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var c = new Cap(3);
+        Console.WriteLine(c.Field());
+        Console.WriteLine(c.Make()());
+    }
+}
+""");
+        }
+
+        // ---- record structs are value types ------------------------------------
+
+        [TestMethod]
+        public async Task RecordStructsCopyByValue()
+        {
+            await RunTest("""
+using System;
+
+public record struct Inner(int V);
+public record struct Outer(Inner I, int N);
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new Outer(new Inner(1), 2);
+        var b = a;
+        b.I = new Inner(9);
+        Console.WriteLine(a.I.V + " " + b.I.V);          // the assignment copied the value
+
+        var c = a with { N = 5 };
+        Console.WriteLine(a.N + " " + c.N);
+        Console.WriteLine(c.I.V);
+
+        Mutate(a);
+        Console.WriteLine(a.N);                           // by-value argument
+
+        var arr = new Outer[2];
+        Console.WriteLine(arr[0].N + " " + arr[0].I.V);   // default-initialized elements
+
+        object boxed = a;
+        var d = (Outer)boxed;
+        d.N = 77;
+        Console.WriteLine(a.N + " " + d.N);
+    }
+
+    static void Mutate(Outer o) { o.N = 100; }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordStructMembersAndMutation()
+        {
+            await RunTest("""
+using System;
+
+public readonly record struct RS(int X, string S)
+{
+    public int Double => X * 2;                 // a get-only computed member on a readonly struct
+    public RS Grow() => this with { X = X + 1 };
+}
+
+public record struct MS(int X)
+{
+    public void Bump() => X++;
+}
+
+public record struct SExplicit(int X)
+{
+    public SExplicit() : this(42) { }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new RS(1, "a");
+        Console.WriteLine(a.Double);
+        Console.WriteLine(a.Grow());
+        Console.WriteLine(a);
+
+        var m = new MS(1);
+        m.Bump();
+        Console.WriteLine(m);
+        var m2 = m;
+        m2.Bump();
+        Console.WriteLine(m + " " + m2);
+
+        Console.WriteLine(new SExplicit());
+        Console.WriteLine(new SExplicit(1));
+    }
+}
+""");
+        }
+
+        // ---- reflection and collections ----------------------------------------
+
+        [TestMethod]
+        public async Task RecordsInLinqAndCollections()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public record Item(string Name, int Qty);
+
+public class Program
+{
+    public static void Main()
+    {
+        var items = new List<Item> { new("b", 2), new("a", 1), new("a", 1) };
+        Console.WriteLine(items.Distinct().Count());
+        Console.WriteLine(string.Join(";", items.OrderBy(i => i.Name).Select(i => i.Name)));
+        Console.WriteLine(items.GroupBy(i => i).Count());
+        Console.WriteLine(items.Contains(new Item("a", 1)));
+        Console.WriteLine(items.Distinct().ToDictionary(i => i, i => i.Qty)[new Item("a", 1)]);
+        Console.WriteLine(items.FirstOrDefault(i => i.Name == "z") is null);
+        Console.WriteLine(items.Any(i => i is Item("a", 1)));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordRuntimeTypes()
+        {
+            await RunTest("""
+using System;
+
+public record R(int X);
+public record struct S(int X);
+public abstract record BaseR(int A);
+public record DerivedR(int A, int B) : BaseR(A);
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new R(1).GetType().Name);
+        Console.WriteLine(new S(1).GetType().Name);
+        Console.WriteLine(typeof(R).Name);
+        BaseR b = new DerivedR(1, 2);
+        Console.WriteLine(b.GetType().Name);
+        Console.WriteLine(b is DerivedR);
+        Console.WriteLine(typeof(DerivedR).BaseType.Name);
+
+        object o = new S(3);
+        Console.WriteLine(o is S);
+        Console.WriteLine(((S)o).X);
+        Console.WriteLine(o.ToString());
+        Console.WriteLine(o.Equals(new S(3)));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordShapesWithoutAPositionalConstructor()
+        {
+            await RunTest("""
+using System;
+
+// Nothing public: ToString prints an empty body, but the private field still separates the values.
+public record Hidden { private int _x = 1; internal int I { get; init; } }
+public record OnlyField { public int F = 2; }
+
+public abstract record AbstractBase { public int A { get; init; } }
+public record Concrete : AbstractBase { public int B { get; init; } }
+
+public interface IWithDefault { int N { get; } }
+public record WithInterface(int X) : IWithDefault { public int N => 5; }
+
+public record struct SOuter(int X) { public record SInner(int Y); }
+public record Tupled((int A, string B) T, WithInterface Maybe);
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new Hidden { I = 3 });
+        Console.WriteLine(new Hidden { I = 3 } == new Hidden { I = 4 });
+        Console.WriteLine(new OnlyField());
+        Console.WriteLine(new Concrete { A = 1, B = 2 });
+        Console.WriteLine(new Concrete { A = 1, B = 2 } == new Concrete { A = 1, B = 2 });
+        Console.WriteLine(((IWithDefault)new WithInterface(1)).N);
+        Console.WriteLine(new SOuter.SInner(1));
+        Console.WriteLine(new Tupled((1, "b"), null));
+        Console.WriteLine(new Tupled((1, "b"), new WithInterface(2)));
+        Console.WriteLine(new Tupled((1, "b"), null) == new Tupled((1, "b"), null));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordsWithUserDefinedOperatorsAndConversions()
+        {
+            // Declaring operators does not displace the record's synthesized `==`, which stays value-wise.
+            await RunTest("""
+using System;
+
+public record Money(decimal Amount, string Currency)
+{
+    public static Money operator +(Money a, Money b) => new Money(a.Amount + b.Amount, a.Currency);
+    public static implicit operator decimal(Money m) => m.Amount;
+    public override string ToString() => Amount + " " + Currency;
+}
+
+public record struct Vec(double X, double Y)
+{
+    public static Vec operator +(Vec a, Vec b) => new Vec(a.X + b.X, a.Y + b.Y);
+    public static bool operator >(Vec a, Vec b) => a.X > b.X;
+    public static bool operator <(Vec a, Vec b) => a.X < b.X;
+}
+
+public record Wrapper<T>(T Value) where T : notnull
+{
+    public Wrapper<TOut> Map<TOut>(Func<T, TOut> f) where TOut : notnull => new Wrapper<TOut>(f(Value));
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var m = new Money(1.5m, "EUR") + new Money(2.5m, "EUR");
+        Console.WriteLine(m);
+        decimal d = m;
+        Console.WriteLine(d);
+        Console.WriteLine(new Vec(1, 2) + new Vec(3, 4));
+        Console.WriteLine(new Vec(3, 0) > new Vec(1, 0));
+        Console.WriteLine(new Wrapper<int>(2).Map(x => "v" + x));
+        Console.WriteLine(new Vec(1, 2) == new Vec(1, 2));
+        Console.WriteLine(new Money(1m, "E") == new Money(1m, "E"));
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public async Task RecordsAcrossAsyncBoundariesAndSwitchGuards()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public record Job(int Id, string Name);
+
+public class Program
+{
+    static async Task<Job> Fetch(int id) => await Task.FromResult(new Job(id, "j" + id));
+
+    public static void Main() { Run().Wait(); }
+
+    static async Task Run()
+    {
+        var j = await Fetch(1);
+        Console.WriteLine(j);
+        var all = await Task.WhenAll(Enumerable.Range(1, 3).Select(Fetch));
+        Console.WriteLine(string.Join(";", all.Select(x => x.Name)));
+        Console.WriteLine(Describe(j));
+        Console.WriteLine(Describe(new Job(99, "big")));
+        // A record built after an await is still the same dictionary key.
+        var d = new Dictionary<Job, int> { [j] = 1 };
+        Console.WriteLine(d[await Fetch(1)]);
+        Console.WriteLine("<<DONE>>");
+    }
+
+    static string Describe(Job j) => j switch
+    {
+        Job(var id, _) when id > 50 => "big " + id,
+        Job(1, var n) => "first " + n,
+        _ => "other"
+    };
+}
+""", waitForOutput: "<<DONE>>");
+        }
+
+        // ---- renamed members ---------------------------------------------------
+
+        [TestMethod]
+        public async Task RenamedRecordMembersKeepTheirCSharpNameInToString()
+        {
+            // [Name] moves the member's JS slot; ToString still prints the C# name (that is what .NET
+            // writes), and the positional store, equality and Deconstruct all have to follow the slot.
+            const string code = """
+using System;
+using Transpose;
+
+public record R([property: Name("jsX")] int X)
+{
+    [Name("jsF")] public int F = 3;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var r = new R(1);
+        Console.WriteLine(r);
+        Console.WriteLine(r.X + " " + r.F);
+        Console.WriteLine(r == new R(1));
+        r.Deconstruct(out var x);
+        Console.WriteLine(x);
+    }
+}
+""";
+            await RunTest(code, overrideRoslynCode: code
+                .Replace("using Transpose;", "")
+                .Replace("""[property: Name("jsX")] """, "")
+                .Replace("""[Name("jsF")] """, ""));
+        }
+
+        // ---- [ObjectLiteral] ---------------------------------------------------
+
+        [TestMethod]
+        public async Task ObjectLiteralRecordCarriesItsPositionalArguments()
+        {
+            // A record is the natural way to declare the shape of a plain JavaScript object, so an
+            // [ObjectLiteral] record's positional arguments have to become the literal's members.
+            // Natively the attribute does nothing (it is [NonScriptable]), so the same program run as
+            // real records must observe the same values — which is what the comparison asserts.
+            const string code = """
+using System;
+using Transpose;
+
+[ObjectLiteral]
+public record Point(int X, int Y);
+
+[ObjectLiteral]
+public record struct SPoint(int X, int Y);
+
+[ObjectLiteral]
+public record Defaults(int X = 7, string S = "d");
+
+[ObjectLiteral]
+public record Named(int A, int B);
+
+public class Program
+{
+    public static void Main()
+    {
+        var p = new Point(1, 2);
+        Console.WriteLine(p.X + "," + p.Y);
+        var s = new SPoint(3, 4);
+        Console.WriteLine(s.X + "," + s.Y);
+        var d = new Defaults();
+        Console.WriteLine(d.X + "," + d.S);
+        var n = new Named(B: 2, A: 1);
+        Console.WriteLine(n.A + "," + n.B);
+        // `with` on a literal copies the plain object.
+        var w = p with { X = 9 };
+        Console.WriteLine(w.X + "," + w.Y);
+    }
+}
+""";
+            await RunTest(code, overrideRoslynCode: code.Replace("using Transpose;", "")
+                                                        .Replace("[ObjectLiteral]", "")
+                                                        .Replace("[ObjectLiteral(ObjectInitializationMode.DefaultValue)]", ""));
+        }
+
+        [TestMethod]
+        public async Task ObjectLiteralRecordInitializationModes()
+        {
+            const string code = """
+using System;
+using Transpose;
+
+[ObjectLiteral(ObjectInitializationMode.DefaultValue)]
+public record All(string Name) { public int Size { get; init; } = 3; public string Extra { get; init; } }
+
+[ObjectLiteral(ObjectInitializationMode.Initializer)]
+public record Only(string Name) { public int Size { get; init; } = 3; public string Extra { get; init; } }
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new All("n");
+        Console.WriteLine(a.Name + "/" + a.Size + "/" + (a.Extra ?? "<null>"));
+        var b = new Only("i") { Extra = "e" };
+        Console.WriteLine(b.Name + "/" + b.Size + "/" + b.Extra);
+    }
+}
+""";
+            await RunTest(code, overrideRoslynCode: code
+                .Replace("using Transpose;", "")
+                .Replace("[ObjectLiteral(ObjectInitializationMode.DefaultValue)]", "")
+                .Replace("[ObjectLiteral(ObjectInitializationMode.Initializer)]", ""));
+        }
+
+        [TestMethod]
+        public void ObjectLiteralRecordEmitsAPlainJsObjectWithoutCompilerMembers()
+        {
+            var result = new RoslynTranslator().Translate("""
+using System;
+using Transpose;
+
+[ObjectLiteral(ObjectInitializationMode.DefaultValue)]
+public record Point(int X, int Y) { public string Tag { get; init; } = "t"; }
+
+public class Program
+{
+    public static void Main() { Console.WriteLine(new Point(1, 2).X); }
+}
+""");
+            Assert.IsTrue(result.Success, "translation should succeed");
+            var js = result.Javascript!;
+            Assert.IsTrue(js.Contains("""{X: 1, Y: 2, Tag: "t"}"""),
+                "an [ObjectLiteral] record should build a plain JS object from its positional arguments\n" + js);
+            // EqualityContract is compiler bookkeeping a record synthesizes; it is not part of the shape
+            // of the JavaScript object the literal describes.
+            Assert.IsFalse(js.Contains("EqualityContract:"),
+                "a record's synthesized EqualityContract must not leak into the literal\n" + js);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -724,9 +724,25 @@ public sealed partial class Emitter
             _w.Write(StaticMemberAccess(prop));
             return;
         }
+        // `base.P` must reach the BASE type's accessor. `base` emits as `this`, so a plain `this.P`
+        // dispatches to the most-derived override — exactly what `base` exists to bypass. Only
+        // properties with real accessors need this; a plain auto-property IS its slot, which the base
+        // and any (necessarily non-virtual) redeclaration cannot both own.
+        if (thisTarget is BaseExpressionSyntax && HasEmittedAccessors(prop))
+        {
+            _w.Write($"TransposeR.baseGet({TypeRef(prop.ContainingType)}.prototype, ");
+            _w.Write(JsString(TransposeNaming.MemberJsName(prop)));
+            _w.Write(", this)");
+            return;
+        }
         EmitReceiver(thisTarget);
         _w.Write(TransposeNaming.MemberJsName(prop));
     }
+
+    /// <summary>True when a property is emitted as a real accessor pair (a <c>props:</c> entry) rather
+    /// than as a plain slot named after it — the same rule <c>EmitInstanceProperties</c> applies.</summary>
+    private static bool HasEmittedAccessors(IPropertySymbol prop)
+        => !prop.IsIndexer && (!IsAutoProperty(prop) || IsFieldBackedProperty(prop));
 
     /// <summary>
     /// Maps a member's generic type-parameter names to the type arguments bound at the call

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -2330,6 +2330,21 @@ public sealed partial class Emitter
             return;
         }
 
+        // `base.P = v` must reach the BASE type's setter for the same reason `base.P` reads through it
+        // (see EmitPropertyAccess): `base` emits as `this`, so a plain `this.P = v` would run the
+        // most-derived override's setter and write the wrong storage.
+        if (left is MemberAccessExpressionSyntax { Expression: BaseExpressionSyntax } baseMember
+            && _model.GetSymbolInfo(left).Symbol is IPropertySymbol { IsStatic: false } baseProp
+            && HasEmittedAccessors(baseProp))
+        {
+            _w.Write($"TransposeR.baseSet({TypeRef(baseProp.ContainingType)}.prototype, ");
+            _w.Write(JsString(TransposeNaming.MemberJsName(baseProp)));
+            _w.Write(", this, ");
+            emitValue();
+            _w.Write(")");
+            return;
+        }
+
         EmitExpression(left);
         _w.Write(" = ");
         emitValue();

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1105,21 +1105,43 @@ public sealed partial class Emitter
             && ObjectLiteralCreateMode(objLit) != 1)
         {
             var mode = ObjectLiteralInitMode(objLit);
+            var ctorValues = RecordLiteralMemberValues(type, ctor, argList);
+            var emitted = new HashSet<string>(StringComparer.Ordinal);
+            var first = true;
             _w.Write("{");
             if (mode is 1 or 2)
             {
-                var first = true;
                 foreach (var prop in type.GetMembers().OfType<IPropertySymbol>()
-                             .Where(p => !p.IsStatic && !p.IsIndexer && !p.IsWriteOnly))
+                             // A record's synthesized non-positional members (EqualityContract) are
+                             // compiler bookkeeping, not part of the literal's shape — emitting them
+                             // put `EqualityContract: null` into every literal built from a record.
+                             .Where(p => !p.IsStatic && !p.IsIndexer && !p.IsWriteOnly
+                                         && (!p.IsImplicitlyDeclared || IsRecordPositionalProperty(p))))
                 {
                     var propInit = PropertyInitializerExpr(prop);
-                    if (mode == 1 && propInit is null) continue; // Initializer: only initialized members
+                    var name = TransposeNaming.MemberJsName(prop);
+                    var ctorValue = ctorValues.FirstOrDefault(v => v.name == name).value;
+                    // Initializer mode emits only members that carry a value: a `= value` initializer
+                    // or — for a record — a positional constructor argument.
+                    if (mode == 1 && propInit is null && ctorValue is null) continue;
                     if (!first) _w.Write(", ");
                     first = false;
-                    _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(prop))}: ");
-                    if (propInit is not null) EmitExpression(propInit);
+                    emitted.Add(name);
+                    _w.Write($"{NameMangler.JsPropertyKey(name)}: ");
+                    if (ctorValue is not null) _w.Write(ctorValue);
+                    else if (propInit is not null) EmitExpression(propInit);
                     else _w.Write(DefaultValueLiteral(prop.Type));
                 }
+            }
+            // Constructor-supplied members the init mode did not enumerate — in Ignore mode (the
+            // default) that is all of them, so `[ObjectLiteral] record Point(int X, int Y)` emits
+            // `new Point(1, 2)` as `{X: 1, Y: 2}`.
+            foreach (var (name, value) in ctorValues)
+            {
+                if (!emitted.Add(name)) continue;
+                if (!first) _w.Write(", ");
+                first = false;
+                _w.Write($"{NameMangler.JsPropertyKey(name)}: {value}");
             }
             _w.Write("}");
             return;
@@ -1202,6 +1224,45 @@ public sealed partial class Emitter
             if (arg.Type?.ToDisplayString() == "Transpose.ObjectCreateMode" && arg.Value is int v)
                 return v;
         return 0;
+    }
+
+    /// <summary>
+    /// The members an <c>[ObjectLiteral]</c> record's constructor call fills in, as JS member name →
+    /// emitted value, in positional-parameter order.
+    ///
+    /// A record's positional parameters ARE its members, so a record is the most natural way to declare
+    /// the shape of a JavaScript object literal — but a plain-create <c>[ObjectLiteral]</c> emits
+    /// <c>{}</c> plus an object initializer, which dropped the constructor arguments and left every such
+    /// literal empty. Only the positional primary constructor names members this way; any other
+    /// overload is ordinary code and keeps the previous behaviour, as does a non-record class (which
+    /// has <c>ObjectCreateMode.Constructor</c> for running its constructor).
+    /// </summary>
+    private List<(string name, string value)> RecordLiteralMemberValues(
+        INamedTypeSymbol type, IMethodSymbol? ctor, ArgumentListSyntax? argList)
+    {
+        var values = new List<(string, string)>();
+        if (!type.IsRecord || ctor is null) return values;
+        if (ctor.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is not RecordDeclarationSyntax) return values;
+
+        var args = argList?.Arguments ?? default;
+        for (var i = 0; i < ctor.Parameters.Length; i++)
+        {
+            var p = ctor.Parameters[i];
+            // No synthesized property means the record body declared its own member of that name, in
+            // which case the parameter initializes nothing on its own.
+            var member = type.GetMembers(p.Name).OfType<IPropertySymbol>().FirstOrDefault(IsRecordPositionalProperty);
+            if (member is null) continue;
+
+            // Named arguments may appear out of order, so match by name first and fall back to position.
+            var arg = args.FirstOrDefault(a => a.NameColon?.Name.Identifier.Text == p.Name)
+                      ?? (i < args.Count && args[i].NameColon is null ? args[i] : null);
+
+            var value = arg is not null ? Capture(() => EmitExpressionConverted(arg.Expression, p.Type))
+                : p.HasExplicitDefaultValue ? ConstantLiteral(p.ExplicitDefaultValue, p.Type)
+                : DefaultValueLiteral(p.Type);
+            values.Add((TransposeNaming.MemberJsName(member), value));
+        }
+        return values;
     }
 
     /// <summary>The `= value` initializer expression of an auto-property, or null.</summary>
@@ -2022,6 +2083,16 @@ public sealed partial class Emitter
             _w.Write($"System.Enum.toString({TypeRef(type)}, ");
             EmitExpression(operand);
             _w.Write(")");
+        }
+        // A Nullable<char>/Nullable<TEnum> needs the same rendering as its underlying type (`"" +
+        // (Color?)Color.Red` is "Red", not "0"), but the value may be null, so the conversion cannot be
+        // the bare char/enum form above. toStrT tolerates null and dispatches on the runtime type.
+        else if (NullableUnderlyingType(type) is { } nullableUnderlying
+                 && (IsCharType(nullableUnderlying) || nullableUnderlying.TypeKind == TypeKind.Enum))
+        {
+            _w.Write("TransposeR.toStrT(");
+            EmitExpression(operand);
+            _w.Write($", {TypeRef(nullableUnderlying)})");
         }
         // A type parameter only bound at runtime: same reason as the char/enum branches above, but the
         // choice between them can only be made once the threaded type argument is known.
@@ -3279,6 +3350,31 @@ public sealed partial class Emitter
 
     private static bool IsStringType(ITypeSymbol? type) => type?.SpecialType == SpecialType.System_String;
     private static bool IsCharType(ITypeSymbol? type) => type?.SpecialType == SpecialType.System_Char;
+
+    /// <summary>The <c>T</c> of a <c>Nullable&lt;T&gt;</c>, or null for any other type.</summary>
+    private static ITypeSymbol? NullableUnderlyingType(ITypeSymbol? type)
+        => type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T, TypeArguments.Length: 1 } n
+            ? n.TypeArguments[0]
+            : null;
+
+    /// <summary>
+    /// The JS expression that renders an <b>already-written</b> JS value as a .NET string, using the
+    /// same rules as <see cref="EmitConcatOperand"/>: null renders as <c>""</c>, a char as its
+    /// character (chars are code points at runtime), an enum as its member name, and a type parameter
+    /// through the converter for the type argument threaded at runtime. Callers that hold a JS
+    /// expression rather than the C# syntax behind it — a record's synthesized PrintMembers reads
+    /// <c>this.X</c>, which has no ExpressionSyntax to re-walk — go through this instead.
+    /// </summary>
+    private string ToStringJs(string js, ITypeSymbol? type)
+    {
+        if (IsStringType(type)) return $"({js} ?? \"\")";
+        if (IsCharType(type)) return $"TransposeR.chr({js})";
+        if (type is { TypeKind: TypeKind.Enum }) return $"System.Enum.toString({TypeRef(type)}, {js})";
+        if (NullableUnderlyingType(type) is { } u && (IsCharType(u) || u.TypeKind == TypeKind.Enum))
+            return $"TransposeR.toStrT({js}, {TypeRef(u)})";
+        if (type is ITypeParameterSymbol tp && TypeParamInScope(tp)) return $"TransposeR.toStrT({js}, {TypeRef(type)})";
+        return $"TransposeR.toStr({js})";
+    }
 
     private static bool IsIntegerType(ITypeSymbol? type)
     {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -325,13 +325,17 @@ public sealed partial class Emitter
         {
             if (!hasExplicit)
             {
-                // Synthesized default constructor.
+                // Synthesized default constructor. The field initializers run BEFORE the base
+                // constructor, which is C#'s order for every derived type (and what a declared
+                // constructor already does, via EmitConstructorChain) — running them after meant a
+                // base constructor observed this type's slots at their defaults, and any side effect
+                // in an initializer was sequenced after the base's.
                 _w.Write("ctor: function () ");
                 _w.Block(() =>
                 {
                     _w.WriteLine("this.$initialize();");
-                    EmitImplicitBaseCall(type);
                     EmitInstanceFieldInitializers(type);
+                    EmitImplicitBaseCall(type);
                 });
                 _w.WriteLine();
                 return;
@@ -371,14 +375,16 @@ public sealed partial class Emitter
                     _w.WriteLine("this.$initialize();");
                     if (isPrimary)
                     {
-                        // Primary constructor: chain to base, store captured params, run field
-                        // inits. Inside this body, param refs use the raw JS parameter name.
+                        // Primary constructor: run the field initializers, chain to base, then store
+                        // the captured params — the same order a record's primary constructor uses,
+                        // and C#'s (the derived initializers precede the base constructor). Inside
+                        // this body, param refs use the raw JS parameter name.
                         _inPrimaryCtorBody = true;
+                        EmitInstanceFieldInitializers(type);
                         EmitPrimaryBaseCall(type, syntax as TypeDeclarationSyntax);
                         var captured = CapturedPrimaryParamNames(type);
                         foreach (var p in ctor.Parameters.Where(p => captured.Contains(p.Name)))
                             _w.WriteLine($"this.{NameMangler.JsIdentifier(p.Name)} = {NameMangler.JsIdentifier(p.Name)};");
-                        EmitInstanceFieldInitializers(type);
                         _inPrimaryCtorBody = false;
                     }
                     else
@@ -483,7 +489,7 @@ public sealed partial class Emitter
             ITypeSymbol? slotType = m switch
             {
                 IFieldSymbol f when !f.IsConst && f.AssociatedSymbol is null => f.Type,
-                IPropertySymbol p when IsAutoProperty(p) => p.Type,
+                IPropertySymbol p when IsAutoProperty(p) || IsFieldBackedProperty(p) => p.Type,
                 _ => null,
             };
             if (slotType is null) continue;
@@ -495,9 +501,15 @@ public sealed partial class Emitter
                 _ => null,
             };
 
+            // A field-backed property's initializer writes its BACKING slot, never `this.P` — going
+            // through the setter would dispatch to a derived override and initialize the wrong storage.
+            var slot = m is IPropertySymbol fbp && IsFieldBackedProperty(fbp)
+                ? PropertyBackingName(fbp)
+                : TransposeNaming.MemberJsName(m);
+
             if (init is not null && runInitializers)
             {
-                _w.Write($"this.{TransposeNaming.MemberJsName(m)} = ");
+                _w.Write($"this.{slot} = ");
                 EmitExpressionConverted(init, slotType);
                 _w.WriteLine(";");
             }
@@ -508,7 +520,7 @@ public sealed partial class Emitter
                 // (order-independence at define time), so assign the real default here in the ctor,
                 // when the struct type is defined — otherwise e.g. an uninitialized DateTime is null
                 // and `.Equals`/`.UtcDateTime` throws (reading getTime of null).
-                _w.WriteLine($"this.{TransposeNaming.MemberJsName(m)} = Transpose.getDefaultValue({TypeRef(slotType)});");
+                _w.WriteLine($"this.{slot} = Transpose.getDefaultValue({TypeRef(slotType)});");
             }
         }
     }
@@ -796,7 +808,11 @@ public sealed partial class Emitter
     private void EmitInstanceProperties(INamedTypeSymbol type)
     {
         var props = type.GetMembers().OfType<IPropertySymbol>()
-            .Where(p => !p.IsStatic && !p.IsAbstract && !p.IsIndexer && !IsAutoProperty(p)
+            // A field-backed property needs real accessors even when its accessors are auto — that is
+            // what makes a virtual auto-property dispatch to the most-derived declaration instead of
+            // every level sharing one slot.
+            .Where(p => !p.IsStatic && !p.IsAbstract && !p.IsIndexer
+                        && (!IsAutoProperty(p) || IsFieldBackedProperty(p))
                         && !p.IsImplicitlyDeclared
                         && p.DeclaringSyntaxReferences.Length > 0
                         && p.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is PropertyDeclarationSyntax)
@@ -835,8 +851,16 @@ public sealed partial class Emitter
     }
 
     /// <summary>
-    /// A property that needs a compiler-synthesized backing field: it mixes an auto
-    /// accessor with a bodied one, or an accessor uses the C# 14 `field` keyword.
+    /// A property that needs a compiler-synthesized backing field rather than being emitted AS its
+    /// slot: it mixes an auto accessor with a bodied one, an accessor uses the C# 14 `field` keyword,
+    /// or it is a <b>virtual or overriding</b> auto-property.
+    ///
+    /// The last case is what .NET does: each declaration of a virtual auto-property has its own
+    /// backing field, and the base's is reachable only through <c>base.P</c> — every other read goes
+    /// through the virtual getter. Emitting both as one plain slot named after the property collapsed
+    /// them into a single storage location, so with an initializer at each level the base
+    /// constructor's write landed on the derived value (`new D().P` read 1, not 2). Real accessors over
+    /// per-declaration slots restore both the storage and the dispatch.
     /// </summary>
     internal static bool IsFieldBackedProperty(IPropertySymbol p)
     {
@@ -846,10 +870,16 @@ public sealed partial class Emitter
         var anyAuto = accessors.Accessors.Any(a => a.Body is null && a.ExpressionBody is null);
         var anyBodied = accessors.Accessors.Any(a => a.Body is not null || a.ExpressionBody is not null);
         if (anyAuto && anyBodied) return true;
+        if (anyAuto && !anyBodied && (p.IsVirtual || p.IsOverride)) return true;
         return accessors.Accessors.Any(a => a.DescendantNodes().Any(n => n.IsKind(SyntaxKind.FieldExpression)));
     }
 
-    internal static string PropertyBackingName(IPropertySymbol p) => "$" + TransposeNaming.MemberJsName(p);
+    /// <summary>The slot a field-backed property stores into. An OVERRIDE carries its declaring type,
+    /// because .NET gives it storage of its own: sharing the base's slot is exactly what made the base
+    /// constructor's initializer overwrite the override's value.</summary>
+    internal static string PropertyBackingName(IPropertySymbol p)
+        => "$" + TransposeNaming.MemberJsName(p)
+           + (p.IsOverride ? "$" + TransposeNaming.MangledTypeName(p.ContainingType) : "");
 
     private void EmitAccessorBody(IMethodSymbol accessor, bool isGetter)
     {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -351,7 +351,7 @@ public sealed partial class Emitter
                 _w.Block(() =>
                 {
                     _w.WriteLine("this.$initialize();");
-                    EmitInstanceFieldInitializers(type);
+                    EmitInstanceFieldInitializers(type, runInitializers: false);
                 });
                 _w.WriteLine(all.Count > 0 ? "," : "");
             }
@@ -468,7 +468,14 @@ public sealed partial class Emitter
         }
     }
 
-    private void EmitInstanceFieldInitializers(INamedTypeSymbol type)
+    /// <param name="runInitializers">
+    /// False for a struct's <i>implicit</i> parameterless constructor, which zeroes the value rather
+    /// than running the declared <c>= value</c> initializers: C# only runs those from a constructor the
+    /// type declares, so <c>new S().Y</c> is 0 for <c>struct S { public int Y = 1; … }</c>. Running them
+    /// here reported 1 instead. The struct-typed slots are still defaulted either way — the field slot
+    /// is emitted as <c>null</c> for order-independence, so <c>default(T)</c> has to be assigned here.
+    /// </param>
+    private void EmitInstanceFieldInitializers(INamedTypeSymbol type, bool runInitializers = true)
     {
         foreach (var m in type.GetMembers())
         {
@@ -488,7 +495,7 @@ public sealed partial class Emitter
                 _ => null,
             };
 
-            if (init is not null)
+            if (init is not null && runInitializers)
             {
                 _w.Write($"this.{TransposeNaming.MemberJsName(m)} = ");
                 EmitExpressionConverted(init, slotType);

--- a/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
@@ -501,7 +501,14 @@ public sealed partial class Emitter
             _w.WriteLine($"let {holders[i]} = {{ v: null }};");
         }
 
-        _w.WriteLine($"{temp}.Deconstruct({string.Join(", ", holders)});");
+        // Resolve the Deconstruct overload being bound and use ITS JS name: a record synthesizes a
+        // Deconstruct for its positional parameters, so a record that also declares one by hand has two
+        // overloads, and the overload numbering puts them on different slots (Deconstruct /
+        // Deconstruct$1). Hardcoding "Deconstruct" here called whichever one landed on the bare slot.
+        var deconstructName = DeconstructMethod(valueType, targets.Count) is { } dm
+            ? TransposeNaming.MemberJsName(dm)
+            : "Deconstruct";
+        _w.WriteLine($"{temp}.{deconstructName}({string.Join(", ", holders)});");
 
         for (var i = 0; i < targets.Count; i++)
         {
@@ -541,13 +548,17 @@ public sealed partial class Emitter
         if (valueType is INamedTypeSymbol { IsTupleType: true } tuple && tuple.TupleElements.Length == count)
             return tuple.TupleElements.Select(e => (ITypeSymbol?)e.Type).ToArray();
 
-        var deconstruct = valueType?.GetMembers("Deconstruct").OfType<IMethodSymbol>()
-            .FirstOrDefault(m => m.Parameters.Length == count && m.Parameters.All(p => p.RefKind == RefKind.Out));
-
-        if (deconstruct is not null) return deconstruct.Parameters.Select(p => (ITypeSymbol?)p.Type).ToArray();
+        if (DeconstructMethod(valueType, count) is { } deconstruct)
+            return deconstruct.Parameters.Select(p => (ITypeSymbol?)p.Type).ToArray();
 
         return new ITypeSymbol?[count];
     }
+
+    /// <summary>The <c>Deconstruct(out …)</c> overload of <paramref name="valueType"/> that binds
+    /// <paramref name="count"/> positions, or null.</summary>
+    private static IMethodSymbol? DeconstructMethod(ITypeSymbol? valueType, int count)
+        => valueType?.GetMembers("Deconstruct").OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.Parameters.Length == count && m.Parameters.All(p => p.RefKind == RefKind.Out));
 
     private IEnumerable<DeconstructionTarget> CollectDeconstructionTargets(ExpressionSyntax left)
     {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -58,7 +58,15 @@ public sealed partial class Emitter
     }
 
     /// <summary>Full JS name a type is registered / referenced under.</summary>
+    /// <summary>
+    /// The JavaScript expression that names a type at runtime. A named type resolves through
+    /// <see cref="UnshadowedTypeRef"/>, so a local binding of the same name cannot intercept it; a type
+    /// PARAMETER never does, because it IS a local binding (the generic define's own parameter).
+    /// </summary>
     private string TypeRef(ITypeSymbol type)
+        => type is ITypeParameterSymbol ? TypeRefCore(type) : UnshadowedTypeRef(TypeRefCore(type));
+
+    private string TypeRefCore(ITypeSymbol type)
     {
         // `dynamic` has no runtime type of its own — it is System.Object at runtime.
         if (type.TypeKind == TypeKind.Dynamic) return "System.Object";
@@ -343,9 +351,94 @@ public sealed partial class Emitter
     private void EmitClassLike(INamedTypeSymbol type)
     {
         var prevEmitType = _currentEmitType;
+        var prevShadowing = _shadowingNames;
         _currentEmitType = type;
+        _shadowingNames = ShadowingIdentifiers(type);
         try { EmitClassLikeCore(type); }
-        finally { _currentEmitType = prevEmitType; }
+        finally { _currentEmitType = prevEmitType; _shadowingNames = prevShadowing; }
+    }
+
+    /// <summary>
+    /// Every JS identifier this type's code introduces as a local binding — parameters (of methods,
+    /// constructors, lambdas, local functions and a record header), locals, <c>out var</c>/pattern
+    /// designations, <c>foreach</c> and <c>catch</c> variables, and query range variables.
+    ///
+    /// A type is referenced by its bare emitted name, so any of these shadows a same-named type for
+    /// the whole of the function it is declared in: <c>record RD(int A, int B) : RB(A)</c> whose base
+    /// is named <c>B</c> emitted <c>B.ctor.call(this, A)</c> inside <c>function (A, B)</c> and read
+    /// the int. <see cref="TypeRef"/> consults this set and routes such a reference through
+    /// <c>Transpose.global</c>, which nothing can shadow.
+    ///
+    /// Deliberately collected per TYPE rather than per function: a name that only shadows inside a
+    /// sibling function is then qualified as well, which is merely redundant, whereas tracking exact
+    /// scopes would have to be threaded through every body-emitting path to stay correct.
+    /// </summary>
+    private static HashSet<string> ShadowingIdentifiers(INamedTypeSymbol type)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var reference in type.DeclaringSyntaxReferences)
+        {
+            var declaration = reference.GetSyntax();
+            foreach (var node in declaration.DescendantNodesAndSelf())
+            {
+                switch (node)
+                {
+                    case ParameterSyntax p:
+                        Add(p.Identifier.Text);
+                        break;
+                    // A field's declarator is `this.X`, never a bare identifier — only locals shadow.
+                    case VariableDeclaratorSyntax v when v.Parent?.Parent is LocalDeclarationStatementSyntax
+                                                             or UsingStatementSyntax or ForStatementSyntax
+                                                             or FixedStatementSyntax:
+                        Add(v.Identifier.Text);
+                        break;
+                    case SingleVariableDesignationSyntax d:
+                        Add(d.Identifier.Text);
+                        break;
+                    case ForEachStatementSyntax f:
+                        Add(f.Identifier.Text);
+                        break;
+                    case CatchDeclarationSyntax c:
+                        Add(c.Identifier.Text);
+                        break;
+                    case FromClauseSyntax from:
+                        Add(from.Identifier.Text);
+                        break;
+                    case LetClauseSyntax let:
+                        Add(let.Identifier.Text);
+                        break;
+                    case JoinClauseSyntax join:
+                        Add(join.Identifier.Text);
+                        break;
+                    case JoinIntoClauseSyntax into:
+                        Add(into.Identifier.Text);
+                        break;
+                    case QueryContinuationSyntax cont:
+                        Add(cont.Identifier.Text);
+                        break;
+                    case LocalFunctionStatementSyntax fn:
+                        Add(fn.Identifier.Text);
+                        break;
+                }
+            }
+        }
+        return names;
+
+        void Add(string name)
+        {
+            if (name.Length > 0) names.Add(NameMangler.JsIdentifier(name));
+        }
+    }
+
+    /// <summary>Wraps a type reference so a local binding of the same name cannot shadow it. The
+    /// runtime registers every global-scope type on <c>Transpose.global</c> (the real global object),
+    /// so this reaches the same value by a path no local can intercept.</summary>
+    private string UnshadowedTypeRef(string reference)
+    {
+        if (_shadowingNames is null || _shadowingNames.Count == 0) return reference;
+        var dot = reference.IndexOfAny(new[] { '.', '(' });
+        var head = dot < 0 ? reference : reference.Substring(0, dot);
+        return _shadowingNames.Contains(head) ? "Transpose.global." + reference : reference;
     }
 
     private void EmitClassLikeCore(INamedTypeSymbol type)
@@ -486,13 +579,16 @@ public sealed partial class Emitter
             if (m.IsStatic) continue;
             if (m is IFieldSymbol f && !f.IsConst && f.AssociatedSymbol is null && f.CanBeReferencedByName)
                 yield return (TransposeNaming.MemberJsName(f), FieldDefaultLiteral(f.Type), f);
+            // Checked before the plain auto-property slot below: a virtual/overriding auto-property is
+            // field-backed (it needs real accessors so it dispatches, over storage of its own), so it
+            // must take the backing slot rather than the property's own name.
+            else if (m is IPropertySymbol fbp && IsFieldBackedProperty(fbp))
+                yield return (PropertyBackingName(fbp), FieldDefaultLiteral(fbp.Type), fbp);
             else if (m is IPropertySymbol p && !p.IsAbstract && !p.IsIndexer
                      && (IsAutoProperty(p) || IsRecordPositionalProperty(p)))
                 yield return (TransposeNaming.MemberJsName(p), FieldDefaultLiteral(p.Type), p);
             else if (m is IEventSymbol ev && IsFieldLikeEvent(ev))
                 yield return (TransposeNaming.MemberJsName(ev), "null", ev);
-            else if (m is IPropertySymbol fbp && IsFieldBackedProperty(fbp))
-                yield return (PropertyBackingName(fbp), FieldDefaultLiteral(fbp.Type), fbp);
         }
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.ValueTypes.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.ValueTypes.cs
@@ -30,27 +30,96 @@ public sealed partial class Emitter
            && (p.IsImplicitlyDeclared
                || p.DeclaringSyntaxReferences.Any(r => r.GetSyntax() is ParameterSyntax));
 
-    /// <summary>All instance properties that participate in a record's value equality / ToString,
-    /// ordered base-record members first — matching C#'s synthesized PrintMembers / Equals /
-    /// GetHashCode, which chain to the base record before the derived members. A derived record
-    /// that only listed its own members would drop the inherited ones from ToString/equality.</summary>
-    private List<string> RecordValuePropNames(INamedTypeSymbol type)
+    /// <summary>The record inheritance chain ending at <paramref name="type"/>, base record first.
+    /// C#'s synthesized PrintMembers / Equals / GetHashCode chain to the base record before handling
+    /// the derived members, so a derived record that only listed its own members would drop the
+    /// inherited ones from ToString/equality.</summary>
+    private static List<INamedTypeSymbol> RecordChain(INamedTypeSymbol type)
     {
         var chain = new List<INamedTypeSymbol>();
         for (var t = type; t is not null && t.IsRecord; t = t.BaseType)
             chain.Add(t);
         chain.Reverse(); // base → derived
-
-        var names = new List<string>();
-        foreach (var t in chain)
-            foreach (var p in t.GetMembers().OfType<IPropertySymbol>()
-                         .Where(p => !p.IsStatic && p.GetMethod is not null && !p.IsIndexer && p.Name != "EqualityContract"))
-            {
-                var n = TransposeNaming.MemberJsName(p);
-                if (!names.Contains(n)) names.Add(n);
-            }
-        return names;
+        return chain;
     }
+
+    /// <summary>
+    /// The members one record's synthesized <c>PrintMembers</c> prints: its own non-static
+    /// <b>public</b> fields and <b>public readable</b> properties, in declaration order. Note this is
+    /// a different set from the one equality uses (<see cref="RecordEqualitySlots"/>): ToString prints
+    /// members — including computed properties, which have no storage — while Equals compares fields,
+    /// including private ones. A non-public member is printed by neither, and <c>EqualityContract</c>
+    /// (protected) is excluded by the accessibility test.
+    /// </summary>
+    /// <remarks>The printed LABEL is the C# member name (that is what .NET writes), while the value is
+    /// read through the member's JS name — the two differ for a <c>[Name]</c>-renamed member or one that
+    /// took a hiding slot.</remarks>
+    private static List<(string label, string js, ITypeSymbol type)> RecordPrintableMembers(INamedTypeSymbol type)
+    {
+        var members = new List<(string, string, ITypeSymbol)>();
+        foreach (var m in type.GetMembers())
+        {
+            if (m.IsStatic || m.DeclaredAccessibility != Accessibility.Public) continue;
+            // An OVERRIDE is not a member of this record's own set: the base record's PrintMembers
+            // already prints it, and virtual dispatch reads the override's value there — printing it
+            // again here gave `OverrideProp2 { A = 1, V = 2, V = 2 }`. A `new` member is different: C#
+            // prints both the hidden and the hiding one, which the base/derived split does naturally.
+            if (m.IsOverride) continue;
+            switch (m)
+            {
+                // A backing field (AssociatedSymbol) is private, so it never reaches here; the
+                // property it backs is printed instead.
+                case IFieldSymbol { IsConst: false, AssociatedSymbol: null } f when f.CanBeReferencedByName:
+                    members.Add((f.Name, TransposeNaming.MemberJsName(f), f.Type));
+                    break;
+                case IPropertySymbol { IsIndexer: false, IsAbstract: false } p when p.GetMethod is not null:
+                    members.Add((p.Name, TransposeNaming.MemberJsName(p), p.Type));
+                    break;
+            }
+        }
+        return members;
+    }
+
+    /// <summary>
+    /// The instance slots a record's synthesized <c>Equals</c>/<c>GetHashCode</c> compare, base record
+    /// first. C# compares a record's <b>fields</b> — every instance field, public or private, including
+    /// the compiler-generated backing field of each auto-property — which is exactly the set of slots
+    /// the emitter lays down. Comparing the <i>properties</i> instead diverged twice over: a public
+    /// field of a record body was ignored, and a computed (storage-less) property was compared, so
+    /// <c>record Node(int V) { public int[] Cache => new[] { V }; }</c> reported two equal values as
+    /// unequal because each read allocated a fresh array.
+    /// </summary>
+    private List<(string name, ITypeSymbol? type)> RecordEqualitySlots(INamedTypeSymbol type)
+    {
+        var slots = new List<(string, ITypeSymbol?)>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var t in RecordChain(type))
+            foreach (var (name, _, symbol) in InstanceFieldSlots(t))
+                if (seen.Add(name))
+                    slots.Add((name, symbol switch
+                    {
+                        IFieldSymbol f => f.Type,
+                        IPropertySymbol p => p.Type,
+                        IEventSymbol e => e.Type,
+                        _ => null,
+                    }));
+        return slots;
+    }
+
+    /// <summary>The record member C# synthesizes for this signature, or null when the record declares
+    /// its own (which the ordinary method walk emits instead, so nothing must be synthesized for it).
+    /// Recognised by <see cref="ISymbol.IsImplicitlyDeclared"/> — true for every member the record
+    /// machinery adds, and false as soon as the user writes one.</summary>
+    private static IMethodSymbol? SynthesizedRecordMethod(
+        INamedTypeSymbol type, string name, Func<IMethodSymbol, bool> signature)
+        => type.GetMembers(name).OfType<IMethodSymbol>()
+            .FirstOrDefault(m => !m.IsStatic && m.IsImplicitlyDeclared && signature(m));
+
+    /// <summary>The record's <c>PrintMembers(StringBuilder)</c> signature — not just any one-parameter
+    /// method of that name, which an unrelated overload could also be.</summary>
+    private static bool IsRecordPrintMembers(IMethodSymbol m)
+        => m.Parameters is [{ Type: { Name: "StringBuilder" } t }]
+           && t.ContainingNamespace?.ToDisplayString() == "System.Text";
 
     /// <summary>The declared type behind each emitted instance slot, keyed by its JS name.</summary>
     private static Dictionary<string, ITypeSymbol> SlotTypesByName(
@@ -126,13 +195,12 @@ public sealed partial class Emitter
     /// <summary>Appends synthesized value-type methods (struct $clone/equals, record members).</summary>
     private void AddValueTypeMethodEntries(INamedTypeSymbol type, List<Action> entries)
     {
-        // Everything a value-copy must carry: backing fields/auto-props plus (for record
-        // structs) the positional value properties, which are synthesized without slots.
+        // Everything a value-copy must carry: the type's real slots (fields, auto-properties and a
+        // record's positional properties, which InstanceFieldSlots already covers). Only slots — a
+        // get-only computed property is not storage, and assigning one in $clone threw "Cannot set
+        // property … which has only a getter" for `readonly record struct RS(int X) { int D => X*2; }`.
         var slots = InstanceFieldSlots(type).ToList();
         var fields = slots.Select(f => f.name).ToList();
-        if (type.IsRecord)
-            foreach (var p in RecordValuePropNames(type))
-                if (!fields.Contains(p)) fields.Add(p);
 
         if (type.TypeKind == TypeKind.Struct)
         {
@@ -191,66 +259,161 @@ public sealed partial class Emitter
             }
         }
 
-        if (type.IsRecord)
+        if (type.IsRecord) AddRecordMethodEntries(type, entries);
+    }
+
+    /// <summary>
+    /// Appends the members C# synthesizes for a record: <c>PrintMembers</c>/<c>ToString</c>,
+    /// <c>Equals(object)</c>/<c>Equals(T)</c>/<c>GetHashCode</c> and <c>Deconstruct</c>.
+    ///
+    /// Each one is emitted only when the record does not declare it itself — a hand-written
+    /// <c>ToString</c>, <c>PrintMembers</c>, <c>Equals</c> or <c>Deconstruct</c> is emitted by the
+    /// ordinary member walk, and synthesizing a second entry under the same key made JavaScript keep
+    /// whichever came last (so the user's override silently never ran). Every key comes from
+    /// <see cref="TransposeNaming.MemberJsName"/> on the synthesized symbol itself, which also keeps a
+    /// synthesized member and a same-named user overload on distinct, correctly-numbered slots (a
+    /// record with its own two-out-parameter <c>Deconstruct</c> used to collide with the synthesized
+    /// one-parameter form).
+    /// </summary>
+    private void AddRecordMethodEntries(INamedTypeSymbol type, List<Action> entries)
+    {
+        // ToString() is `"Name { " + PrintMembers(sb) + " }"`, routed through the real PrintMembers so
+        // a hand-written or inherited override participates — matching C#, where ToString calls the
+        // virtual PrintMembers and a derived record's PrintMembers chains to its base.
+        var printMembers = SynthesizedRecordMethod(type, "PrintMembers", IsRecordPrintMembers);
+        if (printMembers is not null)
         {
-            var props = RecordValuePropNames(type);
+            var printName = TransposeNaming.MemberJsName(printMembers);
+            var printable = RecordPrintableMembers(type);
+            // A derived record prints the base record's members first, via the base's PrintMembers.
+            var basePrint = type.BaseType is { IsRecord: true } br ? $"{TypeRef(br)}.prototype.{printName}" : null;
             entries.Add(() =>
             {
-                _w.Write("toString: function () ");
+                _w.Write($"{NameMangler.JsPropertyKey(printName)}: function (builder) ");
                 _w.Block(() =>
                 {
-                    if (props.Count == 0) { _w.WriteLine($"return \"{type.Name} {{ }}\";"); return; }
-                    var parts = string.Join(" + \", \" + ", props.Select(p => $"\"{p} = \" + TransposeR.toStr(this.{p})"));
-                    _w.WriteLine($"return \"{type.Name} {{ \" + {parts} + \" }}\";");
+                    if (basePrint is not null)
+                    {
+                        // The base returns whether it printed anything; only then is a separator due.
+                        _w.WriteLine($"var $printed = {basePrint}.call(this, builder);");
+                        if (printable.Count == 0) { _w.WriteLine("return $printed;"); return; }
+                        _w.WriteLine("if ($printed) { builder.append(\", \"); }");
+                    }
+                    else if (printable.Count == 0)
+                    {
+                        _w.WriteLine("return false;");
+                        return;
+                    }
+                    for (var i = 0; i < printable.Count; i++)
+                    {
+                        if (i > 0) _w.WriteLine("builder.append(\", \");");
+                        var (label, js, memberType) = printable[i];
+                        _w.WriteLine($"builder.append(\"{label} = \");");
+                        _w.WriteLine($"builder.append({ToStringJs($"this.{js}", memberType)});");
+                    }
+                    _w.WriteLine("return true;");
                 });
             });
-            // The value-equality body, shared by the object override `equals(obj)` and the
-            // strongly-typed IEquatable<T> `equalsT(other)` a record synthesizes. Both are needed:
-            // `a.Equals(b)` binds to IEquatable<T>.Equals → `equalsT`, while ==/collections go
-            // through `equals`. Without `equalsT` a direct `.Equals(record)` call threw
-            // "equalsT is not a function".
-            void EmitRecordEqualsBody(string param)
-            {
-                _w.WriteLine($"if ({param} == null || {param}.constructor !== this.constructor) {{ return false; }}");
-                _w.Write("return ");
-                _w.Write(props.Count == 0 ? "true" : string.Join(" && ", props.Select(p => $"TransposeR.equals(this.{p}, {param}.{p})")));
-                _w.WriteLine(";");
-            }
+        }
+
+        var toString = SynthesizedRecordMethod(type, "ToString", m => m.Parameters.Length == 0);
+        if (toString is not null)
+        {
+            // The PrintMembers ToString calls — the synthesized one above, or the record's own.
+            var printName = TransposeNaming.MemberJsName(
+                type.GetMembers("PrintMembers").OfType<IMethodSymbol>().First(m => !m.IsStatic && IsRecordPrintMembers(m)));
             entries.Add(() =>
             {
-                _w.Write("equals: function (o) ");
-                _w.Block(() => EmitRecordEqualsBody("o"));
+                _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(toString))}: function () ");
+                _w.Block(() =>
+                {
+                    _w.WriteLine("var $sb = new System.Text.StringBuilder();");
+                    _w.WriteLine($"$sb.append(\"{type.Name}\");");
+                    _w.WriteLine("$sb.append(\" { \");");
+                    _w.WriteLine($"if (this.{printName}($sb)) {{ $sb.append(\" \"); }}");
+                    _w.WriteLine("$sb.append(\"}\");");
+                    _w.WriteLine("return $sb.toString();");
+                });
             });
+        }
+
+        // The value-equality body, shared by the object override `equals(obj)` and the strongly-typed
+        // IEquatable<T> `equalsT(other)` a record synthesizes. Both are needed: `a.Equals(b)` binds to
+        // IEquatable<T>.Equals → `equalsT`, while ==/collections go through `equals`. Without
+        // `equalsT` a direct `.Equals(record)` call threw "equalsT is not a function".
+        var slots = RecordEqualitySlots(type);
+        void EmitRecordEqualsBody(string param)
+        {
+            _w.WriteLine($"if ({param} == null || {param}.constructor !== this.constructor) {{ return false; }}");
+            _w.Write("return ");
+            _w.Write(slots.Count == 0
+                ? "true"
+                : string.Join(" && ", slots.Select(s => $"TransposeR.equals(this.{s.name}, {param}.{s.name})")));
+            _w.WriteLine(";");
+        }
+
+        // The strongly-typed Equals a record gets from IEquatable<T> — synthesized, or hand-written when
+        // the record defines its own value equality. A derived record also carries a sealed override of
+        // the base record's Equals(Base); both land on the same JS slot, so prefer the one whose
+        // parameter is this very type to keep the choice deterministic.
+        var typedEquals = type.GetMembers("Equals").OfType<IMethodSymbol>()
+            .Where(m => m is { IsStatic: false, Parameters.Length: 1 }
+                        && m.Parameters[0].Type.SpecialType != SpecialType.System_Object)
+            .OrderByDescending(m => SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, type))
+            .FirstOrDefault();
+
+        var equalsObj = SynthesizedRecordMethod(type, "Equals",
+            m => m.Parameters is [{ Type.SpecialType: SpecialType.System_Object }]);
+        if (equalsObj is not null)
             entries.Add(() =>
             {
-                _w.Write("equalsT: function (other) ");
+                _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(equalsObj))}: function (o) ");
+                _w.Block(() =>
+                {
+                    // C# synthesizes `Equals(object obj) => Equals(obj as T)`, so the object override
+                    // must DELEGATE to the typed one rather than repeat the field-wise comparison: a
+                    // record that writes its own Equals(T) governs ==, HashSet/Dictionary lookups AND
+                    // `Equals((object)x)` alike, and a duplicated body ignored it for the last of those.
+                    if (typedEquals is null) { EmitRecordEqualsBody("o"); return; }
+                    _w.WriteLine("if (o == null || o.constructor !== this.constructor) { return false; }");
+                    _w.WriteLine($"return this.{TransposeNaming.MemberJsName(typedEquals)}(o);");
+                });
+            });
+
+        if (typedEquals is { IsImplicitlyDeclared: true })
+            entries.Add(() =>
+            {
+                _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(typedEquals))}: function (other) ");
                 _w.Block(() => EmitRecordEqualsBody("other"));
             });
+
+        var getHashCode = SynthesizedRecordMethod(type, "GetHashCode", m => m.Parameters.Length == 0);
+        if (getHashCode is not null)
             entries.Add(() =>
             {
-                _w.Write("getHashCode: function () ");
+                _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(getHashCode))}: function () ");
                 _w.Block(() =>
                 {
                     _w.WriteLine("var h = 17;");
-                    foreach (var p in props) _w.WriteLine($"h = (h * 31 + TransposeR.hash(this.{p})) | 0;");
+                    foreach (var s in slots) _w.WriteLine($"h = (h * 31 + TransposeR.hash(this.{s.name})) | 0;");
                     _w.WriteLine("return h;");
                 });
             });
 
-            var positional = RecordPositionalProps(type).Select(p => TransposeNaming.MemberJsName(p)).ToList();
-            if (positional.Count > 0)
+        var positional = RecordPositionalProps(type).Select(p => TransposeNaming.MemberJsName(p)).ToList();
+        var deconstruct = SynthesizedRecordMethod(type, "Deconstruct", m => m.Parameters.Length == positional.Count);
+        if (positional.Count > 0 && deconstruct is not null)
+        {
+            entries.Add(() =>
             {
-                entries.Add(() =>
+                var holders = positional.Select((_, i) => "$p" + i).ToList();
+                _w.Write($"{NameMangler.JsPropertyKey(TransposeNaming.MemberJsName(deconstruct))}: function ({string.Join(", ", holders)}) ");
+                _w.Block(() =>
                 {
-                    var holders = positional.Select((_, i) => "$p" + i).ToList();
-                    _w.Write($"Deconstruct: function ({string.Join(", ", holders)}) ");
-                    _w.Block(() =>
-                    {
-                        for (var i = 0; i < positional.Count; i++)
-                            _w.WriteLine($"{holders[i]}.v = this.{positional[i]};");
-                    });
+                    for (var i = 0; i < positional.Count; i++)
+                        _w.WriteLine($"{holders[i]}.v = this.{positional[i]};");
                 });
-            }
+            });
         }
     }
 
@@ -258,8 +421,31 @@ public sealed partial class Emitter
     private bool TryEmitRecordCtors(INamedTypeSymbol type)
     {
         if (!type.IsRecord) return false;
-        var recordDecl = type.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).OfType<RecordDeclarationSyntax>().FirstOrDefault();
+        var recordDecl = type.DeclaringSyntaxReferences.Select(r => r.GetSyntax())
+            .OfType<RecordDeclarationSyntax>().FirstOrDefault(r => r.ParameterList is not null)
+            ?? type.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).OfType<RecordDeclarationSyntax>().FirstOrDefault();
         var positional = recordDecl?.ParameterList?.Parameters.Select(p => NameMangler.JsIdentifier(p.Identifier.Text)).ToList() ?? new List<string>();
+
+        // The primary constructor's symbol, for the parameter defaults: a positional parameter may be
+        // optional (`record Defaults(int X = 5)`), and a JS call that omits it passes undefined, so the
+        // default has to be applied in the body exactly as it is for an ordinary constructor. Without
+        // this `new Defaults()` left every omitted member undefined.
+        var primaryCtor = type.InstanceConstructors
+            .FirstOrDefault(c => c.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is RecordDeclarationSyntax);
+
+        // Only the parameters the record actually synthesized a property for are stored. When the body
+        // declares its own member of that name C# suppresses the synthesized property and the parameter
+        // becomes an ordinary constructor parameter (referenced by initializers, nothing more);
+        // assigning it anyway clobbered the declared member, so
+        // `record R(int X) { public int X { get; init; } = X * 2; }` yielded 3 instead of 6.
+        // The store targets the property's SLOT, which is not always the parameter's own name — a
+        // [property: Name("jsX")] positional member lives at `jsX`, and writing `this.X` left the slot
+        // (and so ToString, equality and Deconstruct, which all read the slot) at its default.
+        var stored = RecordPositionalProps(type).ToDictionary(p => p.Name, TransposeNaming.MemberJsName, StringComparer.Ordinal);
+        var storedPositional = recordDecl?.ParameterList?.Parameters
+            .Where(p => stored.ContainsKey(p.Identifier.Text))
+            .Select(p => (slot: stored[p.Identifier.Text], param: NameMangler.JsIdentifier(p.Identifier.Text)))
+            .ToList() ?? new List<(string slot, string param)>();
 
         // Only user-written constructors (with real ConstructorDeclarationSyntax); the
         // primary constructor lives on the record header and is emitted as "ctor" above.
@@ -267,12 +453,24 @@ public sealed partial class Emitter
             .Where(c => c.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is ConstructorDeclarationSyntax)
             .ToList();
 
+        // A `record struct` also has the implicit parameterless struct constructor that `new S()`,
+        // `default(S)` and `: this()` reach. The positional primary owns the plain "ctor" slot, so this
+        // one is named $ctorN — and it has no syntax of its own, so neither branch above emitted it and
+        // `new S()` on a `record struct S(int X)` threw "S.$ctor1 is not a constructor". It zeroes the
+        // value rather than running the declared field initializers, matching C#.
+        var structDefaultCtor = type.TypeKind == TypeKind.Struct
+            ? type.InstanceConstructors.FirstOrDefault(c => c is { Parameters.Length: 0, IsImplicitlyDeclared: true })
+            : null;
+        // A record struct with no positional parameters already emits that very constructor as "ctor".
+        if (structDefaultCtor is not null && CtorName(structDefaultCtor) == "ctor") structDefaultCtor = null;
+
         _w.Block(() =>
         {
             // primary ctor
             _w.Write($"ctor: function ({string.Join(", ", positional)}) ");
             _w.Block(() =>
             {
+                if (primaryCtor is not null) EmitOptionalDefaults(primaryCtor);
                 _w.WriteLine("this.$initialize();");
                 // A record body may declare ordinary fields/auto-properties, with or without an
                 // initializer, and the positional constructor is the only one that runs — so it has
@@ -301,9 +499,21 @@ public sealed partial class Emitter
                         _w.WriteLine($"{TypeRef(bt)}.ctor.call(this);");
                     }
                 }
-                foreach (var p in positional) _w.WriteLine($"this.{p} = {p};");
+                foreach (var (slot, param) in storedPositional) _w.WriteLine($"this.{slot} = {param};");
             });
-            _w.WriteLine(explicitCtors.Count > 0 ? "," : "");
+            _w.WriteLine(explicitCtors.Count > 0 || structDefaultCtor is not null ? "," : "");
+
+            if (structDefaultCtor is not null)
+            {
+                _w.Write($"{CtorName(structDefaultCtor)}: function () ");
+                _w.Block(() =>
+                {
+                    _w.WriteLine("this.$initialize();");
+                    EmitInstanceFieldInitializers(type, runInitializers: false);
+                });
+                _w.WriteLine(explicitCtors.Count > 0 ? "," : "");
+            }
+
             // explicit ctors kept as $ctorN. C# requires each to chain `: this(...)` back to the
             // positional primary; emit that delegation (EmitConstructorChain) then the body — else
             // the delegated-to primary never runs and the record's members stay unset.

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -40,6 +40,10 @@ public sealed partial class Emitter
     /// type (accessible in C# but not emitted as a parameter here) is not in scope.</summary>
     private INamedTypeSymbol? _currentEmitType;
 
+    /// <summary>JS identifiers the type being emitted binds locally, which would otherwise shadow a
+    /// same-named type reference. See <c>ShadowingIdentifiers</c> / <c>UnshadowedTypeRef</c>.</summary>
+    private HashSet<string>? _shadowingNames;
+
     /// <summary>
     /// Active goto label-dispatch contexts. When non-empty a statement body is being lowered
     /// into a `for(;;) switch($state)` machine: `goto L` sets the state and continues the loop.

--- a/Transpose/Transpose.Translator/README.md
+++ b/Transpose/Transpose.Translator/README.md
@@ -86,6 +86,32 @@ object's shape: `new Point(1, 2)` on `[ObjectLiteral] record Point(int X, int Y)
 
 `RecordTests.cs` covers all of the above end to end, diffing against native .NET.
 
+## Object model invariants
+
+Three rules the emitter upholds for every type, each of which a record's synthesized members made
+visible first (`ObjectToStringAndInitOrderTests.cs`):
+
+- **Instance field initializers run before the base constructor**, which is C#'s order — so a base
+  constructor observes the derived slots already initialized, and the side effects of an initializer are
+  sequenced ahead of the base's.
+- **A virtual or overriding auto-property has storage of its own** (`IsFieldBackedProperty`): it is
+  emitted as a real accessor pair over a per-declaration backing slot (`$P`, and `$P$<Type>` for an
+  override) rather than AS the slot named after the property. Sharing one slot collapsed the base's
+  field and the override's into a single location, so the base constructor's initializer landed on the
+  override's value and no read ever dispatched. A non-virtual auto-property is still the plain slot.
+- **A local binding never shadows a type reference.** A type is named by its bare emitted identifier,
+  so a parameter, local, `out var`, `foreach`/`catch` variable or query range variable of the same name
+  would shadow it (`record RD(int A, int B) : RB(A)` with a base named `B` emitted `B.ctor.call(this, A)`
+  inside `function (A, B)`). `EmitClassLike` collects the identifiers a type binds and `TypeRef` routes a
+  colliding reference through `Transpose.global`, which nothing can intercept.
+
+`object.ToString()` follows .NET rather than JavaScript, in the runtime (`Transpose.toString`): an
+array reports its type name instead of its joined elements, a `DateTime` the culture's general
+date/time pattern instead of the JS `Date` string, a `Type` its display name instead of the
+constructor's source text, and the fallback for a type with no `ToString` of its own is
+`GetType().ToString()` — which names generic arguments plainly (`List`1[System.Int32]`), not
+assembly-qualified as `FullName` does.
+
 ## Extending
 
 1. Add a language feature by handling its `SyntaxNode` in the relevant `Emitter.*.cs` file.

--- a/Transpose/Transpose.Translator/README.md
+++ b/Transpose/Transpose.Translator/README.md
@@ -45,13 +45,46 @@ Entry point: `RoslynTranslator.Translate(source)` → `TranslationResult { Javas
   initializers, arrays, element access, lambdas / anonymous methods, `?.`, `await`, method groups, enums,
   `ref`/`out` parameters (holder objects), `params`, named/optional arguments.
 - Modern C#: pattern matching (type/constant/relational/logical/property/positional), switch expressions,
-  tuples + deconstruction, records (positional, value equality, `with`, `Deconstruct`, ToString).
+  tuples + deconstruction, records — see below.
 - Collections: `List<T>`, `Dictionary<K,V>`, `HashSet<T>`, arrays; LINQ-to-objects; iterators (`yield`).
 - BCL surface: `Console`, `String` (+ static), `StringBuilder`, `Math`/`MathF`, `Convert`, numeric parsing,
   `Char`, `Task`/`Task<T>` (→ Promise), `TaskCompletionSource`, exceptions with `Message`/`InnerException`.
 - Async/await → native JS `async`/`await`; async `Main` bootstrap.
 - Unsupported-feature reporting: pointers, `unsafe`, `fixed`, `stackalloc`, P/Invoke, File I/O, sockets,
   threading primitives (Task-based async is allowed).
+
+## Records
+
+`record`, `record class`, `record struct` and `readonly record struct` are all supported, in the
+one-line positional form and with a body, at any depth of a record inheritance chain. What the emitter
+synthesizes (`Emitter.ValueTypes.cs`, `AddRecordMethodEntries` + `TryEmitRecordCtors`) mirrors C#:
+
+| Member | Emitted as | Over which members |
+| --- | --- | --- |
+| `PrintMembers(StringBuilder)` | `PrintMembers` | the record's non-static **public** fields and **public readable** properties, chaining to the base record's `PrintMembers` first |
+| `ToString()` | `toString` | `"Name { " + PrintMembers + " }"` — via the real `PrintMembers`, so an override participates |
+| `Equals(object)` | `equals` | delegates to the typed `Equals` after a type check, as C#'s `Equals(obj as T)` does |
+| `Equals(T)` | `equalsT` | every instance **field** slot, base record first — private fields and auto-property backing fields included, computed properties excluded |
+| `GetHashCode()` | `getHashCode` | the same slots |
+| `Deconstruct(out …)` | `Deconstruct` | the positional properties |
+| primary constructor | `ctor` | parameter defaults, field initializers, the `: Base(…)` call, then the positional stores |
+
+Two consequences worth keeping in mind when changing this code:
+
+- **ToString and equality cover different member sets.** ToString *prints* members (so a computed
+  `int Doubled => X * 2` shows up, and a non-public member never does); equality *compares* fields (so a
+  public field of the record body participates, and a get-only property that allocates on each read —
+  `int[] Cache => new[] { V }` — does not, or two equal records would compare unequal).
+- **A declared member replaces the synthesized one.** Each entry above is emitted only when the record
+  does not declare it (`ISymbol.IsImplicitlyDeclared`), and every key comes from
+  `TransposeNaming.MemberJsName` on the synthesized symbol — which is also what puts a hand-written
+  `Deconstruct(out int, out int)` on `Deconstruct$1`, clear of the synthesized one-parameter form.
+
+A record may also carry `[ObjectLiteral]`, which makes it the declaration of a plain JavaScript
+object's shape: `new Point(1, 2)` on `[ObjectLiteral] record Point(int X, int Y)` emits `{X: 1, Y: 2}`
+(the positional arguments become the literal's members; the synthesized `EqualityContract` does not).
+
+`RecordTests.cs` covers all of the above end to end, diffing against native .NET.
 
 ## Extending
 

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -11,6 +11,28 @@
         try { return Transpose.toString(v); } catch (e) { return v.toString ? v.toString() : String(v); }
     };
     TransposeR.chr = function (code) { return String.fromCharCode(code); };
+    // `base.P` / `base.P = v` on a property with real accessors. `base` emits as `this`, so a plain
+    // `this.P` would dispatch to the most-derived override — the very thing `base` bypasses. Accessors
+    // are installed with Object.defineProperty on each type's prototype, so walk from the base type's
+    // prototype up to the nearest one that declares the member and invoke it with the real receiver.
+    TransposeR.baseGet = function (proto, name, obj) {
+        for (var p = proto; p; p = Object.getPrototypeOf(p)) {
+            var d = Object.getOwnPropertyDescriptor(p, name);
+            if (d) { return d.get ? d.get.call(obj) : d.value; }
+        }
+        return obj[name];
+    };
+    TransposeR.baseSet = function (proto, name, obj, value) {
+        for (var p = proto; p; p = Object.getPrototypeOf(p)) {
+            var d = Object.getOwnPropertyDescriptor(p, name);
+            if (d) {
+                if (d.set) { d.set.call(obj, value); } else { obj[name] = value; }
+                return value;
+            }
+        }
+        obj[name] = value;
+        return value;
+    };
     // Box a char (a bare code-point number at runtime) so it stringifies / compares as its
     // character once widened to object — `object o = 'A'; o.ToString()` must be "A", not "65".
     TransposeR.boxChar = function (c) { return Transpose.box(c, System.Char, TransposeR.chr); };

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -714,7 +714,7 @@ internal static class TransposeNaming
     /// type-level <c>[Transpose.Name]</c> (its dotted value becomes the mangled prefix, e.g.
     /// <c>[Name("tss.IC")]</c> → <c>tss$IC</c>), so interface-member slots stay consistent with the
     /// type's registered name.</summary>
-    private static string MangledTypeName(INamedTypeSymbol type)
+    internal static string MangledTypeName(INamedTypeSymbol type)
     {
         if (MangledSelf(type) is { } named) return named;
         var parts = new System.Collections.Generic.List<string>();


### PR DESCRIPTION
Records were emitted from a single set of "value properties", which was the wrong
set for both of the things it fed and left every user-declared record member
colliding with the synthesized one. Split the two sets the way C# does, honour a
declared member, and cover the whole feature with tests that diff against native
.NET.

ToString / PrintMembers
  - PrintMembers is now emitted as a real method and ToString goes through it, so a
    hand-written PrintMembers or ToString participates and a derived record chains to
    its base. Previously both were ignored: `record R(int X) { public override string
    ToString() => ...; }` printed `R { X = 1 }`.
  - It prints public FIELDS as well as public readable properties (a record body's
    `public int F = 1;` was missing), and only PUBLIC ones (internal/private
    properties were being printed).
  - An override is printed once, by the base — it was printed twice.
  - A char renders as its character, an enum (and a nullable enum) as its member name,
    a type-parameter member through the runtime converter; they rendered as numbers.
    The nullable char/enum fix also applies to plain string concatenation, which had
    the same gap.

Equality / GetHashCode
  - Compare instance FIELDS base-record-first, as C# does, instead of properties: a
    public field now participates, and a computed property no longer does — with
    `record Node(int V) { public int[] Cache => new[] { V }; }` two equal values
    compared unequal because each read allocated.
  - Equals(object) delegates to the typed Equals, so a record's own Equals(T) /
    GetHashCode governs ==, HashSet/Dictionary and Equals((object)x) alike.

Construction
  - Optional positional parameters default (`new Defaults()` left members undefined).
  - A positional parameter is stored only when the record synthesized a property for
    it, so `record R(int X) { public int X { get; init; } = X * 2; }` no longer has
    its declared member clobbered — and the store targets the property's slot, which
    a [property: Name("...")] member moves.
  - A record struct's implicit parameterless constructor is emitted: `new S()` on a
    `record struct S(int X)` threw "S.$ctor1 is not a constructor". It zeroes the
    value rather than running the declared field initializers, matching C# — which
    also fixes the same divergence for a plain struct.
  - $clone copies only real slots; it assigned get-only computed properties, so
    `readonly record struct RS(int X) { int D => X * 2; }` threw on any copy.

Naming
  - Every synthesized member's key comes from TransposeNaming.MemberJsName on the
    symbol itself, so a hand-written Deconstruct(out int, out int) lands on
    Deconstruct$1 clear of the synthesized one-parameter form instead of overwriting
    it, and deconstruction call sites resolve the overload they bound.

[ObjectLiteral] on a record
  - A record's positional arguments become the literal's members, so
    `new Point(1, 2)` on `[ObjectLiteral] record Point(int X, int Y)` emits
    `{X: 1, Y: 2}` — it emitted `{}` and dropped them. The synthesized
    EqualityContract no longer leaks into the literal.

BCL
  - Add System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute, a
    compiler-required member: without it any `required` member failed to compile.

Tests: RecordTests.cs, 41 tests over class/struct records in one-line and bodied
form — declaration shapes, construction, equality, ToString, with, inheritance,
deconstruction, patterns, generics, interfaces, operators, async, value-copy
semantics, declared-member overrides and [ObjectLiteral]. Translator suite 707
passed, Newtonsoft.Json suite 131 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TKzm4YFuVex3d8ZmpHfycx