### PR TITLE
Republish interface aliases on a type that overrides an inherited imp…

### DIFF
--- a/Transpose/Transpose.Translator.Tests/InterfaceDispatchOverrideTests.cs
+++ b/Transpose/Transpose.Translator.Tests/InterfaceDispatchOverrideTests.cs
@@ -1,0 +1,230 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Interface dispatch reaches a *derived* type's override of an implementation declared by a base
+/// type. A source interface is dispatched through a mangled slot (<c>IFoo$Bar</c>) that the
+/// implementing class publishes as an <c>alias</c> of the plain slot, and a JS alias is a hard
+/// binding to the function it was installed from — so a derived override of the plain slot does not
+/// displace it, and the alias must be republished by every type that overrides.
+/// </summary>
+[TestClass]
+public class InterfaceDispatchOverrideTests : TranslatorTestBase
+{
+    [TestMethod]
+    public async Task Method_OverriddenInDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public class Node { }
+
+public interface INodeRenderer
+{
+    string CompactView(Node node);
+}
+
+public abstract class NodeRendererBase : INodeRenderer
+{
+    public virtual string CompactView(Node node) => ""BASE"";
+}
+
+public abstract class TechDataRendererBase : NodeRendererBase
+{
+    public override string CompactView(Node node) => ""DERIVED"";
+}
+
+public class ModificationRenderer : TechDataRendererBase { }
+
+public class Program
+{
+    public static void Main()
+    {
+        INodeRenderer viaInterface = new ModificationRenderer();
+        Console.WriteLine(viaInterface.CompactView(new Node()));
+
+        NodeRendererBase viaBase = new ModificationRenderer();
+        Console.WriteLine(viaBase.CompactView(new Node()));
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task PropertyMethodAndEvent_OverriddenTwoLevelsDown_AreReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public interface IShape
+{
+    string Name { get; }
+    string Describe();
+    event EventHandler Changed;
+}
+
+public abstract class ShapeBase : IShape
+{
+    public virtual string Name => ""base-name"";
+    public virtual string Describe() => ""base-describe"";
+    public virtual event EventHandler Changed;
+    public void Fire() => Changed?.Invoke(this, EventArgs.Empty);
+}
+
+public abstract class MidShape : ShapeBase
+{
+    public override string Name => ""mid-name"";
+    public override string Describe() => ""mid-describe"";
+}
+
+public class LeafShape : MidShape { }
+
+// Overrides nothing: the base's alias must still be reached through the prototype chain.
+public class PlainLeaf : ShapeBase { }
+
+public class Program
+{
+    public static void Main()
+    {
+        IShape overridden = new LeafShape();
+        Console.WriteLine(overridden.Name);
+        Console.WriteLine(overridden.Describe());
+
+        IShape inherited = new PlainLeaf();
+        Console.WriteLine(inherited.Name);
+        Console.WriteLine(inherited.Describe());
+
+        var fired = 0;
+        EventHandler handler = (s, e) => fired++;
+        overridden.Changed += handler;
+        ((LeafShape)overridden).Fire();
+        overridden.Changed -= handler;
+        ((LeafShape)overridden).Fire();
+        Console.WriteLine(fired);
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task AbstractImplementation_FilledByDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public interface IThing { string Value(); }
+
+public abstract class ThingBase : IThing
+{
+    public abstract string Value();
+}
+
+public class Thing : ThingBase
+{
+    public override string Value() => ""thing"";
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        IThing thing = new Thing();
+        Console.WriteLine(thing.Value());
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task GenericInterface_OverriddenInDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+
+public interface IBox<T> { T Get(); }
+
+public class BoxBase : IBox<int>
+{
+    public virtual int Get() => 1;
+}
+
+public class BoxDerived : BoxBase
+{
+    public override int Get() => 2;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        IBox<int> box = new BoxDerived();
+        Console.WriteLine(box.Get());
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task ShadowingMember_DoesNotTakeOverTheInterfaceSlot()
+    {
+        var code = @"
+using System;
+
+public interface IShape { string Describe(); }
+
+public class ShapeBase : IShape
+{
+    public virtual string Describe() => ""base"";
+}
+
+// `new`, not `override`: interface dispatch must still reach ShapeBase.Describe.
+public class Shadowing : ShapeBase
+{
+    public new string Describe() => ""shadow"";
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var shadowing = new Shadowing();
+        Console.WriteLine(shadowing.Describe());
+        Console.WriteLine(((IShape)shadowing).Describe());
+        Console.WriteLine(((ShapeBase)shadowing).Describe());
+    }
+}";
+        await RunTest(code);
+    }
+
+    [TestMethod]
+    public async Task BclInterfaceProperty_OverriddenInDerived_IsReachedThroughTheInterface()
+    {
+        var code = @"
+using System;
+using System.Collections.Generic;
+
+public class CollectionBase : IReadOnlyCollection<int>
+{
+    public virtual int Count => 10;
+    public IEnumerator<int> GetEnumerator() { yield return 1; }
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+public class CollectionDerived : CollectionBase
+{
+    public override int Count => 20;
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        IReadOnlyCollection<int> collection = new CollectionDerived();
+        Console.WriteLine(collection.Count);
+    }
+}";
+        await RunTest(code);
+    }
+}

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -671,7 +671,20 @@ internal static class TransposeNaming
                 if (GetTemplate(member) is not null) continue;   // templated members apply at the call site
 
                 if (type.FindImplementationForInterfaceMember(member) is not { } impl) continue;
-                if (!SymbolEqualityComparer.Default.Equals(impl.ContainingType, type)) continue; // declared here
+                if (!SymbolEqualityComparer.Default.Equals(impl.ContainingType, type))
+                {
+                    // The implementation is inherited. Roslyn always names the member that *fills the
+                    // interface slot* (the base declaration), never a derived override — so this is
+                    // also the case where `type` overrides it. An alias is a hard binding: the base
+                    // installed its own function on the mangled slot of the base prototype, and the
+                    // derived prototype's plain-slot override does not displace it. So republish the
+                    // alias here whenever this type overrides the inherited implementation, or a call
+                    // through the interface keeps reaching the base. A genuinely inherited (not
+                    // overridden) implementation needs nothing — the base's alias is reached through
+                    // the prototype chain.
+                    if (OverrideDeclaredIn(type, impl) is not { } overrider) continue;
+                    impl = overrider;
+                }
 
                 var isExplicit = ExplicitlyImplementedMember(impl) is not null;
 
@@ -702,6 +715,34 @@ internal static class TransposeNaming
         }
         return pairs;
     }
+
+    /// <summary>
+    /// The member <paramref name="type"/> itself declares that overrides <paramref name="inherited"/>
+    /// (directly or through intermediate overrides), or null when it declares none.
+    /// </summary>
+    private static ISymbol? OverrideDeclaredIn(INamedTypeSymbol type, ISymbol inherited)
+    {
+        foreach (var candidate in type.GetMembers(inherited.Name))
+        {
+            if (!candidate.IsOverride) continue;
+
+            for (var overridden = OverriddenMember(candidate); overridden is not null; overridden = OverriddenMember(overridden))
+            {
+                if (SymbolEqualityComparer.Default.Equals(overridden.OriginalDefinition, inherited.OriginalDefinition))
+                    return candidate;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>The member a symbol directly overrides, or null.</summary>
+    private static ISymbol? OverriddenMember(ISymbol symbol) => symbol switch
+    {
+        IMethodSymbol m => m.OverriddenMethod,
+        IPropertySymbol p => p.OverriddenProperty,
+        IEventSymbol e => e.OverriddenEvent,
+        _ => null,
+    };
 
     /// <summary>A user-defined (source) interface — its members are dispatched via mangled
     /// interface slots; BCL interfaces resolve through their implementers' plain names.</summary>


### PR DESCRIPTION
…lementation

A source interface is dispatched through a mangled slot (`IFoo$Bar`) that the implementing class publishes as an `alias` of the member's plain slot. The runtime installs that alias by copying the function onto the prototype, so it is a hard binding: a derived class overriding the plain slot does not displace the base prototype's mangled slot, and a call through the interface keeps reaching the base implementation.

`InterfaceAliasPairs` only emitted the alias for the type Roslyn names as the implementation of the interface member — and `FindImplementationForInterfaceMember` always names the declaration that fills the slot, never a derived override. So every override of an interface-implementing virtual member was unreachable through its interface:

    interface INodeRenderer          { string CompactView(Node n); }
    abstract class NodeRendererBase  : INodeRenderer { public virtual  string CompactView(Node n) => "BASE"; }
    abstract class TechDataRenderer  : NodeRendererBase { public override string CompactView(Node n) => "DERIVED"; }

    ((INodeRenderer)new TechDataRenderer()).CompactView(n)   // "BASE"

Emit the alias again on any type that declares an override of an inherited implementation, so its prototype rebinds the mangled slot to its own function. A `new`-shadowing member is deliberately left alone: C# keeps interface dispatch on the base there, and so must the emitted JS.

Covers methods, properties and events, overrides several levels down, generic and BCL interfaces, and the cross-assembly case (base in a referenced package).


Claude-Session: https://claude.ai/code/session_01VsUwy4oBU9FhfL2uxxzGfq