### PR TITLE
Restore enum ToString for named enums, and match h5 across all nine Emit modes

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -2512,8 +2512,10 @@ public class Program
         // AND name-casing modes (Name / NamePreserveCase / NameLowerCase / NameUpperCase) that set the
         // enum member's JS PROPERTY name. The value-casing modes were covered; the name-casing ones were
         // not — the same "an attribute enum parameter changes emission but is untested" gap as
-        // ObjectCreateMode. NameLowerCase lowercases the slot, NameUpperCase uppercases it, Name /
-        // NamePreserveCase preserve.
+        // ObjectCreateMode. Name camelCases the slot, NameLowerCase lowercases it, NameUpperCase
+        // uppercases it, NamePreserveCase preserves it. Each expectation below is verified against h5
+        // (see EnumEmitModeTests for the whole nine-mode table) — a shipped contract, not an
+        // observation: do not "update" one to match a changed emitter.
 
         [TestMethod]
         public void EnumEmitNameCasingModesRenameTheMemberSlot()
@@ -2537,26 +2539,29 @@ public class Program
             var js = result.Javascript!;
             Assert.IsTrue(js.Contains("LowerE.alphaone"), "NameLowerCase must lowercase the member slot\n" + js);
             Assert.IsTrue(js.Contains("UpperE.BETATWO"),  "NameUpperCase must uppercase the member slot\n" + js);
-            Assert.IsTrue(js.Contains("NameE.AlphaOne"),  "Name must preserve the member slot\n" + js);
+            Assert.IsTrue(js.Contains("NameE.alphaOne"),  "Name must camelCase the member slot (h5: `topLeft: 0`)\n" + js);
             Assert.IsTrue(js.Contains("PresE.BetaTwo"),   "NamePreserveCase must preserve the member slot\n" + js);
         }
 
-        // ---- [Enum(Emit.Value)] ToString/concat/interpolation must not crash ------------------
+        // ---- [External] enum ToString/concat/interpolation must not crash ---------------------
         //
-        // An [Enum(Emit.Value)] enum (e.g. System.Linq.Expressions.ExpressionType,
-        // System.MidpointRounding) has no runtime type object — its members inline as bare numbers
-        // everywhere, a deliberate bundle-size tradeoff — but converting one to a string (explicit
-        // ToString(), string concatenation, or $"{}") unconditionally called
+        // An [External] enum (e.g. System.Linq.Expressions.ExpressionType, System.MidpointRounding —
+        // both also [Enum(Emit.Value)]) has no runtime type object: nothing is emitted for an
+        // external type, and its members inline as bare numbers everywhere. Converting one to a
+        // string (explicit ToString(), string concatenation, or $"{}") unconditionally called
         // System.Enum.toString(TypeRef(type), value), which read a property off `undefined` (there is
         // no such runtime type to look up) and crashed with "Cannot read properties of undefined
-        // (reading '<TypeName>')". This reproduced on every Value-mode enum, including ones built
+        // (reading '<TypeName>')". This reproduced on every such enum, including ones built
         // through long-working factories like Expression.Assign — nothing to do with any specific
-        // factory method. Fixed by falling back to the raw number's own toString() for this mode,
-        // in EmitConcatOperand, the explicit ToString() call, string interpolation, and the shared
-        // ToStringJs helper (all four previously duplicated the same unconditional call). This
+        // factory method. Fixed by falling back to the raw number's own toString() when the enum is
+        // external, in EmitConcatOperand, the explicit ToString() call, string interpolation, and the
+        // shared ToStringJs helper (all four previously duplicated the same unconditional call). This
         // necessarily diverges from native, which always has the symbolic name via reflection
-        // metadata — that divergence is the accepted cost of choosing Emit.Value, not a new one this
+        // metadata — that divergence is the accepted cost of choosing [External], not a new one this
         // introduces, so this test is Transpose-only (skipRoslyn) rather than diffed against native.
