### PR TITLE
Add comprehensive LINQ test suite and fix query expression support

### DIFF
--- a/BCL/Transpose.BCL/Resources/Core.js
+++ b/BCL/Transpose.BCL/Resources/Core.js
@@ -38,6 +38,32 @@
                     : "System.Array";
             }
 
+            // A C# anonymous type is a plain literal here, so Object.prototype.toString would win the
+            // check further down and report the TYPE name. .NET renders the members instead, with each
+            // value's own ToString() and an empty string for null.
+            if (instance.$$anon === true && Transpose.isPlainObject(instance)) {
+                var anonParts = [];
+
+                for (var anonKey in instance) {
+                    if (instance.hasOwnProperty(anonKey)) {
+                        var anonValue = instance[anonKey];
+                        var anonText;
+
+                        if (anonValue == null) {
+                            anonText = "";
+                        } else if (instance.$$anonFormat && instance.$$anonFormat[anonKey]) {
+                            anonText = instance.$$anonFormat[anonKey](anonValue);
+                        } else {
+                            anonText = Transpose.toString(anonValue);
+                        }
+
+                        anonParts.push(anonKey + " = " + anonText);
+                    }
+                }
+
+                return "{ " + anonParts.join(", ") + " }";
+            }
+
             // A DateTime is backed by a native Date, whose toString() is the JS date form
             // ("Thu Jan 02 2020 00:00:00 GMT+0000 (…)"); .NET's is the culture's general pattern.
             if (instance instanceof Date) {
@@ -262,6 +288,34 @@
             }
 
             return false;
+        },
+
+        /// Tags a plain object literal as a C# ANONYMOUS TYPE instance. An anonymous type in .NET is a
+        /// generated class with value-based Equals/GetHashCode and a "{ A = 1, B = x }" ToString, so a
+        /// bare literal (which compares by reference) is not enough: `xs.Select(x => new { x.A, x.B })
+        /// .Distinct()` would keep every duplicate. The marker is NON-ENUMERABLE on purpose — the
+        /// structural comparison, hashing, JSON.stringify and every `for..in` over the object must not
+        /// see it — and the prototype is left alone so `isPlainObject` (and everything keyed off it,
+        /// e.g. object-literal interop and JSON serialization) still recognises the object.
+        anon: function (obj, formatters) {
+            Object.defineProperty(obj, "$$anon", { value: true, enumerable: false, configurable: true, writable: true });
+
+            if (formatters) {
+                // A char and an enum are both plain numbers at runtime, so ToString cannot recover "c"
+                // or "Monday" from the value alone. The emitter passes a { member: fn } map for exactly
+                // those members; anything whose own toString already matches .NET is absent.
+                Object.defineProperty(obj, "$$anonFormat", { value: formatters, enumerable: false, configurable: true, writable: true });
+            }
+
+            return obj;
+        },
+
+        /// True for a plain object that carries structural (value-based) equality: a C# anonymous type
+        /// or a ValueTuple, both of which are emitted as plain literals.
+        isStructuralObject: function (obj) {
+            return obj != null && typeof obj === "object"
+                && (obj.$$anon === true || obj.hasOwnProperty("Item1"))
+                && Transpose.isPlainObject(obj);
         },
 
         toPlain: function (o) {
@@ -758,7 +812,7 @@
                 return value.$$hashCode;
             }
 
-            if (deep !== false && value.hasOwnProperty("Item1") && Transpose.isPlainObject(value)) {
+            if (deep !== false && Transpose.isStructuralObject(value)) {
                 deep = true;
             }
 
@@ -774,15 +828,27 @@
                 }
 
                 if (result !== 0) {
-                    value.$$hashCode = result;
+                    Transpose.defineHashCode(value, result);
 
                     return result;
                 }
             }
 
-            value.$$hashCode = (Math.random() * 0x100000000) | 0;
+            Transpose.defineHashCode(value, (Math.random() * 0x100000000) | 0);
 
             return value.$$hashCode;
+        },
+
+        /// Memoizes a computed hash on an object without making it an enumerable own property:
+        /// deepEquals walks both operands' own properties, so a visible $$hashCode on one side only
+        /// (the usual case — the hash of the needle is computed before the haystack's) reported two
+        /// structurally equal objects as different.
+        defineHashCode: function (value, hash) {
+            try {
+                Object.defineProperty(value, "$$hashCode", { value: hash, enumerable: false, configurable: true, writable: true });
+            } catch (ex) {
+                // Sealed/frozen or an exotic host object: the memo is an optimization, not a contract.
+            }
         },
 
         getDefaultValue: function (type) {
@@ -1440,7 +1506,7 @@
                     return Transpose.getHashCode(a) === Transpose.getHashCode(b) && Transpose.objectEquals(a, b);
                 }
 
-                if (!eq && a && b && a.hasOwnProperty("Item1") && Transpose.isPlainObject(a) && b.hasOwnProperty("Item1") && Transpose.isPlainObject(b)) {
+                if (!eq && Transpose.isStructuralObject(a) && Transpose.isStructuralObject(b)) {
                     return Transpose.objectEquals(a, b, true);
                 }
 

--- a/BCL/Transpose.BCL/Resources/Integer.js
+++ b/BCL/Transpose.BCL/Resources/Integer.js
@@ -15,13 +15,88 @@
                 return 0;
             },
 
+            /// The number of significant digits in the SHORTEST decimal string that round-trips back to
+            /// `value` — what .NET Core 3.0+ uses for `double.ToString()` / `float.ToString()` / the "G"
+            /// and "R" formats. (.NET Framework used a fixed 15 for double and 7 for float, which is
+            /// what `System.Double.precision` still carries for an explicit "G15".)
+            ///
+            /// For a double, JS's own `toExponential()` with no argument is defined to use "as many
+            /// digits as necessary to uniquely specify the number", i.e. exactly the shortest
+            /// round-trippable form. A float has to be probed instead: the value is held in a double, so
+            /// the shortest form is the fewest digits that still survive a round-trip through
+            /// `Math.fround` (1f/3f prints "0.33333334", not "0.3333333432674408").
+            shortestDigits: function (value, isSingle) {
+                if (!isFinite(value) || value === 0) {
+                    return 1;
+                }
+
+                var v = Math.abs(value);
+
+                if (isSingle) {
+                    for (var p = 1; p < 9; p++) {
+                        if (Math.fround(parseFloat(v.toPrecision(p))) === v) {
+                            return p;
+                        }
+                    }
+
+                    return 9;
+                }
+
+                var mantissa = v.toExponential(),
+                    dot = mantissa.indexOf("."),
+                    exp = mantissa.indexOf("e");
+
+                return dot < 0 ? 1 : exp - dot;
+            },
+
+            /// The default `ToString()` (and bare "G"/"R") of a double or float on .NET Core 3.0+: the
+            /// SHORTEST decimal string that round-trips back to the value. The digit count comes from
+            /// `shortestDigits`; the notation rule is .NET's own — scientific once the value's scale (the
+            /// count of digits before the decimal point) exceeds the type's full precision, 17 for a
+            /// double and 9 for a float, or once the value drops below 1e-4.
+            shortestFormat: function (number, isSingle, nf) {
+                var isNeg = number < 0 || (number === 0 && (1 / number) < 0),
+                    magnitude = Math.abs(number),
+                    digits = this.shortestDigits(magnitude, isSingle),
+                    // Rounding the ORIGINAL value to `digits` significant digits reproduces the shortest
+                    // form exactly; rounding a separately computed coefficient does not (its own binary
+                    // value is a hair below, and 1.2345678901234568E+17 came out …4567E+17).
+                    exponential = magnitude.toExponential(digits - 1),
+                    eIndex = exponential.indexOf("e"),
+                    exponent = parseInt(exponential.substring(eIndex + 1), 10),
+                    scale = exponent + 1,
+                    text;
+
+                if (scale > (isSingle ? 9 : 17) || scale < -3) {
+                    // The mantissa already carries exactly `digits` significant digits, so it is used as
+                    // the STRING it is: re-parsing it and re-rendering through defaultFormat would round
+                    // the mantissa's own binary value and drop the last digit.
+                    text = exponential.substring(0, eIndex).replace(".", nf.numberDecimalSeparator)
+                        + "E" + (exponent < 0 ? nf.negativeSign : nf.positiveSign)
+                        + this.defaultFormat(Math.abs(exponent), 2, 0, 0, nf, true);
+                } else {
+                    text = this.defaultFormat(parseFloat(exponential), 1, 0, Math.max(0, Math.min(100, digits - scale)), nf, true);
+                }
+
+                return (isNeg ? nf.negativeSign : "") + text;
+            },
+
             format: function (number, format, provider, T, toUnsign) {
+                // A float is carried in a JS number (a double), and arithmetic on it is done at double
+                // precision, so the value can hold bits a real `float` never had: 1f/3f sits here as
+                // 0.3333333333333333 rather than 0.3333333432674408. Rounding to single precision before
+                // rendering is what makes float.ToString() agree with .NET ("0.33333334").
+                if (T === System.Single && typeof number === "number" && isFinite(number) && Math.fround) {
+                    number = Math.fround(number);
+                }
+
                 var nf = (provider || System.Globalization.CultureInfo.getCurrentCulture()).getFormat(System.Globalization.NumberFormatInfo),
                     decimalSeparator = nf.numberDecimalSeparator,
                     groupSeparator = nf.numberGroupSeparator,
                     isDecimal = number instanceof System.Decimal,
                     isLong = number instanceof System.Int64 || number instanceof System.UInt64,
-                    isNeg = isDecimal || isLong ? (number.isZero() ? false : number.isNegative()) : number < 0,
+                    isNeg = isDecimal || isLong ? (number.isZero() ? false : number.isNegative())
+                        : (number < 0 || (number === 0 && (1 / number) < 0)),
                     match,
                     precision,
                     groups,
@@ -42,6 +117,13 @@
                     precision = parseInt(match[2], 10);
                     //precision = precision > 15 ? 15 : precision;
 
+                    // The default ToString of a double/float — and a bare "G" — is the shortest
+                    // round-trippable form since .NET Core 3.0, not a fixed 15/7 significant digits. An
+                    // explicit "G15"/"G7" still means what it says and falls through below.
+                    if (fs === "G" && isNaN(precision) && (T === System.Double || T === System.Single)) {
+                        return this.shortestFormat(number, T === System.Single, nf);
+                    }
+
                     switch (fs) {
                         case "D":
                             return this.defaultFormat(number, isNaN(precision) ? 1 : precision, 0, 0, nf, true);
@@ -61,29 +143,35 @@
                                 minDecimals,
                                 maxDecimals;
 
-                            while (isDecimal || isLong ? coefficient.gte(10) : (coefficient >= 10)) {
-                                if (isDecimal || isLong) {
+                            if (isDecimal || isLong) {
+                                while (coefficient.gte(10)) {
                                     coefficient = coefficient.div(10);
-                                } else {
-                                    coefficient /= 10;
+                                    exponent++;
                                 }
 
-                                exponent++;
-                            }
-
-                            while (isDecimal || isLong ? (coefficient.ne(0) && coefficient.lt(1)) : (coefficient !== 0 && coefficient < 1)) {
-                                if (isDecimal || isLong) {
+                                while (coefficient.ne(0) && coefficient.lt(1)) {
                                     coefficient = coefficient.mul(10);
-                                } else {
-                                    coefficient *= 10;
+                                    exponent--;
                                 }
+                            } else if (coefficient !== 0) {
+                                // Normalising by repeated *10 / /10 accumulates error at the extremes of
+                                // the double range (1e-320 ended up with a coefficient of 10, printing
+                                // "10E-321"); toExponential gives the coefficient and exponent exactly.
+                                var normalized = coefficient.toExponential(),
+                                    eIndex = normalized.indexOf("e");
 
-                                exponent--;
+                                coefficient = parseFloat(normalized.substring(0, eIndex));
+                                exponent = parseInt(normalized.substring(eIndex + 1), 10);
                             }
 
                             if (fs === "G") {
                                 var noPrecision = isNaN(precision);
 
+                                // A "G" with no explicit precision is the DEFAULT ToString of a double or
+                                // float, and since .NET Core 3.0 that is the shortest round-trippable form
+                                // rather than a fixed 15/7 significant digits — so `(7.0/3).ToString()` is
+                                // "2.3333333333333335", not "2.33333333333333". An explicit "G15"/"G7"
+                                // keeps the requested precision, and decimal/long keep their own widths.
                                 if (noPrecision) {
                                     if (isDecimal) {
                                         precision = 29;
@@ -98,7 +186,13 @@
 
                                 if ((exponent > -5 && exponent < precision) || isDecimal && noPrecision) {
                                     minDecimals = 0;
-                                    maxDecimals = precision - (exponent > 0 ? exponent + 1 : 1);
+                                    // `precision` counts SIGNIFICANT digits, so the decimals available are
+                                    // those left after the integer part. The `exponent > 0 ? … : 1` form
+                                    // below is the historical approximation: it is one digit short for a
+                                    // value below 1 (exponent < 0), which the shortest form cannot absorb.
+                                    maxDecimals = isDecimal
+                                        ? precision - (exponent > 0 ? exponent + 1 : 1)
+                                        : Math.max(0, Math.min(100, precision - exponent - 1));
 
                                     return this.defaultFormat(number, 1, isDecimal ? Math.min(27, Math.max(minDecimals, number.$precision)) : minDecimals, maxDecimals, nf, true);
                                 }
@@ -260,7 +354,18 @@
                 } else if (isLong) {
                     str = number.eq(System.Int64.MinValue) ? number.value.toUnsigned().toString() : number.abs().toString();
                 } else {
-                    str = "" + (+Math.abs(number).toFixed(maxDecLen));
+                    str = Math.abs(number).toFixed(maxDecLen);
+
+                    if (str.indexOf("e") >= 0) {
+                        // toFixed falls back to exponential notation at 1e21 and beyond; leave that shape
+                        // to the numeric round-trip, as before.
+                        str = "" + (+str);
+                    } else if (str.indexOf(".") >= 0) {
+                        // Drop the trailing fraction zeros as a STRING. The old form (`+str`) round-tripped
+                        // through a double, which silently collapsed every digit beyond the shortest
+                        // round-trippable form — "G17" of 2.0/3 came back with 16 digits instead of 17.
+                        str = str.replace(/0+$/, "").replace(/\.$/, "");
+                    }
                 }
 
                 isZero = str.split("").every(function (s) { return s === "0" || s === "."; });

--- a/BCL/Transpose.BCL/Resources/linq.js
+++ b/BCL/Transpose.BCL/Resources/linq.js
@@ -1142,7 +1142,7 @@
             return new IEnumerator(
                 function () {
                     outerEnumerator = source.GetEnumerator();
-                    lookup = Enumerable.from(inner).toLookup(innerKeySelector, Functions.Identity, comparer);
+                    lookup = Enumerable.from(inner).toLookup(innerKeySelector, Functions.Identity, comparer, true);
                 },
                 function () {
                     while (true) {
@@ -1187,7 +1187,7 @@
             return new IEnumerator(
                 function () {
                     enumerator = source.GetEnumerator();
-                    lookup = Enumerable.from(inner).toLookup(innerKeySelector, Functions.Identity, comparer);
+                    lookup = Enumerable.from(inner).toLookup(innerKeySelector, Functions.Identity, comparer, true);
                 },
                 function () {
                     if (enumerator.moveNext()) {
@@ -2414,7 +2414,11 @@
     // Overload:function (keySelector)
     // Overload:function (keySelector, elementSelector)
     // Overload:function (keySelector, elementSelector, compareSelector)
-    Enumerable.prototype.toLookup = function (keySelector, elementSelector, comparer) {
+    // `$skipNullKeys` is internal, for the lookups join/groupJoin build: a null key NEVER matches in
+    // System.Linq (its join lookup simply drops null-keyed elements), whereas ToLookup itself does keep a
+    // null-keyed grouping. Without it, an outer and an inner element that both had a null key were paired
+    // up, and GroupJoin reported a match for an outer element .NET gives an empty group.
+    Enumerable.prototype.toLookup = function (keySelector, elementSelector, comparer, $skipNullKeys) {
         keySelector = Utils.createLambda(keySelector);
         elementSelector = Utils.createLambda(elementSelector);
 
@@ -2428,6 +2432,10 @@
             var array = { v: null };
 
             if (key == null) {
+                if ($skipNullKeys) {
+                    return;
+                }
+
                 if (!nullKey) {
                     nullKey = [];
                     order.push(key);

--- a/BCL/Transpose.BCL/Resources/linq.js
+++ b/BCL/Transpose.BCL/Resources/linq.js
@@ -114,6 +114,29 @@
         }
     };
 
+    // The exceptions the element operators raise. These MUST be real BCL exception objects, not raw
+    // JavaScript `Error`s: a `catch (InvalidOperationException)` in transpiled C# tests the thrown
+    // value against the BCL type, so a raw Error escapes every C# catch clause and tears down the
+    // program instead. The message text matches System.Linq's ThrowHelper exactly, because user code
+    // (and the test suite) compares `ex.Message` against native .NET.
+    var Errors = {
+        noElements: function () {
+            return new System.InvalidOperationException.$ctor1("Sequence contains no elements");
+        },
+        noMatch: function () {
+            return new System.InvalidOperationException.$ctor1("Sequence contains no matching element");
+        },
+        moreThanOneElement: function () {
+            return new System.InvalidOperationException.$ctor1("Sequence contains more than one element");
+        },
+        moreThanOneMatch: function () {
+            return new System.InvalidOperationException.$ctor1("Sequence contains more than one matching element");
+        },
+        outOfRange: function (paramName) {
+            return new System.ArgumentOutOfRangeException.$ctor1(paramName);
+        }
+    };
+
     // IEnumerator State
     var State = { Before: 0, Running: 1, After: 2 };
 
@@ -447,6 +470,9 @@
     // Overload:function (start, count, step)
     Enumerable.range = function (start, count, step) {
         if (step == null) step = 1;
+        // Enumerable.Range validates EAGERLY in .NET (before anything is enumerated), so the check
+        // belongs here rather than inside the iterator.
+        if (count < 0) throw Errors.outOfRange("count");
 
         return new Enumerable(function () {
             var value;
@@ -523,7 +549,12 @@
     // Overload:function (element)
     // Overload:function (element, count)
     Enumerable.repeat = function (element, count) {
-        if (count != null) return Enumerable.repeat(element).take(count);
+        // count == null is linq.js's infinite form (used internally); only the .NET-facing
+        // Repeat(element, count) overload has a count to validate, and it validates eagerly.
+        if (count != null) {
+            if (count < 0) throw Errors.outOfRange("count");
+            return Enumerable.repeat(element).take(count);
+        }
 
         return new Enumerable(function () {
             return new IEnumerator(
@@ -2045,7 +2076,7 @@
             }
         });
 
-        if (!found) throw new Error("index is less than 0 or greater than or equal to the number of elements in source.");
+        if (!found) throw Errors.outOfRange("index");
         return value;
     };
 
@@ -2066,8 +2097,10 @@
 
     // Overload:function ()
     // Overload:function (predicate)
-    Enumerable.prototype.first = function (predicate) {
-        if (predicate != null) return this.where(predicate).first();
+    // `$matching` is internal: the predicate overload filters and then re-enters this method, and
+    // .NET distinguishes "no elements" from "no matching element", so the flag carries which it was.
+    Enumerable.prototype.first = function (predicate, $matching) {
+        if (predicate != null) return this.where(predicate).first(null, true);
 
         var value;
         var found = false;
@@ -2077,7 +2110,7 @@
             return false;
         });
 
-        if (!found) throw new Error("first:No element satisfies the condition.");
+        if (!found) throw $matching ? Errors.noMatch() : Errors.noElements();
         return value;
     };
 
@@ -2097,8 +2130,8 @@
 
     // Overload:function ()
     // Overload:function (predicate)
-    Enumerable.prototype.last = function (predicate) {
-        if (predicate != null) return this.where(predicate).last();
+    Enumerable.prototype.last = function (predicate, $matching) {
+        if (predicate != null) return this.where(predicate).last(null, true);
 
         var value;
         var found = false;
@@ -2107,7 +2140,7 @@
             value = x;
         });
 
-        if (!found) throw new Error("last:No element satisfies the condition.");
+        if (!found) throw $matching ? Errors.noMatch() : Errors.noElements();
         return value;
     };
 
@@ -2128,8 +2161,8 @@
 
     // Overload:function ()
     // Overload:function (predicate)
-    Enumerable.prototype.single = function (predicate) {
-        if (predicate != null) return this.where(predicate).single();
+    Enumerable.prototype.single = function (predicate, $matching) {
+        if (predicate != null) return this.where(predicate).single(null, true);
 
         var value;
         var found = false;
@@ -2137,18 +2170,18 @@
             if (!found) {
                 found = true;
                 value = x;
-            } else throw new Error("single:sequence contains more than one element.");
+            } else throw $matching ? Errors.moreThanOneMatch() : Errors.moreThanOneElement();
         });
 
-        if (!found) throw new Error("single:No element satisfies the condition.");
+        if (!found) throw $matching ? Errors.noMatch() : Errors.noElements();
         return value;
     };
 
     // Overload:function (defaultValue)
     // Overload:function (defaultValue,predicate)
-    Enumerable.prototype.singleOrDefault = function (predicate, defaultValue) {
+    Enumerable.prototype.singleOrDefault = function (predicate, defaultValue, $matching) {
         if (defaultValue === undefined) defaultValue = null;
-        if (predicate != null) return this.where(predicate).singleOrDefault(null, defaultValue);
+        if (predicate != null) return this.where(predicate).singleOrDefault(null, defaultValue, true);
 
         var value;
         var found = false;
@@ -2156,7 +2189,7 @@
             if (!found) {
                 found = true;
                 value = x;
-            } else throw new Error("single:sequence contains more than one element.");
+            } else throw $matching ? Errors.moreThanOneMatch() : Errors.moreThanOneElement();
         });
 
         return (!found) ? defaultValue : value;
@@ -3051,7 +3084,9 @@
     // dictionary = Dictionary<TKey, TValue[]>
     var Lookup = function (dictionary, order, nullKey) {
         this.count = function () {
-            return dictionary.Count;
+            // The null key is held outside `dictionary` (a BCL Dictionary rejects a null key), so it
+            // has to be added back in — System.Linq.Lookup counts a null-keyed grouping like any other.
+            return dictionary.Count + (nullKey ? 1 : 0);
         };
         this.get = function (key) {
             if (key == null) {

--- a/BCL/Transpose.BCL/System/Array.cs
+++ b/BCL/Transpose.BCL/System/Array.cs
@@ -139,7 +139,16 @@ namespace System
 
         public extern object Pop();
 
-        public extern void Reverse();
+        /// <summary>
+        /// The JavaScript <c>Array.prototype.reverse()</c> — reverses the array **in place**.
+        /// Named <c>JsReverse</c> rather than <c>Reverse</c> (the <c>JsSort</c> precedent above) because an
+        /// instance method beats an extension method in overload resolution: a plain <c>Reverse()</c> here
+        /// hid <see cref="System.Linq.Enumerable.Reverse{TSource}"/> for every array, so
+        /// <c>arr.Reverse()</c> resolved to this void member and <c>foreach (var x in arr.Reverse())</c>
+        /// failed to compile. Use <see cref="Reverse(Array)"/> for the in-place BCL form.
+        /// </summary>
+        [Transpose.Name("reverse")]
+        public extern void JsReverse();
 
         public extern object Shift();
 

--- a/BCL/Transpose.BCL/System/Collections/Generic/Dictionary.cs
+++ b/BCL/Transpose.BCL/System/Collections/Generic/Dictionary.cs
@@ -317,7 +317,10 @@ namespace System.Collections.Generic
                 {
                     if (add)
                     {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_AddingDuplicate);
+                        // The KEYED overload: .NET's message names the offending key ("An item with the
+                        // same key has already been added. Key: x"), whereas the resource-only form
+                        // reported the bare resource name, "Argument_AddingDuplicate".
+                        ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
                     }
 
                     entries[GetBucket(this.simpleBuckets, key)].value = value;
@@ -362,7 +365,7 @@ namespace System.Collections.Generic
                 {
                     if (add)
                     {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_AddingDuplicate);
+                        ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
                     }
                     entries[i].value = value;
                     version++;

--- a/BCL/Transpose.BCL/System/Collections/Generic/SortedList.cs
+++ b/BCL/Transpose.BCL/System/Collections/Generic/SortedList.cs
@@ -121,7 +121,7 @@ namespace System.Collections.Generic
             if (key == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             int i = Array.BinarySearch<TKey>(keys, 0, _size, key, comparer);
             if (i >= 0)
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_AddingDuplicate);
+                ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
             Insert(~i, key, value);
         }
 

--- a/BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs
+++ b/BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs
@@ -3,12 +3,32 @@ using System.Collections.Generic;
 namespace System.Linq
 {
     /// <summary>
-    /// C#-implemented LINQ operators that are not part of the external, runtime-backed
-    /// <see cref="Enumerable"/> binding (which maps every method onto <c>linq.js</c>). These are the
-    /// .NET 6+ additions <see cref="Chunk"/>, <see cref="MinBy{TSource,TKey}(IEnumerable{TSource},Func{TSource,TKey})"/>
-    /// and <see cref="MaxBy{TSource,TKey}(IEnumerable{TSource},Func{TSource,TKey})"/>. They are written
-    /// as ordinary transpiled C# (no <c>[External]</c>) so they behave exactly like their BCL
-    /// counterparts — including the empty-sequence and null-key rules of <c>MinBy</c>/<c>MaxBy</c>.
+    /// The LINQ operators added to <c>System.Linq.Enumerable</c> after the surface the external,
+    /// runtime-backed <see cref="Enumerable"/> binding covers (which maps every method onto
+    /// <c>linq.js</c>, whose API predates them). They are written as ordinary transpiled C# — no
+    /// <c>[External]</c>, no <c>[Template]</c> — so they behave exactly like their BCL counterparts,
+    /// including the argument validation, the eager-versus-deferred split (an operator validates its
+    /// arguments when it is CALLED and does its work when the result is enumerated) and the
+    /// key-comparer and null-key rules.
+    ///
+    /// By .NET version:
+    /// <list type="bullet">
+    /// <item><description>Core 2.0/4.7.1: <c>Append</c>, <c>Prepend</c>, <c>ToHashSet</c>,
+    /// <c>SkipLast</c>, <c>TakeLast</c></description></item>
+    /// <item><description>.NET 6: <c>Chunk</c>, <c>MinBy</c>, <c>MaxBy</c>, <c>DistinctBy</c>,
+    /// <c>UnionBy</c>, <c>IntersectBy</c>, <c>ExceptBy</c>, <c>TryGetNonEnumeratedCount</c>, the
+    /// tuple-returning <c>Zip</c> overloads, <c>ElementAt</c>/<c>ElementAtOrDefault</c> by
+    /// <see cref="Index"/> and <c>Take</c> by <see cref="Range"/></description></item>
+    /// <item><description>.NET 7: <c>Order</c>, <c>OrderDescending</c></description></item>
+    /// <item><description>.NET 9: <c>Index</c>, <c>CountBy</c>, <c>AggregateBy</c></description></item>
+    /// </list>
+    ///
+    /// <para><b>One documented difference.</b> <see cref="TryGetNonEnumeratedCount"/> answers true only
+    /// for a real collection. .NET also answers true for some lazy operators whose count it can work out
+    /// cheaply (<c>Enumerable.Range</c>, <c>Select</c> over a list, …), which the runtime's
+    /// <c>EnumerableInstance</c> cannot expose. Answering false is always <i>correct</i> — the contract
+    /// is "can I have the count without enumerating?", and false only means the caller has to enumerate
+    /// — but it does mean the answer can differ from .NET's for those sources.</para>
     /// </summary>
     public static class EnumerableExtras
     {
@@ -188,6 +208,628 @@ namespace System.Linq
                 }
 
                 return value;
+            }
+        }
+
+        // ---- Append / Prepend -------------------------------------------------------------------
+
+        /// <summary>Returns the sequence followed by <paramref name="element"/>.</summary>
+        public static IEnumerable<TSource> Append<TSource>(this IEnumerable<TSource> source, TSource element)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return AppendIterator(source, element);
+        }
+
+        private static IEnumerable<TSource> AppendIterator<TSource>(IEnumerable<TSource> source, TSource element)
+        {
+            foreach (var item in source) yield return item;
+            yield return element;
+        }
+
+        /// <summary>Returns <paramref name="element"/> followed by the sequence.</summary>
+        public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource element)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return PrependIterator(source, element);
+        }
+
+        private static IEnumerable<TSource> PrependIterator<TSource>(IEnumerable<TSource> source, TSource element)
+        {
+            yield return element;
+            foreach (var item in source) yield return item;
+        }
+
+        // ---- ToHashSet --------------------------------------------------------------------------
+
+        /// <summary>Copies the sequence into a <see cref="HashSet{T}"/> using the default comparer.</summary>
+        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source)
+            => ToHashSet(source, null);
+
+        /// <summary>
+        /// Copies the sequence into a <see cref="HashSet{T}"/> using <paramref name="comparer"/> (or the
+        /// default when it is null). Duplicates collapse, and the set keeps first-seen order.
+        /// </summary>
+        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source,
+            IEqualityComparer<TSource> comparer)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return new HashSet<TSource>(source, comparer);
+        }
+
+        // ---- The *By set operators --------------------------------------------------------------
+
+        /// <summary>Returns the elements with distinct keys, keeping the first element per key.</summary>
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector)
+            => DistinctBy(source, keySelector, null);
+
+        /// <summary>
+        /// Returns the elements with distinct keys — the FIRST element of each key, compared with
+        /// <paramref name="comparer"/> (or the default when it is null).
+        /// </summary>
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
+            return DistinctByIterator(source, keySelector, comparer);
+        }
+
+        private static IEnumerable<TSource> DistinctByIterator<TSource, TKey>(IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            var seen = new HashSet<TKey>(comparer);
+
+            foreach (var item in source)
+            {
+                if (seen.Add(keySelector(item))) yield return item;
+            }
+        }
+
+        /// <summary>Set union by key: the elements of both sequences with distinct keys.</summary>
+        public static IEnumerable<TSource> UnionBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second, Func<TSource, TKey> keySelector)
+            => UnionBy(first, second, keySelector, null);
+
+        /// <summary>
+        /// Set union by key: the elements of <paramref name="first"/> then <paramref name="second"/>,
+        /// keeping the first element of each distinct key.
+        /// </summary>
+        public static IEnumerable<TSource> UnionBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            if (first == null) throw new ArgumentNullException(nameof(first));
+            if (second == null) throw new ArgumentNullException(nameof(second));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
+            return UnionByIterator(first, second, keySelector, comparer);
+        }
+
+        private static IEnumerable<TSource> UnionByIterator<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TSource> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            var seen = new HashSet<TKey>(comparer);
+
+            foreach (var item in first)
+            {
+                if (seen.Add(keySelector(item))) yield return item;
+            }
+
+            foreach (var item in second)
+            {
+                if (seen.Add(keySelector(item))) yield return item;
+            }
+        }
+
+        /// <summary>Set intersection by key. <paramref name="second"/> is a sequence of KEYS.</summary>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second, Func<TSource, TKey> keySelector)
+            => IntersectBy(first, second, keySelector, null);
+
+        /// <summary>
+        /// The distinct elements of <paramref name="first"/> whose key appears in
+        /// <paramref name="second"/>. Note that <paramref name="second"/> is a sequence of <b>keys</b>,
+        /// not of elements — that is what distinguishes these overloads from
+        /// <see cref="Enumerable.Intersect{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>.
+        /// </summary>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            if (first == null) throw new ArgumentNullException(nameof(first));
+            if (second == null) throw new ArgumentNullException(nameof(second));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
+            return IntersectByIterator(first, second, keySelector, comparer);
+        }
+
+        private static IEnumerable<TSource> IntersectByIterator<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            var wanted = new HashSet<TKey>(second, comparer);
+
+            foreach (var item in first)
+            {
+                // Removing on a hit is what de-duplicates the result: a key can only be yielded once.
+                if (wanted.Remove(keySelector(item))) yield return item;
+            }
+        }
+
+        /// <summary>Set difference by key. <paramref name="second"/> is a sequence of KEYS.</summary>
+        public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second, Func<TSource, TKey> keySelector)
+            => ExceptBy(first, second, keySelector, null);
+
+        /// <summary>
+        /// The distinct elements of <paramref name="first"/> whose key does NOT appear in
+        /// <paramref name="second"/>, which is a sequence of <b>keys</b>.
+        /// </summary>
+        public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            if (first == null) throw new ArgumentNullException(nameof(first));
+            if (second == null) throw new ArgumentNullException(nameof(second));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
+            return ExceptByIterator(first, second, keySelector, comparer);
+        }
+
+        private static IEnumerable<TSource> ExceptByIterator<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            // Seeding with the excluded keys means Add both filters them out and de-duplicates the rest.
+            var seen = new HashSet<TKey>(second, comparer);
+
+            foreach (var item in first)
+            {
+                if (seen.Add(keySelector(item))) yield return item;
+            }
+        }
+
+        // ---- SkipLast / TakeLast ----------------------------------------------------------------
+
+        /// <summary>
+        /// All but the last <paramref name="count"/> elements. A count of zero or less returns the whole
+        /// sequence rather than throwing.
+        /// </summary>
+        public static IEnumerable<TSource> SkipLast<TSource>(this IEnumerable<TSource> source, int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return count <= 0 ? SkipLastIterator(source, 0) : SkipLastIterator(source, count);
+        }
+
+        private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)
+        {
+            if (count == 0)
+            {
+                foreach (var item in source) yield return item;
+                yield break;
+            }
+
+            // A rolling buffer of the trailing `count` elements: an element is only yielded once a later
+            // one has pushed it out of the window, so the last `count` are never yielded at all.
+            var window = new Queue<TSource>();
+
+            foreach (var item in source)
+            {
+                window.Enqueue(item);
+                if (window.Count > count) yield return window.Dequeue();
+            }
+        }
+
+        /// <summary>
+        /// The last <paramref name="count"/> elements, in source order. A count of zero or less returns an
+        /// empty sequence rather than throwing.
+        /// </summary>
+        public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return TakeLastIterator(source, count);
+        }
+
+        private static IEnumerable<TSource> TakeLastIterator<TSource>(IEnumerable<TSource> source, int count)
+        {
+            if (count <= 0) yield break;
+
+            var window = new Queue<TSource>();
+
+            foreach (var item in source)
+            {
+                window.Enqueue(item);
+                if (window.Count > count) window.Dequeue();
+            }
+
+            while (window.Count > 0) yield return window.Dequeue();
+        }
+
+        // ---- Order / OrderDescending ------------------------------------------------------------
+
+        /// <summary>Sorts the elements by themselves, using the default comparer.</summary>
+        public static IOrderedEnumerable<TSource> Order<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return source.OrderBy(Identity);
+        }
+
+        /// <summary>Sorts the elements by themselves, using <paramref name="comparer"/>.</summary>
+        public static IOrderedEnumerable<TSource> Order<TSource>(this IEnumerable<TSource> source,
+            IComparer<TSource> comparer)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return source.OrderBy(Identity, comparer);
+        }
+
+        /// <summary>Sorts the elements by themselves in descending order, using the default comparer.</summary>
+        public static IOrderedEnumerable<TSource> OrderDescending<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return source.OrderByDescending(Identity);
+        }
+
+        /// <summary>Sorts the elements by themselves in descending order, using <paramref name="comparer"/>.</summary>
+        public static IOrderedEnumerable<TSource> OrderDescending<TSource>(this IEnumerable<TSource> source,
+            IComparer<TSource> comparer)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return source.OrderByDescending(Identity, comparer);
+        }
+
+        /// <summary>The key selector <c>Order</c>/<c>OrderDescending</c> sort by: the element itself.</summary>
+        private static TSource Identity<TSource>(TSource value) => value;
+
+        // ---- Index ------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Pairs every element with its zero-based position, as <c>(Index, Item)</c> — the tuple-returning
+        /// form of <c>Select((item, index) =&gt; …)</c> that reads well in a <c>foreach</c>.
+        /// </summary>
+        public static IEnumerable<(int Index, TSource Item)> Index<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return IndexIterator(source);
+        }
+
+        private static IEnumerable<(int Index, TSource Item)> IndexIterator<TSource>(IEnumerable<TSource> source)
+        {
+            int index = 0;
+
+            foreach (var item in source)
+            {
+                yield return (index, item);
+                index++;
+            }
+        }
+
+        // ---- CountBy / AggregateBy --------------------------------------------------------------
+
+        /// <summary>
+        /// Counts the elements per key, as <c>KeyValuePair&lt;TKey, int&gt;</c>s in first-seen key order.
+        /// Cheaper and more direct than <c>GroupBy(key).Select(g =&gt; …g.Count())</c>, which materializes
+        /// every group.
+        /// </summary>
+        public static IEnumerable<KeyValuePair<TKey, int>> CountBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
+            return CountByIterator(source, keySelector, keyComparer);
+        }
+
+        private static IEnumerable<KeyValuePair<TKey, int>> CountByIterator<TSource, TKey>(
+            IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> keyComparer)
+        {
+            // The key order is the order the keys were first SEEN, which a Dictionary does not promise, so
+            // it is tracked separately.
+            var counts = new Dictionary<TKey, int>(keyComparer);
+            var order = new List<TKey>();
+
+            foreach (var item in source)
+            {
+                TKey key = keySelector(item);
+                int existing;
+                if (counts.TryGetValue(key, out existing))
+                {
+                    counts[key] = existing + 1;
+                }
+                else
+                {
+                    counts.Add(key, 1);
+                    order.Add(key);
+                }
+            }
+
+            foreach (var key in order) yield return new KeyValuePair<TKey, int>(key, counts[key]);
+        }
+
+        /// <summary>
+        /// Aggregates the elements per key from a shared <paramref name="seed"/>, as
+        /// <c>KeyValuePair&lt;TKey, TAccumulate&gt;</c>s in first-seen key order.
+        /// </summary>
+        public static IEnumerable<KeyValuePair<TKey, TAccumulate>> AggregateBy<TSource, TKey, TAccumulate>(
+            this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, TAccumulate seed,
+            Func<TAccumulate, TSource, TAccumulate> func, IEqualityComparer<TKey> keyComparer = null)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            if (func == null) throw new ArgumentNullException(nameof(func));
+
+            return AggregateByIterator(source, keySelector, ConstantSeed<TKey, TAccumulate>(seed), func, keyComparer);
+        }
+
+        /// <summary>
+        /// Aggregates the elements per key, with the seed computed per key by
+        /// <paramref name="seedSelector"/> — for an accumulator that must not be shared between keys
+        /// (a <c>List&lt;T&gt;</c>, say).
+        /// </summary>
+        public static IEnumerable<KeyValuePair<TKey, TAccumulate>> AggregateBy<TSource, TKey, TAccumulate>(
+            this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+            Func<TKey, TAccumulate> seedSelector, Func<TAccumulate, TSource, TAccumulate> func,
+            IEqualityComparer<TKey> keyComparer = null)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            if (seedSelector == null) throw new ArgumentNullException(nameof(seedSelector));
+            if (func == null) throw new ArgumentNullException(nameof(func));
+
+            return AggregateByIterator(source, keySelector, seedSelector, func, keyComparer);
+        }
+
+        /// <summary>Turns the shared-seed overload's single value into the per-key selector form.</summary>
+        private static Func<TKey, TAccumulate> ConstantSeed<TKey, TAccumulate>(TAccumulate seed)
+            => key => seed;
+
+        private static IEnumerable<KeyValuePair<TKey, TAccumulate>> AggregateByIterator<TSource, TKey, TAccumulate>(
+            IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, TAccumulate> seedSelector,
+            Func<TAccumulate, TSource, TAccumulate> func, IEqualityComparer<TKey> keyComparer)
+        {
+            var accumulators = new Dictionary<TKey, TAccumulate>(keyComparer);
+            var order = new List<TKey>();
+
+            foreach (var item in source)
+            {
+                TKey key = keySelector(item);
+                TAccumulate accumulator;
+                if (!accumulators.TryGetValue(key, out accumulator))
+                {
+                    accumulator = seedSelector(key);
+                    order.Add(key);
+                }
+
+                accumulators[key] = func(accumulator, item);
+            }
+
+            foreach (var key in order) yield return new KeyValuePair<TKey, TAccumulate>(key, accumulators[key]);
+        }
+
+        // ---- TryGetNonEnumeratedCount -----------------------------------------------------------
+
+        /// <summary>
+        /// Reports the element count when it can be had without enumerating — i.e. when the source is a
+        /// real collection. See the type's remarks: a lazy sequence answers false here even where .NET
+        /// could work its count out cheaply, which is a permitted (if less helpful) answer.
+        /// </summary>
+        public static bool TryGetNonEnumeratedCount<TSource>(this IEnumerable<TSource> source, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            if (source is ICollection<TSource> generic)
+            {
+                count = generic.Count;
+                return true;
+            }
+
+            if (source is System.Collections.ICollection collection)
+            {
+                count = collection.Count;
+                return true;
+            }
+
+            count = 0;
+            return false;
+        }
+
+        // ---- The tuple-returning Zip overloads --------------------------------------------------
+
+        /// <summary>
+        /// Pairs the two sequences positionally as tuples, stopping at the shorter one — the selectorless
+        /// form of <see cref="Enumerable.Zip{TFirst, TSecond, TResult}(IEnumerable{TFirst}, IEnumerable{TSecond}, Func{TFirst, TSecond, TResult})"/>.
+        /// </summary>
+        public static IEnumerable<(TFirst First, TSecond Second)> Zip<TFirst, TSecond>(
+            this IEnumerable<TFirst> first, IEnumerable<TSecond> second)
+        {
+            if (first == null) throw new ArgumentNullException(nameof(first));
+            if (second == null) throw new ArgumentNullException(nameof(second));
+
+            return ZipIterator(first, second);
+        }
+
+        private static IEnumerable<(TFirst First, TSecond Second)> ZipIterator<TFirst, TSecond>(
+            IEnumerable<TFirst> first, IEnumerable<TSecond> second)
+        {
+            using (var e1 = first.GetEnumerator())
+            using (var e2 = second.GetEnumerator())
+            {
+                while (e1.MoveNext() && e2.MoveNext())
+                {
+                    yield return (e1.Current, e2.Current);
+                }
+            }
+        }
+
+        /// <summary>Pairs three sequences positionally as tuples, stopping at the shortest.</summary>
+        public static IEnumerable<(TFirst First, TSecond Second, TThird Third)> Zip<TFirst, TSecond, TThird>(
+            this IEnumerable<TFirst> first, IEnumerable<TSecond> second, IEnumerable<TThird> third)
+        {
+            if (first == null) throw new ArgumentNullException(nameof(first));
+            if (second == null) throw new ArgumentNullException(nameof(second));
+            if (third == null) throw new ArgumentNullException(nameof(third));
+
+            return ZipIterator(first, second, third);
+        }
+
+        private static IEnumerable<(TFirst First, TSecond Second, TThird Third)> ZipIterator<TFirst, TSecond, TThird>(
+            IEnumerable<TFirst> first, IEnumerable<TSecond> second, IEnumerable<TThird> third)
+        {
+            using (var e1 = first.GetEnumerator())
+            using (var e2 = second.GetEnumerator())
+            using (var e3 = third.GetEnumerator())
+            {
+                while (e1.MoveNext() && e2.MoveNext() && e3.MoveNext())
+                {
+                    yield return (e1.Current, e2.Current, e3.Current);
+                }
+            }
+        }
+
+        // ---- Index/Range indexing ---------------------------------------------------------------
+
+        /// <summary>
+        /// The element at <paramref name="index"/>, which may count from the end (<c>^1</c> is the last).
+        /// Throws <see cref="ArgumentOutOfRangeException"/> when the index is outside the sequence.
+        /// </summary>
+        public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, System.Index index)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            if (!index.IsFromEnd) return source.ElementAt(index.Value);
+
+            TSource value;
+            if (!TryGetElementFromEnd(source, index.Value, out value))
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// The element at <paramref name="index"/> (which may count from the end), or the type's default
+        /// when the index is outside the sequence.
+        /// </summary>
+        public static TSource ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, System.Index index)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            if (!index.IsFromEnd) return source.ElementAtOrDefault(index.Value);
+
+            TSource value;
+            return TryGetElementFromEnd(source, index.Value, out value) ? value : default(TSource);
+        }
+
+        /// <summary>
+        /// Reads the element <paramref name="fromEnd"/> places from the end (1 being the last) with a
+        /// rolling buffer, so the source is enumerated once and only that many elements are held.
+        /// </summary>
+        private static bool TryGetElementFromEnd<TSource>(IEnumerable<TSource> source, int fromEnd, out TSource value)
+        {
+            value = default(TSource);
+
+            // ^0 is one past the last element, so it is never in range.
+            if (fromEnd <= 0) return false;
+
+            var window = new Queue<TSource>();
+
+            foreach (var item in source)
+            {
+                window.Enqueue(item);
+                if (window.Count > fromEnd) window.Dequeue();
+            }
+
+            if (window.Count < fromEnd) return false;
+
+            value = window.Dequeue();
+            return true;
+        }
+
+        /// <summary>
+        /// The elements in <paramref name="range"/>, whose ends may each count from the start or the end
+        /// (<c>1..^1</c> drops the first and the last). An empty or inverted range yields nothing rather
+        /// than throwing.
+        /// </summary>
+        public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, Range range)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return TakeRangeIterator(source, range);
+        }
+
+        private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, Range range)
+        {
+            System.Index start = range.Start;
+            System.Index end = range.End;
+
+            if (start.IsFromEnd)
+            {
+                // A window that starts from the END cannot be placed until the length is known, so the
+                // source is buffered. (Every other shape streams.)
+                var buffered = new List<TSource>(source);
+                int length = buffered.Count;
+                int from = start.GetOffset(length);
+                int to = end.GetOffset(length);
+                if (from < 0) from = 0;
+                if (to > length) to = length;
+
+                for (int i = from; i < to; i++) yield return buffered[i];
+                yield break;
+            }
+
+            int skip = start.Value;
+
+            if (!end.IsFromEnd)
+            {
+                int stop = end.Value;
+                if (stop <= skip) yield break;
+
+                int index = 0;
+                foreach (var item in source)
+                {
+                    if (index >= stop) break;
+                    if (index >= skip) yield return item;
+                    index++;
+                }
+
+                yield break;
+            }
+
+            int dropped = end.Value;
+
+            if (dropped == 0)
+            {
+                int index = 0;
+                foreach (var item in source)
+                {
+                    if (index >= skip) yield return item;
+                    index++;
+                }
+
+                yield break;
+            }
+
+            // Both ends are known relative to the start except for the trailing `dropped` elements, so a
+            // rolling buffer of that size is enough — the source still streams.
+            var window = new Queue<TSource>();
+            int position = 0;
+
+            foreach (var item in source)
+            {
+                window.Enqueue(item);
+                if (window.Count > dropped)
+                {
+                    TSource ready = window.Dequeue();
+                    if (position >= skip) yield return ready;
+                    position++;
+                }
             }
         }
     }

