### PR TITLE
Strip CSS comments from all stylesheets in the build pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Transpose/                     # The compiler toolchain
 │   ├── RuntimeAssembler.cs    #   stitches Resources/*.js + generated ClassPath files into tps.js
 │   ├── BuildCache.cs          #   the --incremental on-disk cache
 │   ├── JsMinifier.cs          #   NUglify-based bundle minification
+│   ├── CssProcessor.cs        #   strips /* … */ comments from every stylesheet (site + embedded)
 │   ├── TransposeJson.cs       #   reads tps.json (output/fileName/html/resources/reflection)
 │   └── MsBuildDiagnostic.cs   #   canonical MSBuild diagnostic formatting (Origin : Category Code : Text)
 ├── Transpose.Compiler.Library/# Compiler-as-a-library. Package id + AssemblyName Transpose.Compiler.Library

--- a/Transpose/Transpose.Compiler.Core/CssProcessor.cs
+++ b/Transpose/Transpose.Compiler.Core/CssProcessor.cs
@@ -1,0 +1,172 @@
+using System.Text;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// Strips <c>/* … */</c> comments from stylesheets. Every CSS file the compiler produces goes through
+/// here — the ones a <c>tps.json</c> resource group writes into the site, the ones embedded into a
+/// package DLL, and the ones extracted back out of a referenced package — so a shipped site never
+/// carries the authoring comments of a stylesheet or of the framework stylesheets it bundles.
+///
+/// This is a comment pass, not a minifier: whitespace, casing and declaration order are left exactly
+/// as authored, and only the comments go. CSS has no line comments, so <c>/* … */</c> is the whole
+/// surface. Three rules keep the result equivalent to the input:
+///
+/// <list type="bullet">
+/// <item>A <c>/*</c> inside a string (<c>content: "/* not a comment */"</c>) or inside an unquoted
+/// <c>url(…)</c> token is not a comment and is copied through.</item>
+/// <item>A comment between two non-whitespace tokens becomes a single space, so <c>a/**/b</c> cannot
+/// collapse into <c>ab</c>.</item>
+/// <item>A comment that ends its line takes the whitespace around it with it — and the whole line when
+/// nothing else was on it — rather than leaving a blank line or a trailing space behind.</item>
+/// </list>
+///
+/// An unterminated comment is consumed to the end of the file, which is what a browser does with it.
+/// The one behaviour deliberately given up is the ancient IE5/6 comment hacks
+/// (<c>/*\*/…/**/</c>), whose meaning *is* the comment.
+/// </summary>
+internal static class CssProcessor
+{
+    private static readonly UTF8Encoding Utf8NoBom = new(false);
+    private static readonly UTF8Encoding Utf8Strict = new(false, throwOnInvalidBytes: true);
+    private static readonly byte[] Utf8Bom = { 0xEF, 0xBB, 0xBF };
+
+    /// <summary>The stylesheet with every comment removed. Returns the very same string when there is
+    /// nothing to strip, so a caller can detect "unchanged" by reference.</summary>
+    public static string StripComments(string css)
+    {
+        if (string.IsNullOrEmpty(css) || css.IndexOf("/*", StringComparison.Ordinal) < 0) return css;
+
+        var sb = new StringBuilder(css.Length);
+        var i = 0;
+        while (i < css.Length)
+        {
+            var c = css[i];
+            if (c == '"' || c == '\'') { i = CopyString(css, i, sb); continue; }
+            if ((c == 'u' || c == 'U') && IsUrlToken(css, i)) { i = CopyUrl(css, i, sb); continue; }
+            if (c == '/' && i + 1 < css.Length && css[i + 1] == '*') { i = SkipComment(css, i, sb); continue; }
+            sb.Append(c);
+            i++;
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The same pass over a stylesheet's raw bytes — how a CSS resource reaches the site or a package
+    /// DLL. A UTF-8 BOM is preserved, and anything that is not valid UTF-8 (a UTF-16 stylesheet, a
+    /// legacy single-byte encoding) is returned untouched rather than re-encoded: a byte-for-byte copy
+    /// with its comments intact is always better than a mangled one. The original array is returned
+    /// unchanged when there was nothing to strip.
+    /// </summary>
+    public static byte[] StripComments(byte[] bytes)
+    {
+        var hasBom = bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+        var offset = hasBom ? 3 : 0;
+
+        // A comment-free stylesheet is never decoded at all — UTF-8 is ASCII-transparent, so a `/*`
+        // can only be the two bytes themselves, and the common case costs one scan and no allocation.
+        if (!ContainsCommentStart(bytes, offset)) return bytes;
+
+        string text;
+        try { text = Utf8Strict.GetString(bytes, offset, bytes.Length - offset); }
+        catch (DecoderFallbackException) { return bytes; }
+
+        var stripped = StripComments(text);
+        if (ReferenceEquals(stripped, text)) return bytes;
+
+        var encoded = Utf8NoBom.GetBytes(stripped);
+        if (!hasBom) return encoded;
+
+        var result = new byte[Utf8Bom.Length + encoded.Length];
+        Utf8Bom.CopyTo(result, 0);
+        encoded.CopyTo(result, Utf8Bom.Length);
+        return result;
+    }
+
+    /// <summary>Whether the bytes hold a <c>/*</c> anywhere past <paramref name="offset"/>.</summary>
+    private static bool ContainsCommentStart(byte[] bytes, int offset)
+    {
+        for (var i = offset; i + 1 < bytes.Length; i++)
+            if (bytes[i] == (byte)'/' && bytes[i + 1] == (byte)'*') return true;
+        return false;
+    }
+
+    /// <summary>Copies a quoted string through verbatim, honouring backslash escapes. An unterminated
+    /// string ends at the newline, as the CSS tokenizer says it does — so a stray quote cannot swallow
+    /// the rest of the file.</summary>
+    private static int CopyString(string css, int i, StringBuilder sb)
+    {
+        var quote = css[i];
+        sb.Append(quote);
+        i++;
+        while (i < css.Length)
+        {
+            var c = css[i];
+            sb.Append(c);
+            i++;
+            if (c == '\\' && i < css.Length) { sb.Append(css[i]); i++; continue; }
+            if (c == quote || c == '\n') break;
+        }
+        return i;
+    }
+
+    /// <summary>Whether position <paramref name="i"/> starts a <c>url(</c> token — not the tail of a
+    /// longer identifier such as <c>--my-url(</c>.</summary>
+    private static bool IsUrlToken(string css, int i)
+    {
+        if (i + 4 > css.Length) return false;
+        if (!(css[i + 1] is 'r' or 'R') || !(css[i + 2] is 'l' or 'L') || css[i + 3] != '(') return false;
+        if (i > 0 && (char.IsLetterOrDigit(css[i - 1]) || css[i - 1] is '-' or '_' or '\\')) return false;
+        return true;
+    }
+
+    /// <summary>Copies an unquoted <c>url(…)</c> token through verbatim (its contents are not CSS, so a
+    /// <c>/*</c> in a path or data URI is not a comment). A quoted url is left to the string rule.</summary>
+    private static int CopyUrl(string css, int i, StringBuilder sb)
+    {
+        sb.Append(css, i, 4);   // "url("
+        i += 4;
+
+        var j = i;
+        while (j < css.Length && char.IsWhiteSpace(css[j])) j++;
+        if (j < css.Length && (css[j] == '"' || css[j] == '\'')) return i;
+
+        while (i < css.Length)
+        {
+            var c = css[i];
+            sb.Append(c);
+            i++;
+            if (c == ')') break;
+        }
+        return i;
+    }
+
+    /// <summary>Consumes the comment starting at <paramref name="i"/>, appending whatever must take its
+    /// place: nothing at all when it stood on its own line (the line goes with it), a single space when
+    /// it separated two tokens, nothing otherwise.</summary>
+    private static int SkipComment(string css, int i, StringBuilder sb)
+    {
+        var end = css.IndexOf("*/", i + 2, StringComparison.Ordinal);
+        var after = end < 0 ? css.Length : end + 2;   // unterminated: consumed to EOF, as a browser does
+
+        // Nothing but whitespace follows it on its line: the comment ends the line, so take the
+        // whitespace on both sides of it with it — and the line itself when nothing else was on it.
+        var j = after;
+        while (j < css.Length && (css[j] == ' ' || css[j] == '\t')) j++;
+        if (j >= css.Length || css[j] == '\n' || css[j] == '\r')
+        {
+            while (sb.Length > 0 && (sb[sb.Length - 1] == ' ' || sb[sb.Length - 1] == '\t')) sb.Length--;
+            if (sb.Length == 0 || sb[sb.Length - 1] == '\n')      // the line held only the comment
+            {
+                if (j < css.Length && css[j] == '\r') j++;
+                if (j < css.Length && css[j] == '\n') j++;
+            }
+            return j;
+        }
+
+        // Otherwise keep the tokens on either side apart: `a/**/b` must not become `ab`.
+        if (sb.Length > 0 && !char.IsWhiteSpace(sb[sb.Length - 1]) && after < css.Length && !char.IsWhiteSpace(css[after]))
+            sb.Append(' ');
+        return after;
+    }
+}

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -17,6 +17,11 @@ namespace Transpose.Compiler;
 /// (Release keeps the minified one, Debug the formatted one). tps.json resource files are taken as
 /// authored (never re-minified) — a project ships both a <c>foo.js</c> and a <c>foo.min.js</c> group
 /// when it wants both variants, exactly as before.
+///
+/// Stylesheets are the one resource kind that is not copied through verbatim: every CSS file this
+/// build writes — from a resource group, or extracted from a referenced package — has its comments
+/// stripped by <see cref="CssProcessor"/>, as does every stylesheet embedded into a package DLL by
+/// <see cref="CollectEmbeddableItems"/>. Nothing else about it changes; it is not minified.
 /// </summary>
 internal static class OutputBuilder
 {
@@ -196,7 +201,8 @@ internal static class OutputBuilder
         //    first (a library's JS deps load before the app that uses them). A resource group
         //    whose name is a .js/.css file concatenates its files into that one bundle; other
         //    groups (globbed images, etc.) copy each file through. Resource JS is taken as authored:
-        //    a .js group routes to index.html, a .min.js group to index.min.html.
+        //    a .js group routes to index.html, a .min.js group to index.min.html. Resource CSS is
+        //    taken as authored too, minus its comments (CssProcessor).
         foreach (var projectDir in Enumerable.Reverse(project.ProjectDirs))
         {
             var cfg = projectDir == project.ProjectDir ? config : TransposeJson.TryLoad(projectDir, configuration);
@@ -286,6 +292,11 @@ internal static class OutputBuilder
 
             var isBundle = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
                            || name.EndsWith(".css", StringComparison.OrdinalIgnoreCase);
+            // A stylesheet is comment-stripped before it is embedded, exactly as the site build strips
+            // it before writing it to disk (WriteResource) — the two paths must produce the same bytes,
+            // since a consuming project extracts what is embedded here.
+            var css = IsCss(name);
+
             if (isBundle)
             {
                 // Resolve each declared file to text, mapping a self-reference to the in-memory bundle.
@@ -294,7 +305,7 @@ internal static class OutputBuilder
                 {
                     var self = SelfText(Path.GetFileName(raw.Replace('\\', '/')));
                     if (self is not null) texts.Add(self);
-                    else texts.AddRange(ExpandGlob(projectDir, raw).Select(File.ReadAllText));
+                    else texts.AddRange(ExpandGlob(projectDir, raw).Select(f => ReadResourceText(f, css)));
                 }
                 if (texts.Count == 0) continue;
                 items.Add(new EmbeddedItem(name, utf8.GetBytes(string.Join("\n", texts)), destSub, load));
@@ -305,7 +316,11 @@ internal static class OutputBuilder
                 var files = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
                 if (files.Count == 0) continue;
                 foreach (var src in files)
-                    items.Add(new EmbeddedItem(Path.GetFileName(src), File.ReadAllBytes(src), destSub, load));
+                {
+                    var content = File.ReadAllBytes(src);
+                    if (IsCss(src)) content = CssProcessor.StripComments(content);
+                    items.Add(new EmbeddedItem(Path.GetFileName(src), content, destSub, load));
+                }
             }
         }
 
@@ -449,16 +464,40 @@ internal static class OutputBuilder
             else
             {
                 // CSS and copy-through resources (images, fonts): write to disk now.
-                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
-                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                using (var s = asm.Open(resName))
-                using (var fs = File.Create(dest))
-                    s.CopyTo(fs);
-                written.Add(Path.GetFullPath(dest));
-                if (load && rel.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) cssLinks.Add(rel);
+                ExtractResourceFile(asm, resName, outputDir, rel, written);
+                if (load && IsCss(rel)) cssLinks.Add(rel);
             }
         }
         return jsFiles;
+    }
+
+    /// <summary>
+    /// Writes one non-JavaScript embedded resource to the site: the raw bytes, so a binary asset (a
+    /// font, an image) stays intact, except for a stylesheet, which goes through
+    /// <see cref="CssProcessor"/> on the way out. A package built by an older compiler still carries
+    /// its comments, so the strip happens on extraction and not only on the embed side.
+    /// </summary>
+    private static void ExtractResourceFile(
+        AssemblyResources asm, string resourceName, string outputDir, string rel, HashSet<string> written)
+    {
+        var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+
+        using (var s = asm.Open(resourceName))
+        {
+            if (IsCss(rel))
+            {
+                using var buffer = new MemoryStream();
+                s.CopyTo(buffer);
+                File.WriteAllBytes(dest, CssProcessor.StripComments(buffer.ToArray()));
+            }
+            else
+            {
+                using var fs = File.Create(dest);
+                s.CopyTo(fs);
+            }
+        }
+        written.Add(Path.GetFullPath(dest));
     }
 
     /// <summary>
@@ -608,16 +647,29 @@ internal static class OutputBuilder
     }
 
     /// <summary>Writes one resource-group output: a bundle group's files joined with newlines, or a
