### PR TITLE
Republish interface aliases on a type that overrides an inherited implementation

### DIFF
--- a/Transpose/Transpose.Translator.Tests/InterfaceDispatchOverrideTests.cs
+++ b/Transpose/Transpose.Translator.Tests/InterfaceDispatchOverrideTests.cs
@@ -1,0 +1,230 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Interface dispatch reaches a *derived* type's override of an implementation declared by a base
+/// type. A source interface is dispatched through a mangled slot (<c>IFoo$Bar</c>) that the
+/// implementing class publishes as an <c>alias</c> of the plain slot, and a JS alias is a hard
+/// binding to the function it was installed from — so a derived override of the plain slot does not
+/// displace it, and the alias must be republished by every type that overrides.
+/// </summary>
+[TestClass]
+public class InterfaceDispatchOverrideTests : TranslatorTestBase
+{
+    [TestMethod]
+    public async Task Method_OverriddenInDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public class Node { }
+
+public interface INodeRenderer
+{
+    string CompactView(Node node);
+}
+
+public abstract class NodeRendererBase : INodeRenderer
+{
+    public virtual string CompactView(Node node) => ""BASE"";
+}
+
+public abstract class TechDataRendererBase : NodeRendererBase
+{
+    public override string CompactView(Node node) => ""DERIVED"";
+}
+
+public class ModificationRenderer : TechDataRendererBase { }
+
+public class Program
+{
+    public static void Main()
+    {
+        INodeRenderer viaInterface = new ModificationRenderer();
+        Console.WriteLine(viaInterface.CompactView(new Node()));
+
+        NodeRendererBase viaBase = new ModificationRenderer();
+        Console.WriteLine(viaBase.CompactView(new Node()));
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task PropertyMethodAndEvent_OverriddenTwoLevelsDown_AreReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public interface IShape
+{
+    string Name { get; }
+    string Describe();
+    event EventHandler Changed;
+}
+
+public abstract class ShapeBase : IShape
+{
+    public virtual string Name => ""base-name"";
+    public virtual string Describe() => ""base-describe"";
+    public virtual event EventHandler Changed;
+    public void Fire() => Changed?.Invoke(this, EventArgs.Empty);
+}
+
+public abstract class MidShape : ShapeBase
+{
+    public override string Name => ""mid-name"";
+    public override string Describe() => ""mid-describe"";
+}
+
+public class LeafShape : MidShape { }
+
+// Overrides nothing: the base's alias must still be reached through the prototype chain.
+public class PlainLeaf : ShapeBase { }
+
+public class Program
+{
+    public static void Main()
+    {
+        IShape overridden = new LeafShape();
+        Console.WriteLine(overridden.Name);
+        Console.WriteLine(overridden.Describe());
+
+        IShape inherited = new PlainLeaf();
+        Console.WriteLine(inherited.Name);
+        Console.WriteLine(inherited.Describe());
+
+        var fired = 0;
+        EventHandler handler = (s, e) => fired++;
+        overridden.Changed += handler;
+        ((LeafShape)overridden).Fire();
+        overridden.Changed -= handler;
+        ((LeafShape)overridden).Fire();
+        Console.WriteLine(fired);
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task AbstractImplementation_FilledByDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public interface IThing { string Value(); }
+
+public abstract class ThingBase : IThing
+{
+    public abstract string Value();
+}
+
+public class Thing : ThingBase
+{
+    public override string Value() => ""thing"";
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        IThing thing = new Thing();
+        Console.WriteLine(thing.Value());
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task GenericInterface_OverriddenInDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public interface IBox<T> { T Get(); }
+
+public class BoxBase : IBox<int>
+{
+    public virtual int Get() => 1;
+}
+
+public class BoxDerived : BoxBase
+{
+    public override int Get() => 2;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        IBox<int> box = new BoxDerived();
+        Console.WriteLine(box.Get());
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task ShadowingMember_DoesNotTakeOverTheInterfaceSlot()
+    {
+        var code = @"
+using System;
+
+public interface IShape { string Describe(); }
+
+public class ShapeBase : IShape
+{
+    public virtual string Describe() => ""base"";
+}
+
+// `new`, not `override`: interface dispatch must still reach ShapeBase.Describe.
+public class Shadowing : ShapeBase
+{
+    public new string Describe() => ""shadow"";
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var shadowing = new Shadowing();
+        Console.WriteLine(shadowing.Describe());
+        Console.WriteLine(((IShape)shadowing).Describe());
+        Console.WriteLine(((ShapeBase)shadowing).Describe());
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task BclInterfaceProperty_OverriddenInDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+using System.Collections.Generic;
+
+public class CollectionBase : IReadOnlyCollection<int>
+{
+    public virtual int Count => 10;
+    public IEnumerator<int> GetEnumerator() { yield return 1; }
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+public class CollectionDerived : CollectionBase
+{
+    public override int Count => 20;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        IReadOnlyCollection<int> collection = new CollectionDerived();
+        Console.WriteLine(collection.Count);
+    }
+}";
+        await RunTest(code);
+    }
+}

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -671,7 +671,20 @@ internal static class TransposeNaming
                 if (GetTemplate(member) is not null) continue;   // templated members apply at the call site
 
                 if (type.FindImplementationForInterfaceMember(member) is not { } impl) continue;
-                if (!SymbolEqualityComparer.Default.Equals(impl.ContainingType, type)) continue; // declared here
+                if (!SymbolEqualityComparer.Default.Equals(impl.ContainingType, type))
+                {
+                    // The implementation is inherited. Roslyn always names the member that *fills the
+                    // interface slot* (the base declaration), never a derived override — so this is
+                    // also the case where `type` overrides it. An alias is a hard binding: the base
+                    // installed its own function on the mangled slot of the base prototype, and the
+                    // derived prototype's plain-slot override does not displace it. So republish the
+                    // alias here whenever this type overrides the inherited implementation, or a call
+                    // through the interface keeps reaching the base. A genuinely inherited (not
+                    // overridden) implementation needs nothing — the base's alias is reached through
+                    // the prototype chain.
+                    if (OverrideDeclaredIn(type, impl) is not { } overrider) continue;
+                    impl = overrider;
+                }
 
                 var isExplicit = ExplicitlyImplementedMember(impl) is not null;
 
@@ -702,6 +715,34 @@ internal static class TransposeNaming
         }
         return pairs;
     }
+
+    /// <summary>
+    /// The member <paramref name="type"/> itself declares that overrides <paramref name="inherited"/>
+    /// (directly or through intermediate overrides), or null when it declares none.
+    /// </summary>
+    private static ISymbol? OverrideDeclaredIn(INamedTypeSymbol type, ISymbol inherited)
+    {
+        foreach (var candidate in type.GetMembers(inherited.Name))
+        {
+            if (!candidate.IsOverride) continue;
+
+            for (var overridden = OverriddenMember(candidate); overridden is not null; overridden = OverriddenMember(overridden))
+            {
+                if (SymbolEqualityComparer.Default.Equals(overridden.OriginalDefinition, inherited.OriginalDefinition))
+                    return candidate;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>The member a symbol directly overrides, or null.</summary>
+    private static ISymbol? OverriddenMember(ISymbol symbol) => symbol switch
+    {
+        IMethodSymbol m => m.OverriddenMethod,
+        IPropertySymbol p => p.OverriddenProperty,
+        IEventSymbol e => e.OverriddenEvent,
+        _ => null,
+    };
 
     /// <summary>A user-defined (source) interface — its members are dispatched via mangled
     /// interface slots; BCL interfaces resolve through their implementers' plain names.</summary>


### PR DESCRIPTION
## The bug

An override of an interface-implementing virtual member was unreachable through its interface — the base implementation was called instead.

```csharp
public interface INodeRenderer             { string CompactView(Node node); }
public abstract class NodeRendererBase     : INodeRenderer      { public virtual  string CompactView(Node n) => "BASE"; }
public abstract class TechDataRendererBase : NodeRendererBase   { public override string CompactView(Node n) => "DERIVED"; }
public class ModificationRenderer : TechDataRendererBase { }

INodeRenderer viaInterface = new ModificationRenderer();
viaInterface.CompactView(node);   // native .NET: "DERIVED"   transpose: "BASE"

NodeRendererBase viaBase = new ModificationRenderer();
viaBase.CompactView(node);        // both: "DERIVED"
```

Reported from the Curiosity front-end: `TechDataRendererBase.CompactView` never ran, because every caller (`SearchBoxComponent`, `UI.cs`, `CurrentChatComponent`, the CSV-import editors) holds an `INodeRenderer`, not the concrete type.

## Root cause

A source interface is dispatched through a mangled slot (`INodeRenderer$CompactView`) that the implementing class publishes as an `alias` of the member's plain slot:

```js
Transpose.define("NodeRendererBase", {
    alias: ["CompactView", "INodeRenderer$CompactView"],           // ← only emitted here
    methods: { CompactView: function (node) { return "BASE"; } }
});
Transpose.define("TechDataRendererBase", {
    methods: { CompactView: function (node) { return "DERIVED"; } } // no alias
});
```

The runtime installs an alias by **copying the function** onto the prototype (`Class.js`, `initConfig`: `obj[alias] = m`). That is a hard binding, so a derived class overriding the *plain* slot never displaces the base prototype's *mangled* slot, and interface dispatch keeps landing on the base.

`TransposeNaming.InterfaceAliasPairs` emitted the alias only when `type.FindImplementationForInterfaceMember(member).ContainingType == type`. Verified directly against Roslyn: that API always names the declaration that **fills the interface slot** (the base's `CompactView`), never a derived override — so every override in a chain was skipped.

## The fix

`Transpose/Transpose.Translator/Support/TransposeNaming.cs` — when the implementation is inherited, check whether this type declares an override of it (walking the `OverriddenMethod`/`OverriddenProperty`/`OverriddenEvent` chain) and republish the alias if so, rebinding the mangled slot to the derived function. A genuinely inherited implementation still emits nothing and resolves through the prototype chain.

A `new`-shadowing member is deliberately left alone — C# keeps interface dispatch on the base there, and the emitted JS now matches native on that too.

## Validation

- New `InterfaceDispatchOverrideTests` (6 tests): methods, properties and events; overrides two levels down; abstract-in-base filled by the derived type; generic interfaces; BCL interfaces; and the `new`-shadowing case. **3 of the 6 fail against the unfixed compiler**, all 6 pass with it.
- Full translator suite: **848 passed, 0 failed** (17 skipped, the usual DOM-only tests).
- Cross-assembly check with the real `tps` CLI — base class in a referenced package DLL, override in the consumer (the shape that produced the report). Both assemblies now emit `alias: ["CompactView", "Mosaik$Components$INodeRenderer$CompactView"]` and dispatch resolves to `DERIVED`.
- `bootstrap.sh` re-transpiles the BCL and all six binding libraries cleanly.

Emitted output changes by design: an overriding type now carries an `alias` entry it previously omitted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsUwy4oBU9FhfL2uxxzGfq)_