--- a/BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs
+++ b/BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs
@@ -21,7 +21,12 @@ namespace System.Linq
     /// <see cref="Index"/> and <c>Take</c> by <see cref="Range"/></description></item>
     /// <item><description>.NET 7: <c>Order</c>, <c>OrderDescending</c></description></item>
     /// <item><description>.NET 9: <c>Index</c>, <c>CountBy</c>, <c>AggregateBy</c></description></item>
+    /// <item><description>.NET 10: <c>Shuffle</c>, <c>LeftJoin</c>, <c>RightJoin</c></description></item>
     /// </list>
+    ///
+    /// Plus the <c>FirstOrDefault</c>/<c>LastOrDefault</c>/<c>SingleOrDefault</c> overloads that take an
+    /// explicit default (.NET 6). <c>EnumerableInstance</c> — what a chained query evaluates to — already
+    /// binds those onto <c>linq.js</c>, so only an <c>IEnumerable&lt;T&gt;</c> receiver needed them.
     ///
     /// <para><b>One documented difference.</b> <see cref="TryGetNonEnumeratedCount"/> answers true only
     /// for a real collection. .NET also answers true for some lazy operators whose count it can work out
@@ -690,6 +695,279 @@ namespace System.Linq
                     yield return (e1.Current, e2.Current, e3.Current);
                 }
             }
+        }
+
+        // ---- The *OrDefault overloads that take an explicit default ----------------------------
+
+        /// <summary>The first element, or <paramref name="defaultValue"/> when the sequence is empty.</summary>
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            foreach (var item in source) return item;
+
+            return defaultValue;
+        }
+
+        /// <summary>The first matching element, or <paramref name="defaultValue"/> when none matches.</summary>
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate, TSource defaultValue)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            foreach (var item in source)
+            {
+                if (predicate(item)) return item;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>The last element, or <paramref name="defaultValue"/> when the sequence is empty.</summary>
+        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            TSource last = defaultValue;
+            foreach (var item in source) last = item;
+
+            return last;
+        }
+
+        /// <summary>The last matching element, or <paramref name="defaultValue"/> when none matches.</summary>
+        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate, TSource defaultValue)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            TSource last = defaultValue;
+            foreach (var item in source)
+            {
+                if (predicate(item)) last = item;
+            }
+
+            return last;
+        }
+
+        /// <summary>
+        /// The single element, or <paramref name="defaultValue"/> when the sequence is empty. Still throws
+        /// when the sequence holds more than one element — the "OrDefault" covers emptiness, not ambiguity.
+        /// </summary>
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            using (var e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) return defaultValue;
+
+                TSource single = e.Current;
+                if (e.MoveNext()) throw new InvalidOperationException("Sequence contains more than one element");
+
+                return single;
+            }
+        }
+
+        /// <summary>
+        /// The single matching element, or <paramref name="defaultValue"/> when none matches. Throws when
+        /// more than one element matches.
+        /// </summary>
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate, TSource defaultValue)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            TSource single = defaultValue;
+            bool found = false;
+
+            foreach (var item in source)
+            {
+                if (!predicate(item)) continue;
+                if (found) throw new InvalidOperationException("Sequence contains more than one matching element");
+
+                single = item;
+                found = true;
+            }
+
+            return single;
+        }
+
+        // ---- Shuffle ----------------------------------------------------------------------------
+
+        /// <summary>
+        /// The elements in a random order, using <see cref="Random.Shared"/>. Deferred: nothing is drawn
+        /// until the result is enumerated, and each enumeration shuffles afresh.
+        /// </summary>
+        public static IEnumerable<TSource> Shuffle<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ShuffleIterator(source);
+        }
+
+        private static IEnumerable<TSource> ShuffleIterator<TSource>(IEnumerable<TSource> source)
+        {
+            // The whole sequence has to be in hand before the first element can be known, so it is
+            // buffered and shuffled in place (Fisher-Yates) rather than streamed.
+            var buffer = new List<TSource>(source);
+            var random = Random.Shared;
+
+            for (int i = buffer.Count - 1; i > 0; i--)
+            {
+                int j = random.Next(i + 1);
+                TSource swap = buffer[i];
+                buffer[i] = buffer[j];
+                buffer[j] = swap;
+            }
+
+            foreach (var item in buffer) yield return item;
+        }
+
+        // ---- LeftJoin / RightJoin ---------------------------------------------------------------
+
+        /// <summary>
+        /// Correlates the two sequences on a key, keeping every element of <paramref name="outer"/>: an
+        /// outer element with no match is paired with <c>default(TInner)</c>.
+        /// </summary>
+        public static IEnumerable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer,
+            IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector,
+            Func<TOuter, TInner, TResult> resultSelector)
+            => LeftJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, null);
+
+        /// <summary>
+        /// Correlates the two sequences on a key compared with <paramref name="comparer"/>, keeping every
+        /// element of <paramref name="outer"/>. The result is in outer order, with each outer element's
+        /// matches in inner order. A null key never matches, so an outer element with one is always paired
+        /// with <c>default(TInner)</c>.
+        /// </summary>
+        public static IEnumerable<TResult> LeftJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer,
+            IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector,
+            Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            if (outer == null) throw new ArgumentNullException(nameof(outer));
+            if (inner == null) throw new ArgumentNullException(nameof(inner));
+            if (outerKeySelector == null) throw new ArgumentNullException(nameof(outerKeySelector));
+            if (innerKeySelector == null) throw new ArgumentNullException(nameof(innerKeySelector));
+            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
+            return LeftJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+        private static IEnumerable<TResult> LeftJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer,
+            IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector,
+            Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            using (var e = outer.GetEnumerator())
+            {
+                // An empty outer means no result at all, and .NET does not even enumerate the inner
+                // sequence in that case — so the lookup is built only once there is something to match.
+                if (!e.MoveNext()) yield break;
+
+                var lookup = BuildJoinLookup(inner, innerKeySelector, comparer);
+
+                do
+                {
+                    TOuter item = e.Current;
+                    TKey key = outerKeySelector(item);
+                    List<TInner> matches;
+
+                    if (key != null && lookup.TryGetValue(key, out matches))
+                    {
+                        foreach (var match in matches) yield return resultSelector(item, match);
+                    }
+                    else
+                    {
+                        yield return resultSelector(item, default(TInner));
+                    }
+                }
+                while (e.MoveNext());
+            }
+        }
+
+        /// <summary>
+        /// Correlates the two sequences on a key, keeping every element of <paramref name="inner"/>: an
+        /// inner element with no match is paired with <c>default(TOuter)</c>.
+        /// </summary>
+        public static IEnumerable<TResult> RightJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer,
+            IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector,
+            Func<TOuter, TInner, TResult> resultSelector)
+            => RightJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, null);
+
+        /// <summary>
+        /// Correlates the two sequences on a key compared with <paramref name="comparer"/>, keeping every
+        /// element of <paramref name="inner"/>. The result is in INNER order (the kept side drives it),
+        /// with each inner element's matches in outer order.
+        /// </summary>
+        public static IEnumerable<TResult> RightJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer,
+            IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector,
+            Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            if (outer == null) throw new ArgumentNullException(nameof(outer));
+            if (inner == null) throw new ArgumentNullException(nameof(inner));
+            if (outerKeySelector == null) throw new ArgumentNullException(nameof(outerKeySelector));
+            if (innerKeySelector == null) throw new ArgumentNullException(nameof(innerKeySelector));
+            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
+            return RightJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+        private static IEnumerable<TResult> RightJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer,
+            IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector,
+            Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            using (var e = inner.GetEnumerator())
+            {
+                if (!e.MoveNext()) yield break;
+
+                var lookup = BuildJoinLookup(outer, outerKeySelector, comparer);
+
+                do
+                {
+                    TInner item = e.Current;
+                    TKey key = innerKeySelector(item);
+                    List<TOuter> matches;
+
+                    if (key != null && lookup.TryGetValue(key, out matches))
+                    {
+                        foreach (var match in matches) yield return resultSelector(match, item);
+                    }
+                    else
+                    {
+                        yield return resultSelector(default(TOuter), item);
+                    }
+                }
+                while (e.MoveNext());
+            }
+        }
+
+        /// <summary>
+        /// Groups a join's matched side by key, in source order within each key. Null-keyed elements are
+        /// DROPPED, which is how System.Linq's join lookup behaves — a null key never correlates.
+        /// </summary>
+        private static Dictionary<TKey, List<TElement>> BuildJoinLookup<TElement, TKey>(IEnumerable<TElement> source,
+            Func<TElement, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            var lookup = new Dictionary<TKey, List<TElement>>(comparer);
+
+            foreach (var item in source)
+            {
+                TKey key = keySelector(item);
+                if (key == null) continue;
+
+                List<TElement> bucket;
+                if (!lookup.TryGetValue(key, out bucket))
+                {
+                    bucket = new List<TElement>();
+                    lookup.Add(key, bucket);
+                }
+
+                bucket.Add(item);
+            }
+
+            return lookup;
         }
 
         // ---- Index/Range indexing ---------------------------------------------------------------

--- a/BCL/Transpose.BCL/System/MemoryExtensions.cs
+++ b/BCL/Transpose.BCL/System/MemoryExtensions.cs
@@ -35,14 +35,19 @@ namespace System
              return new ReadOnlySpan<char>(text.ToCharArray(), start, length);
         }
 
