### PR TITLE
Disable NUglify inversions that break block-scoped let/const

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,21 @@ The short version:
   `index.html` (formatted) and `index.min.html` (minified) and collapses them per build configuration
   (Release keeps the minified one as `index.html`, Debug the formatted one) — a port of the legacy
   `HtmlGenerator`. **Source maps** for the emitted bundle are still remaining.
+
+  Two NUglify transforms are switched off through `CodeSettings.KillSwitch` because they are unsound
+  for the JavaScript we emit, and `JsMinifierTests` guards both. Besides the `??`-under-`&&` collapse
+  above, **`InvertIfReturn`/`InvertIfContinue`** rewrite a guard clause by moving every following
+  statement into a *new* block (`if (c) return; rest…` → `if (!c) { rest… }`). That is fine for `var`
+  and wrong for `let`: we emit locals as `let` (`LocalDeclKeyword`) and hoist a C# local function to
+  the top of its block as a `var f = () => …` (it must be callable before its textual position), so
+  the closure ends up *before* the guard and the `let` it captures ends up *after* it — the
+  declaration is swept into the new block and the closure throws
+  `ReferenceError: <name> is not defined`. Disabling both costs ~0.03% of bundle size.
+
+  The lesson is more general than the two flags: **a minification bug is invisible to the test
+  suite**, which runs the *formatted* output on Node — that output was valid JavaScript in both
+  cases. Only `JsMinifierTests` exercises the minified form, so a bug reported against a
+  `*.min.js` belongs there.
 - **Value-copy semantics are scoped to in-source structs.** A struct copy (assignment, by-value
   argument/return, array fill, boxing, a collection insert, `with`) clones the value — including,
   since `StructAndClassInitializerTests`, its struct-typed slots recursively — but only for a struct

--- a/Transpose/Transpose.Compiler.Core/JsMinifier.cs
+++ b/Transpose/Transpose.Compiler.Core/JsMinifier.cs
@@ -35,6 +35,36 @@ internal static class JsMinifier
     // source, and keeping `if (cond) stmt;` intact costs negligible size.
     private const long KillIfConditionCollapse = (long)TreeModifications.IfConditionCallToConditionAndCall;
 
+    // NUglify's early-exit inversions are unsound for `let`/`const`. Both rewrite a guard clause by
+    // moving every statement that follows it into a NEW block:
+    //
+    //   InvertIfReturn:    if (c) return;   rest…   ->   if (!c) { rest… }
+    //   InvertIfContinue:  if (c) continue; rest…   ->   if (!c) { rest… }
+    //
+    // That is a valid transform for `var` (function-scoped, so moving the declaration into a block
+    // changes nothing), and WRONG for a block-scoped declaration: a `let` among `rest…` becomes
+    // scoped to the new block, so any closure created *before* the guard that captures it silently
+    // loses the binding and throws `ReferenceError: <name> is not defined` at runtime.
+    //
+    // We emit exactly that shape. A C# local function is hoisted (callable before its textual
+    // position), so `EmitLocalFunction` emits it as a `var f = () => …` at the TOP of the block,
+    // ahead of the `let` locals it captures — which are declared further down, after any guard
+    // clause. Tesserae's `Router.Navigate` is the reported case:
+    //
+    //   var ExecuteTheNavigation = () => { if (!windowLocationSaysAlreadyThere) … };
+    //   if (…) { if (!_onWillNavigate(path)) return; }
+    //   let windowLocationSaysAlreadyThere = …;         // <- swept into the inverted if's block
+    //
+    // The bug only ever appears in a MINIFIED bundle (Release), which is why the Node-based test
+    // suite — which runs the formatted output, and that output is correct JavaScript — cannot see it.
+    // Disabling both inversions costs ~0.03% of bundle size (335 bytes on the 1.2 MB minified
+    // runtime), so there is nothing to trade off here.
+    private const long KillBlockScopeUnsafeInversions =
+        (long)(TreeModifications.InvertIfReturn | TreeModifications.InvertIfContinue);
+
+    // Everything the settings profiles below switch off.
+    private const long KillSwitches = KillIfConditionCollapse | KillBlockScopeUnsafeInversions;
+
     // Safe profile: never rename locals, terminate statements with semicolons, escape non-ASCII.
     private static CodeSettings Safe() => new()
     {
@@ -44,7 +74,7 @@ internal static class JsMinifier
         StrictMode           = false,
         RemoveUnneededCode   = false,
         AlwaysEscapeNonAscii = true,
-        KillSwitch           = KillIfConditionCollapse,
+        KillSwitch           = KillSwitches,
     };
 
     // Safe profile but crunch local variable names (smaller output; opted into per project).
