### PR TITLE
Fix package resource variant routing for single-variant authored files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,11 +397,20 @@ The short version:
   body) via `JsMinifier`. Packages ship
   their compiled JS in both a formatted and a pre-minified variant — the runtime (`tps.min.js` /
   `tps.meta.min.js`, embedded by `tps --build-runtime`) and library packages (`CollectEmbeddableItems`)
-  — so a site build reuses those and only minifies the per-project bundle/metadata/shim itself (with a
-  compile-time fallback for older packages that predate the `.min.js`). `OutputBuilder` emits
+  — so a site build reuses those and only minifies the per-project bundle/metadata/shim itself; a
+  package's JavaScript is never re-minified. `OutputBuilder` emits
   `index.html` (formatted) and `index.min.html` (minified) and collapses them per build configuration
   (Release keeps the minified one as `index.html`, Debug the formatted one) — a port of the legacy
   `HtmlGenerator`. **Source maps** for the emitted bundle are still remaining.
+
+  **The `.js` ⇄ `.min.js` switch only applies to a file that exists in both variants.** That is what a
+  compiled bundle always looks like, and it is also how a library declares an authored bundle it wants
+  both variants of (Curiosity's `ExternalBundle.js` + `.min.js`). A resource that ships in **one**
+  variant — Monaco's `editor.main.js`, a vendored `d3.min.js` — has no other variant to switch to and
+  is copied through under its authored name in *every* configuration, whether the site build reads it
+  from disk or extracts it from a referenced package. Renaming it would break the app: a module loader,
+  a `new Worker(...)` or an import map fetches that file by a path the compiler does not rewrite
+  (`PackageResourceVariantTests`).
 
   Two NUglify transforms are switched off through `CodeSettings.KillSwitch` because they are unsound
   for the JavaScript we emit, and `JsMinifierTests` guards both. Besides the `??`-under-`&&` collapse

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -9,14 +9,18 @@ namespace Transpose.Compiler;
 /// assembly's <c>Transpose.Resources.json</c>), copies the tps.json resource files (CSS/images), and
 /// generates index.html — mirroring what the existing tps compiler produces.
 ///
-/// When <c>outputFormatting</c> is <c>Minified</c> or <c>Both</c>, every compiler-produced JS output
-/// (the extracted runtime, the compiled bundle and its reflection metadata, and referenced library
-/// code) is minified with NUglify into a <c>.min.js</c> sibling. The generated HTML then follows the
-/// legacy compiler's rule: index.html links the formatted variants, index.min.html links the
-/// minified variants, and the active build configuration collapses the pair to a single index.html
-/// (Release keeps the minified one, Debug the formatted one). tps.json resource files are taken as
-/// authored (never re-minified) — a project ships both a <c>foo.js</c> and a <c>foo.min.js</c> group
-/// when it wants both variants, exactly as before.
+/// When <c>outputFormatting</c> is <c>Minified</c> or <c>Both</c>, the JS this compilation itself
+/// produces — the compiled bundle, its reflection metadata and the TransposeR shim — is minified with
+/// NUglify into a <c>.min.js</c> sibling. A referenced package's JS is never minified here: the
+/// package already ships a pre-minified variant of its own compiled code, and that pair is simply
+/// reused. The generated HTML then follows the legacy compiler's rule: index.html links the formatted
+/// variants, index.min.html links the minified variants, and the active build configuration collapses
+/// the pair to a single index.html (Release keeps the minified one, Debug the formatted one).
+///
+/// tps.json resource files are taken as authored — never minified, and never renamed — whether this
+/// build reads them from disk or extracts them from a referenced package: a project ships both a
+/// <c>foo.js</c> and a <c>foo.min.js</c> group when it wants both variants, exactly as before, and a
+/// resource that exists in only one variant keeps that name in every build configuration.
 ///
 /// Stylesheets are the one resource kind that is not copied through verbatim: every CSS file this
 /// build writes — from a resource group, or extracted from a referenced package — has its comments
@@ -121,12 +125,22 @@ internal static class OutputBuilder
             jsOuts.Add(o);
         }
 
