### PR TITLE
Fix user-defined conversions in initializers and extern properties

### DIFF
--- a/Packages/Transpose.Newtonsoft.Json.Tests/CuriosityUsageTests.cs
+++ b/Packages/Transpose.Newtonsoft.Json.Tests/CuriosityUsageTests.cs
@@ -11,6 +11,8 @@ namespace Transpose.Newtonsoft.Json.Tests;
 ///   <item><c>LocalStorage.Get&lt;T&gt;</c> — deserialization behind a generic type parameter;</item>
 ///   <item>a UID128-style value type that is a plain string at runtime and converts through an
 ///     explicit cast operator;</item>
+///   <item>a LanguageDTO-style struct that IS its code string at runtime, reached only through
+///     <c>[Template]</c> members and an implicit conversion from an enum;</item>
 ///   <item>a server payload whose members are short <c>[JsonProperty]</c> names on internal members;</item>
 ///   <item>polymorphic renderer definitions (in <see cref="TypeNameHandlingTests"/>).</item>
 /// </list>
@@ -594,5 +596,112 @@ public class App
     }
 }";
         await RunAndCompare(code);
+    }
+
+    /// <summary>
+    /// The <c>LanguageDTO</c> pattern: the server exchanges a language as its code string ("de"), and
+    /// this library has no custom-converter support, so the front-end models it as a struct whose
+    /// runtime value IS that string — produced by an <c>implicit operator LanguageDTO(Language)</c> and
+    /// read back through <c>[Template]</c> members. What made this worth pinning is that the conversion
+    /// was NOT applied inside an object initializer, so `new Request { Language = someEnum }` stored the
+    /// enum's number and the request went out as <c>{"Language":42}</c>.
+    ///
+    /// JS-only: <c>[Template]</c> and <c>Script.Write</c> have no native equivalent to diff against.
+    /// </summary>
+    [TestMethod]
+    public async Task StringBackedLanguageDtoRoundTrips()
+    {
+        var code = @"
+using System;
+using Transpose;
+using Newtonsoft.Json;
+
+public enum Language { Abkhazian, English, German, Any }
+
+public static class Languages
+{
+    public static string EnumToCode(Language input)
+    {
+        switch (input)
+        {
+            case Language.English: return ""en"";
+            case Language.German:  return ""de"";
+            default:               return ""--"";
+        }
+    }
+
+    public static Language CodeToEnum(string input)
+    {
+        switch (input)
+        {
+            case ""en"": return Language.English;
+            case ""de"": return Language.German;
+            default:   return Language.Any;
+        }
+    }
+}
+
+public struct LanguageDTO : IEquatable<LanguageDTO>
+{
+    [Template(""LanguageDTO.Normalize({value})"")]
+    public extern LanguageDTO(string value);
+
+    public static implicit operator LanguageDTO(Language value) => new LanguageDTO(Languages.EnumToCode(value));
+    public static implicit operator Language(LanguageDTO value) => Languages.CodeToEnum(CodeOf(value));
+
+    // Load-bearing for deserialization: the binding finds this cast to land a bare JSON string here.
+    public static explicit operator LanguageDTO(string languageCode) => new LanguageDTO(languageCode);
+
+    public static bool operator ==(LanguageDTO x, LanguageDTO y) => CodeOf(x) == CodeOf(y);
+    public static bool operator !=(LanguageDTO x, LanguageDTO y) => CodeOf(x) != CodeOf(y);
+
+    public bool Equals(LanguageDTO other) => this == other;
+
+    [Template(""{this} === {o}"")]
+    public extern override bool Equals(object o);
+
+    [Template(""Transpose.getHashCode(LanguageDTO.CodeOf({this}))"")]
+    public extern override int GetHashCode();
+
+    private static string CodeOf(LanguageDTO value)
+        => Script.Write<string>(""(typeof {0} === \""string\"" ? {0} : null)"", value) ?? Languages.EnumToCode(Language.Any);
+
+    private static string Normalize(string code) => Languages.EnumToCode(Languages.CodeToEnum(code));
+}
+
+public sealed class Request
+{
+    public string      NodeType { get; set; }
+    public LanguageDTO Language { get; set; }
+}
+
+public class App
+{
+    public static void Main()
+    {
+        var request = new Request { NodeType = ""Person"", Language = Language.German };
+        Console.WriteLine(JsonConvert.SerializeObject(request));
+
+        var back = JsonConvert.DeserializeObject<Request>(""{\""NodeType\"":\""Person\"",\""Language\"":\""en\""}"");
+        Console.WriteLine(Script.Write<string>(""typeof {0}"", back.Language));
+        Console.WriteLine((Language)back.Language);
+        Console.WriteLine(JsonConvert.SerializeObject(back));
+
+        // A copy of the value must stay the bare string, not a String wrapper object.
+        var copy = back.Language;
+        Console.WriteLine(Script.Write<string>(""JSON.stringify({0})"", copy));
+
+        // A never-assigned value has no code string behind it; it reads as Any rather than throwing.
+        Console.WriteLine((Language)new Request().Language);
+    }
+}";
+        await RunJs(code, """
+{"Language":"de","NodeType":"Person"}
+string
+English
+{"Language":"en","NodeType":"Person"}
+"en"
+Any
+""");
     }
 }

