### PR TITLE
Add RegExp.escape() and missing RegExp flag properties

### DIFF
--- a/BCL/Transpose.Core/es5/es5.RegExp.cs
+++ b/BCL/Transpose.Core/es5/es5.RegExp.cs
@@ -94,11 +94,28 @@ namespace Transpose.Core
 
             public static extern es5.RegExp Self(string pattern, string flags);
 
+            /// <summary>
+            /// Escapes any potential regex syntax characters in a string, so it can safely be
+            /// interpolated into a RegExp pattern as a literal match.
+            /// </summary>
+            /// <param name="string">The string to escape.</param>
+            /// <returns>A new string with regex-significant characters escaped.</returns>
+            public static extern string escape(string @string);
+
             public virtual extern es5.RegExpExecArray exec(string @string);
 
             public virtual extern bool test(string @string);
 
             public virtual string source
+            {
+                get;
+            }
+
+            /// <summary>
+            /// The flags string, containing the letters for every flag set on this regular expression, in the order
+            /// d, g, i, m, s, u, v, y.
+            /// </summary>
+            public virtual string flags
             {
                 get;
             }
@@ -114,6 +131,46 @@ namespace Transpose.Core
             }
 
             public virtual bool multiline
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Whether the "d" flag (hasIndices) is set, requesting the start/end indices of captured substrings.
+            /// </summary>
+            public virtual bool hasIndices
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Whether the "s" flag (dotAll) is set, so "." also matches line terminators.
+            /// </summary>
+            public virtual bool dotAll
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Whether the "u" flag (unicode) is set, enabling Unicode code point semantics.
+            /// </summary>
+            public virtual bool unicode
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Whether the "v" flag (unicodeSets) is set, enabling the ES2024 Unicode set-notation mode.
+            /// </summary>
+            public virtual bool unicodeSets
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Whether the "y" flag (sticky) is set, so matching starts exactly at lastIndex.
+            /// </summary>
+            public virtual bool sticky
             {
                 get;
             }

--- a/BCL/Transpose.Core/es5/es5.RegExpConstructor.cs
+++ b/BCL/Transpose.Core/es5/es5.RegExpConstructor.cs
@@ -35,6 +35,8 @@ namespace Transpose.Core
             [Template("{this}({0}, {1})")]
             es5.RegExp Self(string pattern, string flags);
 
+            string escape(string @string);
+
             es5.RegExp prototype { get; }
 
             [Name("$1")]

--- a/BCL/Transpose.Core/es5/es5.RegExpExecArray.cs
+++ b/BCL/Transpose.Core/es5/es5.RegExpExecArray.cs
@@ -22,6 +22,14 @@ namespace Transpose.Core
             {
                 get; set;
             }
+
+            /// <summary>
+            /// The named capture groups of the match, or undefined if the pattern has none.
+            /// </summary>
+            public virtual dynamic groups
+            {
+                get; set;
+            }
         }
     }
 }

--- a/BCL/Transpose.Core/es5/es5.RegExpMatchArray.cs
+++ b/BCL/Transpose.Core/es5/es5.RegExpMatchArray.cs
@@ -23,6 +23,14 @@ namespace Transpose.Core
             {
                 get; set;
             }
+
+            /// <summary>
+            /// The named capture groups of the match, or undefined if the pattern has none.
+            /// </summary>
+            public virtual dynamic groups
+            {
+                get; set;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Extends the ES5 RegExp bindings to include the `RegExp.escape()` static method and adds support for modern RegExp flag properties (`flags`, `hasIndices`, `dotAll`, `unicode`, `unicodeSets`, `sticky`). Also adds the `groups` property to RegExp match array types for named capture group support.

## Key Changes
- **RegExp.escape()**: Added static method to escape regex-significant characters in strings for safe literal interpolation into patterns
- **RegExp flag properties**: Added virtual properties for:
  - `flags` — the flags string in canonical order (d, g, i, m, s, u, v, y)
  - `hasIndices` — "d" flag (start/end indices of captured substrings)
  - `dotAll` — "s" flag (dot matches line terminators)
  - `unicode` — "u" flag (Unicode code point semantics)
  - `unicodeSets` — "v" flag (ES2024 Unicode set-notation mode)
  - `sticky` — "y" flag (matching starts at lastIndex)
- **Match array groups**: Added `groups` property to both `RegExpExecArray` and `RegExpMatchArray` for named capture group access
- **RegExpConstructor**: Added `escape()` method to the constructor interface

## Implementation Details
All additions are extern/virtual declarations with XML documentation, maintaining consistency with the existing binding pattern for ES5 RegExp APIs. The changes align with modern JavaScript RegExp semantics (ES2018+) while preserving backward compatibility.

https://claude.ai/code/session_01PtUqEHrywMDihNdtNWcqFG