-        public static bool SequenceEqual<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other) where T : IEquatable<T>
-        {
-            if (span.Length != other.Length) return false;
-            for (int i = 0; i < span.Length; i++)
-            {
-                if (!EqualityComparer<T>.Default.Equals(span[i], other[i])) return false;
-            }
-            return true;
-        }
+        /// <summary>
+        /// Element-wise comparison of two spans.
+        /// </summary>
+        /// <remarks>
+        /// Mapped onto a runtime helper rather than written in C# over the span indexer. C# resolves
+        /// <c>someArray.SequenceEqual(otherArray)</c> to *this* overload (the array-to-span conversion
+        /// beats array-to-<c>IEnumerable</c>) rather than to
+        /// <see cref="System.Linq.Enumerable.SequenceEqual{TSource}(IEnumerable{TSource}, IEnumerable{TSource})"/>,
+        /// so this method has to cope with a span that is really the raw JS array — the implicit
+        /// array-to-span conversion is not modelled, so it arrives unwrapped. Indexing it as a span
+        /// (<c>span.getItem(i)</c>) threw "getItem is not a function"; the helper accepts either shape.
+        /// </remarks>
+        [Transpose.Template("TransposeR.spanSequenceEqual({span}, {other})")]
+        public static extern bool SequenceEqual<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other) where T : IEquatable<T>;
     }
 }

--- a/BCL/Transpose.BCL/System/Text/UTF32Encoding.cs
+++ b/BCL/Transpose.BCL/System/Text/UTF32Encoding.cs
@@ -113,7 +113,7 @@ namespace System.Text
 
                 if (this.bigEndian)
                 {
-                    r.Reverse();
+                    Array.Reverse(r);
                 }
 
                 write(r[0]);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,12 +431,14 @@ The short version:
   implemented alongside it as plain transpiled C# in `BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs`:
   `Append`, `Prepend`, `ToHashSet`, `Chunk`, `MinBy`, `MaxBy`, `DistinctBy`, `UnionBy`, `IntersectBy`,
   `ExceptBy`, `SkipLast`, `TakeLast`, `Order`, `OrderDescending`, `Index`, `CountBy`, `AggregateBy`,
-  `TryGetNonEnumeratedCount`, the tuple-returning `Zip` overloads, and `ElementAt`/`ElementAtOrDefault`
-  by `Index` / `Take` by `Range`. Covered by `Linq/LinqModernOperatorTests`. `TryGetNonEnumeratedCount`
-  carries the one documented difference: it answers true only for a real collection, where .NET also
-  answers true for lazy operators whose count it can work out cheaply — false is a permitted answer, but
-  it is not always the *same* answer. Still absent: the `*OrDefault(defaultValue)` overloads
-  (`FirstOrDefault(source, 42)` and friends) and .NET 10's `Shuffle`/`RightJoin`/`LeftJoin`.
+  `TryGetNonEnumeratedCount`, `Shuffle`, `LeftJoin`, `RightJoin`, the tuple-returning `Zip` overloads,
+  `ElementAt`/`ElementAtOrDefault` by `Index` / `Take` by `Range`, and the
+  `FirstOrDefault`/`LastOrDefault`/`SingleOrDefault` overloads that take an explicit default (only for an
+  `IEnumerable<T>` receiver — `EnumerableInstance`, what a chained query evaluates to, already binds those
+  onto `linq.js`). Covered by `Linq/LinqModernOperatorTests`. `TryGetNonEnumeratedCount` carries the one
+  documented difference: it answers true only for a real collection, where .NET also answers true for lazy
+  operators whose count it can work out cheaply — false is a permitted answer, but it is not always the
+  *same* answer.
 - **A positional pattern only resolves members for tuples and records** — `x is Foo(1, 2)` against a
   type with a hand-written `Deconstruct(out …)` still reads `Item1`/`Item2` (see
   `PositionalPatternMemberNames`), because a pattern test is emitted as a single JS expression and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ Transpose/                     # The compiler toolchain
 ├── Transpose.Build.Target/    # MSBuild SDK (package id Transpose.Build.Target) that invokes `tps`
 ├── Transpose.Template/        # `dotnet new` template (package id Transpose.Template)
 ├── Transpose.Translator.Tests/# MSTest suite; transpiles snippets and diffs vs native .NET on Node
+│   ├── Ported/                #   the suites ported from h5, one per language/BCL area
+│   └── Linq/                  #   the LINQ surface: every Enumerable/EnumerableExtras overload, every
+│                              #   element type (class/struct/record/record struct/enum/nullable/tuple/
+│                              #   anonymous/dynamic/…), query syntax, and the exception/edge cases
 └── Transpose.WatchMode.Tests/ # MSTest suite for `tps --watch`: a real tps subprocess + headless
                                #   Chromium (Playwright). Separate project on purpose — it waits on
                                #   wall-clock events, so sharing a host with the Roslyn-heavy suite
@@ -406,7 +410,28 @@ The short version:
   `DateTime`/tuple assignment allocate, so it is a deliberate trade-off rather than an oversight.
 - **`Span<T>` does not accept the implicit array conversion** — `Span<int> s = new int[3];` emits
   the bare array, so `s[0] = 1` throws "setItem is not a function". Unrelated to `stackalloc`;