-        // Routes a package's already-loaded JS resources (runtime bundles, library code) into the
-        // output. A package ships both a formatted and a pre-minified variant of each file, so we
-        // reuse them as-is: the formatted variant links from index.html, the pre-minified from
-        // index.min.html — no re-minification. Only when a package predates the pre-minified variant
-        // (no .min.js sibling) do we minify the formatted one as a fallback. Files are written to disk
-        // on demand so a Formatted build never materialises the .min.js (and vice-versa).
+        // Routes a package's embedded JS into the output — the runtime bundles and compiled library
+        // code, and the authored JavaScript the library shipped through its own tps.json `resources`.
+        //
+        // Only a file that ships in BOTH variants — `x.js` next to `x.min.js` — takes part in the
+        // formatted/minified switch: the formatted one is written and linked from index.html, the
+        // pre-minified one from index.min.html, and neither is re-minified here. That pair is exactly
+        // what a Transpose-compiled bundle looks like (CollectEmbeddableItems embeds both), and it is
+        // also how a library declares an authored bundle it wants both variants of.
+        //
+        // A file that ships ALONE is an authored resource — Monaco's editor.main.js, a vendored
+        // d3.min.js — and no other variant of it exists to switch to. It is copied through verbatim,
+        // under the name it was authored with, in every build configuration. Renaming editor.main.js to
+        // editor.main.min.js for a Minified build (or leaving d3.min.js out of a Formatted one) breaks
+        // every consumer that fetches the file by path — a module loader, a `new Worker(...)`, an
+        // import map — none of which this compiler rewrites. It matches what the same resource group
+        // does when it is built from disk rather than extracted from a package (ProcessResourceGroup).
         void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
         {
             var present = jsFiles.Select(f => f.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -137,42 +151,28 @@ internal static class OutputBuilder
 
             foreach (var f in jsFiles)
             {
-                if (IsMinifiedName(f.FileName))
+                if (!present.Contains(CounterpartName(f.FileName)))
                 {
-                    // A .min.js whose formatted sibling is also in the package is written by that
-                    // sibling below; a standalone .min.js links only from the minified HTML.
-                    if (present.Contains(CounterpartName(f.FileName))) continue;
-                    if (wantMinified)
-                    {
-                        WriteText(f.Rel, f.Text);
-                        if (f.Load) jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = true });
-                    }
+                    // An authored resource: one variant, copied through under its own name, always.
+                    WriteText(f.Rel, f.Text);
+                    // A standalone .min.js is still a Release-only script as far as index.html goes,
+                    // matching how the same group routes from disk. A .dontload resource is on disk
+                    // (above) but never injected into either HTML.
+                    if (f.Load) jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = IsMinifiedName(f.FileName) });
                     continue;
                 }
+
+                // The minified half of a pair is written below, by its formatted sibling.
+                if (IsMinifiedName(f.FileName)) continue;
 
                 var o = new JsOut { Path = f.Rel };
                 if (wantFormatted) WriteText(f.Rel, f.Text); else o.IsEmpty = true;
                 if (wantMinified)
                 {
-                    var minName = CounterpartName(f.FileName);
-                    if (byName.TryGetValue(minName, out var pre))
-                    {
-                        WriteText(pre.Rel, pre.Text);       // pre-built .min.js shipped in the package
-                        o.MinifiedPath = pre.Rel;
-                    }
-                    else
-                    {
-                        // No pre-built .min.js sibling: this JS was not emitted by *this* compilation
-                        // — it is an authored/third-party resource (e.g. Monaco's editor.main.js, which
-                        // NUglify cannot even parse) or an old package that shipped no .min.js. Only
-                        // Transpose-emitted output is a minification candidate, so ship it as authored
-                        // under the .min name rather than running it through the JS minifier.
-                        var minRel = ToMinName(f.Rel);
-                        WriteText(minRel, f.Text);
-                        o.MinifiedPath = minRel;
-                    }
+                    var pre = byName[CounterpartName(f.FileName)];   // pre-built .min.js from the package
+                    WriteText(pre.Rel, pre.Text);
+                    o.MinifiedPath = pre.Rel;
                 }