--- a/Transpose/Transpose.Translator.Tests/UserDefinedConversionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/UserDefinedConversionTests.cs
@@ -1,0 +1,196 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// A user-defined implicit conversion operator changes the runtime representation of a value, so
+    /// every site where C# inserts one silently has to actually call it. Every site did — except an
+    /// object/collection initializer, which wrote the source value straight into the slot.
+    ///
+    /// The Curiosity front-end's <c>LanguageDTO</c> is where that surfaced: it is a struct whose runtime
+    /// value IS its language-code string ("en", "--"), produced by <c>implicit operator
+    /// LanguageDTO(Language)</c>, so `new SpotterFromGraphInfo { Language = someLanguageEnum }` stored
+    /// the enum's NUMBER and the request serialized as `{"Language":2}` instead of `{"Language":"de"}`.
+    ///
+    /// Two more bugs sat behind that same type, both covered here:
+    ///  - an <c>extern</c> property (its accessor is a <c>[Template]</c>) was treated as an auto-property,
+    ///    so a phantom backing field was emitted — and then leaked into the struct's default value,
+    ///    <c>$clone</c>, <c>equals</c> and <c>getHashCode</c>. C# gives an extern property no backing field;
+    ///  - <c>TransposeR.clone</c> ran a value copy of such a struct through <c>Object.assign</c>, turning
+    ///    the string "de" into a String wrapper object (<c>{"0":"d","1":"e"}</c>).
+    /// </summary>
+    [TestClass]
+    public class UserDefinedConversionTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task ImplicitConversionRunsAtEveryConversionSite()
+        {
+            await RunTest("""
+using System;
+using System.Collections.Generic;
+
+public struct Dto
+{
+    public string V;
+    public Dto(string v) { V = v; }
+    public static implicit operator Dto(int value) => new Dto("i" + value);
+    public override string ToString() => V ?? "<null>";
+}
+
+public class Inner { public Dto D { get; set; } }
+public class Holder
+{
+    public Dto D { get; set; }
+    public Dto F;
+    public List<Dto> Items { get; } = new List<Dto>();
+    public Dictionary<string, Dto> Map { get; } = new Dictionary<string, Dto>();
+    public Inner Nest { get; set; } = new Inner();
+}
+
+public class Program
+{
+    static void Take(Dto d) { Console.WriteLine("argument:      " + d); }
+    static Dto Make(int i) => i;
+
+    public static void Main()
+    {
+        int n = 7;
+
+        Dto a = n;
+        Console.WriteLine("local:         " + a);
+        Dto b; b = n;
+        Console.WriteLine("assignment:    " + b);
+        Take(n);
+        Console.WriteLine("return:        " + Make(n));
+        Console.WriteLine("array:         " + new Dto[] { n }[0]);
+
+        var h = new Holder
+        {
+            D = n,
+            F = n,
+            Items = { n },
+            Map = { ["a"] = n },
+            Nest = { D = n },
+        };
+        Console.WriteLine("member prop:   " + h.D);
+        Console.WriteLine("member field:  " + h.F);
+        Console.WriteLine("nested member: " + h.Nest.D);
+        Console.WriteLine("member coll:   " + h.Items[0]);
+        Console.WriteLine("member index:  " + h.Map["a"]);
+
+        Console.WriteLine("collection:    " + new List<Dto> { n }[0]);
+        Console.WriteLine("dictionary:    " + new Dictionary<string, Dto> { { "k", n } }["k"]);
+        Console.WriteLine("dict index:    " + new Dictionary<string, Dto> { ["k"] = n }["k"]);
+    }
+}
+""");
+        }
+
+        [TestMethod]
+        public void ExternPropertyGetsNoBackingField()
+        {
+            var code = """
+using Transpose;
+public struct S
+{
+    private extern int Value { [Template("S.Get({this})")] get; }
+    private static int Get(S s) => 5;
+    public int Read() => Value;
+}
+public class Program { public static void Main() { System.Console.WriteLine(new S().Read()); } }
+""";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, "translation should succeed\n"
+                + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+
+            var js = result.Javascript!;
+            Assert.IsFalse(js.Contains("$.Value = 0"), "the struct default must not carry a phantom field\n" + js);
+            Assert.IsFalse(js.Contains("s.Value = this.Value"), "$clone must not copy a phantom field\n" + js);
+            Assert.IsFalse(js.Contains("props:"), "an extern property has no accessor body to emit\n" + js);
+            Assert.IsTrue(js.Contains("return S.Get(this)"), "the [Template] getter should still be applied\n" + js);
+        }
+
+        /// <summary>
+        /// The <c>LanguageDTO</c> shape end to end: a struct with no storage of its own whose runtime
+        /// value is a plain JS string, reached only through <c>[Template]</c> members.
+        /// </summary>
+        [TestMethod]
+        public async Task TemplateBackedStructStaysItsPrimitiveValue()
+        {
+            var output = await RunTest("""
+using System;
+using Transpose;
+
+public enum Language { Any, English, German }
+
+public static class Languages
+{
+    public static string EnumToCode(Language input)
+    {
+        switch (input)
+        {
+            case Language.English: return "en";
+            case Language.German:  return "de";
+            default:               return "--";
+        }
+    }
+
+    public static Language CodeToEnum(string input)
+    {
+        switch (input)
+        {
+            case "en": return Language.English;
+            case "de": return Language.German;
+            default:   return Language.Any;
+        }
+    }
+}
+
+public struct LanguageDTO
+{
+    [Template("LanguageDTO.Normalize({value})")]
+    public extern LanguageDTO(string value);
+
+    private extern Language Value { [Template("LanguageDTO.ValueOf({this})")] get; }
+
+    public static implicit operator LanguageDTO(Language value) => new LanguageDTO(Languages.EnumToCode(value));
+    public static implicit operator Language(LanguageDTO value) => value.Value;
+
+    private static string Normalize(string code) => Languages.EnumToCode(Languages.CodeToEnum(code));
+    private static Language ValueOf(LanguageDTO value) => Languages.CodeToEnum(Script.Write<string>("{0}", value));
+}
+
+public sealed class Request
+{
+    public string      NodeType { get; set; }
+    public LanguageDTO Language { get; set; }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var request = new Request { NodeType = "X", Language = Language.German };
+        Console.WriteLine("payload:  " + Script.Write<string>("JSON.stringify({0})", request));
+
+        var copy = request.Language;
+        Console.WriteLine("copy:     " + Script.Write<string>("JSON.stringify({0})", copy));
+        Console.WriteLine("typeof:   " + Script.Write<string>("typeof {0}", copy));
+
+        Language asEnum = copy;
+        Console.WriteLine("as enum:  " + asEnum);
+    }
+}
+""", skipRoslyn: true);
+
+            Assert.AreEqual("""
+payload:  {"Language":"de","NodeType":"X"}
+copy:     "de"
+typeof:   string
+as enum:  German
+""".Replace("\r\n", "\n").Trim(), output);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -775,7 +775,7 @@ public sealed partial class Emitter
     /// <summary>True when a property is emitted as a real accessor pair (a <c>props:</c> entry) rather
     /// than as a plain slot named after it — the same rule <c>EmitInstanceProperties</c> applies.</summary>
     private static bool HasEmittedAccessors(IPropertySymbol prop)
-        => !prop.IsIndexer && (!IsAutoProperty(prop) || IsFieldBackedProperty(prop));
+        => !prop.IsIndexer && !IsExternProperty(prop) && (!IsAutoProperty(prop) || IsFieldBackedProperty(prop));
 
     /// <summary>
     /// Maps a member's generic type-parameter names to the type arguments bound at the call

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1291,7 +1291,7 @@ public sealed partial class Emitter
                     var memberSym = _model.GetSymbolInfo(name).Symbol;
                     var memberName = memberSym is not null ? TransposeNaming.MemberJsName(memberSym) : NameMangler.JsIdentifier(name.Identifier.Text);
                     _w.Write($"{target}.{memberName} = ");
-                    EmitExpression(assign.Right);
+                    EmitExpressionConverted(assign.Right, MemberValueType(memberSym));
                     _w.Write("; ");
                     break;
                 // Index initializer: [key] = value
@@ -1299,36 +1299,56 @@ public sealed partial class Emitter
                     _w.Write($"{target}.setItem(");
                     EmitArgumentList(idx.ArgumentList);
                     _w.Write(", ");
-                    EmitExpression(assign.Right);
+                    EmitExpressionConverted(assign.Right, (_model.GetSymbolInfo(idx).Symbol as IPropertySymbol)?.Type);
                     _w.Write("); ");
                     break;
                 // Collection element with multiple values: { k, v }  (e.g. dictionary)
                 case InitializerExpressionSyntax nested:
-                    _w.Write($"{target}.{AddMethodName(nested)}(");
+                    var nestedAdd = AddMethod(nested);
+                    _w.Write($"{target}.{AddMethodName(nestedAdd)}(");
                     for (var i = 0; i < nested.Expressions.Count; i++)
                     {
                         if (i > 0) _w.Write(", ");
-                        EmitExpression(nested.Expressions[i]);
+                        EmitExpressionConverted(nested.Expressions[i], AddParameterType(nestedAdd, i));
                     }
                     _w.Write("); ");
                     break;
                 // Collection element: single value
                 default:
-                    _w.Write($"{target}.{AddMethodName(expr)}(");
-                    EmitExpression(expr);
+                    var add = AddMethod(expr);
+                    _w.Write($"{target}.{AddMethodName(add)}(");
+                    EmitExpressionConverted(expr, AddParameterType(add, 0));
                     _w.Write("); ");
                     break;
             }
         }
     }
 