@@ -56,7 +86,7 @@ internal static class JsMinifier
         StrictMode           = false,
         RemoveUnneededCode   = false,
         AlwaysEscapeNonAscii = true,
-        KillSwitch           = KillIfConditionCollapse,
+        KillSwitch           = KillSwitches,
     };
 
     // Runtime-core profile (tps.js, …): as safe but without the eval/local-renaming overrides.
@@ -66,7 +96,7 @@ internal static class JsMinifier
         StrictMode           = false,
         RemoveUnneededCode   = false,
         AlwaysEscapeNonAscii = true,
-        KillSwitch           = KillIfConditionCollapse,
+        KillSwitch           = KillSwitches,
     };
 
     /// <summary>

--- a/Transpose/Transpose.Translator.Tests/JsMinifierTests.cs
+++ b/Transpose/Transpose.Translator.Tests/JsMinifierTests.cs
@@ -65,4 +65,101 @@ public sealed class JsMinifierTests
         Assert.IsFalse(min.Contains(")??!1}") || min.Contains(")??!1;"),
             $"minifier produced a bare `??` operand of `&&`: {min}");
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Block scoping: a `let` must never be moved into a narrower scope than it was emitted in.
+    //
+    // NUglify's InvertIfReturn / InvertIfContinue rewrite a guard clause by moving every following
+    // statement into a NEW block (`if (c) return; rest…` -> `if (!c) { rest… }`). A `let` among
+    // `rest…` then becomes block-scoped to that new block, and a closure emitted BEFORE the guard —
+    // which is exactly where a hoisted C# local function lands — loses the binding. The failure is
+    // `ReferenceError: <name> is not defined`, only ever in a minified bundle.
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The reported Tesserae case, reduced to the JavaScript the emitter actually produces for
+    /// <c>Router.Navigate</c>: the hoisted local function <c>ExecuteTheNavigation</c> is a
+    /// <c>var</c> arrow at the top of the method, and the <c>let</c> it captures is declared after a
+    /// guard clause. Minification must not separate the two.
+    /// </summary>
+    [TestMethod]
+    public void HoistedLocalFunctionKeepsAccessToALetDeclaredAfterAGuardClause()
+    {
+        var source = """
+            function Navigate(path, reload) {
+                var ExecuteTheNavigation = () => {
+                    if (!windowLocationSaysAlreadyThere) { go(path); return; }
+                    locationChanged(reload);
+                };
+                if (onWillNavigate != null) {
+                    if (!onWillNavigate(path)) { return; }
+                }
+                let windowLocationSaysAlreadyThere = alreadyThere(path);
+                if (reload) { ExecuteTheNavigation(); return; }
+                if (windowLocationSaysAlreadyThere) { return; }
+                ExecuteTheNavigation();
+            }
+            """;
+
+        var min = JsMinifier.Minify(source, "app.js");
+
+        AssertLetIsNotNestedDeeperThanTheClosureCapturingIt(min, "windowLocationSaysAlreadyThere");
+    }
+
+    /// <summary>
+    /// The same defect via <c>InvertIfContinue</c>: the guard is a `continue` in a loop body, and the
+    /// captured local must stay `let` (a loop body needs a fresh per-iteration binding, so it cannot
+    /// simply be emitted as `var`).
+    /// </summary>
+    [TestMethod]
+    public void HoistedLocalFunctionKeepsAccessToALetDeclaredAfterAContinueGuard()
+    {
+        var source = """
+            function Loop(items) {
+                for (var i = 0; i < items.length; i++) {
+                    var H = () => { use(doubled); };
+                    if (i === 1) { continue; }
+                    let doubled = i * 2;
+                    H();
+                }
+            }
+            """;
+
+        var min = JsMinifier.Minify(source, "app.js");
+
+        AssertLetIsNotNestedDeeperThanTheClosureCapturingIt(min, "doubled");
+    }
+
+    /// <summary>
+    /// Asserts that the minified output does not open a brace between the closure that reads
+    /// <paramref name="name"/> and the <c>let</c> that declares it — i.e. the declaration was not
+    /// pushed into a block the closure sits outside of. Brace-depth comparison rather than a literal
+    /// match, so the test keeps working as other (sound) transforms reshape the output.
+    /// </summary>
+    private static void AssertLetIsNotNestedDeeperThanTheClosureCapturingIt(string min, string name)
+    {
+        var declaration = min.IndexOf("let " + name, StringComparison.Ordinal);
+        Assert.IsTrue(declaration >= 0, $"expected a `let {name}` declaration to survive: {min}");
+
+        // The closure's own body is one brace level deeper than where it is declared, so measure the
+        // depth at the arrow's `=>` (the declaration site of the closure) rather than inside it.
+        var closure = min.IndexOf("=>", StringComparison.Ordinal);
+        Assert.IsTrue(closure >= 0 && closure < declaration,
+            $"expected the capturing closure to be emitted before the declaration: {min}");
+
+        Assert.IsTrue(BraceDepth(min, declaration) <= BraceDepth(min, closure),
+            $"minifier moved `let {name}` into a block nested deeper than the closure that captures " +
+            $"it — the closure will throw `ReferenceError: {name} is not defined`: {min}");
+    }
+
+    private static int BraceDepth(string s, int index)
+    {
+        var depth = 0;
+        for (var i = 0; i < index; i++)
+        {
+            if (s[i] == '{') depth++;
+            else if (s[i] == '}') depth--;
+        }
+        return depth;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a minification bug where NUglify's `InvertIfReturn` and `InvertIfContinue` transforms unsoundly move block-scoped `let`/`const` declarations into new blocks, breaking closures that capture them. The bug only manifests in minified bundles (Release builds) because the formatted output is valid JavaScript.

## Changes

- **JsMinifier.cs**: Added `KillBlockScopeUnsafeInversions` kill switch that disables both `InvertIfReturn` and `InvertIfContinue` transforms. Updated all three minification profiles (`Safe()`, `SafeWithLocalRenaming()`, `RuntimeCore()`) to use the combined `KillSwitches` constant. Added detailed comments explaining why these transforms are unsound for the JavaScript we emit.

- **JsMinifierTests.cs**: Added two test cases that guard against the regression:
  - `HoistedLocalFunctionKeepsAccessToALetDeclaredAfterAGuardClause()`: Tests the reported Tesserae `Router.Navigate` case where a hoisted local function (emitted as `var f = () => …` at the top) captures a `let` declared after a guard clause.
  - `HoistedLocalFunctionKeepsAccessToALetDeclaredAfterAContinueGuard()`: Tests the same defect via `continue` in a loop body.
  - Added helper method `AssertLetIsNotNestedDeeperThanTheClosureCapturingIt()` that verifies the `let` declaration is not nested in a block deeper than the closure capturing it, using brace-depth comparison.
  - Added `BraceDepth()` utility to count brace nesting depth.

- **CLAUDE.md**: Documented the issue and the fix in the minification section, explaining that the bug is invisible to the test suite (which runs formatted output on Node) and that minification bugs belong in `JsMinifierTests`.

## Implementation Details

The root cause: C# local functions are hoisted (callable before their textual position), so we emit them as `var f = () => …` at the top of the block. When a guard clause like `if (c) return;` is inverted to `if (!c) { rest… }`, any `let` declarations in `rest…` become scoped to that new block. A closure emitted *before* the guard that captures such a `let` silently loses the binding and throws `ReferenceError: <name> is not defined` at runtime.

Disabling both inversions costs ~0.03% of bundle size (335 bytes on a 1.2 MB minified runtime), making this a safe trade-off with no meaningful performance impact.

https://claude.ai/code/session_01CGuEyP7op92ZdMNFokrqST