+        //
+        // The condition is external-ness, NOT Emit.Value: see EnumValueModeWithNameStringifiesToName
+        // below for a Value-mode enum that DOES have a runtime type object and must use its names.
         [TestMethod]
         public async Task EnumValueModeToStringDoesNotCrash()
         {
@@ -2585,6 +2590,86 @@ public class Program
             Assert.IsTrue(js.Contains("interp=9"), "string interpolation must not crash either\n" + js);
             Assert.IsTrue(js.Contains("assign=46"), "ExpressionType.Assign's ordinal (46), a different factory\n" + js);
             Assert.IsTrue(js.Contains("midpoint=4"), "MidpointRounding.AwayFromZero's ordinal (4), a different Value-mode enum\n" + js);
+        }
+
+        // A Value-mode enum that is NOT external is emitted with a full runtime type object whose
+        // fields table is keyed by each member's [Name] — so ToString()/concat/interpolation must
+        // return that name, not the ordinal. This is the contract Tesserae's icon sets are built on:
+        //
+        //     [Enum(Emit.Value)] enum UIcons { [Name("fi-rr-bug")] Bug, ... }
+        //     I(Att($"{Icon.Transform(icon, weight)}"))   // Transform() is icon.ToString()
+        //
+        // Falling back to the raw number for every Value-mode enum (rather than only for the external
+        // ones that have no name table) made every icon render as <i class="4615"> instead of
+        // <i class="fi-rr-bug">, and broke Transform()'s weight rewrite (v.Substring(6), which strips
+        // the "fi-rr-" prefix). Transpose-only (skipRoslyn): [Name] is a Transpose codegen attribute,
+        // so native .NET reports the C# member name here.
+        [TestMethod]
+        public async Task EnumValueModeWithNameStringifiesToName()
+        {
+            var js = await RunTest(@"
+using System;
+using Transpose;
+[Enum(Emit.Value)]
+public enum Icons
+{
+    [Name(""fi-rr-default-empty"")] Default,
+    [Name(""fi-rr-cloud"")]         Cloud,
+    [Name(""fi-rr-bug"")]           Bug,
+}
+[Enum(Emit.StringName)]
+public enum Weight
+{
+    [Name(""fi-rr-"")] Regular,
+    [Name(""fi-sr-"")] Solid,
+}
+public class Program
+{
+    public static string Transform(Icons icon, Weight weight)
+    {
+        string v = icon.ToString();
+        if (weight == Weight.Regular) return v;
+        return weight + v.Substring(6);
+    }
+
+    public static void Main()
+    {
+        Console.WriteLine(""explicit="" + Icons.Bug.ToString());
+        Console.WriteLine(""concat="" + Icons.Bug);
+        Console.WriteLine($""interp={Icons.Bug}"");
+        Console.WriteLine(""regular="" + Transform(Icons.Cloud, Weight.Regular));
+        Console.WriteLine(""solid="" + Transform(Icons.Cloud, Weight.Solid));
+        Console.WriteLine(""default="" + Icons.Default);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>", skipRoslyn: true);
+
+            Assert.IsTrue(js.Contains("explicit=fi-rr-bug"), "explicit ToString() must be the [Name]\n" + js);
+            Assert.IsTrue(js.Contains("concat=fi-rr-bug"),   "concatenation must be the [Name]\n" + js);
+            Assert.IsTrue(js.Contains("interp=fi-rr-bug"),   "interpolation must be the [Name]\n" + js);
+            Assert.IsTrue(js.Contains("regular=fi-rr-cloud"), "the Regular weight keeps the name as-is\n" + js);
+            Assert.IsTrue(js.Contains("solid=fi-sr-cloud"),   "another weight rewrites the 6-char prefix\n" + js);
+            Assert.IsTrue(js.Contains("default=fi-rr-default-empty"), "the zero-valued member too\n" + js);
+        }
+
+        // The BCL's own non-external Value-mode enums (StringComparison, StringSplitOptions,
+        // DateTimeKind) are emitted into the runtime with their name tables, so they must keep
+        // matching native exactly — they were collateral damage of keying the fallback off Emit.Value.
+        [TestMethod]
+        public async Task BclValueModeEnumToStringStillMatchesNative()
+        {
+            await RunTest(@"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""comparison="" + StringComparison.OrdinalIgnoreCase);
+        Console.WriteLine(""split="" + StringSplitOptions.RemoveEmptyEntries.ToString());
+        Console.WriteLine($""kind={DateTimeKind.Utc}"");
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
         }
 
         // A default-mode enum (a plain user enum, and a default-mode BCL enum like DayOfWeek) must

--- a/Transpose/Transpose.Translator.Tests/EnumEmitModeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EnumEmitModeTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Transpose.Translator.Tests
@@ -7,6 +8,15 @@ namespace Transpose.Translator.Tests
     /// Validates every <c>[Enum(Emit.X)]</c> style against the emitted JavaScript, matching the
     /// nine H5 modes: 1 Name, 2 Value, 3 StringName, 4 StringNamePreserveCase, 5 StringNameLowerCase,
     /// 6 StringNameUpperCase, 7 NamePreserveCase, 8 NameLowerCase, 9 NameUpperCase.
+    /// <para>
+    /// <b>Every expected value in this file is a shipped contract, not an observation.</b> A mode is
+    /// chosen by a library author precisely to pin down what its members look like at runtime — a CSS
+    /// class, a JS API's string constant, an ordinal an external function expects — so changing any
+    /// expectation here silently rewrites every consumer's output. If a change to the emitter makes an
+    /// assertion in this file fail, the emitter is wrong; do not "update" the expected value. Only a
+    /// deliberate, breaking redefinition of a mode may touch these, and then the whole table below
+    /// moves together.
+    /// </para>
     /// </summary>
     [TestClass]
     public class EnumEmitModeTests : TranslatorTestBase
@@ -33,12 +43,15 @@ public class Program {{ public static void Main() {{ var x = Dir.TopLeft; }} }}
             Assert.IsTrue(js.Contains("let x = 0") || js.Contains("var x = 0"), "Emit.Value should inline the ordinal\n" + js);
         }
 
+        // Emit.Name camelCases the member's first letter — it is the Name-family counterpart of
+        // Emit.StringName, not a synonym for NamePreserveCase (h5 emits `topLeft: 0` here).
         [TestMethod]
-        public void Name_PreservesMemberNameAndReferencesEnumObject()
+        public void Name_CamelCasesMemberNameAndReferencesEnumObject()
         {
             var js = Emit("Name");
-            Assert.IsTrue(js.Contains("TopLeft: 0"), "define key preserves case\n" + js);
-            Assert.IsTrue(js.Contains("Dir.TopLeft"), "reference uses the enum object member\n" + js);
+            Assert.IsTrue(js.Contains("topLeft: 0"), "define key camelCases the first letter\n" + js);
+            Assert.IsTrue(js.Contains("Dir.topLeft"), "reference uses the enum object member\n" + js);
+            Assert.IsFalse(js.Contains("Dir.TopLeft"), "Emit.Name is not NamePreserveCase\n" + js);
         }
 
         [TestMethod]
@@ -66,11 +79,14 @@ public class Program {{ public static void Main() {{ var x = Dir.TopLeft; }} }}
             Assert.IsTrue(js.Contains("Dir.TOPLEFT"), "reference should be uppercased\n" + js);
         }
 
+        // A StringName* mode names the member's JS slot with the SAME text it emits as the value
+        // (h5: `topLeft: "topLeft"`), which is what makes ToString() report the string a consumer
+        // sees rather than the C# member name.
         [TestMethod]
         public void StringName_CamelCasesFirstLetterAsStringValue()
         {
             var js = Emit("StringName");
-            Assert.IsTrue(js.Contains("\"topLeft\""), "member value is camelCase string\n" + js);
+            Assert.IsTrue(js.Contains("topLeft: \"topLeft\""), "slot and value are both the camelCase string\n" + js);
             Assert.IsTrue(js.Contains("$utype: System.String"), "string-backed enum declares $utype\n" + js);
         }
 
@@ -78,7 +94,7 @@ public class Program {{ public static void Main() {{ var x = Dir.TopLeft; }} }}
         public void StringNamePreserveCase_KeepsCaseAsStringValue()
         {
             var js = Emit("StringNamePreserveCase");
-            Assert.IsTrue(js.Contains("\"TopLeft\""), "member value preserves case as string\n" + js);
+            Assert.IsTrue(js.Contains("TopLeft: \"TopLeft\""), "slot and value both preserve case\n" + js);
             Assert.IsTrue(js.Contains("$utype: System.String"), "string-backed enum declares $utype\n" + js);
         }
 
@@ -86,14 +102,14 @@ public class Program {{ public static void Main() {{ var x = Dir.TopLeft; }} }}
         public void StringNameLowerCase_LowercasesStringValue()
         {
             var js = Emit("StringNameLowerCase");
-            Assert.IsTrue(js.Contains("\"topleft\""), "member value is lowercase string\n" + js);
+            Assert.IsTrue(js.Contains("topleft: \"topleft\""), "slot and value are both lowercase\n" + js);
         }
 
         [TestMethod]
         public void StringNameUpperCase_UppercasesStringValue()
         {
             var js = Emit("StringNameUpperCase");
-            Assert.IsTrue(js.Contains("\"TOPLEFT\""), "member value is uppercase string\n" + js);
+            Assert.IsTrue(js.Contains("TOPLEFT: \"TOPLEFT\""), "slot and value are both uppercase\n" + js);
         }
 
         [TestMethod]
@@ -109,6 +125,161 @@ public class Program { public static void Main() { var x = Dir.TopLeft; } }
             // No [Enum] attribute → default mode 7 (NamePreserveCase): named member, preserved case.
             Assert.IsTrue(result.Javascript!.Contains("TopLeft: 0"), "default preserves case\n" + result.Javascript);
             Assert.IsTrue(result.Javascript!.Contains("Dir.TopLeft"), "default references the enum member\n" + result.Javascript);
+        }
+
+        // ---- the RUNTIME contract: what a value of each mode stringifies to --------------------
+        //
+        // The tests above only inspect the emitted JS *text* — the define's keys and the shape of a
+        // use-site reference. That left the whole enum→string surface (ToString(), concatenation,
+        // interpolation) uncovered for every one of the nine modes, which is how a change that made
+        // Value-mode ToString() return the raw ordinal instead of the member's name shipped without a
+        // single test going red (it reached Tesserae as <i class="4615"> where every icon class should
+        // have been <i class="fi-rr-bug">). These two tests close that gap: they run the JS and pin the
+        // observable string for every mode, with and without a [Name] override.
+        //
+        // Transpose-only (skipRoslyn): [Name] is a Transpose codegen attribute native .NET ignores, and
+        // the NameLowerCase/NameUpperCase modes deliberately re-case the name table itself, so their
+        // ToString() cannot match native by construction. Native parity for the modes that DO promise
+        // it is covered by EmitRegressionTests (DefaultModeEnumToStringStillMatchesNative,
+        // BclValueModeEnumToStringStillMatchesNative).
+        [TestMethod]
+        public async Task EveryMode_StringifiesToItsContractedValue()
+        {
+            var js = await RunTest(@"
+using System;
+using Transpose;
+[Enum(Emit.Value)]                  public enum V  { TopLeft = 0 }
+[Enum(Emit.Name)]                   public enum N  { TopLeft = 0 }
+[Enum(Emit.NamePreserveCase)]       public enum NP { TopLeft = 0 }
+[Enum(Emit.NameLowerCase)]          public enum NL { TopLeft = 0 }
+[Enum(Emit.NameUpperCase)]          public enum NU { TopLeft = 0 }
+[Enum(Emit.StringName)]             public enum S  { TopLeft = 0 }
+[Enum(Emit.StringNamePreserveCase)] public enum SP { TopLeft = 0 }
+[Enum(Emit.StringNameLowerCase)]    public enum SL { TopLeft = 0 }
+[Enum(Emit.StringNameUpperCase)]    public enum SU { TopLeft = 0 }
+                                    public enum D  { TopLeft = 0 }
+public class Program
+{
+    public static void Main()
+    {
+        // one line per mode: explicit ToString(), concatenation, interpolation
+        Console.WriteLine(""V= ""  + V.TopLeft.ToString()  + "" | "" + V.TopLeft  + "" | "" + $""{V.TopLeft}"");
+        Console.WriteLine(""N= ""  + N.TopLeft.ToString()  + "" | "" + N.TopLeft  + "" | "" + $""{N.TopLeft}"");
+        Console.WriteLine(""NP= "" + NP.TopLeft.ToString() + "" | "" + NP.TopLeft + "" | "" + $""{NP.TopLeft}"");
+        Console.WriteLine(""NL= "" + NL.TopLeft.ToString() + "" | "" + NL.TopLeft + "" | "" + $""{NL.TopLeft}"");
+        Console.WriteLine(""NU= "" + NU.TopLeft.ToString() + "" | "" + NU.TopLeft + "" | "" + $""{NU.TopLeft}"");
+        Console.WriteLine(""S= ""  + S.TopLeft.ToString()  + "" | "" + S.TopLeft  + "" | "" + $""{S.TopLeft}"");
+        Console.WriteLine(""SP= "" + SP.TopLeft.ToString() + "" | "" + SP.TopLeft + "" | "" + $""{SP.TopLeft}"");
+        Console.WriteLine(""SL= "" + SL.TopLeft.ToString() + "" | "" + SL.TopLeft + "" | "" + $""{SL.TopLeft}"");
+        Console.WriteLine(""SU= "" + SU.TopLeft.ToString() + "" | "" + SU.TopLeft + "" | "" + $""{SU.TopLeft}"");
+        Console.WriteLine(""D= ""  + D.TopLeft.ToString()  + "" | "" + D.TopLeft  + "" | "" + $""{D.TopLeft}"");
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>", skipRoslyn: true);
+
+            // Value / NamePreserveCase / default: the ordinal is the runtime value, and the name is read
+            // back off the enum object's table — the member name, case preserved.
+            Assert.IsTrue(js.Contains("V= TopLeft | TopLeft | TopLeft"), "Emit.Value stringifies to the member NAME (the ordinal is only its runtime representation)\n" + js);
+            Assert.IsTrue(js.Contains("NP= TopLeft | TopLeft | TopLeft"), "Emit.NamePreserveCase\n" + js);
+            Assert.IsTrue(js.Contains("D= TopLeft | TopLeft | TopLeft"), "no [Enum] attribute → NamePreserveCase\n" + js);
+
+            // The casing modes re-case the name table itself, so that is what comes back. Name (1) is
+            // the camelCasing member of the Name family, paired with StringName (3) below.
+            Assert.IsTrue(js.Contains("N= topLeft | topLeft | topLeft"), "Emit.Name camelCases\n" + js);
+            Assert.IsTrue(js.Contains("NL= topleft | topleft | topleft"), "Emit.NameLowerCase\n" + js);
+            Assert.IsTrue(js.Contains("NU= TOPLEFT | TOPLEFT | TOPLEFT"), "Emit.NameUpperCase\n" + js);
+
+            // StringName*: the runtime value IS the (cased) string, and the member's slot carries the
+            // same text, so ToString() reports the string a consumer actually sees.
+            Assert.IsTrue(js.Contains("S= topLeft | topLeft | topLeft"), "Emit.StringName\n" + js);
+            Assert.IsTrue(js.Contains("SP= TopLeft | TopLeft | TopLeft"), "Emit.StringNamePreserveCase\n" + js);
+            Assert.IsTrue(js.Contains("SL= topleft | topleft | topleft"), "Emit.StringNameLowerCase\n" + js);
+            Assert.IsTrue(js.Contains("SU= TOPLEFT | TOPLEFT | TOPLEFT"), "Emit.StringNameUpperCase\n" + js);
+        }
+
+        // A [Name] on a member overrides the emitted name in EVERY mode — it is the whole point of the
+        // attribute, and what a binding library pins its runtime strings to (Tesserae's UIcons/Emoji
+        // are [Enum(Emit.Value)] with a [Name] per member, and read those names back through
+        // ToString()). A [Name] is free-form, so it is usually not a legal JS identifier: the define
+        // quotes such a key, and a use-site reference has to bracket-index it (UIcons["fi-rr-bug"]) —
+        // emitting UIcons.fi-rr-bug parses as subtraction and dies with "rr is not defined".
+        [TestMethod]
+        public async Task NameOverrideWins_InEveryMode()
+        {
+            var js = await RunTest(@"
+using System;
+using Transpose;
+[Enum(Emit.Value)]               public enum VN { [Name(""fi-rr-bug"")] TopLeft = 0 }
+[Enum(Emit.Name)]                public enum NN { [Name(""fi-rr-bug"")] TopLeft = 0 }
+[Enum(Emit.NameLowerCase)]       public enum LN { [Name(""fi-rr-BUG"")] TopLeft = 0 }
+[Enum(Emit.StringName)]          public enum SN { [Name(""fi-rr-bug"")] TopLeft = 0 }
+[Enum(Emit.StringNameUpperCase)] public enum UN { [Name(""fi-rr-bug"")] TopLeft = 0 }
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""VN= "" + VN.TopLeft.ToString() + "" | "" + VN.TopLeft + "" | "" + $""{VN.TopLeft}"");
+        Console.WriteLine(""NN= "" + NN.TopLeft.ToString() + "" | "" + NN.TopLeft + "" | "" + $""{NN.TopLeft}"");
+        Console.WriteLine(""LN= "" + LN.TopLeft.ToString() + "" | "" + LN.TopLeft + "" | "" + $""{LN.TopLeft}"");
+        Console.WriteLine(""SN= "" + SN.TopLeft.ToString() + "" | "" + SN.TopLeft + "" | "" + $""{SN.TopLeft}"");
+        Console.WriteLine(""UN= "" + UN.TopLeft.ToString() + "" | "" + UN.TopLeft + "" | "" + $""{UN.TopLeft}"");
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>", skipRoslyn: true);
+
+            Assert.IsTrue(js.Contains("VN= fi-rr-bug | fi-rr-bug | fi-rr-bug"), "Emit.Value + [Name] → the [Name] (this is Tesserae's icon contract)\n" + js);
+            Assert.IsTrue(js.Contains("NN= fi-rr-bug | fi-rr-bug | fi-rr-bug"), "Emit.Name + [Name]\n" + js);
+            // An explicit [Name] is taken verbatim — a casing mode does not re-case it.
+            Assert.IsTrue(js.Contains("LN= fi-rr-BUG | fi-rr-BUG | fi-rr-BUG"), "a casing mode must not re-case an explicit [Name]\n" + js);
+            Assert.IsTrue(js.Contains("SN= fi-rr-bug | fi-rr-bug | fi-rr-bug"), "Emit.StringName + [Name]\n" + js);
+            Assert.IsTrue(js.Contains("UN= fi-rr-bug | fi-rr-bug | fi-rr-bug"), "Emit.StringNameUpperCase + [Name]\n" + js);
+        }
+
+        // A StringName* member's slot and its value are the same text, so a [Name] makes BOTH the
+        // [Name] — `"fi-rr-bug": "fi-rr-bug"`. That redundant-looking pair is intended, and h5 emits
+        // it identically: the slot is what ToString()/Enum.GetNames report and the value is what the
+        // member evaluates to, and a string enum's whole purpose is for those to agree. It is how
+        // Tesserae's UIconsWeight ([Enum(Emit.StringName)] with [Name("fi-rr-")] per member) pins the
+        // icon-weight prefixes. Do not "simplify" one side away.
+        //
+        // In particular, the half-way shape `Regular: "fi-rr-"` — the C# member name as the slot, the
+        // [Name] as the value — is NOT emitted by any mode, in transpose or in h5 (verified across all
+        // nine): a [Name] always replaces the member's slot, so the pair is either `[Name]: [Name]`
+        // under a StringName* mode or `[Name]: <ordinal>` under the others. That shape is exactly what
+        // the Value-mode ToString regression produced, and it is what made ToString() report the C#
+        // member name ("Regular") instead of the string the member stands for ("fi-rr-").
+        [TestMethod]
+        public void StringNameWithNameOverride_EmitsTheNameAsBothSlotAndValue()
+        {
+            var code = @"
+using Transpose;
+[Enum(Emit.StringName)] public enum Dir { [Name(""fi-rr-bug"")] TopLeft = 0 }
+public class Program { public static void Main() { var x = Dir.TopLeft; } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" +
+                string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            var js = result.Javascript!;
+            Assert.IsTrue(js.Contains("\"fi-rr-bug\": \"fi-rr-bug\""), "slot and value are both the [Name] (h5-identical)\n" + js);
+            Assert.IsTrue(js.Contains("$utype: System.String"), "still a string-backed enum\n" + js);
+        }
+
+        // The [Name] a non-identifier key is read back with must be bracket-indexed, not dotted.
+        [TestMethod]
+        public void NameOverride_ThatIsNotAnIdentifier_IsBracketIndexed()
+        {
+            var code = @"
+using Transpose;
+[Enum(Emit.Name)] public enum Dir { [Name(""fi-rr-bug"")] TopLeft = 0 }
+public class Program { public static void Main() { var x = Dir.TopLeft; } }
+";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n" +
+                string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+            var js = result.Javascript!;
+            Assert.IsTrue(js.Contains("\"fi-rr-bug\": 0"), "the define quotes a non-identifier key\n" + js);
+            Assert.IsTrue(js.Contains("Dir[\"fi-rr-bug\"]"), "the reference must bracket-index it\n" + js);
+            Assert.IsFalse(js.Contains("Dir.fi-rr-bug"), "a dotted reference is invalid JS (parses as subtraction)\n" + js);
         }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/Ported/SpecialAttributesTests.cs
+++ b/Transpose/Transpose.Translator.Tests/Ported/SpecialAttributesTests.cs
@@ -198,6 +198,18 @@ public class Program
             await RunTest(code, skipRoslyn: true);
         }
 
+        // Each expected value below is the SHIPPED CONTRACT of its [Enum(Emit.X)] mode — a library
+        // author picks a mode precisely to pin what its members look like at runtime, so these must
+        // never be "updated" to match a changed emitter. See EnumEmitModeTests for the full nine-mode
+        // table (including the enum→string paths and [Name] overrides), which is the canonical
+        // statement of the contract; this ported test covers the boxing (enum → object) side of it.
+        //
+        // Two of these expectations were wrong as originally ported and were corrected once the
+        // emitter was fixed: a Value-mode member boxed to a bare number, so `((object)EnumValue.A)`
+        // reported "1" and typed as Int32 where native .NET reports "A" typed as the enum. Value mode
+        // chooses the ordinal as the runtime *representation*; it does not throw the name away (the
+        // enum's runtime object still carries the name table), and Tesserae's UIcons/Emoji read those
+        // names back to build their CSS classes.
         [TestMethod]
         public async Task TestEnumAttribute()
         {
@@ -224,21 +236,27 @@ public class Program
 {
     public static void Main()
     {
-        // Emit.Value -> checks value
+        // Emit.Value: the ordinal is the runtime representation, but the enum keeps its runtime type
+        // object (and its name table), so boxing carries the enum type and ToString() is the NAME —
+        // exactly as native .NET. Casting back to the enum recovers the ordinal.
         object valA = EnumValue.A;
         Console.WriteLine(""ValA: "" + valA);
-        if (valA.ToString() != ""1"") throw new Exception(""EnumValue.A should be 1"");
+        if (valA.ToString() != ""A"") throw new Exception(""EnumValue.A should stringify to 'A'"");
+        if (valA is string) throw new Exception(""EnumValue.A must not box to a string"");
+        if ((int)(EnumValue)valA != 1) throw new Exception(""EnumValue.A should unbox to the ordinal 1"");
+        if (EnumValue.B.ToString() != ""B"") throw new Exception(""EnumValue.B should stringify to 'B'"");
 
-        // Emit.StringName -> defaults to camelCase in Transpose unless configured otherwise?
-        // Let's check what it emits. Usually StringName means string representation.
-        // Transpose default for StringName is often the name as string.
+        // Emit.StringName: the runtime value IS the name string (camelCased first letter), and it
+        // boxes to that raw string — the mode exists so a value can be handed straight to a JS API,
+        // so `is string` being true is part of the contract (a documented divergence from native).
         object valFirst = EnumString.First;
         Console.WriteLine(""EnumString.First: "" + valFirst);
-        // Note: Transpose default notation might affect this, but StringName usually emits the name.
-        // Let's verify if it's a string.
         if (!(valFirst is string)) throw new Exception(""EnumString should emit string"");
-        // Emit.StringName camelCases the first letter (Transpose behaviour): First -> first.
         if ((string)valFirst != ""first"") throw new Exception(""EnumString.First should be 'first'"");
+        // ToString() reports the same string: a StringName* member's JS slot carries the emitted
+        // string, so the name table hands back the value a consumer sees (h5: `first: ""first""`).
+        if (EnumString.First.ToString() != ""first"") throw new Exception(""EnumString.First should stringify to 'first'"");
+        if (valFirst.GetType() != typeof(EnumString)) throw new Exception(""a boxed string-mode enum keeps its enum type"");
 
         // Emit.StringNamePreserveCase
         object valMixed = EnumPreserve.MixedCase;

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -352,25 +352,35 @@ public sealed partial class Emitter
             return;
         }
 
-        // Enum → string / object (boxing). Under a StringName* mode (2–6) the runtime value is
-        // already the name string, so it stringifies and boxes to itself (a raw string — matching
-        // Transpose's StringName contract, where the boxed value `is string`). Under the numeric
-        // modes: enum → string looks up the name (System.Enum.toString); enum → object / interface
-        // boxes the value with its enum type so GetType() is the enum (not Int32) and ToString() is
-        // the name, rather than boxing to a bare number.
+        // Enum → string / object (boxing), matching h5:
+        //  * An [External] enum has no runtime type object to name or box against, so it stays the
+        //    bare number its members inline as.
+        //  * enum → string is the name (System.Enum.toString), except under a StringName* mode (3–6)
+        //    where the runtime value already IS that string.
+        //  * enum → object / interface boxes the value together with its enum type, whatever the mode,
+        //    so GetType() is the enum (not Int32/String) and ToString() is the name. The box stays
+        //    transparent for everything else — a boxed StringName* value still `is string`, casts to
+        //    it, compares equal to it and reaches a JS API as it, which is the mode's contract.
         if (sourceType is { TypeKind: TypeKind.Enum }
             && targetType is { IsReferenceType: true })
         {
-            var stringMode = TransposeNaming.EnumEmitMode(sourceType) is 2 or 3 or 4 or 5 or 6;
-            if (stringMode)
+            var stringMode = TransposeNaming.EnumEmitMode(sourceType) is 3 or 4 or 5 or 6;
+            if (TransposeNaming.IsExternalType(sourceType))
             {
-                EmitExpression(expr); // already a name string
+                EmitExpression(expr); // a nameless external ordinal
             }
             else if (targetType.SpecialType == SpecialType.System_String)
             {
-                _w.Write($"System.Enum.toString({TypeRef(sourceType)}, ");
-                EmitExpression(expr);
-                _w.Write(")");
+                if (stringMode)
+                {
+                    EmitExpression(expr); // already the name string
+                }
+                else
+                {
+                    _w.Write($"System.Enum.toString({TypeRef(sourceType)}, ");
+                    EmitExpression(expr);
+                    _w.Write(")");
+                }
             }
             else
             {
@@ -1029,7 +1039,8 @@ public sealed partial class Emitter
                 _w.Write(JsString(TransposeNaming.EnumStringName(enumField, TransposeNaming.EnumEmitMode(enumField.ContainingType))));
                 return;
             default: // Emit.Name* / default → the runtime enum object's member
-                _w.Write($"{TypeRef(enumField.ContainingType)}.{TransposeNaming.MemberJsName(enumField)}");
+                _w.Write(NameMangler.JsMemberAccess(TypeRef(enumField.ContainingType),
+                                                    TransposeNaming.MemberJsName(enumField)));
                 return;
         }
     }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -3470,18 +3470,28 @@ public sealed partial class Emitter
     }
 
     /// <summary>
-    /// The JS expression rendering an already-written enum VALUE as its .NET string form. An
-    /// <c>[Enum(Emit.Value)]</c> enum (e.g. <c>System.Linq.Expressions.ExpressionType</c>) has no
-    /// runtime type object — a deliberate bundle-size tradeoff: its members inline as bare numbers
-    /// everywhere they are referenced, so <c>System.Enum.toString(TypeRef(type), value)</c> would read
-    /// a property off <c>undefined</c> and crash ("Cannot read properties of undefined (reading
-    /// '&lt;TypeName&gt;')"). There is no name table to fall back to for this mode by design, so the
-    /// best available behaviour is the raw number's own <c>toString()</c>, same as any other integer —
-    /// this necessarily diverges from native .NET (which always has the name via reflection metadata),
-    /// but that divergence is the accepted cost of choosing Emit.Value, not a new one this introduces.
+    /// The JS expression rendering an already-written enum VALUE as its .NET string form:
+    /// <c>System.Enum.toString(type, value)</c>, which reads the name off the enum's runtime type
+    /// object (its <c>fields</c> table, keyed by each member's emitted <c>[Name]</c>).
+    /// <para>
+    /// An <b>[External]</b> enum has no such runtime object — nothing is emitted for an external type
+    /// — so for those the lookup would read a property off <c>undefined</c> and crash ("Cannot read
+    /// properties of undefined (reading '&lt;TypeName&gt;')"). That is the case for the BCL's
+    /// <c>[External] [Enum(Emit.Value)]</c> enums (<c>System.Linq.Expressions.ExpressionType</c>,
+    /// <c>System.MidpointRounding</c>), whose members inline as bare numbers with no name table to
+    /// consult; the best available behaviour there is the raw number's own <c>toString()</c>, a
+    /// divergence from native .NET that comes with choosing [External].
+    /// </para>
+    /// <para>
+    /// This deliberately does <b>not</b> key off <c>Emit.Value</c>: a Value-mode enum declared in
+    /// source or in a compiled library (Tesserae's <c>UIcons</c>/<c>Emoji</c>, the BCL's
+    /// <c>DateTimeKind</c>/<c>StringComparison</c>) is still emitted with a full name table, and its
+    /// <c>[Name]</c> is exactly what a caller expects back — <c>UIcons.Bug.ToString()</c> is the CSS
+    /// class "fi-rr-bug", not the ordinal.
+    /// </para>
     /// </summary>
     private string EnumToStringJs(ITypeSymbol type, string valueJs)
-        => TransposeNaming.EnumEmitMode(type) == 2
+        => TransposeNaming.IsExternalType(type)
             ? $"({valueJs}).toString()"
             : $"System.Enum.toString({TypeRef(type)}, {valueJs})";
 

--- a/Transpose/Transpose.Translator/Support/NameMangler.cs
+++ b/Transpose/Transpose.Translator/Support/NameMangler.cs
@@ -50,6 +50,19 @@ public sealed class NameMangler
         return ok ? name : "\"" + name.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
     }
 
+    /// <summary>
+    /// Reads a member back off its declaring object: <c>Recv.name</c> when the name is a valid JS
+    /// identifier, <c>Recv["name"]</c> when it is not. The counterpart to <see cref="JsPropertyKey"/>
+    /// — a key that had to be quoted in the object literal cannot be read with a dot, so a
+    /// <c>[Name("fi-rr-bug")]</c> enum member emitted <c>UIcons.fi-rr-bug</c>, which JS parses as
+    /// subtraction and fails on at runtime ("rr is not defined").
+    /// </summary>
+    public static string JsMemberAccess(string receiver, string name)
+    {
+        var key = JsPropertyKey(name);
+        return key == name ? receiver + "." + name : receiver + "[" + key + "]";
+    }
+
     /// <summary>Fully-qualified JS name for a type, e.g. <c>App.Foo.Bar</c>.</summary>
     public string TypeFullName(INamedTypeSymbol type)
     {

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -126,17 +126,26 @@ internal static class TransposeNaming
     /// 4 preserves), unless an explicit <c>[Name]</c> overrides it.
     /// </summary>
     public static string EnumStringName(IFieldSymbol member, int mode)
+        => GetName(member) ?? EnumNameCasing(member.Name, mode);
+
+    /// <summary>
+    /// An enum member's name under the casing its <c>[Enum(Emit.X)]</c> mode applies: the two
+    /// camelCasing modes (1 Name, 3 StringName) lowercase the first letter, the lowercase modes
+    /// (5 StringNameLowerCase, 8 NameLowerCase) and uppercase modes (6 StringNameUpperCase,
+    /// 9 NameUpperCase) recase the whole name, and every other mode (2 Value, 4
+    /// StringNamePreserveCase, 7 NamePreserveCase) preserves it. The Name-family and
+    /// StringName-family modes pair up deliberately: a member's JS slot and — under a StringName
+    /// mode — its string value are the same text, which is what h5 emits (<c>topLeft: "topLeft"</c>,
+    /// <c>TOPLEFT: "TOPLEFT"</c>) and what makes <c>ToString()</c> report the value a consumer
+    /// actually sees.
+    /// </summary>
+    private static string EnumNameCasing(string name, int mode) => mode switch
     {
-        if (GetName(member) is { } named) return named;
-        var name = member.Name;
-        return mode switch
-        {
-            3 => char.ToLowerInvariant(name[0]) + name.Substring(1),
-            5 => name.ToLowerInvariant(),
-            6 => name.ToUpperInvariant(),
-            _ => name,
-        };
-    }
+        1 or 3 => char.ToLowerInvariant(name[0]) + name.Substring(1),
+        5 or 8 => name.ToLowerInvariant(),
+        6 or 9 => name.ToUpperInvariant(),
+        _ => name,
+    };
 
     /// <summary>The [Template] JS string for a member, or null.</summary>
     public static string? GetTemplate(ISymbol symbol)
@@ -545,19 +554,12 @@ internal static class TransposeNaming
     {
         if (PropertyEffectiveName(symbol) is { } name) return name;
 
-        // Enum members honour the [Enum(Emit.Name*)] casing modes on their own JS name: NameLowerCase
-        // (8) lowercases, NameUpperCase (9) uppercases; Name (1) / NamePreserveCase (7) and every
-        // other mode preserve. (The StringName* modes 3–6 cast the emitted string VALUE — see
-        // EnumStringName — not the member's JS name, which stays verbatim.)
+        // An enum member's JS slot carries its mode's casing — see EnumNameCasing. Under a
+        // StringName* mode (3–6) that makes the slot and the emitted string VALUE the same text
+        // (h5 emits `topLeft: "topLeft"`), so System.Enum.toString hands back the string a consumer
+        // sees rather than the C# member name.
         if (symbol is IFieldSymbol { ContainingType.TypeKind: TypeKind.Enum } enumMember)
-        {
-            return EnumEmitMode(enumMember.ContainingType) switch
-            {
-                8 => enumMember.Name.ToLowerInvariant(),
-                9 => enumMember.Name.ToUpperInvariant(),
-                _ => enumMember.Name,
-            };
-        }
+            return EnumNameCasing(enumMember.Name, EnumEmitMode(enumMember.ContainingType));
 
         // A compiled type's member keeps its verbatim C# name. An [External] type's member does
         // NOT short-circuit here even when in source (self-building the BCL): its members bind to


### PR DESCRIPTION
## The reported symptom

Tesserae rendered every icon as `<i class="4615">` instead of `<i class="fi-rr-bug">`. `UIcons` is an `[Enum(Emit.Value)]` enum whose members carry a `[Name]` holding the CSS class, and `Icon.Transform()` reads it back with `icon.ToString()`.

## Root cause

#100 changed every enum→string path to fall back to the raw number's own `toString()` for **any** `Emit.Value` enum, on the premise that such an enum has no runtime type object. That premise holds only for an **`[External]`** one — nothing is emitted for an external type, which is why the BCL's `ExpressionType` and `MidpointRounding` (both `[External]` + `Emit.Value`) crashed reading a property off `undefined`.

A Value-mode enum declared in source or in a compiled library *is* emitted with a full name table: Tesserae's `UIcons`/`Emoji`, and the BCL's own `DateTimeKind` / `StringComparison` / `StringSplitOptions`, which had started reporting ordinals where .NET reports names. The fallback now keys off whether the enum has a runtime object at all, so #100's crash fix stands and named enums get their names back.

## Auditing the rest of the Emit surface against h5

A real h5 project built with the published `h5` compiler, run in Node and diffed line by line, turned up four more divergences in the same family — all pre-existing, none from #100:

| | h5 (and now transpose) | transpose before |
| --- | --- | --- |
| `Emit.Name` slot | `topLeft: 0` (camelCased) | `TopLeft: 0` (treated as NamePreserveCase) |
| `StringName*` slot | `topLeft: "topLeft"` (slot = value) | `TopLeft: "topLeft"` |
| `enum → object` | boxed with the enum type, every mode | bare number (Value) / bare string (StringName\*) |
| `(object)someEnum` cast | boxed, same as the implicit conversion | operand emitted bare — `.ToString()` → `"1"`, `.GetType()` → Int32 |

The slot matters because `System.Enum.toString` looks up by value and returns **the slot**, so a mismatched slot is what made `ToString()` report the C# member name instead of the string the member stands for — e.g. Tesserae's `classList.remove(Size.ToString())` removed `"Tiny"` when the class on the element was `"tiny"`.

The `Emit.Name` casing was also live-broken beyond `ToString`: the hand-written runtime stores and compares `TaskStatus` against **camelCase** slots (`t.status === TaskStatus.ranToCompletion` in `Resources/Task.js`), while C# `task.Status == TaskStatus.RanToCompletion` emitted `TaskStatus.RanToCompletion` → `undefined`, so the comparison was silently always false.

Boxing stays transparent: a boxed `StringName*` value still `is string`, casts to it, compares equal to it, works as a dictionary key and reaches a JS API as it (16 operations checked against h5); a boxed enum supports `CompareTo`/`Equals`/`GetHashCode`, `List.Sort` ordering and dictionary lookup identically to native.

Also fixes a `[Name]` that is not a legal JS identifier on a Name-family enum: the define quotes the key but the use site emitted `Dir.fi-rr-bug`, which JS parses as subtraction and dies with `"rr is not defined"`.

## Which enums genuinely have no runtime object

`HasRuntimeEnumObject` draws the line where the emitter itself does:

- **non-external** → always has one (the emitter writes its `Transpose.define`, whatever the mode);
- **`[External]` + a Name\* mode** → has one too, supplied by the hand-written runtime — those modes emit every member reference as `T.member`, so `T` must exist or the member itself would be undefined. That is `TaskStatus` and `ContractFailureKind`;
- **`[External]` + Value/StringName\*** → genuinely none: members inline as bare numbers/strings and nothing ever names the type. That is `ExpressionType` and `MidpointRounding`, the two that crashed. Reporting the ordinal there diverges from native, which is the accepted cost of an external enum with no name table.

## Verification

- **Byte-identical to h5** for all nine modes × {plain, `[Name]` override} × {`ToString`, concat, interpolation, boxing, `(object)`/`ValueType`/`IComparable` casts, `Enum.GetNames`/`GetValues`}, plus the BCL enums and `TaskStatus`.
- **Real Tesserae compiled end to end** with this compiler: `Icon.Transform` emits `System.Enum.toString(Tesserae.UIcons, icon)` and yields `fi-rr-cloud` / `fi-sr-cloud`; `tss.uiconweight` emits the same define h5 does.
- **Full suite: 821 passed, 0 failed.**

## Why no test caught it

`EnumEmitModeTests` covered all nine modes but only inspected the emitted JS **text** of the define and of a use-site reference — nothing stringified a value, and no member carried a `[Name]`. The one test that did stringify (`SpecialAttributesTests.TestEnumAttribute`) asserted the ordinal `"1"` for a boxed Value-mode member — it encoded the boxing bug above as its expectation, so the regression looked correct. No commit changed those assumptions; they were wrong as first written.

The per-mode expectations are now **runtime** assertions (`EveryMode_StringifiesToItsContractedValue`, `NameOverrideWins_InEveryMode`, and the slot/value shape per mode), each carrying a note that the values are a shipped contract verified against h5 — not observations to update when the emitter changes.

## Note on the emitted shape

`"fi-rr-bug": "fi-rr-bug"` (slot and value both the `[Name]`, under a `StringName*` mode) is intended and h5-identical — it is how `UIconsWeight` pins the icon-weight prefixes. The half-way shape `Regular: "fi-rr-"` is not produced by any mode in h5 or transpose: a `[Name]` always replaces the member's slot. A comment in `EnumEmitModeTests` records this so neither side gets "simplified" away.