+    /// <summary>Resolves the Add method a collection initializer element binds to, or null.</summary>
+    private IMethodSymbol? AddMethod(ExpressionSyntax element)
+        => _model.GetCollectionInitializerSymbolInfo(element).Symbol as IMethodSymbol;
+
     /// <summary>Resolves the JS name of the Add method a collection initializer element binds to.</summary>
-    private string AddMethodName(ExpressionSyntax element)
+    private static string AddMethodName(IMethodSymbol? add)
+        => add is not null ? TransposeNaming.MemberJsName(add) : "add";
+
+    /// <summary>The declared type of the Add parameter an initializer element is passed to, or null.</summary>
+    private static ITypeSymbol? AddParameterType(IMethodSymbol? add, int index)
     {
-        if (_model.GetCollectionInitializerSymbolInfo(element).Symbol is IMethodSymbol add)
-            return TransposeNaming.MemberJsName(add);
-        return "add";
+        if (add is null) return null;
+        // An extension `Add` bound in its UNreduced form carries the receiver as parameter 0.
+        if (add is { IsExtensionMethod: true, ReducedFrom: null }) index++;
+        return index < add.Parameters.Length ? add.Parameters[index].Type : null;
     }
+
+    /// <summary>The value type of an object-initializer member (`X = value`), or null.</summary>
+    private static ITypeSymbol? MemberValueType(ISymbol? member) => member switch
+    {
+        IPropertySymbol p => p.Type,
+        IFieldSymbol f    => f.Type,
+        IEventSymbol e    => e.Type,
+        _                 => null,
+    };
 
     // ---- tuples ------------------------------------------------------------
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -37,7 +37,7 @@ public sealed partial class Emitter
             .Where(m => m.IsStatic && !m.IsImplicitlyDeclared && IsEmittableMethod(m) && !IsEntryPoint(m))
             .ToList();
         var staticProps = type.GetMembers().OfType<IPropertySymbol>()
