### PR TITLE
Fix discard parameter handling in lambda expressions

### DIFF
--- a/Transpose/Transpose.Translator.Tests/Ported/CSharp9Tests.cs
+++ b/Transpose/Transpose.Translator.Tests/Ported/CSharp9Tests.cs
@@ -436,6 +436,28 @@ public class Program
         }
 
         [TestMethod]
+        public async Task LambdaSingleUnderscoreParameterIsNotADiscard()
+        {
+            // A lambda parameter named "_" is only a real (inaccessible) discard when it appears
+            // two or more times; a single "_" is an ordinary, referenceable parameter.
+            var code = """
+using System;
+
+public class Program
+{
+    static int DoSomething(int a, int b, int c) => a + b + c;
+
+    public static void Main()
+    {
+        Func<int, int, int, int> f = (a, b, _) => DoSomething(a, b, _);
+        Console.WriteLine(f(1, 2, 3));
+    }
+}
+""";
+            await RunTest(code);
+        }
+
+        [TestMethod]
         public async Task NativeSizedIntegers()
         {
             var code = """

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -3274,10 +3274,15 @@ public sealed partial class Emitter
         // EmitMaybeAsyncBody), so it composes with Task.Run/WhenAll/ContinueWith; the outer
         // function is therefore not itself `async`.
         _w.Write("(");
-        // Uniquify discard parameters ("_") so JS doesn't see duplicate names.
+        // A parameter named "_" is a real discard only when it appears two or more times —
+        // C# then makes it inaccessible in the body, so it's safe (and necessary, since "use
+        // strict" rejects duplicate parameter names) to uniquify each occurrence. A single "_"
+        // is just a regular, referenceable parameter and must keep its name.
+        var paramList = parameters as IReadOnlyCollection<string> ?? parameters.ToList();
+        var isRealDiscard = paramList.Count(p => p == "_") > 1;
         var discardN = 0;
-        _w.Write(string.Join(", ", parameters.Select(p =>
-            p == "_" ? "$d" + discardN++ : NameMangler.JsIdentifier(p))));
+        _w.Write(string.Join(", ", paramList.Select(p =>
+            p == "_" && isRealDiscard ? "$d" + discardN++ : NameMangler.JsIdentifier(p))));
         _w.Write(") => ");
 
         // Optional lambda parameters (C# 12): default when undefined.


### PR DESCRIPTION
## Summary
Corrects the transpilation of lambda parameters named `_` (underscore) to properly distinguish between real discards and ordinary referenceable parameters. In C#, a parameter named `_` is only a true discard when it appears two or more times in the parameter list; a single `_` is just a regular parameter that happens to be named `_`.

## Changes
- **Test case**: Added `LambdaSingleUnderscoreParameterIsNotADiscard()` to verify that a lambda with a single `_` parameter correctly references that parameter in the body (e.g., `(a, b, _) => DoSomething(a, b, _)` should work).
- **Emitter logic**: Updated `EmitLambda()` in `Emitter.Expressions2.cs` to:
  - Count occurrences of `_` in the parameter list
  - Only uniquify `_` parameters (rename to `$d0`, `$d1`, etc.) when there are 2+ occurrences
  - Preserve the `_` name for single occurrences, allowing it to be referenced in the lambda body
  - Updated comments to explain the C# semantics and the "use strict" constraint in JavaScript

## Implementation Details
The fix materializes the parameter collection to a list (if not already) to enable counting, then conditionally applies the discard uniquification only when `isRealDiscard` is true (count > 1). This ensures the generated JavaScript respects both C# semantics and JavaScript's strict mode parameter-name restrictions.

https://claude.ai/code/session_01Yam2GBLgXo6ntBrhKse8zb