### PR TITLE
Fix char.IsUpper/IsLower method group resolution with Fn

### DIFF
--- a/BCL/Transpose.BCL/System/Char.cs
+++ b/BCL/Transpose.BCL/System/Char.cs
@@ -41,10 +41,10 @@ namespace System
         [Transpose.Template("{this} === {0}")]
         public extern bool Equals(char obj);
 
-        [Transpose.Template("Transpose.isLower({0})")]
+        [Transpose.Template("Transpose.isLower({0})", Fn = "Transpose.isLower")]
         public static extern bool IsLower(char s);
 
-        [Transpose.Template("Transpose.isUpper({0})")]
+        [Transpose.Template("Transpose.isUpper({0})", Fn = "Transpose.isUpper")]
         public static extern bool IsUpper(char s);
 
         /// <summary>

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -2617,6 +2617,37 @@ public class Program
 }", waitForOutput: "<<DONE>>");
         }
 
+        // ---- char.IsUpper / char.IsLower as a method group ------------------------------------
+        //
+        // char.IsUpper(char)/IsLower(char) have a plain [Template] (no Fn), so a method group of
+        // either fell through EmitMethodGroup's Fn check into the generic static-member-access path,
+        // which just name-mangles the method to "isUpper"/"isLower". char.IsLower has no backing
+        // runtime function under that name at all (silently always-truthy predicate — every non-'\0'
+        // char code is truthy, so password.Any(char.IsLower) always returned true), and char.IsUpper
+        // collided with the UNRELATED (string, int) overload's runtime function
+        // (System.Char.isUpper(s, index)), which read `index` as the char code and threw
+        // ArgumentOutOfRangeException. Fixed by giving both a Fn pointing at the already
+        // correctly-shaped (char) -> bool runtime helper (Transpose.isUpper / Transpose.isLower).
+        [TestMethod]
+        public async Task TemplateFnResolvesCharIsUpperIsLowerMethodGroup()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""abc123"".Any(char.IsUpper));   // False
+        Console.WriteLine(""abc123"".Any(char.IsLower));   // True
+        Console.WriteLine(""ABC123"".Any(char.IsLower));   // False
+        Console.WriteLine(""ABC123"".Any(char.IsUpper));   // True
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
         // ---- [Template] 2-arg (format, nonExpandedFormat) — the non-expanded params variant ----
         //
         // A 2-arg [Template] gives a second template for when the trailing `params` argument is supplied


### PR DESCRIPTION
## Summary
Fixes a critical bug where `char.IsUpper` and `char.IsLower` method groups were incorrectly resolved, causing runtime errors or silent failures when used with LINQ predicates like `Any()`.

## Problem
The `char.IsUpper(char)` and `char.IsLower(char)` methods had `[Template]` attributes without an `Fn` parameter. During method group emission, the translator fell through the `Fn` check and used generic static-member-access logic, which name-mangled the methods to `isUpper`/`isLower`. This caused two issues:

1. **char.IsLower**: No backing runtime function existed under that name, resulting in a silent always-truthy predicate (every non-'\0' char code is truthy), so `password.Any(char.IsLower)` always returned `true`
2. **char.IsUpper**: Collided with the unrelated `(string, int)` overload's runtime function `System.Char.isUpper(s, index)`, which read `index` as the char code and threw `ArgumentOutOfRangeException`

## Changes
- **Transpose.BCL/System/Char.cs**: Added `Fn = "Transpose.isUpper"` and `Fn = "Transpose.isLower"` parameters to the `[Template]` attributes for both methods, pointing to the correctly-shaped `(char) -> bool` runtime helpers
- **EmitRegressionTests.cs**: Added `TemplateFnResolvesCharIsUpperIsLowerMethodGroup()` test to verify correct behavior with `string.Any(char.IsUpper/IsLower)` predicates

## Testing
The new regression test validates that:
- `"abc123".Any(char.IsUpper)` returns `false`
- `"abc123".Any(char.IsLower)` returns `true`
- `"ABC123".Any(char.IsLower)` returns `false`
- `"ABC123".Any(char.IsUpper)` returns `true`

https://claude.ai/code/session_01TyzdNrc52Q5SnpicRnaCCm