-  the conversion itself is simply not modelled.
+  the conversion itself is simply not modelled. A span therefore reaches JS in one of two shapes —
+  a real span object (built by a span constructor, e.g. through `string.AsSpan`) or the bare array —
+  so a span helper has to normalise first (`TransposeR.spanArray`). `MemoryExtensions.SequenceEqual`
+  does: C# resolves `someArray.SequenceEqual(other)` to *it* rather than to `Enumerable.SequenceEqual`
+  (the array-to-span conversion beats array-to-`IEnumerable`), so that very common LINQ call would
+  otherwise throw "getItem is not a function".
+- **A boxed numeric loses its exact type.** Every JS number is a double, so `(object)1 is double` is
+  true and `objects.OfType<double>()` also matches the boxed `int`s. `long`/`ulong`/`decimal` are
+  real runtime objects and are unaffected, as are reference types and structs.
+- **`dynamic` has no runtime overload resolver.** A generic call with a `dynamic` argument works when
+  the method has one candidate (`Enumerable.Count(dyn)`); with numeric overloads to choose between
+  (`Enumerable.Sum(dyn)`) there is no single binding and the emitted call does not exist.
+- **The BCL's `ThrowHelper` messages are resource NAMES, not text.** `SR` is not ported, so a throw
+  routed through `ThrowHelper.Throw*Exception(ExceptionResource.X)` reports "X" as its message where
+  .NET reports a sentence. Sites whose message is user-facing (e.g. the duplicate key
+  `ToDictionary` surfaces) call the keyed helper instead, which carries real text.
+- **LINQ operators added after .NET 6 are not in the BCL.** `Enumerable` covers the classic surface
+  plus `Chunk`/`MinBy`/`MaxBy` (the latter three in `EnumerableExtras`, as plain transpiled C#).
+  Missing, so a call fails to compile: `Append`, `Prepend`, `ToHashSet`, `DistinctBy`, `UnionBy`,
+  `IntersectBy`, `ExceptBy`, `SkipLast`, `TakeLast`, `Order`, `OrderDescending`, `Index`, `CountBy`,
+  `AggregateBy`, `TryGetNonEnumeratedCount`, the two-argument tuple `Zip`, `ElementAt(Index)` and
+  `Take(Range)`. `EnumerableExtras` is where they belong.
 - **A positional pattern only resolves members for tuples and records** — `x is Foo(1, 2)` against a
   type with a hand-written `Deconstruct(out …)` still reads `Item1`/`Item2` (see
   `PositionalPatternMemberNames`), because a pattern test is emitted as a single JS expression and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,12 +426,17 @@ The short version:
   routed through `ThrowHelper.Throw*Exception(ExceptionResource.X)` reports "X" as its message where
   .NET reports a sentence. Sites whose message is user-facing (e.g. the duplicate key
   `ToDictionary` surfaces) call the keyed helper instead, which carries real text.
-- **LINQ operators added after .NET 6 are not in the BCL.** `Enumerable` covers the classic surface
-  plus `Chunk`/`MinBy`/`MaxBy` (the latter three in `EnumerableExtras`, as plain transpiled C#).
-  Missing, so a call fails to compile: `Append`, `Prepend`, `ToHashSet`, `DistinctBy`, `UnionBy`,
-  `IntersectBy`, `ExceptBy`, `SkipLast`, `TakeLast`, `Order`, `OrderDescending`, `Index`, `CountBy`,
-  `AggregateBy`, `TryGetNonEnumeratedCount`, the two-argument tuple `Zip`, `ElementAt(Index)` and
-  `Take(Range)`. `EnumerableExtras` is where they belong.
+- **The modern LINQ surface lives in `EnumerableExtras` (done).** `Enumerable` is the external binding
+  onto `linq.js`, whose API predates everything `System.Linq` gained after it, so those operators are
+  implemented alongside it as plain transpiled C# in `BCL/Transpose.BCL/System/Linq/EnumerableExtras.cs`:
+  `Append`, `Prepend`, `ToHashSet`, `Chunk`, `MinBy`, `MaxBy`, `DistinctBy`, `UnionBy`, `IntersectBy`,
+  `ExceptBy`, `SkipLast`, `TakeLast`, `Order`, `OrderDescending`, `Index`, `CountBy`, `AggregateBy`,
+  `TryGetNonEnumeratedCount`, the tuple-returning `Zip` overloads, and `ElementAt`/`ElementAtOrDefault`
+  by `Index` / `Take` by `Range`. Covered by `Linq/LinqModernOperatorTests`. `TryGetNonEnumeratedCount`
+  carries the one documented difference: it answers true only for a real collection, where .NET also
+  answers true for lazy operators whose count it can work out cheaply — false is a permitted answer, but
+  it is not always the *same* answer. Still absent: the `*OrDefault(defaultValue)` overloads
+  (`FirstOrDefault(source, 42)` and friends) and .NET 10's `Shuffle`/`RightJoin`/`LeftJoin`.
 - **A positional pattern only resolves members for tuples and records** — `x is Foo(1, 2)` against a
   type with a hand-written `Deconstruct(out …)` still reads `Item1`/`Item2` (see
   `PositionalPatternMemberNames`), because a pattern test is emitted as a single JS expression and

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqElementTypeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqElementTypeTests.cs
@@ -1,0 +1,682 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Linq
+{
+    /// <summary>
+    /// LINQ over <b>every kind of element type</b> and the combinations of them: the primitives
+    /// (int/long/float/double/decimal/string/char/bool), an enum, a class, a struct, a record class, a
+    /// record struct, a nullable value type (including a nullable struct), a ValueTuple, a
+    /// <c>KeyValuePair</c>, an anonymous type, <c>dynamic</c>, an interface, a type parameter inside a
+    /// generic method — and, where the element type has structure, a nested combination of them.
+    ///
+    /// The element type is what decides how the operators that need <b>equality</b>
+    /// (<c>Distinct</c>/<c>Union</c>/<c>Intersect</c>/<c>Except</c>/<c>Contains</c>/<c>GroupBy</c>/
+    /// <c>ToLookup</c>/<c>ToDictionary</c>/<c>SequenceEqual</c>) and <b>ordering</b>
+    /// (<c>OrderBy</c>/<c>Min</c>/<c>Max</c>/<c>MinBy</c>/<c>MaxBy</c>) behave, so each type is put
+    /// through both families rather than just through <c>Select</c>/<c>Where</c>.
+    ///
+    /// <para><b>Deliberately not covered — known limitations, not regressions:</b></para>
+    /// <list type="bullet">
+    /// <item><description><c>OfType&lt;double&gt;()</c> / <c>OfType&lt;float&gt;()</c> over a sequence of
+    /// boxed integers. Every JS number is a double, so a boxed <c>int</c> is indistinguishable from a
+    /// boxed <c>double</c> and <c>(object)1 is double</c> is true — the same limitation as elsewhere in
+    /// the runtime, not something LINQ can fix. <c>OfType</c> over reference types, structs and
+    /// <c>long</c> (a real object at runtime) IS covered.</description></item>
+    /// <item><description>A <c>dynamic</c> receiver whose operator has numeric overloads
+    /// (<c>Enumerable.Sum(dyn)</c>). There is no runtime overload resolver, so the call has no single
+    /// binding; a dynamic receiver on an unambiguous operator (<c>Enumerable.Count(dyn)</c>) is
+    /// covered.</description></item>
+    /// </list>
+    /// </summary>
+    [TestClass]
+    public class LinqElementTypeTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task ClassElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Person
+{
+    public string Name;
+    public int Age;
+    public override string ToString() => Name + "/" + Age;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var ps = new List<Person>
+        {
+            new Person { Name = "bob", Age = 30 },
+            new Person { Name = "amy", Age = 25 },
+            new Person { Name = "cal", Age = 30 },
+        };
+        Console.WriteLine(string.Join(",", ps.OrderBy(p => p.Age).ThenBy(p => p.Name)));
+        Console.WriteLine(ps.Sum(p => p.Age) + "," + ps.Max(p => p.Age) + "," + ps.Average(p => p.Age));
+        Console.WriteLine(ps.MinBy(p => p.Age) + "," + ps.MaxBy(p => p.Name));
+        Console.WriteLine(string.Join(";", ps.GroupBy(p => p.Age).OrderBy(g => g.Key).Select(g => g.Key + ":" + g.Count())));
+        Console.WriteLine(ps.First(p => p.Age == 25));
+        Console.WriteLine(string.Join(",", ps.Select(p => p.Name).Distinct()));
+        Console.WriteLine(ps.ToDictionary(p => p.Name)["amy"]);
+        Console.WriteLine(string.Join(",", ps.Where(p => p.Age > 26).Select(p => p.Name)));
+        // A class has reference equality, so Distinct keeps all three and Contains needs the same instance.
+        Console.WriteLine(ps.Contains(ps[0]) + "," + ps.Contains(new Person { Name = "bob", Age = 30 }));
+        Console.WriteLine(ps.Distinct().Count());
+        Console.WriteLine(ps.ToLookup(p => p.Age).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task StructElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public struct Pt
+{
+    public int X;
+    public int Y;
+    public override string ToString() => "(" + X + "," + Y + ")";
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var pts = new List<Pt>
+        {
+            new Pt { X = 2, Y = 1 },
+            new Pt { X = 1, Y = 5 },
+            new Pt { X = 2, Y = 1 },
+        };
+        Console.WriteLine(string.Join(",", pts.OrderBy(p => p.X).ThenBy(p => p.Y)));
+        Console.WriteLine(pts.Sum(p => p.X) + "," + pts.Count(p => p.X == 2));
+        // A struct has VALUE equality, so the duplicate collapses and Contains matches by value.
+        Console.WriteLine(pts.Distinct().Count());
+        Console.WriteLine(pts.Contains(new Pt { X = 1, Y = 5 }));
+        Console.WriteLine(string.Join(";", pts.GroupBy(p => p.X).OrderBy(g => g.Key).Select(g => g.Key + ":" + g.Count())));
+        Console.WriteLine(pts.MaxBy(p => p.Y) + "," + pts.MinBy(p => p.Y));
+        var arr = pts.ToArray();
+        Console.WriteLine(arr.Length + " " + arr[0]);
+        Console.WriteLine(pts.First() + "," + pts.ElementAt(1) + "," + pts.Last());
+        Console.WriteLine(string.Join(",", pts.Select(p => p.X + p.Y)));
+        Console.WriteLine(pts.SequenceEqual(new List<Pt> { new Pt { X = 2, Y = 1 }, new Pt { X = 1, Y = 5 }, new Pt { X = 2, Y = 1 } }));
+        Console.WriteLine(pts.Except(new[] { new Pt { X = 1, Y = 5 } }).Count());
+        Console.WriteLine(pts.ToLookup(p => p).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task RecordClassElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public record Rec(string Name, int Age);
+
+public class Program
+{
+    public static void Main()
+    {
+        var rs = new List<Rec> { new Rec("bob", 30), new Rec("amy", 25), new Rec("bob", 30) };
+        Console.WriteLine(string.Join(",", rs.OrderBy(r => r.Name).ThenBy(r => r.Age).Select(r => r.Name + r.Age)));
+        // A record has synthesized value equality, so Distinct collapses the duplicate.
+        Console.WriteLine(rs.Distinct().Count());
+        Console.WriteLine(rs.Contains(new Rec("amy", 25)));
+        Console.WriteLine(rs.Sum(r => r.Age) + "," + rs.Average(r => r.Age));
+        Console.WriteLine(string.Join(";", rs.GroupBy(r => r.Name).OrderBy(g => g.Key).Select(g => g.Key + "=" + g.Count())));
+        Console.WriteLine(rs.MinBy(r => r.Age));
+        Console.WriteLine(string.Join(",", rs.Select(r => r with { Age = r.Age + 1 }).Select(r => r.Age)));
+        Console.WriteLine(rs.ToLookup(r => r.Name)["bob"].Count());
+        Console.WriteLine(string.Join(",", rs.Union(new[] { new Rec("cal", 1) }).Select(r => r.Name)));
+        Console.WriteLine(string.Join(",", rs.Except(new[] { new Rec("bob", 30) }).Select(r => r.Name)));
+        Console.WriteLine(rs.GroupBy(r => r).Count());
+        Console.WriteLine(rs.Distinct().ToDictionary(r => r.Name + r.Age).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task RecordStructElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public readonly record struct RS(int A, string B);
+
+public class Program
+{
+    public static void Main()
+    {
+        var rs = new List<RS> { new RS(2, "x"), new RS(1, "y"), new RS(2, "x") };
+        Console.WriteLine(string.Join(",", rs.OrderBy(r => r.A).ThenBy(r => r.B).Select(r => r.A + r.B)));
+        Console.WriteLine(rs.Distinct().Count());
+        Console.WriteLine(rs.Contains(new RS(1, "y")));
+        Console.WriteLine(rs.Sum(r => r.A));
+        Console.WriteLine(string.Join(";", rs.GroupBy(r => r.A).OrderBy(g => g.Key).Select(g => g.Key + "=" + g.Count())));
+        Console.WriteLine(rs.MaxBy(r => r.A) + "," + rs.MinBy(r => r.A));
+        Console.WriteLine(string.Join(",", rs.Select(r => r with { A = r.A * 10 }).Select(r => r.A)));
+        Console.WriteLine(rs.SequenceEqual(new List<RS> { new RS(2, "x"), new RS(1, "y"), new RS(2, "x") }));
+        Console.WriteLine(rs.ToLookup(r => r).Count);
+        Console.WriteLine(rs.Intersect(new[] { new RS(1, "y") }).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task EnumElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public enum Colour { Red = 1, Green = 2, Blue = 3 }
+
+public class Program
+{
+    public static void Main()
+    {
+        var cs = new List<Colour> { Colour.Blue, Colour.Red, Colour.Green, Colour.Red };
+        Console.WriteLine(string.Join(",", cs.OrderBy(c => c)));
+        Console.WriteLine(string.Join(",", cs.OrderByDescending(c => c)));
+        Console.WriteLine(string.Join(",", cs.Distinct()));
+        Console.WriteLine(cs.Max() + "," + cs.Min() + "," + cs.MaxBy(c => (int)c));
+        Console.WriteLine(cs.Count(c => c == Colour.Red) + "," + cs.Sum(c => (int)c));
+        Console.WriteLine(string.Join(";", cs.GroupBy(c => c).OrderBy(g => g.Key).Select(g => g.Key + "=" + g.Count())));
+        Console.WriteLine(cs.Contains(Colour.Green));
+        Console.WriteLine(string.Join(",", cs.Select(c => c.ToString())));
+        Console.WriteLine(cs.ToLookup(c => c).Count);
+        Console.WriteLine(cs.Distinct().ToDictionary(c => c, c => (int)c).Count);
+        Console.WriteLine(string.Join(",", cs.Except(new[] { Colour.Red })));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task NullableElements_IncludingANullableStruct()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public struct Small
+{
+    public int X;
+    public override string ToString() => "S" + X;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new List<Small?> { new Small { X = 1 }, null, new Small { X = 2 } };
+        Console.WriteLine(xs.Count(x => x.HasValue) + "," + xs.Count(x => x == null));
+        Console.WriteLine(string.Join(",", xs.Where(x => x.HasValue).Select(x => x.Value.X)));
+        Console.WriteLine(string.Join(",", xs.OrderBy(x => x.HasValue ? x.Value.X : -1).Select(x => x == null ? "null" : x.ToString())));
+        Console.WriteLine(xs.Distinct().Count());
+        Console.WriteLine(xs.First() != null);
+
+        var ns = new List<int?> { 3, null, 1 };
+        // A null key sorts FIRST in .NET's default nullable comparison.
+        Console.WriteLine(string.Join(",", ns.OrderBy(x => x).Select(x => x == null ? "null" : x.ToString())));
+        Console.WriteLine(string.Join(",", ns.OrderByDescending(x => x).Select(x => x == null ? "null" : x.ToString())));
+        Console.WriteLine(ns.Distinct().Count() + "," + ns.Contains(null));
+        Console.WriteLine(ns.GroupBy(x => x).Count() + "," + ns.ToLookup(x => x).Count);
+        Console.WriteLine(ns.Sum() + "," + ns.Min() + "," + ns.Max());
+        Console.WriteLine(string.Join(",", ns.Except(new int?[] { null })));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task TupleAndKeyValuePairElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var ts = new List<(int A, string B)> { (2, "x"), (1, "y"), (2, "x") };
+        Console.WriteLine(string.Join(",", ts.OrderBy(t => t.A).ThenBy(t => t.B).Select(t => t.A + t.B)));
+        // A ValueTuple has value equality.
+        Console.WriteLine(ts.Distinct().Count() + "," + ts.Contains((1, "y")));
+        Console.WriteLine(ts.Sum(t => t.A) + "," + ts.MaxBy(t => t.A).B);
+        Console.WriteLine(string.Join(";", ts.GroupBy(t => t.A).OrderBy(g => g.Key).Select(g => g.Key + "=" + g.Count())));
+        Console.WriteLine(ts.GroupBy(t => t).Count() + "," + ts.ToLookup(t => t).Count);
+        Console.WriteLine(ts.Except(new[] { (2, "x") }).Count() + "," + ts.Union(new[] { (2, "x") }).Count());
+        Console.WriteLine(ts.Distinct().ToDictionary(t => t.B, t => t.A).Count);
+        Console.WriteLine(new HashSet<(int, string)>(ts).Count);
+
+        var kvs = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
+        Console.WriteLine(string.Join(",", kvs.OrderBy(k => k.Key).Select(k => k.Key + "=" + k.Value)));
+        Console.WriteLine(kvs.Sum(k => k.Value) + "," + kvs.Max(k => k.Value));
+        Console.WriteLine(string.Join(",", kvs.Select(k => Tuple.Create(k.Key, k.Value)).OrderBy(t => t.Item1).Select(t => t.Item1 + t.Item2)));
+        Console.WriteLine(new[] { Tuple.Create(1, "a"), Tuple.Create(1, "a") }.Distinct().Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task AnonymousTypeElements_HaveValueEqualityAndAMemberwiseToString()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var rows = new[]
+        {
+            new { A = 1, B = "x", C = 9 },
+            new { A = 1, B = "x", C = 8 },
+            new { A = 2, B = "y", C = 7 },
+        };
+        // An anonymous type is a generated class with VALUE equality, so projecting a subset of the
+        // columns and calling Distinct is the canonical way to de-duplicate.
+        var pairs = rows.Select(r => new { r.A, r.B }).Distinct().ToList();
+        Console.WriteLine(pairs.Count);
+        Console.WriteLine(string.Join(";", pairs.OrderBy(p => p.A).Select(p => p.A + p.B)));
+        Console.WriteLine(rows.Select(r => new { r.A }).Distinct().Count());
+        Console.WriteLine(rows.GroupBy(r => new { r.A, r.B }).Count());
+        Console.WriteLine(new HashSet<object>(rows.Select(r => (object)new { r.A, r.B })).Count);
+        Console.WriteLine(rows.Select(r => new { r.A, r.B }).Contains(new { A = 2, B = "y" }));
+        Console.WriteLine(rows.Select(r => new { r.A, r.B }).ToLookup(p => p).Count);
+        Console.WriteLine(rows.OrderByDescending(r => r.C).First().C);
+        Console.WriteLine(rows.Sum(r => r.C) + "," + rows.MaxBy(r => r.C).B);
+
+        Console.WriteLine(new { A = 1, B = "x" }.ToString());
+        Console.WriteLine(new { A = 1, B = "x" }.Equals(new { A = 1, B = "x" }));
+        Console.WriteLine(new { A = 1, B = "x" }.Equals(new { A = 2, B = "x" }));
+        Console.WriteLine(new { A = 1, B = "x" }.GetHashCode() == new { A = 1, B = "x" }.GetHashCode());
+        Console.WriteLine(new { A = 1, B = (string)null }.ToString());
+        Console.WriteLine(new { X = 1.5, Y = true, Z = 'c' }.ToString());
+        Console.WriteLine(new { E = DayOfWeek.Monday, D = new DateTime(2020, 1, 2) }.ToString());
+        Console.WriteLine(new { Nested = new { Q = 1 } }.ToString());
+        Console.WriteLine(new { Nested = new { Q = 1 } }.Equals(new { Nested = new { Q = 1 } }));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task DynamicElements()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new List<dynamic> { 3, 1, 2 };
+        Console.WriteLine(xs.Count());
+        Console.WriteLine(string.Join(",", xs.Select(x => (int)x * 2)));
+        Console.WriteLine(string.Join(",", xs.OrderBy(x => (int)x)));
+        Console.WriteLine(xs.Sum(x => (int)x) + "," + xs.Any(x => (int)x > 2) + "," + xs.First());
+        // A generic operator invoked on a dynamic receiver: the type argument is never inferred, so the
+        // emitted runtime type reference has to fall back to System.Object.
+        dynamic seq = new List<int> { 5, 6 };
+        Console.WriteLine(Enumerable.Count(seq));
+        IEnumerable<dynamic> ds = new dynamic[] { "a", "bb" };
+        Console.WriteLine(string.Join(",", ds.Select(d => ((string)d).Length)));
+        Console.WriteLine(string.Join(",", ds.Where(d => ((string)d).Length > 1)));
+        Console.WriteLine(ds.Count() + "," + ds.Distinct().Count());
+        Console.WriteLine(string.Join(",", ds.Reverse()));
+        dynamic d1 = 5;
+        dynamic d2 = 6;
+        Console.WriteLine(new[] { d1, d2 }.Max());
+        Console.WriteLine(string.Join(",", new[] { d1, d2 }.OrderByDescending(x => x)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task StringCharAndBoolElements()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        // A string IS an IEnumerable<char>, so every operator applies to it directly.
+        var s = "hello world";
+        Console.WriteLine(s.Count(c => c == 'l'));
+        Console.WriteLine(new string(s.Where(c => c != 'l').ToArray()));
+        Console.WriteLine(new string(s.Distinct().ToArray()));
+        Console.WriteLine(string.Join("", s.Reverse()));
+        Console.WriteLine(s.OrderBy(c => c).First() + "," + s.Max() + "," + s.Min());
+        Console.WriteLine(s.GroupBy(c => c).Count());
+        Console.WriteLine(s.Select(c => char.ToUpper(c)).Take(3).Aggregate("", (a, c) => a + c));
+        Console.WriteLine(string.Join(",", s.Split(' ').OrderByDescending(w => w)));
+        Console.WriteLine(s.ToLookup(c => c).Count);
+
+        var bs = new[] { true, false, true };
+        Console.WriteLine(bs.Count(b => b) + "," + bs.Distinct().Count());
+        Console.WriteLine(bs.All(b => b) + "," + bs.Any(b => !b) + "," + bs.Contains(false));
+        Console.WriteLine(string.Join(",", bs.OrderBy(b => b)));
+        Console.WriteLine(string.Join(";", bs.GroupBy(b => b).OrderBy(g => g.Key).Select(g => g.Key + ":" + g.Count())));
+        Console.WriteLine(bs.ToLookup(b => b).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task DateTimeTimeSpanGuidAndObjectIdentityElements()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var ds = new[] { new DateTime(2021, 3, 1), new DateTime(2020, 1, 1), new DateTime(2021, 3, 1) };
+        Console.WriteLine(string.Join(",", ds.OrderBy(d => d).Select(d => d.ToString("yyyy-MM-dd"))));
+        Console.WriteLine(ds.Min().ToString("yyyy-MM-dd") + " " + ds.Max().ToString("yyyy-MM-dd"));
+        Console.WriteLine(ds.Distinct().Count() + "," + ds.Contains(new DateTime(2020, 1, 1)));
+        Console.WriteLine(ds.GroupBy(d => d.Year).Count() + "," + ds.ToLookup(d => d.Year).Count);
+        Console.WriteLine(ds.MaxBy(d => d).ToString("yyyy-MM-dd"));
+
+        var ts = new[] { TimeSpan.FromMinutes(3), TimeSpan.FromMinutes(1) };
+        Console.WriteLine(ts.Min() + " " + ts.Max());
+        Console.WriteLine(string.Join(",", ts.OrderByDescending(t => t)));
+        Console.WriteLine(ts.Sum(t => t.TotalMinutes) + "," + ts.Distinct().Count());
+
+        var g1 = new Guid("11111111-1111-1111-1111-111111111111");
+        var g2 = new Guid("22222222-2222-2222-2222-222222222222");
+        var gs = new[] { g2, g1, g1 };
+        Console.WriteLine(gs.Distinct().Count() + "," + gs.Contains(g1));
+        Console.WriteLine(string.Join(",", gs.OrderBy(g => g).Select(g => g.ToString().Substring(0, 1))));
+        Console.WriteLine(gs.GroupBy(g => g).Count() + "," + gs.ToLookup(g => g).Count);
+
+        var o1 = new object();
+        var o2 = new object();
+        var os = new[] { o1, o2, o1 };
+        Console.WriteLine(os.Distinct().Count() + "," + os.Contains(o2) + "," + os.Count(o => ReferenceEquals(o, o1)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task InterfaceElementsAndPolymorphicProjections()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public interface IShape { double Area { get; } string Tag { get; } }
+public class Square : IShape { public double S; public double Area => S * S; public string Tag => "sq"; }
+public class Circle : IShape { public double R; public double Area => 3 * R * R; public string Tag => "ci"; }
+
+public class Base2 { public int V; public override string ToString() => "b" + V; }
+public class Derived2 : Base2 { }
+
+public class Program
+{
+    public static void Main()
+    {
+        var shapes = new List<IShape> { new Square { S = 2 }, new Circle { R = 1 }, new Square { S = 3 } };
+        Console.WriteLine(shapes.Count() + "," + shapes.OfType<Square>().Count() + "," + shapes.OfType<Circle>().Count());
+        Console.WriteLine(shapes.Sum(x => x.Area) + "," + shapes.Select(x => x.Area).Max());
+        Console.WriteLine(string.Join(",", shapes.OrderByDescending(x => x.Area).Select(x => x.Tag)));
+        Console.WriteLine(string.Join(";", shapes.GroupBy(x => x.Tag).OrderBy(g => g.Key).Select(g => g.Key + "=" + g.Count())));
+        Console.WriteLine(shapes.MaxBy(x => x.Area).Tag + "," + shapes.Cast<IShape>().Count());
+
+        // Covariance: an IEnumerable<Derived> used as an IEnumerable<Base>.
+        IEnumerable<Derived2> derived = new List<Derived2> { new Derived2 { V = 1 }, new Derived2 { V = 2 } };
+        IEnumerable<Base2> bases = derived;
+        Console.WriteLine(bases.Sum(x => x.V));
+        Console.WriteLine(string.Join(",", bases.OrderByDescending(x => x.V)));
+        Console.WriteLine(bases.OfType<Derived2>().Count() + "," + bases.Cast<Derived2>().Count());
+        Console.WriteLine(string.Join(",", derived.Concat(new[] { new Derived2 { V = 3 } })));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task TypeParameterElements_InsideAGenericMethod()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    static string Describe<T>(IEnumerable<T> src) where T : IComparable<T>
+        => src.Count() + "/" + src.Min() + "/" + src.Max() + "/" + string.Join(",", src.OrderBy(x => x));
+
+    static int SumOf<T>(IEnumerable<T> src, Func<T, int> f) => src.Sum(f);
+
+    static int DistinctCount<T>(IEnumerable<T> src) => src.Distinct().Count();
+
+    static string GroupSizes<T, TKey>(IEnumerable<T> src, Func<T, TKey> key)
+        => string.Join(";", src.GroupBy(key).OrderBy(g => g.Key.ToString()).Select(g => g.Key + ":" + g.Count()));
+
+    public static void Main()
+    {
+        Console.WriteLine(Describe(new[] { 3, 1, 2 }));
+        Console.WriteLine(Describe(new[] { "b", "a" }));
+        Console.WriteLine(Describe(new[] { 2.5, 1.5 }));
+        Console.WriteLine(Describe(new[] { 'c', 'a' }));
+        Console.WriteLine(Describe(new[] { 3L, 1L }));
+        Console.WriteLine(Describe(new[] { 3.5m, 1.5m }));
+        Console.WriteLine(SumOf(new[] { "aa", "b" }, s => s.Length));
+        Console.WriteLine(DistinctCount(new[] { 1, 1, 2 }) + "," + DistinctCount(new[] { "a", "a" }));
+        Console.WriteLine(GroupSizes(new[] { 1, 2, 3, 4 }, x => x % 2));
+        Console.WriteLine(GroupSizes(new[] { "aa", "b", "cc" }, s => s.Length));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task EveryCollectionKindAsASource()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var hs = new HashSet<int> { 3, 1, 2 };
+        Console.WriteLine(hs.Sum() + "," + string.Join(",", hs.OrderBy(x => x)));
+        var d = new Dictionary<string, int> { { "a", 1 }, { "b", 2 } };
+        Console.WriteLine(d.Sum(kv => kv.Value) + "," + string.Join(",", d.Keys.OrderBy(k => k)) + "," + string.Join(",", d.Values.OrderBy(v => v)));
+        var q = new Queue<int>();
+        q.Enqueue(1);
+        q.Enqueue(2);
+        Console.WriteLine(q.Sum() + "," + q.Count() + "," + string.Join(",", q));
+        var st = new Stack<int>();
+        st.Push(1);
+        st.Push(2);
+        Console.WriteLine(st.Sum() + "," + string.Join(",", st));
+        var ll = new LinkedList<int>();
+        ll.AddLast(1);
+        ll.AddLast(2);
+        Console.WriteLine(ll.Sum() + "," + ll.Count());
+        var sl = new SortedList<int, string> { { 2, "b" }, { 1, "a" } };
+        Console.WriteLine(string.Join(",", sl.Select(kv => kv.Key + kv.Value)));
+        var ss = new SortedSet<int> { 3, 1 };
+        Console.WriteLine(string.Join(",", ss));
+        IList<int> il = new List<int> { 5, 6 };
+        Console.WriteLine(il.Sum());
+        IReadOnlyCollection<int> roc = new List<int> { 7, 8 };
+        Console.WriteLine(roc.Sum());
+        IReadOnlyList<int> rol = new List<int> { 1, 2 };
+        Console.WriteLine(rol.Sum());
+        ICollection<int> col = new List<int> { 9 };
+        Console.WriteLine(col.Sum());
+        var jagged = new[] { new[] { 1, 2 }, new[] { 3 } };
+        Console.WriteLine(jagged.SelectMany(a => a).Sum() + "," + jagged.Sum(a => a.Length));
+        var empty = new int[3];
+        Console.WriteLine(empty.Sum() + "," + empty.Count() + "," + empty.All(x => x == 0));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task IteratorAndDeferredSources()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    static IEnumerable<int> Gen() { yield return 1; yield return 2; yield return 3; }
+    static IEnumerable<string> GenS() { for (int i = 0; i < 3; i++) yield return "s" + i; }
+
+    public static void Main()
+    {
+        Console.WriteLine(Gen().Sum() + "," + Gen().Count() + "," + Gen().Aggregate(0, (a, b) => a + b));
+        Console.WriteLine(string.Join(",", Gen().Where(x => x > 1)));
+        Console.WriteLine(string.Join(",", Gen().Reverse()));
+        Console.WriteLine(string.Join(",", GenS().Select(s => s.ToUpper())));
+        Console.WriteLine(string.Join(",", Gen().Zip(GenS(), (a, b) => a + b)));
+        Console.WriteLine(string.Join(";", GenS().GroupBy(s => s.Length).Select(g => g.Key + ":" + g.Count())));
+        Console.WriteLine(Gen().ToList().Count + "," + Gen().Concat(Gen()).Count());
+        Console.WriteLine(Gen().ToLookup(x => x % 2).Count);
+
+        // A query is re-evaluated on every enumeration, and sees changes made to its source afterwards.
+        var list = new List<int> { 1, 2, 3 };
+        var query = list.Where(x => x > 1);
+        Console.WriteLine(query.Count());
+        list.Add(4);
+        Console.WriteLine(query.Count());
+
+        // Nothing runs until the sequence is enumerated.
+        int calls = 0;
+        var lazy = list.Select(x => { calls++; return x; });
+        Console.WriteLine("before=" + calls);
+        lazy.ToList();
+        Console.WriteLine("after=" + calls);
+
+        var chained = list.Where(x => x > 2).Select(x => x * 2);
+        Console.WriteLine(string.Join(",", chained));
+        Console.WriteLine(string.Join(",", chained));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task NestedAndCombinedElementTypes()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public struct Money { public decimal Amount; public string Ccy; public override string ToString() => Amount + Ccy; }
+public record Line(string Sku, int Qty, Money Price);
+public enum Status { Open = 1, Closed = 2 }
+
+public class Program
+{
+    public static void Main()
+    {
+        var lines = new List<Line>
+        {
+            new Line("a", 2, new Money { Amount = 1.5m, Ccy = "EUR" }),
+            new Line("b", 1, new Money { Amount = 3m, Ccy = "USD" }),
+            new Line("a", 2, new Money { Amount = 1.5m, Ccy = "EUR" }),
+        };
+        // A record whose member is a struct: value equality has to recurse into it.
+        Console.WriteLine(lines.Distinct().Count());
+        Console.WriteLine(lines.Sum(l => l.Qty * l.Price.Amount));
+        Console.WriteLine(string.Join(";", lines.GroupBy(l => l.Price.Ccy).OrderBy(g => g.Key).Select(g => g.Key + "=" + g.Sum(l => l.Qty))));
+        Console.WriteLine(lines.MaxBy(l => l.Price.Amount).Sku);
+        Console.WriteLine(lines.GroupBy(l => l.Price).Count());
+
+        // A tuple of (enum, nullable, struct), grouped and de-duplicated as a composite key.
+        var rows = new[]
+        {
+            (S: Status.Open, N: (int?)1, M: new Money { Amount = 1m, Ccy = "EUR" }),
+            (S: Status.Open, N: (int?)null, M: new Money { Amount = 1m, Ccy = "EUR" }),
+            (S: Status.Open, N: (int?)1, M: new Money { Amount = 1m, Ccy = "EUR" }),
+        };
+        Console.WriteLine(rows.Distinct().Count());
+        Console.WriteLine(rows.GroupBy(r => r.S).Single().Count());
+        Console.WriteLine(rows.Count(r => r.N == null));
+        Console.WriteLine(rows.ToLookup(r => r.M.Ccy).Count);
+
+        // An anonymous type over a record, a struct and a grouping.
+        var shaped = lines.GroupBy(l => l.Sku)
+                          .Select(g => new { Sku = g.Key, Total = g.Sum(l => l.Qty), First = g.First().Price })
+                          .OrderBy(x => x.Sku)
+                          .ToList();
+        foreach (var x in shaped) Console.WriteLine(x.Sku + " " + x.Total + " " + x.First);
+        Console.WriteLine(shaped.Select(x => new { x.Sku, x.Total }).Distinct().Count());
+
+        // A dictionary keyed by a struct, built by LINQ.
+        var byMoney = lines.Distinct().ToDictionary(l => l.Price, l => l.Sku);
+        Console.WriteLine(byMoney.Count + "," + byMoney[new Money { Amount = 3m, Ccy = "USD" }]);
+    }
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqExceptionAndEdgeCaseTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqExceptionAndEdgeCaseTests.cs
@@ -1,0 +1,343 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Linq
+{
+    /// <summary>
+    /// What LINQ does at the edges: the exceptions it throws (which <b>type</b>, and with which
+    /// <b>message</b> — user code catches on the type, and prints the message), the empty and
+    /// single-element sequence for every operator, argument validation, null keys and null elements, and
+    /// the observable evaluation order of the delegates an operator is given.
+    ///
+    /// The exception tests matter more than they look: the transpiled <c>catch (InvalidOperationException)</c>
+    /// checks the thrown value against the BCL type, so an operator that raises a raw JavaScript
+    /// <c>Error</c> escapes every C# catch clause and tears the program down instead of being handled.
+    /// </summary>
+    [TestClass]
+    public class LinqExceptionAndEdgeCaseTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task ElementOperators_ThrowTheRightExceptionWithTheRightMessage()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var empty = new int[0];
+        var xs = new[] { 1, 2, 3 };
+        // .NET distinguishes "no elements" from "no matching element", and "more than one element" from
+        // "more than one matching element".
+        try { empty.First(); } catch (InvalidOperationException e) { Console.WriteLine("A " + e.Message); }
+        try { xs.First(x => x > 9); } catch (InvalidOperationException e) { Console.WriteLine("B " + e.Message); }
+        try { empty.Last(); } catch (InvalidOperationException e) { Console.WriteLine("C " + e.Message); }
+        try { xs.Last(x => x > 9); } catch (InvalidOperationException e) { Console.WriteLine("D " + e.Message); }
+        try { xs.Single(); } catch (InvalidOperationException e) { Console.WriteLine("E " + e.Message); }
+        try { empty.Single(); } catch (InvalidOperationException e) { Console.WriteLine("F " + e.Message); }
+        try { xs.Single(x => x > 9); } catch (InvalidOperationException e) { Console.WriteLine("G " + e.Message); }
+        try { xs.Single(x => x > 1); } catch (InvalidOperationException e) { Console.WriteLine("H " + e.Message); }
+        try { xs.SingleOrDefault(x => x > 1); } catch (InvalidOperationException e) { Console.WriteLine("I " + e.Message); }
+        try { xs.ElementAt(9); } catch (ArgumentOutOfRangeException e) { Console.WriteLine("J " + e.ParamName); }
+        try { xs.ElementAt(-1); } catch (ArgumentOutOfRangeException e) { Console.WriteLine("K " + e.ParamName); }
+        try { empty.Max(); } catch (InvalidOperationException e) { Console.WriteLine("L " + e.Message); }
+        try { empty.Min(); } catch (InvalidOperationException e) { Console.WriteLine("M " + e.Message); }
+        try { empty.Average(); } catch (InvalidOperationException e) { Console.WriteLine("N " + e.Message); }
+        try { empty.Aggregate((a, b) => a + b); } catch (InvalidOperationException e) { Console.WriteLine("O " + e.Message); }
+        // A base-class catch has to see them too.
+        try { empty.First(); } catch (Exception e) { Console.WriteLine("P " + e.GetType().Name); }
+        try { xs.ElementAt(9); } catch (ArgumentException e) { Console.WriteLine("Q " + e.GetType().Name); }
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task ArgumentValidation()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        // Range/Repeat validate EAGERLY — before anything is enumerated.
+        try { Enumerable.Range(0, -1); } catch (ArgumentOutOfRangeException e) { Console.WriteLine("range " + e.ParamName); }
+        try { Enumerable.Repeat("a", -1); } catch (ArgumentOutOfRangeException e) { Console.WriteLine("repeat " + e.ParamName); }
+        try { new[] { 1 }.Chunk(0); } catch (ArgumentOutOfRangeException e) { Console.WriteLine("chunk " + e.ParamName); }
+        try { new[] { 1 }.Chunk(-1); } catch (ArgumentOutOfRangeException e) { Console.WriteLine("chunk- " + e.ParamName); }
+        // A negative count is simply clamped for Take/Skip, and ElementAtOrDefault never throws.
+        Console.WriteLine("[" + string.Join(",", new[] { 1, 2 }.Take(-1)) + "]");
+        Console.WriteLine(string.Join(",", new[] { 1, 2 }.Skip(-1)));
+        Console.WriteLine(new[] { 1 }.ElementAtOrDefault(-1) + "," + new[] { 1 }.ElementAtOrDefault(9));
+        // ToDictionary rejects a duplicate key, naming it.
+        try { new[] { "a", "b", "a" }.ToDictionary(s => s); } catch (ArgumentException e) { Console.WriteLine("dupe " + e.Message); }
+        try { new int[0].MinBy(x => x); } catch (InvalidOperationException e) { Console.WriteLine("minby " + e.Message); }
+        try { new int[0].MaxBy(x => x); } catch (InvalidOperationException e) { Console.WriteLine("maxby " + e.Message); }
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task EmptySequence_ThroughEveryOperator()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var e = Enumerable.Empty<int>();
+        Console.WriteLine(e.Count() + "," + e.Any() + "," + e.All(x => false) + "," + e.Sum());
+        Console.WriteLine("[" + string.Join(",", e.Where(x => true)) + "]|[" + string.Join(",", e.Select(x => x)) + "]");
+        Console.WriteLine("[" + string.Join(",", e.OrderBy(x => x)) + "]|[" + string.Join(",", e.Reverse()) + "]");
+        Console.WriteLine(e.GroupBy(x => x).Count() + "," + e.ToLookup(x => x).Count + "," + e.ToDictionary(x => x).Count);
+        Console.WriteLine(e.ToArray().Length + "," + e.ToList().Count + "," + e.Distinct().Count());
+        Console.WriteLine(e.Concat(e).Count() + "," + e.Union(e).Count() + "," + e.Intersect(e).Count() + "," + e.Except(e).Count());
+        Console.WriteLine(e.Take(3).Count() + "," + e.Skip(3).Count() + "," + e.TakeWhile(x => true).Count() + "," + e.SkipWhile(x => true).Count());
+        Console.WriteLine(e.FirstOrDefault() + "," + e.LastOrDefault() + "," + e.SingleOrDefault() + "," + e.ElementAtOrDefault(0));
+        Console.WriteLine(e.SequenceEqual(e) + "," + e.Contains(1) + "," + e.LongCount());
+        Console.WriteLine(e.Zip(e, (a, b) => a).Count() + "," + e.SelectMany(x => e).Count() + "," + e.Aggregate(5, (a, b) => a + b));
+        Console.WriteLine(string.Join(",", e.DefaultIfEmpty()) + "," + e.Chunk(2).Count());
+        Console.WriteLine(e.Join(e, a => a, b => b, (a, b) => a).Count() + "," + e.GroupJoin(e, a => a, b => b, (a, b) => a).Count());
+        Console.WriteLine(e.Cast<int>().Count() + "," + e.OfType<int>().Count() + "," + e.AsEnumerable().Count());
+        Console.WriteLine(e.Sum(x => x) + "," + e.Count(x => true) + "," + e.LongCount(x => true));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task SingleElementSequence_ThroughEveryOperator()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var s = new[] { 42 };
+        Console.WriteLine(s.Single() + "," + s.First() + "," + s.Last() + "," + s.ElementAt(0));
+        Console.WriteLine(s.Sum() + "," + s.Average() + "," + s.Min() + "," + s.Max() + "," + s.Count());
+        Console.WriteLine(string.Join(",", s.Reverse()) + "," + string.Join(",", s.OrderBy(x => x)));
+        Console.WriteLine(s.Aggregate((a, b) => a + b) + "," + s.Aggregate(1, (a, b) => a + b));
+        Console.WriteLine(string.Join(",", s.DefaultIfEmpty(9)) + "," + s.Chunk(5).Single().Length);
+        Console.WriteLine(s.GroupBy(x => x).Single().Key + "," + s.ToLookup(x => x).Count);
+        Console.WriteLine(s.Distinct().Single() + "," + s.Union(s).Count() + "," + s.Except(s).Count());
+        Console.WriteLine(s.MinBy(x => x) + "," + s.MaxBy(x => x));
+        Console.WriteLine(s.Zip(s, (a, b) => a + b).Single());
+        Console.WriteLine(s.SelectMany(x => new[] { x, x }).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task NullElementsAndNullKeys()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var withNulls = new[] { "a", null, "b", null };
+        Console.WriteLine(withNulls.Count(s => s == null));
+        Console.WriteLine(string.Join(",", withNulls.Where(s => s != null)));
+        Console.WriteLine(withNulls.Distinct().Count() + "," + withNulls.Contains(null));
+        Console.WriteLine(withNulls.GroupBy(s => s == null).Count());
+        // A null KEY is a valid grouping key for GroupBy and ToLookup (but not for ToDictionary).
+        Console.WriteLine(withNulls.GroupBy(s => s).Count() + "," + withNulls.ToLookup(s => s).Count);
+        Console.WriteLine(withNulls.ToLookup(s => s)[null].Count());
+        Console.WriteLine(string.Join(",", withNulls.OrderBy(s => s).Select(s => s ?? "<null>")));
+        Console.WriteLine(string.Join(",", withNulls.Except(new string[] { null })));
+        Console.WriteLine(string.Join(",", withNulls.Union(new string[] { null, "c" }).Select(s => s ?? "<null>")));
+        Console.WriteLine(withNulls.FirstOrDefault(s => s == null) == null);
+        Console.WriteLine(withNulls.Select(s => s?.Length).Sum());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task DelegateInvocationOrderIsObservable()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var log = new List<string>();
+        var xs = new[] { 1, 2, 3 };
+
+        // Where and Select are interleaved per element, not run as two passes.
+        var r = xs.Where(x => { log.Add("w" + x); return x > 1; })
+                  .Select(x => { log.Add("s" + x); return x * 2; })
+                  .ToList();
+        Console.WriteLine(string.Join(",", r));
+        Console.WriteLine(string.Join(",", log));
+
+        // First stops at the first match; Any at the first true; All at the first false.
+        log.Clear();
+        Console.WriteLine(xs.Where(x => { log.Add("W" + x); return x > 1; }).First() + " | " + string.Join(",", log));
+        log.Clear();
+        Console.WriteLine(xs.Any(x => { log.Add("A" + x); return x == 2; }) + " | " + string.Join(",", log));
+        log.Clear();
+        Console.WriteLine(xs.All(x => { log.Add("L" + x); return x == 1; }) + " | " + string.Join(",", log));
+        log.Clear();
+        Console.WriteLine(string.Join(",", xs.TakeWhile(x => { log.Add("T" + x); return x < 3; })) + " | " + string.Join(",", log));
+        log.Clear();
+        Console.WriteLine(xs.Contains(2) + " | " + log.Count);
+
+        // A key selector runs once per element per operator, and OrderBy runs it before comparing.
+        log.Clear();
+        var ordered = xs.OrderByDescending(x => { log.Add("k" + x); return x; }).ToList();
+        Console.WriteLine(string.Join(",", ordered) + " | " + log.Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task ChainedOperatorsOverAQueryReceiver()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4, 5 };
+        var q = xs.Where(x => x > 1);
+        Console.WriteLine(q.Select(x => x * 2).Where(x => x > 4).Sum());
+        Console.WriteLine(q.AsEnumerable().Count() + "," + q.OrderByDescending(x => x).First());
+        Console.WriteLine(q.Skip(1).Take(2).Sum() + "," + q.Concat(xs).Count());
+        Console.WriteLine(q.Reverse().First() + "," + q.DefaultIfEmpty().Count());
+        Console.WriteLine(q.SelectMany(x => new[] { x, x }).Count() + "," + q.Distinct().Count());
+        Console.WriteLine(q.GroupBy(x => x % 2).Count() + "," + q.ToLookup(x => x % 2).Count);
+        Console.WriteLine(q.Zip(xs, (a, b) => a + b).Sum() + "," + q.Aggregate(0, (a, b) => a + b));
+        Console.WriteLine(q.Contains(3) + "," + q.SequenceEqual(new[] { 2, 3, 4, 5 }));
+        Console.WriteLine(q.ElementAt(0) + "," + q.LongCount() + "," + q.Last());
+        Console.WriteLine(q.Chunk(2).Count() + "," + q.MinBy(x => -x));
+        Console.WriteLine(q.ToArray().Length + "," + q.ToList().Count + "," + q.ToDictionary(x => x).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task ArrayReverse_ResolvesToEnumerableReverse()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        // An instance method beats an extension method, so an instance `Reverse()` on Array would hide
+        // Enumerable.Reverse<T>() and make this fail to compile.
+        var a = new[] { 1, 2, 3 };
+        Console.WriteLine(string.Join(",", a.Reverse()));
+        // Enumerable.Reverse does NOT mutate its source.
+        Console.WriteLine(string.Join(",", a));
+        var walked = "";
+        foreach (var x in a.Reverse()) walked += x;
+        Console.WriteLine(walked);
+        Console.WriteLine(a.Reverse().First() + "," + a.Reverse().Sum());
+        Console.WriteLine(string.Join(",", a.Reverse().Select(x => x * 2)));
+
+        // Array.Reverse(array) is the in-place BCL form and still works.
+        Array.Reverse(a);
+        Console.WriteLine(string.Join(",", a));
+
+        // List<T>.Reverse() IS a real instance method in .NET and must stay in-place.
+        var l = new List<int> { 1, 2, 3 };
+        l.Reverse();
+        Console.WriteLine(string.Join(",", l));
+        Console.WriteLine(string.Join(",", Enumerable.Reverse(l)));
+        Console.WriteLine(string.Join("", "abc".Reverse()));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task LinqInsideAsyncMethodsAndClosures()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class Program
+{
+    static async Task<int> SumAsync(IEnumerable<int> src) { await Task.Yield(); return src.Sum(); }
+
+    public static async Task Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        Console.WriteLine(await SumAsync(xs));
+        var tasks = xs.Select(async x => { await Task.Yield(); return x * 2; });
+        var results = await Task.WhenAll(tasks);
+        Console.WriteLine(string.Join(",", results));
+        Console.WriteLine(string.Join(",", results.OrderByDescending(r => r)));
+        var collected = new List<int>();
+        foreach (var x in xs.Where(v => v > 1)) { await Task.Yield(); collected.Add(x); }
+        Console.WriteLine(string.Join(",", collected));
+
+        // A captured local is read when the query RUNS, not when it is built.
+        int threshold = 1;
+        var q = xs.Where(x => x > threshold);
+        Console.WriteLine(string.Join(",", q));
+        threshold = 2;
+        Console.WriteLine(string.Join(",", q));
+
+        // A foreach variable captured per iteration.
+        var fns = new List<Func<int>>();
+        foreach (var x in xs) fns.Add(() => x * 10);
+        Console.WriteLine(string.Join(",", fns.Select(f => f())));
+
+        // Method groups and local functions as operator arguments.
+        bool Odd(int v) => v % 2 == 1;
+        Console.WriteLine(string.Join(",", xs.Where(Odd)));
+        Console.WriteLine(string.Join(",", xs.Select(Describe)));
+        Console.WriteLine(xs.Aggregate(0, Add));
+    }
+
+    static string Describe(int v) => "#" + v;
+    static int Add(int a, int b) => a + b;
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqModernOperatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqModernOperatorTests.cs
@@ -1,0 +1,499 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Linq
+{
+    /// <summary>
+    /// The LINQ operators <c>EnumerableExtras</c> adds on top of the runtime-backed
+    /// <c>Enumerable</c> binding — the ones <c>System.Linq</c> gained after the <c>linq.js</c> API the
+    /// binding maps onto: <c>Append</c>/<c>Prepend</c>, <c>ToHashSet</c>, <c>DistinctBy</c>/
+    /// <c>UnionBy</c>/<c>IntersectBy</c>/<c>ExceptBy</c>, <c>SkipLast</c>/<c>TakeLast</c>,
+    /// <c>Order</c>/<c>OrderDescending</c>, <c>Index</c>, <c>CountBy</c>/<c>AggregateBy</c>,
+    /// <c>TryGetNonEnumeratedCount</c>, the tuple-returning <c>Zip</c> overloads, and indexing by
+    /// <see cref="System.Index"/> / <see cref="System.Range"/>.
+    ///
+    /// Each is covered in every declared overload, over an array/List receiver and over a query receiver
+    /// (which matters: an instance method on <c>EnumerableInstance</c> beats an extension method, so
+    /// <c>query.Take(1..3)</c> and <c>query.ElementAt(^1)</c> have to keep reaching the extension while
+    /// <c>query.Take(2)</c> and <c>query.ElementAt(1)</c> keep reaching the instance member), and across
+    /// the element types whose equality or ordering the operator depends on.
+    ///
+    /// <para><b>One documented difference</b>, spelled out on <c>EnumerableExtras</c>:
+    /// <c>TryGetNonEnumeratedCount</c> answers true only for a real collection, where .NET also answers
+    /// true for some lazy operators whose count it can work out cheaply. False is a correct answer to
+    /// "can I have the count without enumerating?", so the tests below only assert the collection cases
+    /// and the cases where .NET answers false too.</para>
+    /// </summary>
+    [TestClass]
+    public class LinqModernOperatorTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task AppendPrependAndToHashSet()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new List<int> { 1, 2, 3 };
+        Console.WriteLine(string.Join(",", xs.Append(4)));
+        Console.WriteLine(string.Join(",", xs.Prepend(0)));
+        Console.WriteLine(string.Join(",", xs.Append(4).Prepend(0)));
+        Console.WriteLine("[" + string.Join(",", new int[0].Append(1)) + "]");
+        Console.WriteLine("[" + string.Join(",", new int[0].Prepend(1)) + "]");
+        Console.WriteLine(string.Join(",", xs.Where(x => x > 1).Append(9)));
+        Console.WriteLine(string.Join(",", new[] { "a" }.Append(null).Select(s => s ?? "<null>")));
+        // Append does not mutate its source.
+        Console.WriteLine(string.Join(",", xs));
+
+        Console.WriteLine(xs.ToHashSet().Count);
+        Console.WriteLine(string.Join(",", new[] { 1, 1, 2 }.ToHashSet()));
+        Console.WriteLine(new[] { "A", "a" }.ToHashSet().Count);
+        Console.WriteLine(new[] { "A", "a" }.ToHashSet(StringComparer.OrdinalIgnoreCase).Count);
+        Console.WriteLine(new int[0].ToHashSet().Count);
+        var hs = xs.ToHashSet();
+        Console.WriteLine(hs.Contains(2) + "," + hs.Contains(9));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task DistinctByAndUnionBy()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public record Person(string Name, int Age);
+
+public class Program
+{
+    public static void Main()
+    {
+        var ps = new[] { new Person("amy", 30), new Person("bob", 30), new Person("cal", 25) };
+        // DistinctBy keeps the FIRST element of each key.
+        Console.WriteLine(string.Join(",", ps.DistinctBy(p => p.Age).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", ps.DistinctBy(p => p.Name).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", new[] { "A", "a", "b" }.DistinctBy(s => s, StringComparer.OrdinalIgnoreCase)));
+        Console.WriteLine(string.Join(",", new[] { 1, 2, 3, 4 }.DistinctBy(x => x % 2)));
+        Console.WriteLine(new int[0].DistinctBy(x => x).Count());
+
+        var more = new[] { new Person("dan", 30), new Person("eve", 40) };
+        Console.WriteLine(string.Join(",", ps.UnionBy(more, p => p.Age).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", ps.UnionBy(more, p => p.Name).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", new[] { "A" }.UnionBy(new[] { "a", "b" }, s => s, StringComparer.OrdinalIgnoreCase)));
+        Console.WriteLine(string.Join(",", new int[0].UnionBy(new[] { 1 }, x => x)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task IntersectByAndExceptBy_TakeASequenceOfKeys()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public record Person(string Name, int Age);
+
+public class Program
+{
+    public static void Main()
+    {
+        var ps = new[] { new Person("amy", 30), new Person("bob", 30), new Person("cal", 25) };
+        // The second sequence is one of KEYS, not of elements — and the result is distinct BY key, so
+        // only the first of the two 30-year-olds survives.
+        Console.WriteLine(string.Join(",", ps.IntersectBy(new[] { 30 }, p => p.Age).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", ps.IntersectBy(new[] { 25, 30 }, p => p.Age).Select(p => p.Name)));
+        Console.WriteLine("[" + string.Join(",", ps.IntersectBy(new int[0], p => p.Age).Select(p => p.Name)) + "]");
+        Console.WriteLine(string.Join(",", ps.ExceptBy(new[] { 30 }, p => p.Age).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", ps.ExceptBy(new int[0], p => p.Age).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", ps.ExceptBy(new[] { "amy" }, p => p.Name).Select(p => p.Name)));
+        Console.WriteLine(string.Join(",", new[] { "A", "a" }.IntersectBy(new[] { "a" }, s => s, StringComparer.OrdinalIgnoreCase)));
+        Console.WriteLine(string.Join(",", new[] { "A", "a", "b" }.ExceptBy(new[] { "a" }, s => s, StringComparer.OrdinalIgnoreCase)));
+        Console.WriteLine(string.Join(",", new[] { 1, 1, 2 }.IntersectBy(new[] { 1 }, x => x)));
+        Console.WriteLine(string.Join(",", new[] { 1, 1, 2 }.ExceptBy(new[] { 9 }, x => x)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task SkipLastAndTakeLast()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4, 5 };
+        Console.WriteLine("[" + string.Join(",", xs.SkipLast(2)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.SkipLast(0)) + "]");
+        // A negative count is clamped rather than rejected.
+        Console.WriteLine("[" + string.Join(",", xs.SkipLast(-1)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.SkipLast(99)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.TakeLast(2)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.TakeLast(0)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.TakeLast(-1)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.TakeLast(99)) + "]");
+        Console.WriteLine("[" + string.Join(",", new int[0].SkipLast(1)) + "]|[" + string.Join(",", new int[0].TakeLast(1)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Where(x => x > 1).SkipLast(1)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Where(x => x > 1).TakeLast(2)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.TakeLast(3).SkipLast(1)) + "]");
+        Console.WriteLine("[" + string.Join("", "hello".SkipLast(2)) + "]|[" + string.Join("", "hello".TakeLast(2)) + "]");
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task OrderAndOrderDescending()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 3, 1, 2 };
+        Console.WriteLine(string.Join(",", xs.Order()));
+        Console.WriteLine(string.Join(",", xs.OrderDescending()));
+        var reverse = Comparer<int>.Create((a, b) => b - a);
+        Console.WriteLine(string.Join(",", xs.Order(reverse)));
+        Console.WriteLine(string.Join(",", xs.OrderDescending(reverse)));
+        Console.WriteLine(string.Join(",", new[] { "b", "a", "c" }.Order()));
+        Console.WriteLine(string.Join(",", new[] { "b", "a", "c" }.OrderDescending()));
+        Console.WriteLine(string.Join(",", new[] { 2.5, 1.5 }.Order()));
+        Console.WriteLine(string.Join(",", new[] { 'c', 'a' }.Order()));
+        Console.WriteLine(string.Join(",", new[] { 3L, 1L }.Order()));
+        Console.WriteLine(string.Join(",", new[] { 3m, 1m }.OrderDescending()));
+        // Order returns an IOrderedEnumerable, so ThenBy chains onto it.
+        var words = new[] { "bb", "a", "cc" };
+        Console.WriteLine(string.Join(",", words.Order().ThenByDescending(w => w.Length)));
+        Console.WriteLine(string.Join(",", words.OrderDescending().ThenBy(w => w)));
+        Console.WriteLine("[" + string.Join(",", new int[0].Order()) + "]");
+        Console.WriteLine(xs.Order().First() + "," + xs.Order().Last() + "," + xs.Order().Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task IndexCountByAndAggregateBy()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { "a", "b", "c" };
+        foreach (var (i, s) in xs.Index()) Console.WriteLine(i + ":" + s);
+        Console.WriteLine(string.Join(",", xs.Index().Select(t => t.Index + t.Item)));
+        Console.WriteLine(xs.Index().Count() + "," + new string[0].Index().Count());
+        Console.WriteLine(xs.Index().Last().Index);
+        // The index counts the elements the operator actually yields, not their source positions.
+        Console.WriteLine(string.Join(",", xs.Where(s => s != "b").Index().Select(t => t.Index + t.Item)));
+
+        var words = new[] { "apple", "avocado", "banana", "cherry", "apricot" };
+        // CountBy/AggregateBy yield their keys in first-seen order.
+        Console.WriteLine(string.Join(";", words.CountBy(w => w[0]).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", words.CountBy(w => w.Length).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", new[] { "A", "a", "b" }.CountBy(s => s, StringComparer.OrdinalIgnoreCase).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(new string[0].CountBy(s => s).Count());
+
+        Console.WriteLine(string.Join(";", words.AggregateBy(w => w[0], 0, (a, w) => a + w.Length).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", words.AggregateBy(w => w[0], "", (a, w) => a + w[1]).Select(kv => kv.Key + "=" + kv.Value)));
+        // The seed-selector overload computes a fresh seed per key.
+        Console.WriteLine(string.Join(";", words.AggregateBy(w => w[0], k => k.ToString(), (a, w) => a + "/" + w.Length).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", new[] { "A", "a" }.AggregateBy(s => s, 0, (a, s) => a + 1, StringComparer.OrdinalIgnoreCase).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(new string[0].AggregateBy(s => s, 0, (a, s) => a + 1).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task TryGetNonEnumeratedCountAndTupleZip()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        int c;
+        Console.WriteLine(new[] { 1, 2, 3 }.TryGetNonEnumeratedCount(out c) + ":" + c);
+        Console.WriteLine(new List<int> { 1, 2 }.TryGetNonEnumeratedCount(out c) + ":" + c);
+        Console.WriteLine(new HashSet<int> { 1 }.TryGetNonEnumeratedCount(out c) + ":" + c);
+        Console.WriteLine(new Dictionary<int, int> { { 1, 1 } }.TryGetNonEnumeratedCount(out c) + ":" + c);
+        Console.WriteLine(new int[0].TryGetNonEnumeratedCount(out c) + ":" + c);
+        IEnumerable<int> asInterface = new List<int> { 1, 2, 3 };
+        Console.WriteLine(asInterface.TryGetNonEnumeratedCount(out c) + ":" + c);
+        // A filtered query has no cheap count in .NET either.
+        Console.WriteLine(new[] { 1, 2, 3 }.Where(x => x > 1).TryGetNonEnumeratedCount(out c) + ":" + c);
+        Console.WriteLine(new[] { 1, 2, 3 }.Distinct().TryGetNonEnumeratedCount(out c) + ":" + c);
+
+        var a = new[] { 1, 2, 3 };
+        var b = new[] { "x", "y" };
+        // The selectorless Zip pairs into tuples and stops at the shorter sequence.
+        Console.WriteLine(string.Join(";", a.Zip(b).Select(t => t.First + t.Second)));
+        Console.WriteLine(string.Join(";", a.Zip(b).Select(t => t.Item1 + "/" + t.Item2)));
+        Console.WriteLine(a.Zip(new int[0]).Count());
+        foreach (var (n, s) in a.Zip(b)) Console.WriteLine(n + "-" + s);
+        Console.WriteLine(string.Join(";", a.Zip(b, new[] { true, false }).Select(t => t.First + t.Second + t.Third)));
+        Console.WriteLine(a.Zip(b, new bool[0]).Count());
+        // The selector overload still resolves.
+        Console.WriteLine(string.Join(";", a.Zip(b, (x, y) => x + y)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task IndexingByIndexAndRange()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 10, 20, 30, 40, 50 };
+        Console.WriteLine(xs.ElementAt(1) + "," + xs.ElementAt(^1) + "," + xs.ElementAt(^5));
+        Console.WriteLine(xs.ElementAtOrDefault(^1) + "," + xs.ElementAtOrDefault(^9) + "," + xs.ElementAtOrDefault(^0));
+        Console.WriteLine(xs.ElementAt(new Index(2)) + "," + xs.ElementAt(Index.FromEnd(2)));
+        // ^0 is one past the last element, so it is never in range.
+        try { xs.ElementAt(^0); } catch (ArgumentOutOfRangeException) { Console.WriteLine("^0 throws"); }
+        try { xs.ElementAt(^9); } catch (ArgumentOutOfRangeException) { Console.WriteLine("^9 throws"); }
+        Console.WriteLine(xs.Where(x => x > 15).ElementAt(^1));
+
+        Console.WriteLine("[" + string.Join(",", xs.Take(1..3)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(..2)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(3..)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(..)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(1..^1)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(^2..)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(^3..^1)) + "]");
+        // An inverted, empty or over-long range yields nothing rather than throwing.
+        Console.WriteLine("[" + string.Join(",", xs.Take(3..1)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(2..2)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(0..99)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(^9..)) + "]");
+        Console.WriteLine("[" + string.Join(",", new int[0].Take(0..2)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Where(x => x > 15).Take(1..3)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.Take(1..^1).Take(1..)) + "]");
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task RangeExpressionsOutsideAnIndexer()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    static int Describe(Range r) { var (offset, length) = r.GetOffsetAndLength(10); return offset * 100 + length; }
+    static Range Field = 2..5;
+
+    public static void Main()
+    {
+        // A range expression is a System.Range value in any position, not just inside an indexer.
+        Range r = 1..^1;
+        Console.WriteLine(r.Start.Value + "," + r.End.IsFromEnd + "," + r.End.Value);
+        Console.WriteLine(Describe(1..3) + "," + Describe(..2) + "," + Describe(3..) + "," + Describe(..) + "," + Describe(^3..^1));
+        Console.WriteLine(Field.Start.Value + "," + Field.End.Value);
+        var ranges = new[] { 0..1, 1..^1, ^2.. };
+        Console.WriteLine(string.Join(";", ranges.Select(x => x.ToString())));
+        Console.WriteLine((1..3).Equals(1..3) + "," + (1..3).Equals(1..4));
+
+        // Array and string slicing (which lowers a range inline) still works.
+        var xs = new[] { 1, 2, 3, 4, 5 };
+        Console.WriteLine(string.Join(",", xs[1..3]));
+        Console.WriteLine(string.Join(",", xs[..2]) + "|" + string.Join(",", xs[3..]));
+        Console.WriteLine("hello"[1..3] + "," + "hello"[^2..]);
+        Console.WriteLine(xs[^1] + "," + xs[^2]);
+        Console.WriteLine(string.Join(",", xs.Take(r)));
+        Range fromVariable = ^3..;
+        Console.WriteLine(string.Join(",", xs.Take(fromVariable)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task EveryNewOperatorOverAQueryReceiver()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var q = new[] { 1, 2, 3, 4, 5 }.Where(x => x > 1);
+        Console.WriteLine(string.Join(",", q.Append(9)));
+        Console.WriteLine(string.Join(",", q.Prepend(0)));
+        Console.WriteLine(q.ToHashSet().Count);
+        Console.WriteLine(string.Join(",", q.DistinctBy(x => x % 2)));
+        Console.WriteLine(string.Join(",", q.SkipLast(1)) + "|" + string.Join(",", q.TakeLast(2)));
+        Console.WriteLine(string.Join(",", q.Order()) + "|" + string.Join(",", q.OrderDescending()));
+        Console.WriteLine(string.Join(",", q.Index().Select(t => t.Index + ":" + t.Item)));
+        Console.WriteLine(string.Join(";", q.CountBy(x => x % 2).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", q.AggregateBy(x => x % 2, 0, (a, x) => a + x).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", q.Zip(new[] { "a", "b" }).Select(t => t.First + t.Second)));
+        Console.WriteLine(string.Join(",", q.UnionBy(new[] { 9 }, x => x % 2)));
+        Console.WriteLine(string.Join(",", q.IntersectBy(new[] { 0 }, x => x % 2)));
+        Console.WriteLine(string.Join(",", q.ExceptBy(new[] { 0 }, x => x % 2)));
+        // EnumerableInstance declares instance ElementAt(int) and Take(int), which beat an extension
+        // method — so these four calls have to split cleanly between the instance and extension forms.
+        Console.WriteLine(q.ElementAt(^1) + "," + q.ElementAtOrDefault(^9));
+        Console.WriteLine(string.Join(",", q.Take(1..3)));
+        Console.WriteLine(string.Join(",", q.Take(2)));
+        Console.WriteLine(q.ElementAt(1));
+        int c;
+        Console.WriteLine(q.TryGetNonEnumeratedCount(out c) + ":" + c);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task NewOperatorsAcrossElementTypes()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public record Item(string Sku, int Qty);
+public readonly record struct RS(int A, string B);
+public struct Pt : IComparable<Pt> { public int X; public int CompareTo(Pt o) => X.CompareTo(o.X); public override string ToString() => "P" + X; }
+public enum Colour { Red = 1, Green = 2, Blue = 3 }
+
+public class Program
+{
+    public static void Main()
+    {
+        var items = new[] { new Item("a", 2), new Item("b", 1), new Item("a", 3) };
+        Console.WriteLine(string.Join(",", items.DistinctBy(i => i.Sku).Select(i => i.Sku + i.Qty)));
+        Console.WriteLine(string.Join(";", items.CountBy(i => i.Sku).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(";", items.AggregateBy(i => i.Sku, 0, (a, i) => a + i.Qty).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(string.Join(",", items.ExceptBy(new[] { "a" }, i => i.Sku).Select(i => i.Sku)));
+        Console.WriteLine(string.Join(",", items.Append(new Item("z", 0)).Select(i => i.Sku)));
+        Console.WriteLine(items.ToHashSet().Count);
+
+        var rs = new[] { new RS(2, "x"), new RS(1, "y"), new RS(2, "x") };
+        Console.WriteLine(rs.ToHashSet().Count + "," + rs.DistinctBy(r => r.A).Count());
+        // A record does not implement IComparable, so it is ordered by a key rather than by Order().
+        Console.WriteLine(string.Join(",", rs.OrderBy(r => r.A).ThenBy(r => r.B).Select(r => r.A + r.B)));
+
+        var pts = new[] { new Pt { X = 3 }, new Pt { X = 1 } };
+        Console.WriteLine(string.Join(",", pts.Order()) + "|" + string.Join(",", pts.OrderDescending()));
+
+        var cs = new[] { Colour.Blue, Colour.Red, Colour.Green, Colour.Red };
+        Console.WriteLine(string.Join(",", cs.Order()) + "|" + string.Join(",", cs.OrderDescending()));
+        Console.WriteLine(string.Join(";", cs.CountBy(c => c).Select(kv => kv.Key + "=" + kv.Value)));
+        Console.WriteLine(cs.ToHashSet().Count + "," + string.Join(",", cs.DistinctBy(c => (int)c % 2)));
+
+        var ns = new int?[] { 3, null, 1 };
+        Console.WriteLine(string.Join(",", ns.Order().Select(x => x == null ? "null" : x.ToString())));
+        Console.WriteLine(ns.ToHashSet().Count + "," + ns.DistinctBy(x => x).Count());
+
+        var ts = new[] { (1, "a"), (2, "b"), (1, "a") };
+        Console.WriteLine(ts.ToHashSet().Count + "," + string.Join(",", ts.DistinctBy(t => t.Item1).Select(t => t.Item2)));
+        Console.WriteLine(string.Join(",", ts.Order().Select(t => t.Item1 + t.Item2)));
+
+        var anon = new[] { new { A = 1 }, new { A = 1 }, new { A = 2 } };
+        Console.WriteLine(anon.ToHashSet().Count + "," + anon.DistinctBy(x => x.A).Count());
+        Console.WriteLine(string.Join(";", anon.CountBy(x => x.A).Select(kv => kv.Key + "=" + kv.Value)));
+
+        Console.WriteLine(string.Join("", "hello".Order()) + "," + string.Join("", "hello".DistinctBy(ch => ch)));
+        Console.WriteLine(string.Join(",", new[] { 2.5, 1.5 }.Order()) + "," + string.Join(",", new[] { 3m, 1m }.Order()));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task ArgumentValidationOfTheNewOperators()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        IEnumerable<int> nothing = null;
+        // Every one of these validates its arguments EAGERLY: the exception surfaces at the call, before
+        // anything is enumerated.
+        try { nothing.Append(1); } catch (ArgumentNullException e) { Console.WriteLine("append " + e.ParamName); }
+        try { nothing.Prepend(1); } catch (ArgumentNullException e) { Console.WriteLine("prepend " + e.ParamName); }
+        try { nothing.ToHashSet(); } catch (ArgumentNullException e) { Console.WriteLine("tohashset " + e.ParamName); }
+        try { nothing.DistinctBy(x => x); } catch (ArgumentNullException e) { Console.WriteLine("distinctby " + e.ParamName); }
+        try { new[] { 1 }.DistinctBy((Func<int, int>)null); } catch (ArgumentNullException e) { Console.WriteLine("distinctby-key " + e.ParamName); }
+        try { nothing.UnionBy(new[] { 1 }, x => x); } catch (ArgumentNullException e) { Console.WriteLine("unionby " + e.ParamName); }
+        try { new[] { 1 }.UnionBy(null, x => x); } catch (ArgumentNullException e) { Console.WriteLine("unionby-2nd " + e.ParamName); }
+        try { new[] { 1 }.IntersectBy(null, x => x); } catch (ArgumentNullException e) { Console.WriteLine("intersectby-2nd " + e.ParamName); }
+        try { new[] { 1 }.ExceptBy(null, x => x); } catch (ArgumentNullException e) { Console.WriteLine("exceptby-2nd " + e.ParamName); }
+        try { nothing.SkipLast(1); } catch (ArgumentNullException e) { Console.WriteLine("skiplast " + e.ParamName); }
+        try { nothing.TakeLast(1); } catch (ArgumentNullException e) { Console.WriteLine("takelast " + e.ParamName); }
+        try { nothing.Order(); } catch (ArgumentNullException e) { Console.WriteLine("order " + e.ParamName); }
+        try { nothing.OrderDescending(); } catch (ArgumentNullException e) { Console.WriteLine("orderdesc " + e.ParamName); }
+        try { nothing.Index(); } catch (ArgumentNullException e) { Console.WriteLine("index " + e.ParamName); }
+        try { nothing.CountBy(x => x); } catch (ArgumentNullException e) { Console.WriteLine("countby " + e.ParamName); }
+        try { new[] { 1 }.AggregateBy(x => x, 0, null); } catch (ArgumentNullException e) { Console.WriteLine("aggregateby-func " + e.ParamName); }
+        try { new[] { 1 }.Zip((int[])null); } catch (ArgumentNullException e) { Console.WriteLine("zip " + e.ParamName); }
+        try { nothing.Take(0..1); } catch (ArgumentNullException e) { Console.WriteLine("take-range " + e.ParamName); }
+        try { nothing.ElementAt(^1); } catch (ArgumentNullException e) { Console.WriteLine("elementat " + e.ParamName); }
+        int c;
+        try { nothing.TryGetNonEnumeratedCount(out c); } catch (ArgumentNullException e) { Console.WriteLine("trygetcount " + e.ParamName); }
+    }
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqModernOperatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqModernOperatorTests.cs
@@ -9,8 +9,10 @@ namespace Transpose.Translator.Tests.Linq
     /// binding maps onto: <c>Append</c>/<c>Prepend</c>, <c>ToHashSet</c>, <c>DistinctBy</c>/
     /// <c>UnionBy</c>/<c>IntersectBy</c>/<c>ExceptBy</c>, <c>SkipLast</c>/<c>TakeLast</c>,
     /// <c>Order</c>/<c>OrderDescending</c>, <c>Index</c>, <c>CountBy</c>/<c>AggregateBy</c>,
-    /// <c>TryGetNonEnumeratedCount</c>, the tuple-returning <c>Zip</c> overloads, and indexing by
-    /// <see cref="System.Index"/> / <see cref="System.Range"/>.
+    /// <c>TryGetNonEnumeratedCount</c>, the tuple-returning <c>Zip</c> overloads, indexing by
+    /// <see cref="System.Index"/> / <see cref="System.Range"/>, the
+    /// <c>FirstOrDefault</c>/<c>LastOrDefault</c>/<c>SingleOrDefault</c> overloads that take an explicit
+    /// default, <c>Shuffle</c>, and <c>LeftJoin</c>/<c>RightJoin</c>.
     ///
     /// Each is covered in every declared overload, over an array/List receiver and over a query receiver
     /// (which matters: an instance method on <c>EnumerableInstance</c> beats an extension method, so
@@ -455,6 +457,163 @@ public class Program
         }
 
         [TestMethod]
+        public async Task OrDefaultOverloadsWithAnExplicitDefault()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        var empty = new int[0];
+        Console.WriteLine(xs.FirstOrDefault(99) + "," + empty.FirstOrDefault(99));
+        Console.WriteLine(xs.FirstOrDefault(x => x > 2, 99) + "," + xs.FirstOrDefault(x => x > 9, 99));
+        Console.WriteLine(xs.LastOrDefault(99) + "," + empty.LastOrDefault(99));
+        Console.WriteLine(xs.LastOrDefault(x => x < 3, 99) + "," + xs.LastOrDefault(x => x > 9, 99));
+        Console.WriteLine(new[] { 7 }.SingleOrDefault(99) + "," + empty.SingleOrDefault(99));
+        Console.WriteLine(xs.SingleOrDefault(x => x == 2, 99) + "," + xs.SingleOrDefault(x => x > 9, 99));
+        // "OrDefault" covers emptiness, not ambiguity: more than one element still throws.
+        try { xs.SingleOrDefault(99); } catch (InvalidOperationException e) { Console.WriteLine("many: " + e.Message); }
+        try { xs.SingleOrDefault(x => x > 1, 99); } catch (InvalidOperationException e) { Console.WriteLine("manymatch: " + e.Message); }
+
+        var strs = new[] { "a", "b" };
+        Console.WriteLine(strs.FirstOrDefault("z") + "," + new string[0].FirstOrDefault("z"));
+        Console.WriteLine(new string[0].LastOrDefault("z") + "," + new string[0].SingleOrDefault("z"));
+        Console.WriteLine(strs.FirstOrDefault(s => s == "q", "z"));
+        var list = new List<int> { 5 };
+        Console.WriteLine(list.FirstOrDefault(9) + "," + list.LastOrDefault(9) + "," + list.SingleOrDefault(9));
+        // Adding these must not disturb the overloads that were already there: a lambda still binds as a
+        // predicate rather than as a default value.
+        Console.WriteLine(empty.FirstOrDefault() + "," + xs.FirstOrDefault(x => x > 1) + "," + empty.SingleOrDefault());
+        // A query receiver reaches EnumerableInstance's own instance forms, which take the same arguments.
+        var q = xs.Where(x => x > 1);
+        Console.WriteLine(q.FirstOrDefault(99) + "," + q.LastOrDefault(99) + "," + q.FirstOrDefault(x => x > 9, 99));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task LeftJoinAndRightJoin()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var outer = new[] { "1a", "2b", "3c" };
+        var inner = new[] { "1x", "1y", "3z" };
+        Func<string, string> outerKey = o => o.Substring(0, 1);
+        Func<string, string> innerKey = i => i.Substring(0, 1);
+        // LeftJoin keeps every outer element (2b has no match), in outer order.
+        Console.WriteLine(string.Join(";", outer.LeftJoin(inner, outerKey, innerKey, (o, i) => o + "/" + (i ?? "-"))));
+        // RightJoin keeps every inner element, and the result is in INNER order.
+        Console.WriteLine(string.Join(";", outer.RightJoin(inner, outerKey, innerKey, (o, i) => (o ?? "-") + "/" + i)));
+        Console.WriteLine(string.Join(";", outer.LeftJoin(inner, outerKey, innerKey, (o, i) => o + "/" + (i ?? "-"), StringComparer.Ordinal)));
+        Console.WriteLine(string.Join(";", outer.RightJoin(inner, outerKey, innerKey, (o, i) => (o ?? "-") + "/" + i, StringComparer.Ordinal)));
+        Console.WriteLine(outer.LeftJoin(new string[0], outerKey, innerKey, (o, i) => o).Count());
+        Console.WriteLine(new string[0].LeftJoin(inner, outerKey, innerKey, (o, i) => o).Count());
+        Console.WriteLine(outer.RightJoin(new string[0], outerKey, innerKey, (o, i) => i).Count());
+        Console.WriteLine(new string[0].RightJoin(inner, outerKey, innerKey, (o, i) => i).Count());
+
+        // A value-typed unmatched side is the type's default, not null.
+        var ints = new[] { 1, 2 };
+        var pairs = new[] { (K: 1, V: "one") };
+        Console.WriteLine(string.Join(";", ints.LeftJoin(pairs, x => x, p => p.K, (x, p) => x + "=" + (p.V ?? "none"))));
+        Console.WriteLine(string.Join(";", pairs.RightJoin(ints, p => p.K, x => x, (p, x) => x + "=" + (p.V ?? "none"))));
+
+        Console.WriteLine(string.Join(";", new[] { "A" }.LeftJoin(new[] { "a1" }, s => s, s => s.Substring(0, 1), (o, i) => o + "/" + (i ?? "-"), StringComparer.OrdinalIgnoreCase)));
+        Console.WriteLine(string.Join(";", new[] { "A" }.LeftJoin(new[] { "a1" }, s => s, s => s.Substring(0, 1), (o, i) => o + "/" + (i ?? "-"), StringComparer.Ordinal)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task JoinsNeverMatchANullKey()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var outer = new[] { "a1", "b2", null };
+        var inner = new[] { "x1", null, "y1" };
+        Func<string, string> outerKey = o => o == null ? null : o.Substring(1);
+        Func<string, string> innerKey = i => i == null ? null : i.Substring(1);
+        // System.Linq's join lookup drops null-keyed elements, so a null key never correlates — the two
+        // null elements below are NOT paired, and GroupJoin reports an empty group for the null outer.
+        Console.WriteLine(string.Join(";", outer.Join(inner, outerKey, innerKey, (o, i) => (o ?? "N") + "/" + (i ?? "N"))));
+        Console.WriteLine(string.Join(";", outer.GroupJoin(inner, outerKey, innerKey, (o, g) => (o ?? "N") + "=" + g.Count())));
+        Console.WriteLine(string.Join(";", outer.LeftJoin(inner, outerKey, innerKey, (o, i) => (o ?? "N") + "/" + (i ?? "N"))));
+        Console.WriteLine(string.Join(";", outer.RightJoin(inner, outerKey, innerKey, (o, i) => (o ?? "N") + "/" + (i ?? "N"))));
+
+        // A nullable-typed key behaves the same way.
+        var xs = new[] { 1, 2, 3 };
+        var ys = new[] { 1, 3 };
+        Func<int, int?> nullableKey = x => x == 2 ? (int?)null : x;
+        Console.WriteLine(string.Join(";", xs.Join(ys, nullableKey, nullableKey, (a, b) => a + "/" + b)));
+        Console.WriteLine(string.Join(";", xs.GroupJoin(ys, nullableKey, nullableKey, (a, g) => a + "=" + g.Count())));
+        Console.WriteLine(string.Join(";", xs.LeftJoin(ys, nullableKey, nullableKey, (a, b) => a + "/" + b)));
+
+        // The rule is specific to joins: ToLookup and GroupBy DO keep a null-keyed grouping.
+        Console.WriteLine(outer.ToLookup(outerKey).Count + "," + outer.GroupBy(outerKey).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Shuffle_PreservesTheElementsItRandomizes()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = Enumerable.Range(1, 20).ToArray();
+        // The order is random, so only the invariants can be diffed against native .NET: the same
+        // elements, the same number of them, none lost or duplicated.
+        var shuffled = xs.Shuffle().ToList();
+        Console.WriteLine(shuffled.Count);
+        Console.WriteLine(string.Join(",", shuffled.OrderBy(x => x)));
+        Console.WriteLine(shuffled.Distinct().Count() + "," + shuffled.Sum());
+        Console.WriteLine(new int[0].Shuffle().Count());
+        Console.WriteLine(new[] { 7 }.Shuffle().Single());
+        var words = new[] { "a", "b", "c" };
+        Console.WriteLine(string.Join(",", words.Shuffle().OrderBy(s => s)));
+        Console.WriteLine(string.Join(",", words.Shuffle().Where(s => s != "b").OrderBy(s => s)));
+        Console.WriteLine(xs.Where(x => x > 15).Shuffle().Count());
+        // Deferred, and re-drawn on each enumeration — so both remain permutations of the source.
+        var q = xs.Shuffle();
+        Console.WriteLine(string.Join(",", q.OrderBy(x => x).Take(3)));
+        Console.WriteLine(string.Join(",", q.OrderBy(x => x).Take(3)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
         public async Task ArgumentValidationOfTheNewOperators()
         {
             var code = """
@@ -488,6 +647,14 @@ public class Program
         try { new[] { 1 }.Zip((int[])null); } catch (ArgumentNullException e) { Console.WriteLine("zip " + e.ParamName); }
         try { nothing.Take(0..1); } catch (ArgumentNullException e) { Console.WriteLine("take-range " + e.ParamName); }
         try { nothing.ElementAt(^1); } catch (ArgumentNullException e) { Console.WriteLine("elementat " + e.ParamName); }
+        try { nothing.FirstOrDefault(1); } catch (ArgumentNullException e) { Console.WriteLine("firstordefault " + e.ParamName); }
+        try { nothing.LastOrDefault(1); } catch (ArgumentNullException e) { Console.WriteLine("lastordefault " + e.ParamName); }
+        try { nothing.SingleOrDefault(1); } catch (ArgumentNullException e) { Console.WriteLine("singleordefault " + e.ParamName); }
+        try { new[] { 1 }.FirstOrDefault((Func<int, bool>)null, 1); } catch (ArgumentNullException e) { Console.WriteLine("firstordefault-pred " + e.ParamName); }
+        try { nothing.Shuffle(); } catch (ArgumentNullException e) { Console.WriteLine("shuffle " + e.ParamName); }
+        try { nothing.LeftJoin(new[] { 1 }, x => x, x => x, (a, b) => a); } catch (ArgumentNullException e) { Console.WriteLine("leftjoin " + e.ParamName); }
+        try { new[] { 1 }.LeftJoin((int[])null, x => x, x => x, (a, b) => a); } catch (ArgumentNullException e) { Console.WriteLine("leftjoin-inner " + e.ParamName); }
+        try { new[] { 1 }.RightJoin(new[] { 1 }, x => x, x => x, (Func<int, int, int>)null); } catch (ArgumentNullException e) { Console.WriteLine("rightjoin-result " + e.ParamName); }
         int c;
         try { nothing.TryGetNonEnumeratedCount(out c); } catch (ArgumentNullException e) { Console.WriteLine("trygetcount " + e.ParamName); }
     }

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqNumericOperatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqNumericOperatorTests.cs
@@ -1,0 +1,436 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Linq
+{
+    /// <summary>
+    /// The numeric LINQ operators — <c>Sum</c>, <c>Average</c>, <c>Min</c>, <c>Max</c>, <c>Aggregate</c>,
+    /// <c>Count</c>/<c>LongCount</c> — across <b>every element type they are declared for</b> and
+    /// <b>every overload shape</b>: the bare form, the <c>Func&lt;TSource, N&gt;</c> selector form, the
+    /// nullable element type, and the generic <c>Min/Max&lt;TSource&gt;</c> /
+    /// <c>Min/Max&lt;TSource, TResult&gt;</c> forms that work off <c>IComparable</c>.
+    ///
+    /// <c>Enumerable</c> declares these once per numeric type (int, long, float, double, decimal) and
+    /// again for each nullable counterpart, plus a second copy of each taking
+    /// <c>EnumerableInstance&lt;T&gt;</c> so a chained query keeps the same overload set — 100+ signatures
+    /// in total. The receiver therefore matters as much as the element type, and every test below exercises
+    /// both an array/List receiver (binds the <c>IEnumerable&lt;T&gt;</c> overload) and a query receiver
+    /// (binds the <c>EnumerableInstance&lt;T&gt;</c> one).
+    ///
+    /// Each test transpiles the snippet, runs it on Node and diffs the output against the same C# run
+    /// natively, so what is pinned is observable .NET behaviour: the *result type* of an aggregate
+    /// (<c>Average</c> of an int sequence is a double, of a long sequence also a double, of a decimal
+    /// sequence a decimal), how nulls are skipped, what an empty sequence does, and how the result is
+    /// rendered — <c>Average()</c> of {1,2,4} must print 2.3333333333333335, the shortest
+    /// round-trippable form .NET Core uses, not a 15-digit truncation.
+    /// </summary>
+    [TestClass]
+    public class LinqNumericOperatorTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task Sum_Int_AllOverloads()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        int[] xs = { 1, 2, 3, 4 };
+        Console.WriteLine(xs.Sum());
+        Console.WriteLine(xs.Sum(x => x * 2));
+        Console.WriteLine(Enumerable.Empty<int>().Sum());
+        Console.WriteLine(Enumerable.Empty<int>().Sum(x => x));
+
+        List<int> negatives = new List<int> { -5, 10, -1 };
+        Console.WriteLine(negatives.Sum());
+        Console.WriteLine(negatives.AsEnumerable().Sum());
+        Console.WriteLine(negatives.Where(x => x > 0).Sum());
+        Console.WriteLine(negatives.Select(x => x).Sum(x => x));
+        Console.WriteLine(Enumerable.Range(1, 100).Sum());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Sum_NullableInt_SkipsNulls()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        int?[] xs = { 1, null, 3 };
+        Console.WriteLine(xs.Sum());
+        Console.WriteLine(xs.Sum(x => x));
+        Console.WriteLine(new int?[0].Sum());
+        Console.WriteLine(new int?[] { null, null }.Sum());
+        Console.WriteLine(xs.Where(x => x != null).Sum());
+        Console.WriteLine(new[] { 1, 2, 3 }.Sum(x => x == 2 ? (int?)null : x));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Sum_Long_AndNullableLong()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        long[] xs = { 1L, 2L, 3000000000L };
+        Console.WriteLine(xs.Sum());
+        Console.WriteLine(xs.Sum(x => x));
+        long?[] ns = { 1L, null, 5L };
+        Console.WriteLine(ns.Sum());
+        Console.WriteLine(ns.Sum(x => x));
+        Console.WriteLine(new[] { 1, 2, 3 }.Sum(x => (long)x));
+        Console.WriteLine(new[] { 1, 2, 3 }.Select(x => (long)x).Sum());
+        Console.WriteLine(new[] { long.MaxValue / 2, 1L }.Sum());
+        Console.WriteLine(new long[0].Sum());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Sum_FloatAndDouble_AndTheirNullables()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        float[] fs = { 1.5f, 2.25f, -0.75f };
+        Console.WriteLine(fs.Sum());
+        Console.WriteLine(fs.Sum(x => x));
+        double[] ds = { 1.5, 2.25, -0.75 };
+        Console.WriteLine(ds.Sum());
+        Console.WriteLine(ds.Sum(x => x));
+        float?[] nfs = { 1.5f, null, 0.25f };
+        Console.WriteLine(nfs.Sum());
+        Console.WriteLine(nfs.Sum(x => x));
+        double?[] nds = { 1.5, null, 0.25 };
+        Console.WriteLine(nds.Sum());
+        Console.WriteLine(nds.Sum(x => x));
+        Console.WriteLine(new float[0].Sum());
+        Console.WriteLine(new double[0].Sum());
+        Console.WriteLine(new[] { 1, 2 }.Sum(x => (double)x / 4));
+        Console.WriteLine(new[] { 0.1, 0.2 }.Sum());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Sum_Decimal_AndNullableDecimal()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        decimal[] xs = { 1.5m, 2.25m, 0.25m };
+        Console.WriteLine(xs.Sum());
+        Console.WriteLine(xs.Sum(x => x));
+        decimal?[] ns = { 1.5m, null, 2m };
+        Console.WriteLine(ns.Sum());
+        Console.WriteLine(ns.Sum(x => x));
+        Console.WriteLine(new decimal[0].Sum());
+        // 0.1 + 0.2 + 0.3 is exact in decimal and is NOT in double.
+        Console.WriteLine(new[] { 0.1m, 0.2m, 0.3m }.Sum());
+        Console.WriteLine(new[] { 1, 2, 3 }.Sum(x => (decimal)x / 2));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Average_IntAndLong_ReturnDouble()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        int[] xs = { 1, 2, 3, 4 };
+        Console.WriteLine(xs.Average());
+        Console.WriteLine(xs.Average(x => x));
+        // 7/3 does not divide evenly: the result must render as the shortest round-trippable double.
+        Console.WriteLine(new[] { 1, 2, 4 }.Average());
+        Console.WriteLine(new[] { 1L, 2L, 4L }.Average());
+        Console.WriteLine(new[] { 1L, 2L, 4L }.Average(x => x));
+        int?[] ns = { 1, null, 3 };
+        Console.WriteLine(ns.Average());
+        Console.WriteLine(ns.Average(x => x));
+        long?[] nls = { 1L, null, 3L };
+        Console.WriteLine(nls.Average());
+        Console.WriteLine(nls.Average(x => x));
+        Console.WriteLine(Enumerable.Range(1, 10).Average());
+        Console.WriteLine(xs.Where(x => x > 1).Average());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Average_FloatDoubleDecimal_KeepTheirOwnResultType()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        float[] fs = { 1.5f, 2.5f };
+        Console.WriteLine(fs.Average());
+        Console.WriteLine(fs.Average(x => x));
+        Console.WriteLine(new[] { 1.0f, 2.0f, 4.0f }.Average());
+        double[] ds = { 1.5, 2.0 };
+        Console.WriteLine(ds.Average());
+        Console.WriteLine(ds.Average(x => x));
+        Console.WriteLine(new[] { 1.0, 2.0, 4.0 }.Average());
+        decimal[] ms = { 1.5m, 2.0m };
+        Console.WriteLine(ms.Average());
+        Console.WriteLine(ms.Average(x => x));
+        Console.WriteLine(new[] { 1m, 2m, 4m }.Average());
+        float?[] nfs = { 1.5f, null, 2.5f };
+        Console.WriteLine(nfs.Average());
+        Console.WriteLine(nfs.Average(x => x));
+        double?[] nds = { 1.5, null };
+        Console.WriteLine(nds.Average());
+        decimal?[] nms = { 1.5m, null };
+        Console.WriteLine(nms.Average());
+        Console.WriteLine(new int?[] { null }.Average() == null);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task MinMax_EveryNumericType()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new[] { 3, 1, 2 }.Min() + "," + new[] { 3, 1, 2 }.Max());
+        Console.WriteLine(new[] { 3L, 1L }.Min() + "," + new[] { 3L, 1L }.Max());
+        Console.WriteLine(new[] { 3.5f, 1.5f }.Min() + "," + new[] { 3.5f, 1.5f }.Max());
+        Console.WriteLine(new[] { 3.5, 1.5 }.Min() + "," + new[] { 3.5, 1.5 }.Max());
+        Console.WriteLine(new[] { 3.5m, 1.5m }.Min() + "," + new[] { 3.5m, 1.5m }.Max());
+        Console.WriteLine(new[] { long.MinValue, 0L }.Min());
+        Console.WriteLine(new[] { int.MinValue, int.MaxValue }.Min() + "," + new[] { int.MinValue, int.MaxValue }.Max());
+        Console.WriteLine(new[] { 1 }.Min() + "," + new[] { 1 }.Max());
+        Console.WriteLine(new[] { 1, 2, 3 }.Where(x => x > 1).Min());
+        Console.WriteLine(new[] { 1, 2, 3 }.Select(x => x * 2).Max());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task MinMax_NullableNumerics_SkipNullsAndReturnNullWhenEmpty()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(new int?[] { 3, null, 1 }.Min() + "," + new int?[] { 3, null, 1 }.Max());
+        Console.WriteLine(new int?[] { null, null }.Min() == null);
+        Console.WriteLine(new int?[0].Min() == null);
+        Console.WriteLine(new int?[0].Max() == null);
+        Console.WriteLine(new long?[] { 3L, null }.Min() + "," + new long?[] { 3L, null }.Max());
+        Console.WriteLine(new float?[] { 3.5f, null }.Min() + "," + new float?[] { 3.5f, null }.Max());
+        Console.WriteLine(new double?[] { 3.5, null }.Min() + "," + new double?[] { 3.5, null }.Max());
+        Console.WriteLine(new decimal?[] { 3.5m, null }.Min() + "," + new decimal?[] { 3.5m, null }.Max());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task MinMax_SelectorOverloads_ForEveryNumericResult()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { "a", "bbb", "cc" };
+        Console.WriteLine(xs.Min(s => s.Length) + "," + xs.Max(s => s.Length));
+        Console.WriteLine(xs.Min(s => (long)s.Length) + "," + xs.Max(s => (long)s.Length));
+        Console.WriteLine(xs.Min(s => (float)s.Length) + "," + xs.Max(s => (float)s.Length));
+        Console.WriteLine(xs.Min(s => (double)s.Length) + "," + xs.Max(s => (double)s.Length));
+        Console.WriteLine(xs.Min(s => (decimal)s.Length) + "," + xs.Max(s => (decimal)s.Length));
+        Console.WriteLine(xs.Min(s => (int?)s.Length) + "," + xs.Max(s => (int?)s.Length));
+        Console.WriteLine(xs.Min(s => s.Length == 1 ? (int?)null : s.Length));
+        // The generic Min<TSource>/Max<TSource, TResult> forms, over IComparable rather than a number.
+        Console.WriteLine(xs.Min() + "," + xs.Max());
+        Console.WriteLine(xs.Min(s => s + "!") + "," + xs.Max(s => s + "!"));
+        Console.WriteLine(new[] { 'c', 'a' }.Min() + "," + new[] { 'c', 'a' }.Max());
+        var dates = new[] { new DateTime(2020, 1, 2), new DateTime(2019, 5, 5) };
+        Console.WriteLine(dates.Min().ToString("yyyy-MM-dd") + "," + dates.Max().ToString("yyyy-MM-dd"));
+        Console.WriteLine(dates.Min(d => d.Year) + "," + dates.Max(d => d.Year));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Aggregate_AllThreeOverloads()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4 };
+        Console.WriteLine(xs.Aggregate((a, b) => a + b));
+        Console.WriteLine(xs.Aggregate(10, (a, b) => a + b));
+        Console.WriteLine(xs.Aggregate(10, (a, b) => a + b, r => "r=" + r));
+        var ss = new[] { "a", "b" };
+        Console.WriteLine(ss.Aggregate((a, b) => a + "|" + b));
+        Console.WriteLine(ss.Aggregate("", (a, b) => a + b.ToUpper()));
+        Console.WriteLine(ss.Aggregate(0, (a, b) => a + b.Length, n => n * 2));
+        Console.WriteLine(xs.Where(x => x > 2).Aggregate(0, (a, b) => a + b));
+        Console.WriteLine(new int[0].Aggregate(7, (a, b) => a + b));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Aggregate_AccumulatorOfEveryShape()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        Console.WriteLine(xs.Aggregate(new List<int>(), (acc, x) => { acc.Add(x * 2); return acc; }).Count);
+        Console.WriteLine(xs.Aggregate("", (acc, x) => acc + x));
+        Console.WriteLine(xs.Aggregate(1L, (acc, x) => acc * x));
+        Console.WriteLine(xs.Aggregate(0.5, (acc, x) => acc + x));
+        Console.WriteLine(xs.Aggregate(0m, (acc, x) => acc + x));
+        Console.WriteLine(xs.Aggregate(new StringBuilder(), (acc, x) => acc.Append(x), sb => sb.ToString()));
+        Console.WriteLine(xs.Aggregate(new Dictionary<int, int>(), (acc, x) => { acc[x] = x * x; return acc; }, d => d.Count));
+        Console.WriteLine(xs.Aggregate((int?)0, (acc, x) => acc + x));
+        Console.WriteLine(xs.Aggregate(new[] { 0 }, (acc, x) => acc.Concat(new[] { x }).ToArray()).Length);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task CountAndLongCount_BothOverloads()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        Console.WriteLine(xs.Count() + "," + xs.Count(x => x > 1));
+        Console.WriteLine(xs.LongCount() + "," + xs.LongCount(x => x > 1));
+        Console.WriteLine(new int[0].Count() + "," + new int[0].LongCount());
+        Console.WriteLine(xs.Where(x => x > 1).Count() + "," + xs.Where(x => x > 1).LongCount());
+        Console.WriteLine(new List<string> { "a", "bb" }.Count(s => s.Length > 1));
+        Console.WriteLine("hello".Count(c => c == 'l'));
+        Console.WriteLine(Enumerable.Range(0, 1000).Count(x => x % 7 == 0));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task NumericAggregates_OverAQueryReceiver_BindTheEnumerableInstanceOverloads()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4 };
+        var q = xs.Where(x => x > 1);
+        Console.WriteLine(q.Sum() + "," + q.Average() + "," + q.Min() + "," + q.Max() + "," + q.Count());
+        var ls = xs.Select(x => (long)x).Where(x => x > 1);
+        Console.WriteLine(ls.Sum() + "," + ls.Min() + "," + ls.Max());
+        var fs = xs.Select(x => (float)x / 2).Where(x => x > 0.5f);
+        Console.WriteLine(fs.Sum() + "," + fs.Min() + "," + fs.Max());
+        var ds = xs.Select(x => (double)x / 4).Where(x => x > 0.25);
+        Console.WriteLine(ds.Sum() + "," + ds.Min() + "," + ds.Max());
+        var ms = xs.Select(x => (decimal)x / 2).Where(x => x > 0.5m);
+        Console.WriteLine(ms.Sum() + "," + ms.Average() + "," + ms.Min() + "," + ms.Max());
+        var ns = xs.Select(x => x == 2 ? (int?)null : x);
+        Console.WriteLine(ns.Sum() + "," + ns.Min() + "," + ns.Max());
+    }
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqQuerySyntaxTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqQuerySyntaxTests.cs
@@ -1,0 +1,275 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Linq
+{
+    /// <summary>
+    /// LINQ <b>query expression</b> syntax — every clause the language defines, and the combinations that
+    /// force C#'s "transparent identifier" lowering: <c>from</c> (including a second and third one),
+    /// <c>let</c>, <c>join</c> and <c>join … into</c>, <c>where</c>, <c>orderby</c> (with several keys and
+    /// mixed directions), <c>select</c>, <c>group … by</c>, and an <c>into</c> continuation.
+    ///
+    /// The interesting cases are the ones where more than one range variable is live at once: a clause is
+    /// a single-parameter lambda, so the compiler has to carry the variables in a frame object and every
+    /// later clause reads them out of it. These tests pin the resulting *behaviour* against native .NET
+    /// rather than the emitted shape, so the frame layout is free to change.
+    /// </summary>
+    [TestClass]
+    public class LinqQuerySyntaxTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task SingleFrom_WhereOrderBySelect()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 5, 3, 8, 1 };
+        Console.WriteLine(string.Join(",", from x in xs where x > 2 orderby x select x * 2));
+        Console.WriteLine(string.Join(",", from x in xs orderby x descending select x));
+        Console.WriteLine(string.Join(",", from x in xs select x));
+        Console.WriteLine(string.Join(",", from x in xs where x > 100 select x));
+        Console.WriteLine(string.Join(",", from x in xs orderby x % 3, x descending select x));
+        Console.WriteLine(string.Join(",", from x in xs orderby x % 3 descending, x select x));
+        Console.WriteLine(string.Join(",", from x in xs where x > 2 where x < 8 select x));
+        Console.WriteLine(string.Join(",", from x in xs select new { X = x, Sq = x * x } into p select p.X + "^" + p.Sq));
+        Console.WriteLine((from x in xs select x).Count());
+        Console.WriteLine((from x in xs where x > 3 select x).Sum());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task LetClause()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4 };
+        Console.WriteLine(string.Join(",", from x in xs let y = x * 10 where y > 20 select x + "/" + y));
+        Console.WriteLine(string.Join(",", from x in xs let a = x + 1 let b = a * 2 select x + ":" + a + ":" + b));
+        Console.WriteLine(string.Join(",", from x in xs let s = x.ToString() orderby s descending select s));
+        var words = new[] { "hello", "hi" };
+        Console.WriteLine(string.Join(",", from w in words let n = w.Length where n > 2 select w + n));
+        Console.WriteLine(string.Join(",", from x in xs let y = x * 2 group y by x % 2 into g select g.Key + "=" + g.Sum()));
+        // A let whose expression is itself a query over the outer range variable.
+        Console.WriteLine(string.Join(",", from x in xs let y = xs.Where(z => z > x).Count() select x + "->" + y));
+        Console.WriteLine(string.Join(",", from x in xs let y = x let z = y select x + y + z));
+        Console.WriteLine(string.Join(",", from x in xs let y = x % 2 == 0 ? "even" : "odd" orderby y, x select y + x));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task MultipleFromClauses()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        var ys = new[] { "a", "b" };
+        Console.WriteLine(string.Join(",", from x in xs from y in ys select x + y));
+        Console.WriteLine(string.Join(",", from x in xs where x > 1 from y in ys where y == "a" select x + y));
+        Console.WriteLine(string.Join(",", from x in xs from y in ys from z in xs where z == x select x + y + z));
+        // The second source may depend on the first range variable.
+        Console.WriteLine(string.Join(",", from x in xs from y in Enumerable.Range(1, x) select x + "^" + y));
+        Console.WriteLine(string.Join(",", from x in xs from y in ys orderby y, x descending select x + y));
+        Console.WriteLine(string.Join(",", from x in xs from y in ys let k = x + y select k.ToUpper()));
+        Console.WriteLine(string.Join(",", from x in xs from y in ys group x by y into g select g.Key + ":" + g.Sum()));
+        Console.WriteLine((from x in xs from y in ys select x).Count());
+        Console.WriteLine(string.Join(",", from s in ys from c in s select s + c));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task JoinAndJoinInto()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var outer = new[] { 1, 2, 3 };
+        var inner = new[] { "1a", "1b", "3c" };
+        Console.WriteLine(string.Join(",", from o in outer
+                                          join i in inner on o.ToString() equals i.Substring(0, 1)
+                                          select o + "/" + i));
+        Console.WriteLine(string.Join(",", from o in outer
+                                          join i in inner on o.ToString() equals i.Substring(0, 1) into g
+                                          select o + "=" + g.Count()));
+        // join-into followed by a from over the group: the "left outer join" shape.
+        Console.WriteLine(string.Join(",", from o in outer
+                                          join i in inner on o.ToString() equals i.Substring(0, 1) into g
+                                          from i2 in g
+                                          select o + "-" + i2));
+        Console.WriteLine(string.Join(",", from o in outer
+                                          join i in inner on o.ToString() equals i.Substring(0, 1)
+                                          where i.EndsWith("b")
+                                          select o + "!" + i));
+        Console.WriteLine(string.Join(",", from o in outer
+                                          join i in inner on o.ToString() equals i.Substring(0, 1)
+                                          orderby i descending
+                                          select i));
+        Console.WriteLine(string.Join(",", from o in outer
+                                          let t = o * 10
+                                          join i in inner on o.ToString() equals i.Substring(0, 1)
+                                          select t + ":" + i));
+        Console.WriteLine(string.Join(";", from o in outer
+                                          join i in inner on o.ToString() equals i.Substring(0, 1) into g
+                                          select o + "[" + string.Join("|", g) + "]"));
+        Console.WriteLine((from o in outer join i in new string[0] on o.ToString() equals i select o).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task GroupByAndIntoContinuation()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4, 5 };
+        Console.WriteLine(string.Join(",", from x in xs group x by x % 2 into g orderby g.Key select g.Key + ":" + g.Count()));
+        Console.WriteLine(string.Join(",", from g in (from x in xs group x by x % 2) select g.Key + "/" + g.Sum()));
+        Console.WriteLine(string.Join(",", from x in xs group x * 10 by x % 2 into g orderby g.Key select g.Key + "=" + string.Join("+", g)));
+        Console.WriteLine(string.Join(",", from x in xs where x > 1 group x by x % 3 into g where g.Count() > 1 select g.Key.ToString()));
+        Console.WriteLine((from x in xs group x by x % 2).Count());
+        var words = new[] { "apple", "avocado", "banana" };
+        Console.WriteLine(string.Join(";", from w in words group w by w[0] into g select g.Key + ":" + g.Count()));
+        Console.WriteLine(string.Join(";", from w in words
+                                          group w by w[0] into g
+                                          let longest = g.OrderByDescending(s => s.Length).First()
+                                          select g.Key + "->" + longest));
+        // An into continuation that itself introduces further range variables.
+        Console.WriteLine(string.Join(";", from w in words
+                                          select w into s
+                                          let n = s.Length
+                                          from c in s.Substring(0, 1)
+                                          orderby n descending
+                                          select c + n));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task ExplicitlyTypedRangeVariable_IsACast()
+        {
+            var code = """
+using System;
+using System.Collections;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        // `from T x in src` is defined as Cast<T>(src), so a non-generic IEnumerable becomes queryable.
+        IEnumerable objs = new object[] { 1, 2, 3 };
+        Console.WriteLine(string.Join(",", from int i in objs select i * 2));
+        Console.WriteLine((from int i in objs where i > 1 select i).Sum());
+        IEnumerable strs = new object[] { "a", "bb" };
+        Console.WriteLine(string.Join(",", from string s in strs select s.Length));
+        Console.WriteLine(string.Join(",", from int i in objs from string s in strs select i + s));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task QuerySyntax_OverRealObjectGraphs()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    class Order { public int Id; public string Cust; public decimal Total; }
+
+    public static void Main()
+    {
+        var orders = new List<Order>
+        {
+            new Order { Id = 1, Cust = "amy", Total = 10m },
+            new Order { Id = 2, Cust = "bob", Total = 25m },
+            new Order { Id = 3, Cust = "amy", Total = 5m },
+        };
+        var custs = new[] { "amy", "cal" };
+
+        var q = from o in orders
+                join c in custs on o.Cust equals c
+                let big = o.Total > 6m
+                where big
+                orderby o.Total descending, o.Id
+                select new { o.Id, o.Cust, o.Total, big };
+        foreach (var r in q) Console.WriteLine(r.Id + " " + r.Cust + " " + r.Total + " " + r.big);
+
+        var g = from o in orders
+                group o by o.Cust into byCust
+                let total = byCust.Sum(x => x.Total)
+                where total > 6m
+                orderby byCust.Key
+                select byCust.Key + "=" + total;
+        Console.WriteLine(string.Join(",", g));
+
+        var nested = from o in orders
+                     from ch in o.Cust
+                     where ch != 'a'
+                     select o.Id + ch.ToString();
+        Console.WriteLine(string.Join(",", nested));
+
+        // A query inside a clause of another query.
+        var correlated = from o in orders
+                         let peers = (from p in orders where p.Cust == o.Cust && p.Id != o.Id select p.Id).ToList()
+                         orderby o.Id
+                         select o.Id + "~[" + string.Join(",", peers) + "]";
+        Console.WriteLine(string.Join(";", correlated));
+
+        // Query syntax reading an instance field through `this` is why a clause must be an arrow function.
+        Console.WriteLine(new Program().Filtered(orders));
+    }
+
+    private readonly string _target = "amy";
+    string Filtered(List<Order> orders) =>
+        string.Join(",", from o in orders where o.Cust == _target orderby o.Id select o.Id);
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/Linq/LinqSequenceOperatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Linq/LinqSequenceOperatorTests.cs
@@ -1,0 +1,655 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests.Linq
+{
+    /// <summary>
+    /// Every non-numeric LINQ operator <c>Enumerable</c> (and <c>EnumerableExtras</c>) implements, once per
+    /// declared overload: projection (<c>Select</c>/<c>SelectMany</c>, both with and without the index),
+    /// filtering, partitioning, the set operators (each in its default-comparer and
+    /// <c>IEqualityComparer</c> form), ordering (<c>OrderBy</c>/<c>ThenBy</c> and their descending
+    /// counterparts, with and without an <c>IComparer</c>), grouping (all eight <c>GroupBy</c>
+    /// signatures), the two joins, the element operators, the conversion operators (all four
+    /// <c>ToDictionary</c> and all four <c>ToLookup</c> shapes), generation, <c>Zip</c>,
+    /// <c>Cast</c>/<c>OfType</c>, and the .NET 6 additions <c>Chunk</c>/<c>MinBy</c>/<c>MaxBy</c>.
+    ///
+    /// Every test diffs its output against the same C# run natively, so ordering, laziness and the exact
+    /// element set are all pinned — not just the count.
+    /// </summary>
+    [TestClass]
+    public class LinqSequenceOperatorTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task WhereAndSelect_WithAndWithoutIndex()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 10, 20, 30, 40 };
+        Console.WriteLine(string.Join(",", xs.Where(x => x > 15)));
+        Console.WriteLine(string.Join(",", xs.Where((x, i) => i % 2 == 0)));
+        Console.WriteLine(string.Join(",", xs.Select(x => x + 1)));
+        Console.WriteLine(string.Join(",", xs.Select((x, i) => x * i)));
+        Console.WriteLine(string.Join(",", xs.Where(x => x > 15).Select((x, i) => i + ":" + x)));
+        Console.WriteLine(string.Join(",", xs.Where(x => false)));
+        Console.WriteLine(string.Join(",", xs.Select(x => x.ToString())));
+        Console.WriteLine(string.Join(",", xs.AsEnumerable().Where(x => x < 35)));
+        Console.WriteLine(string.Join(",", Enumerable.Where(xs, x => x == 20)));
+        Console.WriteLine(string.Join(",", Enumerable.Select(xs, x => x / 10)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task SelectMany_AllFourOverloads()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { new[] { 1, 2 }, new[] { 3 } };
+        Console.WriteLine(string.Join(",", xs.SelectMany(a => a)));
+        Console.WriteLine(string.Join(",", xs.SelectMany((a, i) => a.Select(v => v * 10 + i))));
+        Console.WriteLine(string.Join(",", xs.SelectMany(a => a, (a, v) => a.Length + "/" + v)));
+        Console.WriteLine(string.Join(",", xs.SelectMany((a, i) => a, (a, v) => a.Length + "-" + v)));
+        var words = new[] { "ab", "c" };
+        Console.WriteLine(string.Join(",", words.SelectMany(w => w.ToCharArray())));
+        Console.WriteLine(string.Join(",", words.SelectMany(w => w)));
+        Console.WriteLine(new int[0].SelectMany(x => new[] { x }).Count());
+        Console.WriteLine(string.Join(",", xs.SelectMany(a => a.Where(v => v > 1))));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Partitioning_TakeSkipTakeWhileSkipWhile()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3, 4, 5 };
+        Console.WriteLine(string.Join(",", xs.Take(2)));
+        Console.WriteLine("[" + string.Join(",", xs.Take(0)) + "]");
+        Console.WriteLine(string.Join(",", xs.Take(99)));
+        Console.WriteLine("[" + string.Join(",", xs.Take(-1)) + "]");
+        Console.WriteLine(string.Join(",", xs.Skip(3)));
+        Console.WriteLine(string.Join(",", xs.Skip(0)));
+        Console.WriteLine("[" + string.Join(",", xs.Skip(99)) + "]");
+        Console.WriteLine(string.Join(",", xs.Skip(-1)));
+        Console.WriteLine(string.Join(",", xs.TakeWhile(x => x < 3)));
+        Console.WriteLine(string.Join(",", xs.TakeWhile((x, i) => i < 2)));
+        Console.WriteLine(string.Join(",", xs.SkipWhile(x => x < 3)));
+        Console.WriteLine(string.Join(",", xs.SkipWhile((x, i) => i < 2)));
+        Console.WriteLine("[" + string.Join(",", xs.TakeWhile(x => false)) + "]");
+        Console.WriteLine("[" + string.Join(",", xs.SkipWhile(x => true)) + "]");
+        Console.WriteLine(string.Join(",", xs.Skip(1).Take(2)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task SetOperators_DefaultComparer()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new[] { 1, 2, 2, 3 };
+        var b = new[] { 3, 4 };
+        Console.WriteLine(string.Join(",", a.Distinct()));
+        Console.WriteLine(string.Join(",", a.Union(b)));
+        Console.WriteLine(string.Join(",", a.Intersect(b)));
+        Console.WriteLine(string.Join(",", a.Except(b)));
+        Console.WriteLine(string.Join(",", a.Concat(b)));
+        Console.WriteLine(string.Join(",", a.Reverse()));
+        Console.WriteLine(string.Join(",", Enumerable.Reverse(a)));
+        Console.WriteLine(string.Join(",", a.Select(x => x).Reverse()));
+        Console.WriteLine(string.Join("", "abc".Reverse()));
+        Console.WriteLine(string.Join(",", new[] { "b", "a", "b" }.Distinct()));
+        Console.WriteLine(a.Union(b).Count() + "," + a.Intersect(b).Count() + "," + a.Except(b).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task SetOperators_WithEqualityComparer()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var s = new[] { "A", "a", "b" };
+        var cmp = StringComparer.OrdinalIgnoreCase;
+        Console.WriteLine(string.Join(",", s.Distinct(cmp)));
+        Console.WriteLine(string.Join(",", s.Union(new[] { "B" }, cmp)));
+        Console.WriteLine(string.Join(",", s.Intersect(new[] { "A" }, cmp)));
+        Console.WriteLine(string.Join(",", s.Except(new[] { "A" }, cmp)));
+        Console.WriteLine(s.Contains("A", cmp) + "," + s.Contains("z", cmp));
+        Console.WriteLine(new[] { "a" }.SequenceEqual(new[] { "A" }, cmp));
+        Console.WriteLine(string.Join(",", s.Distinct(StringComparer.Ordinal)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task SetOperators_WithACustomEqualityComparer()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Box
+{
+    public int V;
+    public Box(int v) { V = v; }
+    public override string ToString() => "B" + V;
+}
+
+public class ByRemainder : IEqualityComparer<Box>
+{
+    public bool Equals(Box a, Box b) => a.V % 3 == b.V % 3;
+    public int GetHashCode(Box b) => (b.V % 3).GetHashCode();
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { new Box(1), new Box(4), new Box(2) };
+        var c = new ByRemainder();
+        Console.WriteLine(string.Join(",", xs.Distinct(c)));
+        Console.WriteLine(string.Join(",", xs.Union(new[] { new Box(7) }, c)));
+        Console.WriteLine(string.Join(",", xs.Intersect(new[] { new Box(7) }, c)));
+        Console.WriteLine(string.Join(",", xs.Except(new[] { new Box(7) }, c)));
+        Console.WriteLine(xs.Contains(new Box(7), c));
+        Console.WriteLine(xs.SequenceEqual(new[] { new Box(4), new Box(1), new Box(5) }, c));
+        Console.WriteLine(string.Join(";", xs.GroupBy(x => x, c).Select(g => g.Key + ":" + g.Count())));
+        Console.WriteLine(xs.ToLookup(x => x, c).Count);
+        Console.WriteLine(xs.Distinct(c).ToDictionary(x => x, c).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Ordering_AllEightOverloads()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 3, 1, 2 };
+        Console.WriteLine(string.Join(",", xs.OrderBy(x => x)));
+        Console.WriteLine(string.Join(",", xs.OrderByDescending(x => x)));
+        var people = new[] { "bob:2", "amy:1", "cal:2" };
+        Console.WriteLine(string.Join(",", people.OrderBy(p => p.Split(':')[1]).ThenBy(p => p.Split(':')[0])));
+        Console.WriteLine(string.Join(",", people.OrderBy(p => p.Split(':')[1]).ThenByDescending(p => p.Split(':')[0])));
+        Console.WriteLine(string.Join(",", people.OrderByDescending(p => p.Split(':')[1]).ThenBy(p => p.Split(':')[0])));
+        Console.WriteLine(string.Join(",", people.OrderByDescending(p => p.Split(':')[1]).ThenByDescending(p => p.Split(':')[0])));
+        var reverse = Comparer<int>.Create((a, b) => b - a);
+        Console.WriteLine(string.Join(",", xs.OrderBy(x => x, reverse)));
+        Console.WriteLine(string.Join(",", xs.OrderByDescending(x => x, reverse)));
+        Console.WriteLine(string.Join(",", people.OrderBy(p => p.Length).ThenBy(p => p, StringComparer.Ordinal)));
+        Console.WriteLine(string.Join(",", people.OrderBy(p => p.Length).ThenByDescending(p => p, StringComparer.Ordinal)));
+        Console.WriteLine(string.Join(",", xs.OrderBy(x => x % 2).ThenBy(x => x).ThenByDescending(x => x)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Ordering_IsStableAndReusable()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        // OrderBy is documented as a STABLE sort, so equal keys keep their source order — and so does
+        // OrderByDescending (it reverses the comparison, not the ties).
+        var items = new[] { "a1", "b1", "c0", "d1", "e0" };
+        Console.WriteLine(string.Join(",", items.OrderBy(s => s[1])));
+        Console.WriteLine(string.Join(",", items.OrderByDescending(s => s[1])));
+
+        // An IOrderedEnumerable is a query, not a snapshot: enumerating it repeatedly, extending it with
+        // ThenBy and chaining other operators onto it must all work.
+        var ordered = new[] { 3, 1, 2 }.OrderBy(x => x);
+        Console.WriteLine(string.Join(",", ordered));
+        Console.WriteLine(string.Join(",", ordered));
+        Console.WriteLine(string.Join(",", ordered.ThenByDescending(x => x)));
+        Console.WriteLine(string.Join(",", ordered.Select(x => x * 2)));
+        Console.WriteLine(ordered.First() + "," + ordered.Last() + "," + ordered.Count());
+        Console.WriteLine(string.Join(",", ordered.Reverse()));
+        Console.WriteLine(string.Join(",", ordered.Take(2)));
+        Console.WriteLine(string.Join(",", ordered.ToList()));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task GroupBy_AllEightOverloads()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { "apple", "avocado", "banana", "cherry" };
+        foreach (var g in xs.GroupBy(s => s[0])) Console.WriteLine("1:" + g.Key + ":" + string.Join(",", g));
+        foreach (var g in xs.GroupBy(s => s[0], s => s.Length)) Console.WriteLine("2:" + g.Key + ":" + string.Join(",", g));
+        foreach (var r in xs.GroupBy(s => s[0], (k, g) => k + "#" + g.Count())) Console.WriteLine("3:" + r);
+        foreach (var r in xs.GroupBy(s => s[0], s => s.Length, (k, g) => k + "#" + g.Sum())) Console.WriteLine("4:" + r);
+        var cmp = StringComparer.OrdinalIgnoreCase;
+        foreach (var g in xs.GroupBy(s => s.Substring(0, 1), cmp)) Console.WriteLine("5:" + g.Key + ":" + g.Count());
+        foreach (var g in xs.GroupBy(s => s.Substring(0, 1), s => s.Length, cmp)) Console.WriteLine("6:" + g.Key + ":" + string.Join(",", g));
+        foreach (var r in xs.GroupBy(s => s.Substring(0, 1), (k, g) => k + "!" + g.Count(), cmp)) Console.WriteLine("7:" + r);
+        foreach (var r in xs.GroupBy(s => s.Substring(0, 1), s => s.Length, (k, g) => k + "*" + g.Count(), cmp)) Console.WriteLine("8:" + r);
+        Console.WriteLine(new string[0].GroupBy(s => s).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Grouping_AndLookup_ExposeTheFullIGroupingApi()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { "aa", "b", "cc", "d" };
+        IEnumerable<IGrouping<int, string>> gs = xs.GroupBy(s => s.Length);
+        foreach (var g in gs)
+        {
+            Console.WriteLine(g.Key + " -> " + string.Join(",", g) + " count=" + g.Count());
+            Console.WriteLine("  first=" + g.First() + " any=" + g.Any() + " sum=" + g.Sum(s => s.Length));
+        }
+
+        var lk = xs.ToLookup(s => s.Length);
+        Console.WriteLine("count=" + lk.Count);
+        Console.WriteLine("contains1=" + lk.Contains(1) + " contains9=" + lk.Contains(9));
+        Console.WriteLine("idx1=" + string.Join(",", lk[1]));
+        Console.WriteLine("idx9empty=" + !lk[9].Any());
+        foreach (var g in lk.OrderBy(g2 => g2.Key)) Console.WriteLine(g.Key + ":" + string.Join("|", g));
+        Console.WriteLine(string.Join(",", lk.SelectMany(g => g).OrderBy(s => s)));
+
+        // A nested group, and a grouping used as the source of another query.
+        var nested = xs.GroupBy(s => s.Length)
+                       .Select(g => g.Key + "=[" + string.Join(",", g.GroupBy(s => s[0]).Select(h => h.Key.ToString())) + "]");
+        Console.WriteLine(string.Join(";", nested.OrderBy(s => s)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Joins_BothOverloadsOfJoinAndGroupJoin()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var outer = new[] { "1a", "2b", "3c" };
+        var inner = new[] { "1x", "1y", "3z" };
+        foreach (var r in outer.Join(inner, o => o[0], i => i[0], (o, i) => o + "/" + i)) Console.WriteLine(r);
+        Console.WriteLine("--");
+        foreach (var r in outer.Join(inner, o => o.Substring(0, 1), i => i.Substring(0, 1), (o, i) => o + "/" + i, StringComparer.Ordinal)) Console.WriteLine(r);
+        Console.WriteLine("--");
+        foreach (var r in outer.GroupJoin(inner, o => o[0], i => i[0], (o, g) => o + "=[" + string.Join(",", g) + "]")) Console.WriteLine(r);
+        Console.WriteLine("--");
+        foreach (var r in outer.GroupJoin(inner, o => o.Substring(0, 1), i => i.Substring(0, 1), (o, g) => o + "=" + g.Count(), StringComparer.Ordinal)) Console.WriteLine(r);
+        Console.WriteLine("--");
+        Console.WriteLine(outer.Join(new string[0], o => o[0], i => i[0], (o, i) => o).Count());
+        Console.WriteLine(new string[0].GroupJoin(inner, o => o[0], i => i[0], (o, g) => o).Count());
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task ElementOperators_AllOverloads()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        Console.WriteLine(xs.First() + "," + xs.First(x => x > 1));
+        Console.WriteLine(xs.FirstOrDefault() + "," + xs.FirstOrDefault(x => x > 9));
+        Console.WriteLine(xs.Last() + "," + xs.Last(x => x < 3));
+        Console.WriteLine(xs.LastOrDefault() + "," + xs.LastOrDefault(x => x > 9));
+        Console.WriteLine(xs.ElementAt(0) + "," + xs.ElementAt(2));
+        Console.WriteLine(xs.ElementAtOrDefault(1) + "," + xs.ElementAtOrDefault(9) + "," + xs.ElementAtOrDefault(-1));
+        Console.WriteLine(new[] { 7 }.Single() + "," + xs.Single(x => x == 2));
+        Console.WriteLine(xs.SingleOrDefault(x => x > 9) + "," + new[] { 7 }.SingleOrDefault());
+        Console.WriteLine(new int[0].FirstOrDefault() + "," + new int[0].LastOrDefault() + "," + new int[0].SingleOrDefault());
+        Console.WriteLine(new string[0].FirstOrDefault() == null);
+        Console.WriteLine(xs.Where(x => x > 1).First() + "," + xs.Where(x => x > 1).Last());
+        Console.WriteLine(xs.OrderByDescending(x => x).ElementAt(1));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Quantifiers_AnyAllContainsSequenceEqual()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        Console.WriteLine(xs.Any() + "," + new int[0].Any());
+        Console.WriteLine(xs.Any(x => x > 2) + "," + xs.Any(x => x > 9));
+        Console.WriteLine(xs.All(x => x > 0) + "," + xs.All(x => x > 1) + "," + new int[0].All(x => false));
+        Console.WriteLine(xs.Contains(2) + "," + xs.Contains(9));
+        // int[].SequenceEqual(int[]) binds to the SPAN overload (the array-to-span conversion wins over
+        // array-to-IEnumerable), so both the span form and the IEnumerable form need covering.
+        Console.WriteLine(xs.SequenceEqual(new[] { 1, 2, 3 }));
+        Console.WriteLine(xs.SequenceEqual(new[] { 1, 2 }) + "," + xs.SequenceEqual(new[] { 1, 2, 4 }));
+        Console.WriteLine(new[] { "a", "b" }.SequenceEqual(new[] { "a", "b" }));
+        Console.WriteLine(new int[0].SequenceEqual(new int[0]));
+        IEnumerable<int> e = xs;
+        Console.WriteLine(e.SequenceEqual(new[] { 1, 2, 3 }));
+        Console.WriteLine(xs.Where(x => x > 0).SequenceEqual(xs));
+        Console.WriteLine(xs.ToList().SequenceEqual(new List<int> { 1, 2, 3 }));
+        Console.WriteLine("abc".AsSpan().SequenceEqual("abc".AsSpan()));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Conversion_ToArrayToListAllToDictionaryAndToLookupOverloads()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { "aa", "b", "ccc" };
+        var arr = xs.ToArray();
+        Console.WriteLine(arr.Length + ":" + string.Join(",", arr));
+        var list = xs.ToList();
+        Console.WriteLine(list.Count + ":" + string.Join(",", list));
+
+        var d1 = xs.ToDictionary(s => s);
+        Console.WriteLine(string.Join(",", d1.OrderBy(k => k.Key).Select(k => k.Key + "=" + k.Value)));
+        var d2 = xs.ToDictionary(s => s, s => s.Length);
+        Console.WriteLine(string.Join(",", d2.OrderBy(k => k.Key).Select(k => k.Key + "=" + k.Value)));
+        var d3 = xs.ToDictionary(s => s, StringComparer.OrdinalIgnoreCase);
+        Console.WriteLine(d3.Count + ":" + d3["AA"]);
+        var d4 = xs.ToDictionary(s => s, s => s.Length, StringComparer.OrdinalIgnoreCase);
+        Console.WriteLine(d4["AA"]);
+
+        var l1 = xs.ToLookup(s => s.Length);
+        Console.WriteLine(string.Join(";", l1.OrderBy(g => g.Key).Select(g => g.Key + ":" + string.Join(",", g))));
+        var l2 = xs.ToLookup(s => s.Length, s => s.ToUpper());
+        Console.WriteLine(string.Join(";", l2.OrderBy(g => g.Key).Select(g => g.Key + ":" + string.Join(",", g))));
+        var l3 = xs.ToLookup(s => s.Substring(0, 1), StringComparer.OrdinalIgnoreCase);
+        Console.WriteLine(l3.Count);
+        var l4 = xs.ToLookup(s => s.Substring(0, 1), s => s.Length, StringComparer.OrdinalIgnoreCase);
+        Console.WriteLine(string.Join(";", l4.Select(g => g.Key + ":" + string.Join(",", g))));
+
+        Console.WriteLine(new int[0].ToArray().Length + "," + new int[0].ToList().Count);
+        Console.WriteLine(xs.Where(s => s.Length > 1).ToArray().Length);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Lookup_CountsANullKeyedGrouping()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        // System.Linq.Lookup allows a null key; the transpiled Lookup keeps it outside its backing
+        // Dictionary (which cannot store one), so Count has to add it back in.
+        var xs = new[] { "a", null, "b", null };
+        Console.WriteLine(xs.ToLookup(s => s).Count);
+        Console.WriteLine(xs.ToLookup(s => s)[null].Count());
+        Console.WriteLine(xs.ToLookup(s => s).Contains(null));
+        Console.WriteLine(xs.GroupBy(s => s).Count());
+        var ys = new[] { 1, 2, 3 };
+        Console.WriteLine(ys.ToLookup(y => y == 2 ? (int?)null : y).Count);
+        Console.WriteLine(ys.GroupBy(y => y == 2 ? (int?)null : y).Count());
+        Console.WriteLine(new[] { "a" }.ToLookup(s => s).Count);
+        Console.WriteLine(new[] { "a" }.ToLookup(s => s).Contains(null));
+        Console.WriteLine(new string[0].ToLookup(s => s).Count);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Generation_RangeRepeatEmptyDefaultIfEmpty()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(string.Join(",", Enumerable.Range(1, 5)));
+        Console.WriteLine(string.Join(",", Enumerable.Range(-2, 3)));
+        Console.WriteLine(Enumerable.Range(0, 0).Count());
+        Console.WriteLine(Enumerable.Range(1, 5).Sum());
+        Console.WriteLine(string.Join(",", Enumerable.Repeat("x", 3)));
+        Console.WriteLine(string.Join(",", Enumerable.Repeat(7, 2)));
+        Console.WriteLine(Enumerable.Repeat(1, 0).Count());
+        Console.WriteLine(Enumerable.Empty<int>().Count() + ",[" + string.Join(",", Enumerable.Empty<string>()) + "]");
+        Console.WriteLine(string.Join(",", new int[0].DefaultIfEmpty()));
+        Console.WriteLine(string.Join(",", new int[0].DefaultIfEmpty(9)));
+        Console.WriteLine(string.Join(",", new[] { 1 }.DefaultIfEmpty(9)));
+        Console.WriteLine(new string[0].DefaultIfEmpty("d").Single());
+        Console.WriteLine(new string[0].DefaultIfEmpty().Single() == null);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task Zip_AndTheDotNet6Additions()
+        {
+            var code = """
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new[] { 1, 2, 3 };
+        var b = new[] { "x", "y" };
+        Console.WriteLine(string.Join(",", a.Zip(b, (i, s) => i + s)));
+        Console.WriteLine(string.Join(",", b.Zip(a, (s, i) => s + i)));
+        Console.WriteLine(a.Zip(new int[0], (x, y) => x + y).Count());
+        Console.WriteLine(string.Join(",", a.Zip(a, (x, y) => x * y)));
+        Console.WriteLine(string.Join(",", a.Where(x => x > 1).Zip(b, (x, s) => x + s)));
+
+        foreach (var c in a.Chunk(2)) Console.WriteLine(string.Join("+", c));
+        Console.WriteLine(new int[0].Chunk(2).Count());
+        Console.WriteLine(a.Chunk(5).Single().Length);
+        Console.WriteLine(string.Join(";", Enumerable.Range(1, 7).Chunk(3).Select(c => string.Join(",", c))));
+
+        var words = new[] { "bbb", "a", "cc" };
+        Console.WriteLine(words.MinBy(w => w.Length) + "," + words.MaxBy(w => w.Length));
+        Console.WriteLine(words.MinBy(w => w) + "," + words.MaxBy(w => w));
+        var reverse = Comparer<int>.Create((x, y) => y - x);
+        Console.WriteLine(words.MinBy(w => w.Length, reverse) + "," + words.MaxBy(w => w.Length, reverse));
+        // MinBy/MaxBy skip null keys, and return the first element when every key is null.
+        Console.WriteLine(words.MinBy(w => (string)null) + "|" + words.MaxBy(w => (string)null));
+        Console.WriteLine(words.MinBy(w => w.Length == 1 ? null : w) + "|" + words.MaxBy(w => w.Length == 1 ? null : w));
+        Console.WriteLine(new string[0].MinBy(w => w) == null);
+        Console.WriteLine(new string[0].MaxBy(w => w) == null);
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task CastAndOfType()
+        {
+            var code = """
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+public struct Point3 { public int V; }
+
+public class Program
+{
+    public static void Main()
+    {
+        var objs = new object[] { 1, "two", 3, null };
+        Console.WriteLine(string.Join(",", objs.OfType<int>()));
+        Console.WriteLine(string.Join(",", objs.OfType<string>()));
+        Console.WriteLine(objs.OfType<object>().Count());
+        var ints = new object[] { 1, 2, 3 };
+        Console.WriteLine(string.Join(",", ints.Cast<int>()));
+        IEnumerable<object> boxed = new object[] { "a", "b" };
+        Console.WriteLine(string.Join(",", boxed.Cast<string>()));
+        IEnumerable plain = objs;
+        Console.WriteLine(plain.OfType<int>().Count() + "," + plain.Cast<object>().Count());
+
+        // A struct and a class element type, both boxed into object[].
+        var mixed = new object[] { new Point3 { V = 9 }, "s", 1 };
+        Console.WriteLine(mixed.OfType<Point3>().Count() + ":" + mixed.OfType<Point3>().Single().V);
+        Console.WriteLine(mixed.OfType<string>().Single());
+
+        // A multi-dimensional array is only IEnumerable, so Cast is how LINQ reaches it.
+        var md = new int[2, 2] { { 1, 2 }, { 3, 4 } };
+        Console.WriteLine(md.Cast<int>().Sum() + "," + md.Cast<int>().Count());
+        Console.WriteLine(string.Join(",", md.Cast<int>().OrderByDescending(x => x)));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
+        public async Task StaticInvocationForm_BindsTheSameOverloads()
+        {
+            var code = """
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var xs = new[] { 1, 2, 3 };
+        Console.WriteLine(string.Join(",", Enumerable.Where(xs, x => x > 1)));
+        Console.WriteLine(string.Join(",", Enumerable.Select(xs, x => x * 2)));
+        Console.WriteLine(Enumerable.Count(xs) + "," + Enumerable.Sum(xs) + "," + Enumerable.Average(xs));
+        Console.WriteLine(Enumerable.Max(xs) + "," + Enumerable.Min(xs));
+        Console.WriteLine(Enumerable.Aggregate(xs, (a, b) => a * b));
+        Console.WriteLine(string.Join(",", Enumerable.OrderByDescending(xs, x => x)));
+        Console.WriteLine(Enumerable.ToList(xs).Count + "," + Enumerable.ToArray(xs).Length);
+        Console.WriteLine(string.Join(",", Enumerable.Concat(xs, xs)));
+        Console.WriteLine(Enumerable.SequenceEqual(xs, new[] { 1, 2, 3 }));
+        Console.WriteLine(string.Join(",", Enumerable.Reverse(xs)));
+        Console.WriteLine(Enumerable.First(xs) + "," + Enumerable.Last(xs) + "," + Enumerable.ElementAt(xs, 1));
+        Console.WriteLine(Enumerable.Any(xs, x => x > 2) + "," + Enumerable.All(xs, x => x > 0));
+        Console.WriteLine(Enumerable.GroupBy(xs, x => x % 2).Count());
+        Console.WriteLine(string.Join(",", Enumerable.Distinct(new[] { 1, 1, 2 })));
+    }
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -133,6 +133,9 @@ public sealed partial class Emitter
             case PrefixUnaryExpressionSyntax prefix:
                 EmitPrefixUnary(prefix);
                 break;
+            case RangeExpressionSyntax rangeExpr:
+                EmitRangeExpression(rangeExpr);
+                break;
             case PostfixUnaryExpressionSyntax postfix:
                 EmitPostfixUnary(postfix);
                 break;

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -758,7 +758,9 @@ public sealed partial class Emitter
             if (ps.Length != args.Length) return;
             for (var i = 0; i < ps.Length; i++)
             {
-                (map ??= new())[ps[i].Name] = TypeRef(args[i]);
+                (map ??= new())[ps[i].Name] = member is IMethodSymbol mm
+                    ? TemplateTypeRef(mm, args[i])
+                    : TypeRef(args[i]);
                 // {T:default} in a template → the default value of the bound type argument.
                 map[ps[i].Name + ":default"] = DefaultValueLiteral(args[i]);
                 // {T:ToString} → a value→string FUNCTION for the bound type (fn arg of
@@ -774,6 +776,23 @@ public sealed partial class Emitter
             Add(m.OriginalDefinition.TypeParameters, m.TypeArguments);
         return map;
     }
+
+    /// <summary>
+    /// The runtime type a <c>[Template]</c> token like <c>{T}</c> resolves to. Same as
+    /// <see cref="TypeRef(ITypeSymbol)"/>, except that a type argument which is still the CALLEE's OWN
+    /// type parameter — i.e. inference never substituted it — degrades to <c>System.Object</c> rather
+    /// than emitting its bare name. That happens when a generic method is invoked with a
+    /// <c>dynamic</c> argument: <c>Enumerable.Count(dyn)</c> expanded to
+    /// <c>Enumerable.from(dyn, TSource)</c> and threw "TSource is not defined" at runtime. A type
+    /// parameter of the *enclosing* generic method or type is a real substitution and keeps its name,
+    /// which is in scope there as a threaded argument.
+    /// </summary>
+    private string TemplateTypeRef(IMethodSymbol callee, ITypeSymbol argument)
+        => argument is ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } tp
+           && SymbolEqualityComparer.Default.Equals(
+                  tp.DeclaringMethod?.OriginalDefinition, callee.OriginalDefinition)
+            ? "System.Object"
+            : TypeRef(argument);
 
     /// <summary>
     /// The JS function that converts a value of <paramref name="t"/> to its .NET <c>ToString()</c>

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -638,6 +638,13 @@ public sealed partial class Emitter
             case IEventSymbol ev:
                 _w.Write(ev.IsStatic ? StaticMemberAccess(ev) : $"this.{TransposeNaming.MemberJsName(ev)}");
                 break;
+            // A query-expression range variable: `x` in `from x in xs …`. Each clause is emitted as a
+            // one-parameter lambda, so once a query introduces a second range variable they are carried
+            // in a frame object and `x` has to read `$q0.x` — see Emitter.Query.cs.
+            case IRangeVariableSymbol range when _queryRanges is not null
+                                                 && _queryRanges.TryGetValue(range.Name, out var rangeAccess):
+                _w.Write(rangeAccess);
+                break;
             case IMethodSymbol { MethodKind: MethodKind.LocalFunction } localFn:
                 _w.Write(NameMangler.JsIdentifier(localFn.Name));
                 break;

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -2488,6 +2488,61 @@ public sealed partial class Emitter
         _w.Write(")");
     }
 
+    /// <summary>
+    /// Emits a range expression (<c>a..b</c>, <c>a..</c>, <c>..b</c>, <c>..</c>) as the
+    /// <see cref="System.Range"/> value C# defines it to be. Array and string slicing lowers a range
+    /// inline (see <c>EmitElementAccess</c>), so this covers every other position — a <c>Range</c>-typed
+    /// argument such as <c>xs.Take(1..^1)</c>, a <c>Range r = 1..^1;</c> initializer, a field of that
+    /// type. The three static factories are used where they apply so only <c>a..b</c> needs the
+    /// constructor, and each end is emitted through the ordinary conversion path, which supplies the
+    /// implicit <c>int</c>-to-<c>Index</c> conversion (a <c>^n</c> end is already an <c>Index</c>).
+    /// </summary>
+    private void EmitRangeExpression(RangeExpressionSyntax range)
+    {
+        var info = _model.GetTypeInfo(range);
+        if ((info.Type ?? info.ConvertedType) is not INamedTypeSymbol rangeType
+            || rangeType.ToDisplayString() != "System.Range")
+        {
+            Unsupported(range, "range expression");
+            return;
+        }
+
+        var left = range.LeftOperand;
+        var right = range.RightOperand;
+
+        // `..` is the whole sequence.
+        if (left is null && right is null)
+        {
+            if (RangeMember(rangeType, "All") is not { } all) { Unsupported(range, "range expression"); return; }
+            _w.Write($"{TypeRef(rangeType)}.{TransposeNaming.MemberJsName(all)}");
+            return;
+        }
+
+        // `..b` / `a..` — one end is open, which is exactly what EndAt/StartAt mean.
+        if (left is null || right is null)
+        {
+            var factoryName = left is null ? "EndAt" : "StartAt";
+            if (RangeMember(rangeType, factoryName) is not IMethodSymbol factory) { Unsupported(range, "range expression"); return; }
+            _w.Write($"{TypeRef(rangeType)}.{TransposeNaming.MemberJsName(factory)}(");
+            EmitExpressionConverted(left ?? right!, factory.Parameters[0].Type);
+            _w.Write(")");
+            return;
+        }
+
+        var ctor = rangeType.InstanceConstructors.FirstOrDefault(c => c.Parameters.Length == 2);
+        if (ctor is null) { Unsupported(range, "range expression"); return; }
+
+        _w.Write($"new {TypeRef(rangeType)}.{TransposeNaming.ConstructorName(ctor)}(");
+        EmitExpressionConverted(left, ctor.Parameters[0].Type);
+        _w.Write(", ");
+        EmitExpressionConverted(right, ctor.Parameters[1].Type);
+        _w.Write(")");
+    }
+
+    /// <summary>The single public static member of <c>System.Range</c> called <paramref name="name"/>.</summary>
+    private static ISymbol? RangeMember(INamedTypeSymbol rangeType, string name)
+        => rangeType.GetMembers(name).FirstOrDefault(m => m.IsStatic);
+
     private void EmitPrefixUnary(PrefixUnaryExpressionSyntax prefix)
     {
         // `^n` (from-end index) as a value → a System.Index. Array element access handles `^n`

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -415,7 +415,7 @@ public sealed partial class Emitter
     {
         for (var i = 0; i < definition.TypeParameters.Length && i < constructed.TypeArguments.Length; i++)
         {
-            byName[definition.TypeParameters[i].Name] = TypeRef(constructed.TypeArguments[i]);
+            byName[definition.TypeParameters[i].Name] = TemplateTypeRef(definition, constructed.TypeArguments[i]);
             byName[definition.TypeParameters[i].Name + ":default"] = DefaultValueLiteral(constructed.TypeArguments[i]);
             if (ToStringFnLiteral(constructed.TypeArguments[i]) is { } tsFn)
                 byName[definition.TypeParameters[i].Name + ":ToString"] = tsFn;
@@ -1365,9 +1365,22 @@ public sealed partial class Emitter
         _w.Write(" }");
     }
 
+    /// <summary>
+    /// Emits <c>new { A = 1, B = x }</c> as a plain object literal tagged by <c>Transpose.anon</c>. The tag
+    /// is what gives the object the anonymous type's .NET semantics — value-based <c>Equals</c>/
+    /// <c>GetHashCode</c> (so <c>Select(x =&gt; new { x.A }).Distinct()</c>, <c>GroupBy</c> on an anonymous
+    /// key and <c>Contains</c> work) and the <c>{ A = 1, B = x }</c> <c>ToString</c>. The object stays a
+    /// plain literal so object-literal interop and JSON serialization are unaffected.
+    /// </summary>
     private void EmitAnonymousObject(AnonymousObjectCreationExpressionSyntax anon)
     {
-        _w.Write("{ ");
+        // A char or enum member is a plain JS number at runtime, so the runtime's ToString cannot tell
+        // it from an int. Each such member's value-to-string converter is passed along so the
+        // "{ Z = c, E = Monday }" rendering stays right; members whose own toString already matches
+        // .NET contribute nothing.
+        var memberFormatters = new List<string>();
+
+        _w.Write("Transpose.anon({ ");
         for (var i = 0; i < anon.Initializers.Count; i++)
         {
             if (i > 0) _w.Write(", ");
@@ -1377,10 +1390,21 @@ public sealed partial class Emitter
                 ?? (init.Expression as MemberAccessExpressionSyntax)?.Name.Identifier.Text
                 ?? (init.Expression as IdentifierNameSyntax)?.Identifier.Text
                 ?? $"Item{i + 1}";
-            _w.Write($"{NameMangler.JsIdentifier(name)}: ");
+            var jsName = NameMangler.JsIdentifier(name);
+            var memberType = _model.GetTypeInfo(init.Expression).Type;
+            if (memberType is not null && ToStringFnLiteral(memberType) is { } fn)
+                memberFormatters.Add($"{jsName}: {fn}");
+            _w.Write($"{jsName}: ");
             EmitExpression(init.Expression);
         }
         _w.Write(" }");
+        if (memberFormatters.Count > 0)
+        {
+            _w.Write(", { ");
+            _w.Write(string.Join(", ", memberFormatters));
+            _w.Write(" }");
+        }
+        _w.Write(")");
     }
 
     // ---- binary / unary / assignment --------------------------------------

--- a/Transpose/Transpose.Translator/Emit/Emitter.Query.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Query.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -9,44 +10,180 @@ namespace Transpose.Translator;
 public sealed partial class Emitter
 {
     /// <summary>
+    /// The range variables visible at the point being emitted, mapped to the JavaScript expression that
+    /// reads each one. A query clause becomes a lambda of ONE parameter, so a query that introduces more
+    /// than one range variable (a second <c>from</c>, a <c>let</c>, a <c>join</c>) has to carry them in a
+    /// frame object — C#'s "transparent identifier" — and every later clause reads <c>$q0.x</c> rather
+    /// than <c>x</c>. <see cref="EmitIdentifier"/> consults this map, so a range variable resolves
+    /// correctly however deeply it is nested inside a clause (including inside a lambda of its own).
+    /// </summary>
+    private Dictionary<string, string>? _queryRanges;
+
+    /// <summary>Counter behind the <c>$q&lt;n&gt;</c> frame parameter names; global so the frames of a
+    /// query nested inside another query's clause cannot collide.</summary>
+    private int _queryFrameId;
+
+    /// <summary>
+    /// One query clause's view of its range variables: the JS lambda parameter the clause receives, and
+    /// the range-variable names reachable through it.
+    /// </summary>
+    private sealed class QueryScope
+    {
+        /// <summary>The JS lambda parameter name a clause is emitted against.</summary>
+        public required string Parameter { get; init; }
+
+        /// <summary>The range-variable names in scope, in declaration order.</summary>
+        public required List<string> Variables { get; init; }
+
+        /// <summary>True when <see cref="Parameter"/> is a frame object holding the variables as members,
+        /// false when it IS the single range variable.</summary>
+        public required bool Transparent { get; init; }
+
+        /// <summary>The JS expression that reads range variable <paramref name="name"/>.</summary>
+        public string Access(string name) =>
+            Transparent ? $"{Parameter}.{NameMangler.JsIdentifier(name)}" : Parameter;
+
+        public Dictionary<string, string> Map()
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var v in Variables) map[v] = Access(v);
+            return map;
+        }
+    }
+
+    /// <summary>
     /// Translates a LINQ query expression into the tps.js Enumerable chain
-    /// (<c>System.Linq.Enumerable.from(src).where(fn).orderBy(fn).select(fn)</c>) — the same
-    /// runtime API the method-syntax <c>[Template]</c>s target. Supports single-source
-    /// from/where/orderby/select/group by; multi-from, let, and join are reported unsupported.
+    /// (<c>System.Linq.Enumerable.from(src).where(fn).orderBy(fn).select(fn)</c>) — the same runtime API
+    /// the method-syntax <c>[Template]</c>s target. All clauses are supported: from (including a second
+    /// and subsequent one, which lowers to <c>selectMany</c>), let, join / join-into, where, orderby,
+    /// select, group-by and an <c>into</c> continuation.
     /// </summary>
     private void EmitQuery(QueryExpressionSyntax query)
     {
-        Action emit = () =>
+        var outerRanges = _queryRanges;
+        try
         {
-            _w.Write("System.Linq.Enumerable.from(");
-            EmitExpression(query.FromClause.Expression);
-            _w.Write(")");
-        };
-        EmitQueryBody(emit, NameMangler.JsIdentifier(query.FromClause.Identifier.Text), query.Body);
+            var from = query.FromClause;
+            Action emit = () =>
+            {
+                _w.Write("System.Linq.Enumerable.from(");
+                EmitExpression(from.Expression);
+                _w.Write(")");
+                // `from int x in objects` is an explicitly typed range variable, which C# defines as a
+                // Cast<T> of the source.
+                if (from.Type is not null && _model.GetTypeInfo(from.Type).Type is { } castTo)
+                    _w.Write($".select(function (x) {{ return Transpose.cast(x, {TypeRef(castTo)}); }})");
+            };
+
+            var scope = new QueryScope
+            {
+                Parameter = NameMangler.JsIdentifier(from.Identifier.Text),
+                Variables = [from.Identifier.Text],
+                Transparent = false,
+            };
+            EmitQueryBody(emit, scope, query.Body);
+        }
+        finally
+        {
+            _queryRanges = outerRanges;
+        }
     }
 
-    private void EmitQueryBody(Action emitSource, string range, QueryBodySyntax body)
+    private void EmitQueryBody(Action emitSource, QueryScope scope, QueryBodySyntax body)
     {
         var emit = emitSource;
 
         foreach (var clause in body.Clauses)
         {
             var inner = emit;
+            var current = scope;
             switch (clause)
             {
                 case WhereClauseSyntax where:
                     emit = () =>
                     {
                         inner();
-                        _w.Write(".where("); OpenQueryLambda(range);
+                        _w.Write(".where("); OpenQueryLambda(current);
                         EmitExpression(where.Condition);
                         _w.Write("; })");
                     };
                     break;
 
                 case OrderByClauseSyntax orderBy:
-                    emit = () => EmitOrderBy(inner, range, orderBy);
+                    emit = () => EmitOrderBy(inner, current, orderBy);
                     break;
+
+                case LetClauseSyntax let:
+                    {
+                        var next = ExtendScope(current, let.Identifier.Text);
+                        emit = () =>
+                        {
+                            inner();
+                            // let y = e  →  .select(frame => ({ …carried…, y: e }))
+                            _w.Write($".select(({current.Parameter}) => (");
+                            EmitQueryFrame(current, let.Identifier.Text,
+                                () => WithRanges(current, () => EmitExpression(let.Expression)));
+                            _w.Write("))");
+                        };
+                        scope = next;
+                        break;
+                    }
+
+                case FromClauseSyntax nestedFrom:
+                    {
+                        var next = ExtendScope(current, nestedFrom.Identifier.Text);
+                        var nestedParam = NameMangler.JsIdentifier(nestedFrom.Identifier.Text);
+                        emit = () =>
+                        {
+                            inner();
+                            // from y in ys  →  .selectMany(frame => ys, (frame, y) => ({ …carried…, y }))
+                            // The collection expression may read the range variables already in scope,
+                            // which is exactly what distinguishes it from a join's inner source.
+                            _w.Write($".selectMany(({current.Parameter}) => {{ return ");
+                            var castTo = nestedFrom.Type is null ? null : _model.GetTypeInfo(nestedFrom.Type).Type;
+                            if (castTo is not null) _w.Write("System.Linq.Enumerable.from(");
+                            WithRanges(current, () => EmitExpression(nestedFrom.Expression));
+                            if (castTo is not null)
+                                _w.Write($").select(function (x) {{ return Transpose.cast(x, {TypeRef(castTo)}); }})");
+                            _w.Write($"; }}, ({current.Parameter}, {nestedParam}) => (");
+                            EmitQueryFrame(current, nestedFrom.Identifier.Text, () => _w.Write(nestedParam));
+                            _w.Write("))");
+                        };
+                        scope = next;
+                        break;
+                    }
+
+                case JoinClauseSyntax join:
+                    {
+                        // `join y in ys on outer equals inner` introduces y; with `into g` it introduces g
+                        // instead (y is visible only in the inner key expression).
+                        var introduced = join.Into?.Identifier.Text ?? join.Identifier.Text;
+                        var innerParam = NameMangler.JsIdentifier(join.Identifier.Text);
+                        var resultParam = NameMangler.JsIdentifier(introduced);
+                        var next = ExtendScope(current, introduced);
+                        emit = () =>
+                        {
+                            inner();
+                            _w.Write(join.Into is null ? ".join(" : ".groupJoin(");
+                            // The inner source is evaluated in the ENCLOSING scope — C# does not allow it
+                            // to read a range variable — so it is emitted with the ranges cleared.
+                            WithRanges(null, () => EmitExpression(join.InExpression));
+                            _w.Write(", "); OpenQueryLambda(current);
+                            EmitExpression(join.LeftExpression);
+                            _w.Write("; }, ");
+                            // The inner key selector's only variable is the join's own identifier.
+                            _w.Write($"({innerParam}) => {{ return ");
+                            WithRanges(
+                                new QueryScope { Parameter = innerParam, Variables = [join.Identifier.Text], Transparent = false },
+                                () => EmitExpression(join.RightExpression));
+                            _w.Write("; }, ");
+                            _w.Write($"({current.Parameter}, {resultParam}) => (");
+                            EmitQueryFrame(current, introduced, () => _w.Write(resultParam));
+                            _w.Write("))");
+                        };
+                        scope = next;
+                        break;
+                    }
 
                 default:
                     Unsupported(clause, $"query clause {clause.Kind()} (use method syntax)");
@@ -55,10 +192,13 @@ public sealed partial class Emitter
         }
 
         // Produce the select/group result sequence.
+        var final = scope;
         Action result;
         switch (body.SelectOrGroup)
         {
-            case SelectClauseSyntax select when select.Expression is IdentifierNameSyntax sid && sid.Identifier.Text == range:
+            case SelectClauseSyntax select when !final.Transparent
+                                                && select.Expression is IdentifierNameSyntax sid
+                                                && sid.Identifier.Text == final.Variables[0]:
                 result = emit; // identity projection — the sequence is already the result
                 break;
             case SelectClauseSyntax select:
@@ -67,7 +207,7 @@ public sealed partial class Emitter
                     result = () =>
                     {
                         inner();
-                        _w.Write(".select("); OpenQueryLambda(range);
+                        _w.Write(".select("); OpenQueryLambda(final);
                         EmitExpression(select.Expression);
                         _w.Write("; })");
                     };
@@ -79,12 +219,15 @@ public sealed partial class Emitter
                     result = () =>
                     {
                         inner();
-                        _w.Write(".groupBy("); OpenQueryLambda(range);
+                        _w.Write(".groupBy("); OpenQueryLambda(final);
                         EmitExpression(group.ByExpression);
                         _w.Write("; }");
-                        if (!(group.GroupExpression is IdentifierNameSyntax gid && gid.Identifier.Text == range))
+                        var groupsTheRangeVariable = !final.Transparent
+                            && group.GroupExpression is IdentifierNameSyntax gid
+                            && gid.Identifier.Text == final.Variables[0];
+                        if (!groupsTheRangeVariable)
                         {
-                            _w.Write(", "); OpenQueryLambda(range);
+                            _w.Write(", "); OpenQueryLambda(final);
                             EmitExpression(group.GroupExpression);
                             _w.Write("; }");
                         }
@@ -97,10 +240,16 @@ public sealed partial class Emitter
                 return;
         }
 
-        // `into` continuation: the result becomes the source of a new query body.
+        // `into` continuation: the result becomes the source of a new query body, with a single fresh
+        // range variable and no frame.
         if (body.Continuation is not null)
         {
-            EmitQueryBody(result, NameMangler.JsIdentifier(body.Continuation.Identifier.Text), body.Continuation.Body);
+            EmitQueryBody(result, new QueryScope
+            {
+                Parameter = NameMangler.JsIdentifier(body.Continuation.Identifier.Text),
+                Variables = [body.Continuation.Identifier.Text],
+                Transparent = false,
+            }, body.Continuation.Body);
         }
         else
         {
@@ -108,7 +257,34 @@ public sealed partial class Emitter
         }
     }
 
-    private void EmitOrderBy(Action inner, string range, OrderByClauseSyntax orderBy)
+    /// <summary>The scope after a clause introduces <paramref name="introduced"/>: every variable now
+    /// lives in a fresh frame object, since a clause lambda takes only one parameter.</summary>
+    private QueryScope ExtendScope(QueryScope scope, string introduced) => new()
+    {
+        Parameter = "$q" + _queryFrameId++,
+        Variables = [.. scope.Variables, introduced],
+        Transparent = true,
+    };
+
+    /// <summary>
+    /// Emits the transparent-identifier frame object <c>{ x: …, y: … }</c> that carries the range
+    /// variables of <paramref name="scope"/> plus the newly introduced one. The carried members are read
+    /// through <paramref name="scope"/> (the OUTER view), which is why this runs before the scope is
+    /// swapped for the extended one.
+    /// </summary>
+    private void EmitQueryFrame(QueryScope scope, string introduced, Action emitIntroduced)
+    {
+        _w.Write("{ ");
+        foreach (var v in scope.Variables)
+        {
+            _w.Write($"{NameMangler.JsIdentifier(v)}: {scope.Access(v)}, ");
+        }
+        _w.Write($"{NameMangler.JsIdentifier(introduced)}: ");
+        emitIntroduced();
+        _w.Write(" }");
+    }
+
+    private void EmitOrderBy(Action inner, QueryScope scope, OrderByClauseSyntax orderBy)
     {
         inner();
         for (var i = 0; i < orderBy.Orderings.Count; i++)
@@ -117,19 +293,33 @@ public sealed partial class Emitter
             var method = i == 0
                 ? (descending ? "orderByDescending" : "orderBy")
                 : (descending ? "thenByDescending" : "thenBy");
-            _w.Write($".{method}("); OpenQueryLambda(range);
+            _w.Write($".{method}("); OpenQueryLambda(scope);
             EmitExpression(orderBy.Orderings[i].Expression);
             _w.Write("; })");
         }
     }
 
     /// <summary>
-    /// Opens a query-clause lambda: <c>(range) =&gt; { return </c>. An ARROW, never a <c>function</c> —
-    /// a query clause's expression is user code that may read <c>this</c> (e.g.
-    /// <c>where x.Id == this._id</c> inside an instance method), and a plain function rebinds
-    /// <c>this</c> to undefined under the bundle's "use strict", so such a clause threw
-    /// "Cannot read properties of undefined". C# forbids <c>await</c> in a query clause, so the
-    /// arrow never needs the async form.
+    /// Opens a query-clause lambda: <c>(range) =&gt; { return </c>, with the clause's range variables in
+    /// scope for the expression that follows. An ARROW, never a <c>function</c> — a query clause's
+    /// expression is user code that may read <c>this</c> (e.g. <c>where x.Id == this._id</c> inside an
+    /// instance method), and a plain function rebinds <c>this</c> to undefined under the bundle's
+    /// "use strict", so such a clause threw "Cannot read properties of undefined". C# forbids
+    /// <c>await</c> in a query clause, so the arrow never needs the async form.
     /// </summary>
-    private void OpenQueryLambda(string range) => _w.Write($"({range}) => {{ return ");
+    private void OpenQueryLambda(QueryScope scope)
+    {
+        _w.Write($"({scope.Parameter}) => {{ return ");
+        _queryRanges = scope.Map();
+    }
+
+    /// <summary>Runs <paramref name="emit"/> with a specific set of range variables in scope, restoring
+    /// the previous set afterwards.</summary>
+    private void WithRanges(QueryScope? scope, Action emit)
+    {
+        var saved = _queryRanges;
+        _queryRanges = scope?.Map();
+        try { emit(); }
+        finally { _queryRanges = saved; }
+    }
 }

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -109,6 +109,23 @@
         }
         return Object.assign(Object.create(Object.getPrototypeOf(o)), o);
     };
+    // A Span/ReadOnlySpan reaches JS in one of two shapes: as a real span object (built by one of the
+    // span constructors, e.g. through string.AsSpan) or as the bare underlying JS array, because the
+    // implicit array-to-span conversion is not modelled and hands the array straight through. Any span
+    // helper therefore has to normalise first.
+    TransposeR.spanArray = function (s) {
+        if (s == null) { return []; }
+        return typeof s.toArray === 'function' ? s.toArray() : s;
+    };
+    TransposeR.spanSequenceEqual = function (a, b) {
+        a = TransposeR.spanArray(a);
+        b = TransposeR.spanArray(b);
+        if (a.length !== b.length) { return false; }
+        for (var i = 0; i < a.length; i++) {
+            if (!Transpose.equals(a[i], b[i])) { return false; }
+        }
+        return true;
+    };
     // Copies one slot of a struct's $clone whose declared type is a TYPE PARAMETER, where only the
     // runtime value can say whether a value copy is due: `struct Wrap<T> { public T Value; }` must
     // clone Value for Wrap<SomeStruct> (C# copies the whole value) and must NOT clone it for


### PR DESCRIPTION
## Summary

This PR adds a comprehensive test suite for LINQ operators and fixes support for LINQ query expressions (from/let/join/group-by clauses). The test suite validates every non-numeric and numeric LINQ operator, element types, exception handling, and query syntax against native .NET behavior. Query expressions now properly handle multiple range variables through transparent identifier frames.

## Key Changes

### Test Suite (New Files)
- **LinqElementTypeTests.cs**: Tests LINQ operators across all element types (primitives, enums, classes, structs, records, nullable types, ValueTuple, KeyValuePair, anonymous types, dynamic, interfaces, type parameters) and their combinations
- **LinqSequenceOperatorTests.cs**: Tests every non-numeric LINQ operator (Select/Where/SelectMany, partitioning, set operators, ordering, grouping, joins, element operators, conversions, generation, Zip, Cast/OfType, Chunk/MinBy/MaxBy)
- **LinqNumericOperatorTests.cs**: Tests numeric operators (Sum, Average, Min, Max, Aggregate, Count/LongCount) across all numeric types and nullable variants
- **LinqExceptionAndEdgeCaseTests.cs**: Tests exception types/messages, argument validation, empty/single-element sequences, null handling, and delegate evaluation order
- **LinqQuerySyntaxTests.cs**: Tests LINQ query expression syntax (from, let, join, where, orderby, select, group-by, into continuations)

### Compiler Changes
- **Emitter.Query.cs**: Complete rewrite of query expression support
  - Added `_queryRanges` dictionary to track range variables and their JS expressions
  - Added `_queryFrameId` counter for generating unique frame parameter names (`$q0`, `$q1`, etc.)
  - Added `QueryScope` class to manage range variables and transparent identifier frames
  - Implemented proper handling of multiple range variables through frame objects
  - Support for all query clauses: from (including multiple), let, join/join-into, where, orderby, select, group-by, and into continuations
  - Range variables now resolve correctly through nested lambdas and frames

- **Emitter.Expressions.cs**: Added query range variable resolution in `EmitIdentifier`
  - Range variables now consult `_queryRanges` map for proper JS expression

- **Emitter.Expressions2.cs**: Minor fix to `TemplateTypeRef` usage in type argument mapping

### Runtime/BCL Changes
- **Integer.js**: Added `shortestDigits()` and `toStringCore()` methods for proper double/float formatting
  - Implements .NET Core 3.0+ shortest round-trippable decimal representation
  - Handles both double and single-precision floats correctly

- **Core.js**: Added anonymous type `ToString()` support
  - Renders anonymous type members with their own `ToString()` values
  - Handles null members as empty strings

- **linq.js**: Added proper exception objects for element operators
  - `InvalidOperationException` for "no elements", "no matching element", "more than one element"
  - `ArgumentOutOfRangeException` for out-of-range indices
  - Exception messages match System.Linq's ThrowHelper exactly

- **MemoryExtensions.cs**: Enhanced `SequenceEqual` with optional `IEqualityComparer` support

- **Array.cs**: Documented `Reverse()` as JavaScript `Array.prototype.reverse()`

- **Dictionary.cs** / **SortedList.cs**: Updated exception handling for duplicate keys

- **UTF32Encoding.cs**: Fixed to use `Array.Reverse()` instead of instance method

### Documentation
- Updated CLAUDE.md to document the new test structure under `Transpose.Translator.Tests/`

## Notable Implementation Details

- Query expressions with multiple range variables use C#'s "transparent identifier" pattern: a frame object (`$q0`, `$q1`, etc.) carries all variables, and later clauses read them as properties
- Range variable resolution is context-aware: the `_queryRanges` map is consulted by `EmitIdentifier`, so variables resolve correctly even when nested inside lambdas within a clause
- All test suites diff their output against

https://claude.ai/code/session_01TbRhv7fmWqj7vyh1aekK1v