-    /// single file copied through byte for byte. <paramref name="written"/> is null for a CSS-only
-    /// rebuild, which rewrites files the last full build already recorded in its manifest.</summary>
+    /// single file copied through byte for byte. A stylesheet goes through <see cref="CssProcessor"/>
+    /// first, so no authoring comment reaches the site — bundled or copied through alike, and per
+    /// source file so an unterminated comment in one cannot swallow the next.
+    /// <paramref name="written"/> is null for a CSS-only rebuild, which rewrites files the last full
+    /// build already recorded in its manifest.</summary>
     private static void WriteResource(
         string outputDir, string rel, IReadOnlyList<string> sources, bool concatenate, HashSet<string>? written)
     {
         var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
         Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-        if (concatenate) File.WriteAllText(dest, string.Join("\n", sources.Select(File.ReadAllText)));
+        var css = IsCss(rel);
+        if (concatenate)
+            File.WriteAllText(dest, string.Join("\n", sources.Select(s => ReadResourceText(s, css))));
+        else if (css) File.WriteAllBytes(dest, CssProcessor.StripComments(File.ReadAllBytes(sources[0])));
         else File.Copy(sources[0], dest, overwrite: true);
         written?.Add(Path.GetFullPath(dest));
+    }
+
+    /// <summary>One bundle member's text, comment-stripped when it is a stylesheet.</summary>
+    private static string ReadResourceText(string path, bool css)
+    {
+        var text = File.ReadAllText(path);
+        return css ? CssProcessor.StripComments(text) : text;
     }
 
     /// <summary>