-            .Where(p => p.IsStatic && !p.IsAbstract && !IsAutoProperty(p) && !p.IsIndexer)
+            .Where(p => p.IsStatic && !p.IsAbstract && !IsAutoProperty(p) && !IsExternProperty(p) && !p.IsIndexer)
             .ToList();
 
         var sections = new List<Action>();
@@ -813,6 +813,7 @@ public sealed partial class Emitter
             // every level sharing one slot.
             .Where(p => !p.IsStatic && !p.IsAbstract && !p.IsIndexer
                         && (!IsAutoProperty(p) || IsFieldBackedProperty(p))
+                        && !IsExternProperty(p)
                         && !p.IsImplicitlyDeclared
                         && p.DeclaringSyntaxReferences.Length > 0
                         && p.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is PropertyDeclarationSyntax)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -598,8 +598,21 @@ public sealed partial class Emitter
 
     // ---- shared helpers ----------------------------------------------------
 
+    /// <summary>
+    /// An <c>extern</c> property — its accessors are bodyless, but the implementation lives outside
+    /// the compilation (a <c>[Template]</c>/<c>[Script]</c> applied at the call site), so C# gives it
+    /// no backing field and there is no accessor body to emit.
+    /// </summary>
+    internal static bool IsExternProperty(IPropertySymbol prop)
+        => prop.IsExtern || prop.GetMethod is { IsExtern: true } || prop.SetMethod is { IsExtern: true };
+
     internal static bool IsAutoProperty(IPropertySymbol prop)
     {
+        // Not an auto-property: treating one as such invented a phantom backing field that then leaked
+        // into the struct's default value, $clone, equals and getHashCode (e.g. LanguageDTO, whose
+        // runtime value IS its JS string).
+        if (IsExternProperty(prop)) return false;
+
         foreach (var reference in prop.DeclaringSyntaxReferences)
         {
             if (reference.GetSyntax() is PropertyDeclarationSyntax decl)

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -97,6 +97,12 @@
     };
     TransposeR.clone = function (o) {
         if (!o) { return o; }
+        // A struct whose members are all [Template]/[Script] IS its JS value at runtime — a bare
+        // string, number or boolean (e.g. a language code, a UID). Copying it by value is the identity;
+        // the Object.assign path below would wrap it in a String/Number object, whose typeof is
+        // "object" and which JSON.stringify writes out as {"0":"d","1":"e"}. Functions (a delegate
+        // value) are likewise copied by reference.
+        if (typeof o !== 'object') { return o; }
         if (o.$clone) { return o.$clone(); }
         // A DateTime is backed by a native Date; Object.assign onto Object.create(Date.prototype)
         // would drop the internal [[DateValue]] (d.getTime() then throws). Copy it as a real Date,


### PR DESCRIPTION
## Summary

Fixes three related bugs in struct handling that surfaced with `LanguageDTO` (a struct whose runtime value IS a plain JS string, produced by an implicit conversion operator):

1. **User-defined implicit conversions were not applied in object/collection initializers** — `new Holder { D = someEnum }` stored the enum's number instead of calling the conversion operator
2. **Extern properties were incorrectly treated as auto-properties** — phantom backing fields were emitted and leaked into struct defaults, `$clone`, `equals`, and `getHashCode`
3. **Value copies of primitive-backed structs were wrapped in objects** — `Object.assign` on a bare string turned it into `{"0":"d","1":"e"}`

## Key Changes

- **Emitter.Expressions2.cs**: Modified initializer emission to apply type conversions at assignment sites
  - Object member assignments (`D = value`) now call `EmitExpressionConverted` with the member's declared type
  - Collection initializer elements now resolve their target `Add` method and apply conversions to match parameter types
  - Added helpers: `AddMethod()`, `AddParameterType()`, `MemberValueType()`

- **Emitter.Types.cs**: Added `IsExternProperty()` check to prevent extern properties from being treated as auto-properties
  - Extern properties (those with `[Template]`/`[Script]` implementations) have no backing field in C#
  - Prevents phantom field emission in struct defaults and helper methods

- **tps.shim.js**: Enhanced `TransposeR.clone()` to preserve primitive values
  - Added early return for non-object types (strings, numbers, booleans, functions)
  - Prevents wrapping primitive-backed structs in String/Number wrapper objects

- **Tests**: Added comprehensive test coverage
  - `UserDefinedConversionTests.cs`: Tests implicit conversions at all sites (locals, assignments, arguments, returns, arrays, initializers, collections)
  - `ExternPropertyGetsNoBackingField()`: Validates no phantom fields in extern properties
  - `TemplateBackedStructStaysItsPrimitiveValue()`: End-to-end test of `LanguageDTO` pattern with serialization
  - `CuriosityUsageTests.StringBackedLanguageDtoRoundTrips()`: Integration test with Newtonsoft.Json deserialization

## Implementation Details

- Conversion application now respects the declared parameter/member types from Roslyn's symbol information
- Extension `Add` methods are handled correctly (receiver is parameter 0 in unreduced form)
- The fix preserves the identity semantics of primitive-backed structs: a bare string stays a string through copy operations

https://claude.ai/code/session_01NxnRCfTbJ96Wm8TDoSkNK3