-                // A .dontload resource is written to disk (above) but never injected into index.html.
                 if (f.Load) jsOuts.Add(o);
             }
         }

--- a/Transpose/Transpose.Translator.Tests/PackageResourceVariantTests.cs
+++ b/Transpose/Transpose.Translator.Tests/PackageResourceVariantTests.cs
@@ -1,0 +1,216 @@
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers which name a referenced package's embedded JavaScript lands under in a site build, per
+/// <c>outputFormatting</c> — the <c>.js</c> / <c>.min.js</c> switch in <c>OutputBuilder.RoutePackageJs</c>.
+///
+/// The rule the reported bug broke: the switch applies only to a file the package ships in BOTH
+/// variants (the compiled bundle, or an authored bundle a library deliberately declares twice). An
+/// authored resource that exists in one variant only — Monaco's <c>editor.main.js</c>, a vendored
+/// <c>d3.min.js</c> — has no other variant to switch to and must be copied through under its own name
+/// in every configuration. It was instead renamed to <c>editor.main.min.js</c> in a Minified build
+/// (and a standalone <c>d3.min.js</c> was dropped entirely from a Formatted one), so Monaco's loader —
+/// which fetches <c>vs/editor/editor.main.js</c> by path — 404'd in Release.
+/// </summary>
+[TestClass]
+public sealed class PackageResourceVariantTests
+{
+    private string _root = "";
+    private string _libDir = "";
+    private string _appDir = "";
+    private string _outputDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-pkgres-" + Guid.NewGuid().ToString("N"));
+        _libDir = Path.Combine(_root, "lib");
+        _appDir = Path.Combine(_root, "app");
+        _outputDir = Path.Combine(_root, "site");
+        Directory.CreateDirectory(_libDir);
+        Directory.CreateDirectory(_appDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ---------------------------------------------------------------- the library package
+
+    /// <summary>Builds the package a consumer references: a library whose tps.json embeds the same
+    /// shapes the Curiosity front-end does — Monaco's single-variant <c>editor.main.js</c>, a
+    /// single-variant vendored <c>d3.min.js</c>, and an authored bundle declared in both variants —
+    /// alongside its own compiled bundle (which the compiler embeds formatted and pre-minified).</summary>
+    private string LibraryPackage()
+    {
+        Asset(_libDir, "tps/assets/js/monaco/vs/editor/editor.main.js", "// monaco editor.main");
+        Asset(_libDir, "tps/assets/js/d3.min.js", "// vendored d3, already minified");
+        Asset(_libDir, "tps/assets/js/vendor-one.js", "// vendor one");
+
+        File.WriteAllText(Path.Combine(_libDir, "tps.json"), @"{
+            ""fileName"": ""Lib.js"",
+            ""outputFormatting"": ""Both"",
+            ""resources"": [
+                {
+                    ""name"": ""monaco#editor.main.js.dontload"",
+                    ""files"": [ ""tps/assets/js/monaco/vs/editor/editor.main.js"" ],
+                    ""output"": ""assets/js/monaco/vs/editor/""
+                },
+                {
+                    ""name"": ""d3.min.js.dontload"",
+                    ""files"": [ ""tps/assets/js/d3.min.js"" ],
+                    ""output"": ""assets/js""
+                },
+                {
+                    ""name"": ""Lib.ExternalBundle.js"",
+                    ""files"": [ ""tps/assets/js/vendor-one.js"" ],
+                    ""output"": ""assets/js""
+                },
+                {
+                    ""name"": ""Lib.ExternalBundle.min.js"",
+                    ""files"": [ ""tps/assets/js/vendor-one.js"" ],
+                    ""output"": ""assets/js""
+                }
+            ]
+        }");
+
+        var config = TransposeJson.TryLoad(_libDir, "Release");
+        Assert.IsNotNull(config, "the library's tps.json must load");
+
+        return PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(_libDir, config!, "Lib.js", "var lib = 1;", null));
+    }
+
+    // ---------------------------------------------------------------- the tests
+
+    [TestMethod]
+    public void AMinifiedBuildKeepsASingleVariantPackageResourceUnderItsAuthoredName()
+    {
+        var html = BuildSite(LibraryPackage(), "Minified", "Release");
+
+        AssertInOutput("assets/js/monaco/vs/editor/editor.main.js",
+            "an authored package resource must keep the name it was authored with — Monaco's loader fetches it by path");
+        AssertNotInOutput("assets/js/monaco/vs/editor/editor.main.min.js",
+            "the compiler must not rename an authored resource it never minified");
+
+        // The same file, unchanged: a resource is copied through, never run through the JS minifier.
+        Assert.AreEqual("// monaco editor.main",
+            File.ReadAllText(Path.Combine(_outputDir, "assets", "js", "monaco", "vs", "editor", "editor.main.js")));
+
+        Assert.IsFalse(html.Contains("editor.main"), "a .dontload resource is on disk but never in index.html");
+    }
+
+    [TestMethod]
+    public void AFormattedBuildStillWritesASingleVariantMinifiedPackageResource()
+    {
+        // The mirror image: a vendored library that only ever existed as `d3.min.js` is not a Release
+        // variant of anything, so a Formatted build must still put it on disk — the app lazy-loads it
+        // by that path in every configuration.
+        BuildSite(LibraryPackage(), "Formatted", "Debug");
+
+        AssertInOutput("assets/js/d3.min.js", "a standalone .min.js resource must be extracted in a Formatted build too");
+        AssertNotInOutput("assets/js/d3.js", "and must not be renamed to a formatted variant that does not exist");
+    }
+
+    [TestMethod]
+    public void AResourceDeclaredInBothVariantsStillSwitchesPerConfiguration()
+    {
+        // A library that deliberately ships both variants of an authored bundle keeps the legacy
+        // behaviour: the minified build takes the .min.js, the formatted build takes the .js.
+        var dll = LibraryPackage();
+
+        BuildSite(dll, "Minified", "Release");
+        AssertInOutput("assets/js/Lib.ExternalBundle.min.js", "a declared .min.js variant is what a Minified build writes");
+        AssertNotInOutput("assets/js/Lib.ExternalBundle.js", "…and the formatted variant is not materialised");
+
+        Directory.Delete(_outputDir, recursive: true);
+        Directory.CreateDirectory(_outputDir);
+
+        BuildSite(dll, "Formatted", "Debug");
+        AssertInOutput("assets/js/Lib.ExternalBundle.js", "a Formatted build writes the formatted variant");
+        AssertNotInOutput("assets/js/Lib.ExternalBundle.min.js", "…and not the minified one");
+    }
+
+    [TestMethod]
+    public void ThePackagesCompiledBundleStillTakesItsPreMinifiedVariant()
+    {
+        // Unchanged, and the reason the switch exists at all: the library's own compiled JS ships in
+        // both variants, so a Minified consumer build links the pre-minified one.
+        var html = BuildSite(LibraryPackage(), "Minified", "Release");
+
+        AssertInOutput("Lib.min.js", "the package's pre-minified bundle is what a Minified build writes");
+        AssertNotInOutput("Lib.js", "…and the formatted bundle is not materialised");
+        StringAssert.Contains(html, "src=\"Lib.min.js\"", "index.html must link the minified bundle in Release");
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static string Asset(string dir, string rel, string content)
+    {
+        var full = Path.Combine(dir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    /// <summary>Builds a consuming project that has no resources of its own — everything in the site
+    /// comes from <paramref name="packageDll"/> — and returns its index.html.</summary>
+    private string BuildSite(string packageDll, string outputFormatting, string configuration)
+    {
+        File.WriteAllText(Path.Combine(_appDir, "tps.json"),
+            @"{ ""fileName"": ""app.js"", ""outputFormatting"": """ + outputFormatting + @""" }");
+
+        var config = TransposeJson.TryLoad(_appDir, configuration);
+        Assert.IsNotNull(config, "the app's tps.json must load");
+
+        var project = new ResolvedProject
+        {
+            CsprojPath      = Path.Combine(_appDir, "App.csproj"),
+            ProjectDir      = _appDir,
+            AssemblyName    = "App",
+            TargetFramework = "netstandard2.0",
+            Sources         = new List<(string, string)>(),
+            ReferencePaths  = new List<string> { packageDll },
+            DefineConstants = new List<string>(),
+            LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+            ProjectDirs     = new List<string> { _appDir },
+        };
+
+        OutputBuilder.Build(project, config!, "var app = 1;", _outputDir, configuration);
+
+        var html = Path.Combine(_outputDir, "index.html");
+        Assert.IsTrue(File.Exists(html), "the build must generate index.html");
+        return File.ReadAllText(html);
+    }
+
+    private void AssertInOutput(string rel, string because)
+        => Assert.IsTrue(File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))), because);
+
+    private void AssertNotInOutput(string rel, string because)
+        => Assert.IsFalse(File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))), because);
+
+    /// <summary>Embeds <paramref name="items"/> into an assembly through the real
+    /// <see cref="ResourceEmbedder"/> — the same call <c>tps --emit-package</c> makes — and returns the
+    /// package DLL's path.</summary>
+    private string PackageDll(string assemblyName, IReadOnlyList<EmbeddedItem> items)
+    {
+        byte[] bytes;
+        using (var asm = AssemblyDefinition.CreateAssembly(
+                   new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)), assemblyName, ModuleKind.Dll))
+        using (var ms = new MemoryStream())
+        {
+            asm.Write(ms);
+            bytes = ms.ToArray();
+        }
+
+        var path = Path.Combine(_root, "packages", assemblyName + ".dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        ResourceEmbedder.Embed(path, bytes, items);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a bug in `OutputBuilder.RoutePackageJs` where authored package resources that exist in only one variant (e.g., Monaco's `editor.main.js`, a vendored `d3.min.js`) were incorrectly renamed or omitted based on the build's `outputFormatting` setting. These single-variant resources must be copied through under their authored name in every configuration, since consumers fetch them by path through mechanisms the compiler does not rewrite (module loaders, `new Worker(...)`, import maps, etc.).

## Changes

- **OutputBuilder.cs**: Rewrote `RoutePackageJs` to distinguish between:
  - **Paired files** (both `x.js` and `x.min.js` present): participate in the formatted/minified switch; the formatted variant is written for `index.html`, the pre-minified for `index.min.html`
  - **Single-variant files** (only one exists): copied through verbatim under their authored name in every build configuration, matching the behavior of the same resource group when built from disk via `ProcessResourceGroup`
  
  The logic now checks `!present.Contains(CounterpartName(f.FileName))` to identify authored resources and writes them unconditionally, then skips the minified half of pairs (since it is written by its formatted sibling).

- **PackageResourceVariantTests.cs** (new): Comprehensive test suite covering:
  - A minified build keeps single-variant `editor.main.js` under its authored name (not renamed to `.min.js`)
  - A formatted build still writes single-variant `d3.min.js` (not omitted or renamed to `.js`)
  - A resource declared in both variants still switches per configuration (legacy behavior preserved)
  - The package's compiled bundle still takes its pre-minified variant in minified builds

- **CLAUDE.md**: Updated documentation to clarify that the `.js` ⇄ `.min.js` switch applies only to files that exist in both variants, and that single-variant resources are copied through under their authored name in every configuration.

## Implementation Details

The fix ensures that `IsMinifiedName(f.FileName)` is only used to determine HTML linking behavior for single-variant files (a standalone `.min.js` is still Release-only), not to rename or omit them. This mirrors how `ProcessResourceGroup` handles the same scenario when resources are built from disk rather than extracted from a package.

https://claude.ai/code/session_01JWsfAWcNfVJA8aBweVafyG