@@ -802,12 +854,7 @@ internal static class OutputBuilder
             {
                 // CSS and copy-through resources (fonts, images): copy the raw bytes to disk so binary
                 // assets stay intact, and link stylesheets. These must never reach the JS minifier.
-                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
-                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                using (var s = asm.Open(resName))
-                using (var fs = File.Create(dest))
-                    s.CopyTo(fs);
-                written.Add(Path.GetFullPath(dest));
+                ExtractResourceFile(asm, resName, outputDir, rel, written);
                 if (load && IsCss(rel)) cssLinks.Add(rel);
             }
         }

--- a/Transpose/Transpose.Translator.Tests/CssCommentStrippingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/CssCommentStrippingTests.cs
@@ -1,0 +1,295 @@
+using System.Text;
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers the CSS comment pass (<see cref="CssProcessor"/>) and its wiring: every stylesheet the
+/// compiler produces is comment-free, whether it is written into the site from a <c>tps.json</c>
+/// resource group (bundled or copied through), embedded into a package DLL, or extracted back out of
+/// a referenced package. Only comments go — the declarations themselves are untouched.
+/// </summary>
+[TestClass]
+public sealed class CssCommentStrippingTests
+{
+    private string _root = "";
+    private string _projectDir = "";
+    private string _outputDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-css-" + Guid.NewGuid().ToString("N"));
+        _projectDir = Path.Combine(_root, "proj");
+        _outputDir = Path.Combine(_root, "site");
+        Directory.CreateDirectory(_projectDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ---------------------------------------------------------------- the pass itself
+
+    [TestMethod]
+    public void ABlockCommentIsRemoved()
+    {
+        Assert.AreEqual("body { color: red }", CssProcessor.StripComments("body { color: red }/* trailing */"));
+        Assert.AreEqual("a { }", CssProcessor.StripComments("/* leading */a { }"));
+    }
+
+    [TestMethod]
+    public void AWholeLineCommentTakesItsLineWithIt()
+    {
+        var stripped = CssProcessor.StripComments("/* banner */\nbody { color: red }\n    /* indented */\na { }\n");
+        Assert.AreEqual("body { color: red }\na { }\n", stripped);
+    }
+
+    [TestMethod]
+    public void AMultiLineCommentIsRemovedWhole()
+    {
+        var stripped = CssProcessor.StripComments("/*\n * a banner\n */\nbody { }\n");
+        Assert.AreEqual("body { }\n", stripped);
+    }
+
+    [TestMethod]
+    public void ACommentBetweenTwoTokensBecomesASpace()
+    {
+        // `a/**/b` must not collapse into the single type selector `ab`.
+        Assert.AreEqual("a b { }", CssProcessor.StripComments("a/**/b { }"));
+        Assert.AreEqual("color: red ;", CssProcessor.StripComments("color: red/* why */;"));
+    }
+
+    [TestMethod]
+    public void ACommentInsideAStringIsNotAComment()
+    {
+        const string css = "a::after { content: \"/* not a comment */\" }";
+        Assert.AreEqual(css, CssProcessor.StripComments(css));
+
+        const string single = "a::after { content: '/* nor this */' }";
+        Assert.AreEqual(single, CssProcessor.StripComments(single));
+    }
+
+    [TestMethod]
+    public void AnEscapedQuoteDoesNotEndTheString()
+    {
+        const string css = "a::after { content: \"he said \\\" /* still a string */\" }";
+        Assert.AreEqual(css, CssProcessor.StripComments(css));
+    }
+
+    [TestMethod]
+    public void ACommentInsideAnUnquotedUrlIsNotAComment()
+    {
+        const string css = "a { background: url(/img/*.png) }";
+        Assert.AreEqual(css, CssProcessor.StripComments(css));
+
+        // …while a real comment right after the url token still goes.
+        Assert.AreEqual(
+            "a { background: url(/img/x.png) }",
+            CssProcessor.StripComments("a { background: url(/img/x.png)/* c */ }"));
+    }
+
+    [TestMethod]
+    public void AnIdentifierEndingInUrlIsNotAUrlToken()
+    {
+        // `--my-url(` must not be mistaken for a url token — the comment after it is a real comment.
+        Assert.AreEqual("a { b: --my-url(x) }", CssProcessor.StripComments("a { b: --my-url(x)/* c */ }"));
+    }
+
+    [TestMethod]
+    public void AnUnterminatedCommentIsConsumedToTheEndOfTheFile()
+    {
+        Assert.AreEqual("a { }\n", CssProcessor.StripComments("a { }\n/* never closed\nb { }\n"));
+    }
+
+    [TestMethod]
+    public void AStylesheetWithoutCommentsIsReturnedUnchanged()
+    {
+        const string css = "body { color: red }\n";
+        Assert.AreSame(css, CssProcessor.StripComments(css), "no comments must mean no work and no rewrite");
+
+        var bytes = Encoding.UTF8.GetBytes(css);
+        Assert.AreSame(bytes, CssProcessor.StripComments(bytes));
+    }
+
+    [TestMethod]
+    public void ACommentEndingALineTakesTheTrailingSpaceWithIt()
+    {
+        Assert.AreEqual(".two { color: blue }", CssProcessor.StripComments(".two { color: blue } /* two */"));
+        Assert.AreEqual("a { }\nb { }\n", CssProcessor.StripComments("a { }   /* c */\nb { }\n"));
+    }
+
+    [TestMethod]
+    public void AUtf8BomAndNonAsciiContentSurvive()
+    {
+        var encoder = new UTF8Encoding(true);
+        var bytes = encoder.GetPreamble().Concat(encoder.GetBytes("/* héllo */\na::after { content: \"—\" }\n")).ToArray();
+        var stripped = CssProcessor.StripComments(bytes);
+
+        Assert.IsTrue(stripped.Length >= 3 && stripped[0] == 0xEF && stripped[1] == 0xBB && stripped[2] == 0xBF,
+            "the BOM must be preserved");
+        Assert.AreEqual("a::after { content: \"—\" }\n", new UTF8Encoding(true).GetString(stripped, 3, stripped.Length - 3));
+    }
+
+    [TestMethod]
+    public void BytesThatAreNotValidUtf8AreLeftAlone()
+    {
+        // A legacy single-byte-encoded stylesheet: a byte-for-byte copy beats a mangled re-encode.
+        var bytes = new byte[] { (byte)'/', (byte)'*', (byte)'x', 0xFF, (byte)'*', (byte)'/', (byte)'a', (byte)'{', (byte)'}' };
+        CollectionAssert.AreEqual(bytes, CssProcessor.StripComments(bytes));
+    }
+
+    // ---------------------------------------------------------------- the site build
+
+    [TestMethod]
+    public void ABundledStylesheetIsWrittenToTheSiteWithoutComments()
+    {
+        Asset("css/one.css", "/* one */\n.one { color: red }\n");
+        Asset("css/two.css", ".two { color: blue } /* two */");
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""site.css"", ""files"": [ ""css/one.css"", ""css/two.css"" ] }
+            ]
+        }"));
+
+        var written = OutputText("site.css");
+        Assert.AreEqual(".one { color: red }\n\n.two { color: blue }", written);
+    }
+
+    [TestMethod]
+    public void ACopiedThroughStylesheetIsWrittenToTheSiteWithoutComments()
+    {
+        Asset("vendor/theme.css", "/* vendor banner */\n.theme { color: red }\n");
+        Asset("vendor/logo.svg", "<svg><!-- kept --></svg>");
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""vendor"", ""files"": [ ""vendor/*"" ], ""output"": ""vendor"" }
+            ]
+        }"));
+
+        Assert.AreEqual(".theme { color: red }\n", OutputText("vendor/theme.css"));
+        Assert.AreEqual("<svg><!-- kept --></svg>", OutputText("vendor/logo.svg"),
+            "a non-CSS resource must be copied through byte for byte");
+    }
+
+    // ---------------------------------------------------------------- packages
+
+    [TestMethod]
+    public void AnEmbeddedStylesheetIsStrippedBeforeItReachesThePackage()
+    {
+        Asset("css/site.css", "/* banner */\n.site { color: red }\n");
+        Asset("css/extra.css", "/* extra */\n.extra { }\n");
+
+        var config = Config(@"{
+            ""fileName"": ""Lib.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""site.css"", ""files"": [ ""css/site.css"" ] },
+                { ""name"": ""assets"",   ""files"": [ ""css/extra.css"" ], ""output"": ""assets"" }
+            ]
+        }");
+
+        var items = OutputBuilder.CollectEmbeddableItems(_projectDir, config, "Lib.js", "var lib = 1;", null);
+
+        Assert.AreEqual(".site { color: red }\n", Text(items.Single(i => i.Name == "site.css")),
+            "a bundled stylesheet must be embedded comment-free");
+        Assert.AreEqual(".extra { }\n", Text(items.Single(i => i.Name == "extra.css")),
+            "a copy-through stylesheet must be embedded comment-free");
+
+        static string Text(EmbeddedItem item) => new UTF8Encoding(false).GetString(item.Content);
+    }
+
+    [TestMethod]
+    public void AStylesheetExtractedFromAPackageBuiltByAnOlderCompilerIsStrippedOnTheWayOut()
+    {
+        // The embed side strips, but a package published before this pass existed still carries its
+        // comments — so extraction strips too. The package here is built by hand for exactly that reason.
+        var utf8 = new UTF8Encoding(false);
+        var dll = PackageDll("Lib", new List<EmbeddedItem>
+        {
+            new("Lib.js", utf8.GetBytes("var lib = 1;"), null),
+            new("legacy.css", utf8.GetBytes("/* shipped with comments */\n.legacy { color: red }\n"), null),
+            new("nested.css", utf8.GetBytes("/* also */\n.nested { }\n"), "assets"),
+        });
+
+        var html = BuildSite(Config(@"{ ""fileName"": ""app.js"", ""outputFormatting"": ""Formatted"" }"), Project(dll));
+
+        Assert.AreEqual(".legacy { color: red }\n", OutputText("legacy.css"));
+        Assert.AreEqual(".nested { }\n", OutputText("assets/nested.css"));
+        StringAssert.Contains(html, "href=\"legacy.css\"", "the stylesheet must still be linked");
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private string Asset(string rel, string content)
+    {
+        var full = Path.Combine(_projectDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    private TransposeJson Config(string tpsJson)
+    {
+        File.WriteAllText(Path.Combine(_projectDir, "tps.json"), tpsJson);
+        var config = TransposeJson.TryLoad(_projectDir, "Debug");
+        Assert.IsNotNull(config, "tps.json must load");
+        return config!;
+    }
+
+    private ResolvedProject Project(params string[] referencePaths) => new()
+    {
+        CsprojPath = Path.Combine(_projectDir, "App.csproj"),
+        ProjectDir = _projectDir,
+        AssemblyName = "App",
+        TargetFramework = "netstandard2.0",
+        Sources = new List<(string, string)>(),
+        ReferencePaths = referencePaths.ToList(),
+        DefineConstants = new List<string>(),
+        LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+        ProjectDirs = new List<string> { _projectDir },
+    };
+
+    private string BuildSite(TransposeJson config, ResolvedProject? project = null)
+    {
+        OutputBuilder.Build(project ?? Project(), config, "var app = 1;", _outputDir, "Debug");
+        var html = Path.Combine(_outputDir, "index.html");
+        return File.Exists(html) ? File.ReadAllText(html) : "";
+    }
+
+    private string OutputText(string rel)
+    {
+        var full = Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Assert.IsTrue(File.Exists(full), $"'{rel}' must be written to the site");
+        return File.ReadAllText(full);
+    }
+
+    /// <summary>Embeds <paramref name="items"/> into an otherwise empty assembly through the real
+    /// <see cref="ResourceEmbedder"/>, standing in for a published package.</summary>
+    private string PackageDll(string assemblyName, IReadOnlyList<EmbeddedItem> items)
+    {
+        byte[] bytes;
+        using (var asm = AssemblyDefinition.CreateAssembly(
+                   new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)), assemblyName, ModuleKind.Dll))
+        using (var ms = new MemoryStream())
+        {
+            asm.Write(ms);
+            bytes = ms.ToArray();
+        }
+
+        var path = Path.Combine(_root, "packages", assemblyName + ".dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        ResourceEmbedder.Embed(path, bytes, items);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a CSS comment-stripping pass (`CssProcessor`) that removes `/* … */` comments from every stylesheet the compiler produces, whether bundled into the site from a `tps.json` resource group, embedded into a package DLL, or extracted from a referenced package. The pass preserves all other CSS content unchanged — no minification, no whitespace normalization — and handles edge cases like comments inside strings, unquoted `url()` tokens, and UTF-8 BOMs.

## Changes

- **New `CssProcessor` class** (`Transpose.Compiler.Core/CssProcessor.cs`):
  - `StripComments(string)` — removes comments from CSS text, returning the original string by reference when there's nothing to strip
  - `StripComments(byte[])` — processes raw stylesheet bytes, preserving UTF-8 BOMs and leaving non-UTF-8 content untouched (legacy single-byte encodings, UTF-16, etc.)
  - Handles three key rules:
    - Comments inside quoted strings (`content: "/* not a comment */"`) and unquoted `url(…)` tokens are preserved
    - Comments between non-whitespace tokens become a single space (so `a/**/b` doesn't collapse to `ab`)
    - Comments ending their line take trailing whitespace with them; whole-line comments remove the line itself
  - Unterminated comments are consumed to EOF, matching browser behavior

- **Updated `OutputBuilder`** (`Transpose.Compiler.Core/OutputBuilder.cs`):
  - `CollectEmbeddableItems()` now strips comments from stylesheets before embedding them into package DLLs
  - `WriteResource()` strips comments from bundled and copy-through CSS files written to the site
  - `ExtractResourceFile()` (new helper) strips comments when extracting stylesheets from referenced packages, handling legacy packages built before this pass existed
  - Added `ReadResourceText()` and `IsCss()` helpers to centralize CSS detection and processing

- **Comprehensive test suite** (`Transpose.Translator.Tests/CssCommentStrippingTests.cs`):
  - Unit tests for the `CssProcessor` pass itself (block comments, multiline comments, strings, `url()` tokens, UTF-8 BOMs, invalid UTF-8, etc.)
  - Integration tests verifying comments are stripped from bundled stylesheets, copy-through stylesheets, embedded resources, and extracted package resources
  - Tests confirm non-CSS resources (SVG, etc.) are copied byte-for-byte unchanged

## Implementation Details

- The pass is applied at three points in the build pipeline: when writing resource groups to the site, when embedding resources into package DLLs, and when extracting resources from referenced packages
- UTF-8 handling is defensive: stylesheets that aren't valid UTF-8 are returned untouched rather than mangled by re-encoding
- The string rule honors backslash escapes and treats unterminated strings as ending at a newline (per CSS tokenizer spec)
- The `url()` rule distinguishes the `url(` token from identifiers ending in `url(` (e.g., `--my-url(`) by checking the preceding character
- Reference equality is used to detect "no work done" cases, avoiding unnecessary allocations for comment-free stylesheets

https://claude.ai/code/session_016totbge2dDEK6ixRtFbdLV