### PR TITLE
Recurse into sub-folders for tps.json resource globs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,21 @@ The short version:
   `references`/`referencesPath` (partially covered by `--reference`).
 - **MSBuild evaluation** stays deliberately shallow: `<Import>` is followed (see above) but
   conditions, arbitrary properties, `Directory.Build.props` and item metadata are not evaluated.
+- **Resource globs recurse with `**` (done).** A `resources` group's `files` entry may use a `**` path
+  segment — `assets/img/**`, or `assets/img/**/*.svg` to narrow it — and a copy-through group then
+  reproduces the sub-folder each file was found in, both in the site it writes and in the package DLL
+  it embeds (the sub-directory lands in the manifest entry's `Path`, and *also* qualifies its `Name`,
+  which is the manifest key — two files sharing a leaf name in different folders would otherwise
+  collapse onto one entry). A plain `*` still matches one directory, which is what every tps.json
+  written so far means by it; and because .NET's own search patterns collapse `**` to `*`, an older
+  compiler reads a recursive pattern as the non-recursive one rather than failing.
+
+  This is the *only* channel a package has for its assets: a library that instead let MSBuild's
+  `<None … CopyToOutputDirectory>` carry them ships fine inside its own repository — a content item
+  flows across a `ProjectReference` — and silently ships nothing to anyone consuming it as a NuGet
+  package, which does not pack `None` items. Curiosity.FrontEnd did exactly that, so every application
+  built against the package was missing 243 icons/illustrations, both variable-font families and the
+  favicon.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 - **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
   reuses the previous build of a project: nothing at all is compiled when every input hashes the same

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -305,21 +305,27 @@ internal static class OutputBuilder
                 {
                     var self = SelfText(Path.GetFileName(raw.Replace('\\', '/')));
                     if (self is not null) texts.Add(self);
-                    else texts.AddRange(ExpandGlob(projectDir, raw).Select(f => ReadResourceText(f, css)));
+                    else texts.AddRange(ExpandGlob(projectDir, raw).Select(m => ReadResourceText(m.FullPath, css)));
                 }
                 if (texts.Count == 0) continue;
                 items.Add(new EmbeddedItem(name, utf8.GetBytes(string.Join("\n", texts)), destSub, load));
             }
             else
             {
-                // Copy-through group (images, fonts): embed each file under its own name.
-                var files = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
-                if (files.Count == 0) continue;
-                foreach (var src in files)
+                // Copy-through group (images, fonts): embed each file under its own name, keyed and
+                // placed by the sub-directory a recursive glob found it in so the group's folder
+                // layout is reproduced on the consumer's side.
+                var matches = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
+                if (matches.Count == 0) continue;
+                foreach (var m in matches)
                 {
-                    var content = File.ReadAllBytes(src);
-                    if (IsCss(src)) content = CssProcessor.StripComments(content);
-                    items.Add(new EmbeddedItem(Path.GetFileName(src), content, destSub, load));
+                    var content = File.ReadAllBytes(m.FullPath);
+                    if (IsCss(m.FullPath)) content = CssProcessor.StripComments(content);
+                    items.Add(new EmbeddedItem(
+                        ResourceKey(m.RelativeDir, Path.GetFileName(m.FullPath)),
+                        content,
+                        JoinOutput(destSub, m.RelativeDir),
+                        load));
                 }
             }
         }
@@ -444,8 +450,11 @@ internal static class OutputBuilder
                 .ToList();
         }
 
+        // The entry's Path already carries the sub-directory a recursive glob matched under, so the
+        // name contributes only its leaf — same split as ExtractEmbeddedJs, which is what keeps a
+        // package DLL and a project DLL extracting one resource to the same place.
         string Rel(string fileName, string? path)
-            => string.IsNullOrEmpty(path) ? fileName : path!.Replace('\\', '/').TrimEnd('/') + "/" + fileName;
+            => string.IsNullOrEmpty(path) ? Path.GetFileName(fileName) : path!.Replace('\\', '/').TrimEnd('/') + "/" + Path.GetFileName(fileName);
 
         foreach (var (fileName, path, load) in entries)
         {
@@ -459,7 +468,7 @@ internal static class OutputBuilder
             {
                 using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
-                jsFiles.Add(new EmbeddedJs(fileName, rel, reader.ReadToEnd(), load));
+                jsFiles.Add(new EmbeddedJs(Path.GetFileName(fileName), rel, reader.ReadToEnd(), load));
             }
             else
             {
@@ -628,20 +637,27 @@ internal static class OutputBuilder
     {
         var outputs = new List<(string, List<string>)>();
         var destSub = (group.Output ?? "").Replace('\\', '/').TrimEnd('/');
-        var files = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
-        if (files.Count == 0) return outputs;
+        var matches = group.Files.SelectMany(p => ExpandGlob(projectDir, p)).ToList();
+        if (matches.Count == 0) return outputs;
 
-        string Rel(string leaf) => string.IsNullOrEmpty(destSub) ? leaf : destSub + "/" + leaf;
+        string Rel(string relativeDir, string leaf)
+        {
+            var dir = JoinOutput(destSub, relativeDir);
+            return string.IsNullOrEmpty(dir) ? leaf : dir + "/" + leaf;
+        }
 
         var (name, _) = ResolveResource(group);
         if (IsBundleName(name))
         {
-            outputs.Add((Rel(name), files));
+            // A bundle group is one output whatever depth its members came from.
+            outputs.Add((Rel("", name), matches.Select(m => m.FullPath).ToList()));
         }
         else
         {
-            foreach (var src in files)
-                outputs.Add((Rel(Path.GetFileName(src)), new List<string> { src }));
+            // Copy-through: each file keeps the sub-directory a recursive glob found it in, so the
+            // site mirrors what a consumer extracting the same group from a package DLL gets.
+            foreach (var m in matches)
+                outputs.Add((Rel(m.RelativeDir, Path.GetFileName(m.FullPath)), new List<string> { m.FullPath }));
         }
         return outputs;
     }
@@ -861,17 +877,85 @@ internal static class OutputBuilder
         return jsFiles;
     }
 
-    private static IEnumerable<string> ExpandGlob(string baseDir, string pattern)
+    /// <summary>One file a <c>tps.json</c> resource glob matched: its full path on disk, and the
+    /// directory it sits in <em>relative to the fixed part of the pattern</em> — empty for a
+    /// non-recursive pattern, and e.g. <c>icons/logos</c> for <c>tps/assets/img/**</c> matching
+    /// <c>tps/assets/img/icons/logos/api.svg</c>. A copy-through group appends that to its
+    /// <c>output</c> directory, so a package's folder layout survives being embedded and extracted
+    /// (an <c>@font-face</c> src or an <c>&lt;img&gt;</c> path into a sub-folder keeps resolving).</summary>
+    private readonly record struct GlobMatch(string FullPath, string RelativeDir);
+
+    /// <summary>
+    /// Expands one resource-group <c>files</c> entry against the project directory.
+    ///
+    /// A <c>**</c> path segment recurses: <c>assets/img/**</c> matches every file below
+    /// <c>assets/img</c> at any depth, and <c>assets/img/**/*.svg</c> narrows that to a file pattern.
+    /// Without <c>**</c> a pattern stays in its own directory — <c>assets/img/*</c> matches the files
+    /// directly under <c>assets/img</c> and nothing below it — which is what every existing tps.json
+    /// means by it.
+    ///
+    /// <c>**</c> is only recognised as a whole segment, and what follows it must be a single file
+    /// pattern (<c>a/**/b/*.js</c> is not a shape any tps.json uses and matches nothing). Results are
+    /// ordered ordinally by path so a build does not inherit the file system's enumeration order.
+    /// </summary>
+    private static IEnumerable<GlobMatch> ExpandGlob(string baseDir, string pattern)
     {
         pattern = pattern.Replace('\\', '/');
-        var dir = Path.GetDirectoryName(pattern) ?? "";
-        var file = Path.GetFileName(pattern);
-        var searchDir = Path.Combine(baseDir, dir);
-        if (!Directory.Exists(searchDir)) return Enumerable.Empty<string>();
-        return file.Contains('*')
-            ? Directory.EnumerateFiles(searchDir, file, SearchOption.TopDirectoryOnly)
-            : File.Exists(Path.Combine(searchDir, file)) ? new[] { Path.Combine(searchDir, file) } : Enumerable.Empty<string>();
+
+        var recurse = pattern.Split('/').Contains("**");
+        if (!recurse)
+        {
+            var dir = Path.GetDirectoryName(pattern) ?? "";
+            var file = Path.GetFileName(pattern);
+            var searchDir = Path.Combine(baseDir, dir);
+            if (!Directory.Exists(searchDir)) return Enumerable.Empty<GlobMatch>();
+            return file.Contains('*')
+                ? Ordered(Directory.EnumerateFiles(searchDir, file, SearchOption.TopDirectoryOnly).Select(f => new GlobMatch(f, "")))
+                : File.Exists(Path.Combine(searchDir, file)) ? new[] { new GlobMatch(Path.Combine(searchDir, file), "") } : Enumerable.Empty<GlobMatch>();
+        }
+
+        var segments = pattern.Split('/');
+        var at = Array.IndexOf(segments, "**");
+        var tail = segments.Skip(at + 1).ToArray();
+        if (tail.Length > 1) return Enumerable.Empty<GlobMatch>();   // "**" followed by more directories
+
+        var root = Path.Combine(baseDir, string.Join("/", segments.Take(at)));
+        if (!Directory.Exists(root)) return Enumerable.Empty<GlobMatch>();
+
+        var filePattern = tail.Length == 0 || tail[0].Length == 0 ? "*" : tail[0];
+        var rootFull = Path.GetFullPath(root);
+
+        return Ordered(Directory.EnumerateFiles(root, filePattern, SearchOption.AllDirectories)
+            .Select(f => new GlobMatch(f, RelativeDirOf(rootFull, f))));
+
+        static string RelativeDirOf(string rootFull, string file)
+        {
+            var dir = Path.GetDirectoryName(Path.GetFullPath(file))!;
+            var rel = Path.GetRelativePath(rootFull, dir).Replace('\\', '/');
+            return rel == "." ? "" : rel;
+        }
+
+        static IEnumerable<GlobMatch> Ordered(IEnumerable<GlobMatch> matches)
+            => matches.OrderBy(m => m.FullPath.Replace('\\', '/'), StringComparer.Ordinal).ToList();
     }
+
+    /// <summary>Joins a resource group's <c>output</c> directory with the sub-directory a recursive
+    /// glob matched under; either side may be absent. Null (rather than "") when both are, so a
+    /// group without an <c>output</c> still writes <c>"Path": null</c> into the resource manifest.</summary>
+    private static string? JoinOutput(string? destSub, string relativeDir)
+    {
+        var head = (destSub ?? "").Replace('\\', '/').TrimEnd('/');
+        if (relativeDir.Length == 0) return string.IsNullOrEmpty(head) ? destSub : head;
+        return head.Length == 0 ? relativeDir : head + "/" + relativeDir;
+    }
+
+    /// <summary>The manifest key a copy-through resource is embedded under: its file name, prefixed
+    /// with the sub-directory a recursive glob found it in. Two files that share a leaf name in
+    /// different sub-folders (<c>icons/api.svg</c> and <c>icons/logos/api.svg</c>) must not collapse
+    /// onto one manifest entry — the manifest is keyed by name, and <see cref="ResourceEmbedder"/>
+    /// replaces same-named resources.</summary>
+    private static string ResourceKey(string relativeDir, string fileName)
+        => relativeDir.Length == 0 ? fileName : relativeDir + "/" + fileName;
 
     /// <summary>
     /// Writes index.html (formatted scripts) and/or index.min.html (minified scripts), then collapses

--- a/Transpose/Transpose.Translator.Tests/RecursiveResourceGlobTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RecursiveResourceGlobTests.cs
@@ -1,0 +1,359 @@
+using System.Text.Json;
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers recursive <c>tps.json</c> resource globs — a <c>**</c> path segment — and the folder layout
+/// they imply.
+///
+/// A copy-through group of assets (images, fonts) is the case that matters: its files routinely sit in
+/// sub-folders, and both halves of the protocol have to agree on where each one lands. The site build
+/// reading the group from disk, and a consuming project extracting the same group out of a package DLL,
+/// must produce the identical tree — otherwise a stylesheet's <c>url(../webfonts/x/y.woff2)</c> or an
+/// <c>&lt;img src="assets/img/icons/logos/x.svg"&gt;</c> resolves in the library's own site and 404s in
+/// every application that consumes it as a package.
+///
+/// Two properties are load-bearing beyond "the file gets copied":
+/// <list type="bullet">
+/// <item>the sub-directory reaches the manifest entry's <c>Path</c>, so extraction reproduces it;</item>
+/// <item>the manifest <em>key</em> is qualified by that sub-directory, so two files sharing a leaf name
+/// in different folders stay two resources (the manifest is keyed by name, and the embedder replaces
+/// same-named resources — an unqualified key silently drops one of them).</item>
+/// </list>
+/// </summary>
+[TestClass]
+public sealed class RecursiveResourceGlobTests
+{
+    private string _root = "";
+    private string _projectDir = "";
+    private string _outputDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-glob-" + Guid.NewGuid().ToString("N"));
+        _projectDir = Path.Combine(_root, "proj");
+        _outputDir = Path.Combine(_root, "site");
+        Directory.CreateDirectory(_projectDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private void Asset(string rel, string content)
+    {
+        var full = Path.Combine(_projectDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+    }
+
+    /// <summary>The asset tree the tests below share: files at the top level and at two further
+    /// depths, plus a leaf name deliberately repeated in two different folders.</summary>
+    private void NestedAssets()
+    {
+        Asset("tps/assets/img/logo.svg", "<svg id='logo'/>");
+        Asset("tps/assets/img/icons/api.svg", "<svg id='icons-api'/>");
+        Asset("tps/assets/img/icons/logos/api.svg", "<svg id='logos-api'/>");
+        Asset("tps/assets/img/icons/logos/aws.svg", "<svg id='aws'/>");
+        Asset("tps/assets/img/illustrations/empty.png", "png-bytes");
+    }
+
+    private TransposeJson Config(string tpsJson)
+    {
+        File.WriteAllText(Path.Combine(_projectDir, "tps.json"), tpsJson);
+        var config = TransposeJson.TryLoad(_projectDir, "Debug");
+        Assert.IsNotNull(config, "tps.json must load");
+        return config!;
+    }
+
+    private ResolvedProject Project(params string[] referencePaths) => new()
+    {
+        CsprojPath = Path.Combine(_projectDir, "App.csproj"),
+        ProjectDir = _projectDir,
+        AssemblyName = "App",
+        TargetFramework = "netstandard2.0",
+        Sources = new List<(string, string)>(),
+        ReferencePaths = referencePaths.ToList(),
+        DefineConstants = new List<string>(),
+        LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+        ProjectDirs = new List<string> { _projectDir },
+    };
+
+    private void BuildSite(TransposeJson config, ResolvedProject? project = null)
+        => OutputBuilder.Build(project ?? Project(), config, "var app = 1;", _outputDir, "Debug");
+
+    private string SiteFile(string rel)
+    {
+        var full = Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+        Assert.IsTrue(File.Exists(full), $"the site must contain {rel}");
+        return File.ReadAllText(full);
+    }
+
+    private void AssertNotInSite(string rel)
+        => Assert.IsFalse(File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))),
+            $"the site must not contain {rel}");
+
+    private const string ImagesRecursively = @"{
+        ""fileName"": ""app.js"",
+        ""outputFormatting"": ""Formatted"",
+        ""resources"": [
+            { ""name"": ""images"", ""files"": [ ""tps/assets/img/**"" ], ""output"": ""assets/img/"" }
+        ]
+    }";
+
+    // ---------------------------------------------------------------- site build, from disk
+
+    [TestMethod]
+    public void ANonRecursiveGlobStillMatchesOnlyItsOwnDirectory()
+    {
+        // The shape every existing tps.json uses. Widening it silently would change what a published
+        // package contains, so "*" has to keep meaning one directory.
+        NestedAssets();
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""images"", ""files"": [ ""tps/assets/img/*"" ], ""output"": ""assets/img/"" }
+            ]
+        }"));
+
+        SiteFile("assets/img/logo.svg");
+        AssertNotInSite("assets/img/icons/api.svg");
+        AssertNotInSite("assets/img/illustrations/empty.png");
+    }
+
+    [TestMethod]
+    public void ARecursiveGlobCopiesEveryDepthAndKeepsTheFolderLayout()
+    {
+        NestedAssets();
+
+        BuildSite(Config(ImagesRecursively));
+
+        Assert.AreEqual("<svg id='logo'/>", SiteFile("assets/img/logo.svg"));
+        Assert.AreEqual("<svg id='icons-api'/>", SiteFile("assets/img/icons/api.svg"));
+        Assert.AreEqual("<svg id='logos-api'/>", SiteFile("assets/img/icons/logos/api.svg"),
+            "a repeated leaf name in a deeper folder must stay its own file");
+        Assert.AreEqual("<svg id='aws'/>", SiteFile("assets/img/icons/logos/aws.svg"));
+        Assert.AreEqual("png-bytes", SiteFile("assets/img/illustrations/empty.png"));
+    }
+
+    [TestMethod]
+    public void ARecursiveGlobCanNarrowToAFilePattern()
+    {
+        NestedAssets();
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""images"", ""files"": [ ""tps/assets/img/**/*.svg"" ], ""output"": ""assets/img/"" }
+            ]
+        }"));
+
+        SiteFile("assets/img/logo.svg");
+        SiteFile("assets/img/icons/logos/aws.svg");
+        AssertNotInSite("assets/img/illustrations/empty.png");
+    }
+
+    [TestMethod]
+    public void ARecursiveGlobWithoutAnOutputDirectorySitsAtTheSiteRoot()
+    {
+        NestedAssets();
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""images"", ""files"": [ ""tps/assets/img/**"" ] }
+            ]
+        }"));
+
+        SiteFile("logo.svg");
+        SiteFile("icons/logos/aws.svg");
+    }
+
+    [TestMethod]
+    public void ARecursiveGlobUnderABundleGroupStillProducesOneFile()
+    {
+        // A group named for a .js/.css file concatenates whatever it matched — depth included — into
+        // that single output; only copy-through groups reproduce a folder layout.
+        Asset("tps/assets/css/a.css", ".a { }");
+        Asset("tps/assets/css/theme/b.css", ".b { }");
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""bundle.css"", ""files"": [ ""tps/assets/css/**/*.css"" ], ""output"": ""assets/css"" }
+            ]
+        }"));
+
+        var bundle = SiteFile("assets/css/bundle.css");
+        StringAssert.Contains(bundle, ".a { }");
+        StringAssert.Contains(bundle, ".b { }");
+        AssertNotInSite("assets/css/theme/b.css");
+    }
+
+    // ---------------------------------------------------------------- packing
+
+    [TestMethod]
+    public void TheSubDirectoryReachesTheResourceManifestAsThePathAndQualifiesTheKey()
+    {
+        NestedAssets();
+
+        var items = OutputBuilder.CollectEmbeddableItems(_projectDir, Config(ImagesRecursively), "Lib.js", "var lib = 1;", null);
+        var manifest = ManifestEntries(PackageDll("Lib", items));
+
+        Assert.AreEqual("assets/img", manifest["logo.svg"]);
+        Assert.AreEqual("assets/img/icons", manifest["icons/api.svg"]);
+        Assert.AreEqual("assets/img/icons/logos", manifest["icons/logos/api.svg"]);
+        Assert.AreEqual("assets/img/illustrations", manifest["illustrations/empty.png"]);
+    }
+
+    [TestMethod]
+    public void TwoFilesSharingALeafNameInDifferentFoldersStayTwoResources()
+    {
+        // The collision the unqualified key produced: the manifest is keyed by name and the embedder
+        // replaces a same-named resource, so both api.svg files collapsed onto one entry — the site
+        // then served one folder's icon from the other's path.
+        NestedAssets();
+
+        var items = OutputBuilder.CollectEmbeddableItems(_projectDir, Config(ImagesRecursively), "Lib.js", "var lib = 1;", null);
+
+        Assert.AreEqual(2, items.Count(i => Path.GetFileName(i.Name) == "api.svg"), "both api.svg files must be embedded");
+
+        using var asm = AssemblyDefinition.ReadAssembly(PackageDll("Lib", items));
+        var resources = asm.MainModule.Resources.OfType<EmbeddedResource>().ToDictionary(r => r.Name);
+        CollectionAssert.AreEqual("<svg id='icons-api'/>"u8.ToArray(), resources["icons/api.svg"].GetResourceData());
+        CollectionAssert.AreEqual("<svg id='logos-api'/>"u8.ToArray(), resources["icons/logos/api.svg"].GetResourceData());
+    }
+
+    [TestMethod]
+    public void AGroupWithoutAnOutputKeepsANullManifestPath()
+    {
+        // Guards the manifest bytes for every existing package: a group with no `output` and no
+        // sub-directory must still serialize Path as null, not "".
+        Asset("tps/assets/img/logo.svg", "<svg/>");
+
+        var items = OutputBuilder.CollectEmbeddableItems(_projectDir, Config(@"{
+            ""fileName"": ""Lib.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""images"", ""files"": [ ""tps/assets/img/*"" ] }
+            ]
+        }"), "Lib.js", "var lib = 1;", null);
+
+        Assert.IsNull(items.Single(i => i.Name == "logo.svg").Output);
+    }
+
+    // ---------------------------------------------------------------- the whole chain
+
+    [TestMethod]
+    public void AReferencingSiteBuildExtractsAPackagesNestedAssetsToTheSamePaths()
+    {
+        // The bug this fixes, end to end: inside the library's own repository these files reached the
+        // site through MSBuild's copy-to-output, which a NuGet consumer never runs — so the package's
+        // embedded resources are the only channel, and they have to carry the whole tree.
+        NestedAssets();
+
+        var libConfig = Config(@"{
+            ""fileName"": ""Lib.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""images"", ""files"": [ ""tps/assets/img/**"" ], ""output"": ""assets/img/"" }
+            ]
+        }");
+        var dll = PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(_projectDir, libConfig, "Lib.js", "var lib = 1;", null));
+
+        // The consuming project declares no resources of its own — everything below comes from the package.
+        BuildSite(Config(@"{ ""fileName"": ""app.js"", ""outputFormatting"": ""Formatted"" }"), Project(dll));
+
+        Assert.AreEqual("<svg id='logo'/>", SiteFile("assets/img/logo.svg"));
+        Assert.AreEqual("<svg id='icons-api'/>", SiteFile("assets/img/icons/api.svg"));
+        Assert.AreEqual("<svg id='logos-api'/>", SiteFile("assets/img/icons/logos/api.svg"));
+        Assert.AreEqual("<svg id='aws'/>", SiteFile("assets/img/icons/logos/aws.svg"));
+        Assert.AreEqual("png-bytes", SiteFile("assets/img/illustrations/empty.png"));
+    }
+
+    [TestMethod]
+    public void ANestedStylesheetIsLinkedFromIndexHtmlAtItsNestedPath()
+    {
+        // CSS found by a recursive glob still gets a <link>, and it has to point at the path the file
+        // was actually written to.
+        Asset("tps/assets/css/theme/dark.css", ".dark { }");
+
+        BuildSite(Config(@"{
+            ""fileName"": ""app.js"",
+            ""outputFormatting"": ""Formatted"",
+            ""resources"": [
+                { ""name"": ""styles"", ""files"": [ ""tps/assets/css/**/*.css"" ], ""output"": ""assets/css"" }
+            ]
+        }"));
+
+        SiteFile("assets/css/theme/dark.css");
+        StringAssert.Contains(SiteFile("index.html"), "href=\"assets/css/theme/dark.css\"");
+    }
+
+    // ---------------------------------------------------------------- determinism
+
+    [TestMethod]
+    public void GlobResultsAreOrderedIndependentlyOfTheFileSystem()
+    {
+        // The resource manifest records the order the group matched in, so a build must not inherit
+        // the enumeration order of whatever file system it runs on.
+        foreach (var name in new[] { "zeta.svg", "alpha.svg", "mid.svg" })
+            Asset("tps/assets/img/icons/" + name, "<svg/>");
+        Asset("tps/assets/img/aaa.svg", "<svg/>");
+
+        var items = OutputBuilder.CollectEmbeddableItems(_projectDir, Config(ImagesRecursively), "Lib.js", "var lib = 1;", null)
+            .Where(i => i.Name.EndsWith(".svg", StringComparison.Ordinal))
+            .Select(i => i.Name)
+            .ToList();
+
+        CollectionAssert.AreEqual(
+            new[] { "aaa.svg", "icons/alpha.svg", "icons/mid.svg", "icons/zeta.svg" },
+            items);
+    }
+
+    // ---------------------------------------------------------------- infrastructure
+
+    /// <summary>Embeds <paramref name="items"/> into an assembly through the real
+    /// <see cref="ResourceEmbedder"/> — the same call <c>tps --emit-package</c> makes — and returns the
+    /// package DLL's path.</summary>
+    private string PackageDll(string assemblyName, IReadOnlyList<EmbeddedItem> items)
+    {
+        byte[] bytes;
+        using (var asm = AssemblyDefinition.CreateAssembly(
+                   new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)), assemblyName, ModuleKind.Dll))
+        using (var ms = new MemoryStream())
+        {
+            asm.Write(ms);
+            bytes = ms.ToArray();
+        }
+
+        var path = Path.Combine(_root, "packages", assemblyName + ".dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        ResourceEmbedder.Embed(path, bytes, items);
+        return path;
+    }
+
+    /// <summary>The package's <c>Transpose.Resources.json</c> manifest, as file name → output path.</summary>
+    private static Dictionary<string, string?> ManifestEntries(string dllPath)
+    {
+        using var asm = AssemblyDefinition.ReadAssembly(dllPath);
+        var manifest = asm.MainModule.Resources.OfType<EmbeddedResource>().Single(r => r.Name == "Transpose.Resources.json");
+        using var doc = JsonDocument.Parse(manifest.GetResourceData());
+        return doc.RootElement.EnumerateArray().ToDictionary(
+            e => e.GetProperty("FileName").GetString()!,
+            e => e.GetProperty("Path").GetString());
+    }
+}


### PR DESCRIPTION
A `resources` group's `files` entry may now use a `**` path segment — `assets/img/**`, or `assets/img/**/*.svg` to narrow it. A copy-through group reproduces the sub-folder each file was found in, both in the site it writes and in the package DLL it embeds, so a consuming project extracts the same tree.

### Why

A package's embedded resources are the **only** channel it has for its assets. A library that instead lets MSBuild's `<None … CopyToOutputDirectory>` carry them works inside its own repository — a content item flows across a `ProjectReference` — and ships nothing to anyone consuming it as a NuGet package, which does not pack `None` items.

That is what hid this. `Curiosity.FrontEnd`'s globs are `tps/assets/img/*` and `tps/assets/webfonts/*`, which match one directory, so its package DLL carried 10 images and 13 fonts. Every application built against the package was missing 243 icons/illustrations, both variable-font families and the favicon — broken icons throughout the admin hubs, and text falling back to a system font because the `@font-face` sources 404 — while the Curiosity front-end's own build looked complete.

### What changed

- **`ExpandGlob`** recognises `**` as a whole path segment and returns, per match, the directory it sits in relative to the fixed part of the pattern. What follows `**` must be a single file pattern.
- **The sub-directory reaches the manifest entry's `Path`**, which is what extraction rebuilds the layout from …
- **… and it also qualifies the entry's `Name`.** The manifest is keyed by name and `ResourceEmbedder` *replaces* a same-named resource, so an unqualified key silently drops one of two files sharing a leaf name in different folders. Curiosity.FrontEnd has exactly one such pair — `img/icons/api.svg` and `img/icons/logos/api.svg`.
- **`ExtractProjectDllResources`** was building its output path from the full manifest name where `ExtractEmbeddedJs` uses the leaf; both use the leaf now, so a project DLL and a package DLL extract one resource to the same place.
- **Glob results are ordered ordinally** instead of in file-system order, so the manifest a build produces doesn't depend on the machine it ran on.

### Compatibility

A plain `*` still matches one directory — every tps.json written so far means it that way, and widening it would change what published packages contain.

.NET's own search patterns collapse `**` to `*`, so an **older compiler reads a recursive pattern as the non-recursive one** rather than failing. A tps.json can therefore adopt `**` before this compiler ships.

### Verification

- 11 new tests in `RecursiveResourceGlobTests.cs`: non-recursive globs stay non-recursive; recursive globs keep the folder layout on disk, in the manifest and out the other side of a package; the leaf-name collision stays two resources; a bundle group still concatenates to one file whatever depth it matched; a nested stylesheet is linked from index.html at its nested path; ordering is deterministic; a group with no `output` still serialises `"Path": null`.
- Full translator suite green — 864 passed, 17 skipped.
- **Byte-identical output gate**: a full site build of a real app (the tech-data-demo front-end, whose packages carry no nested resources) `diff -r`s clean against the released compiler.
- Against a locally rebuilt `Curiosity.FrontEnd` with recursive globs, its package DLL goes from 285 to 536 embedded resources, and a consuming site build gets all 253 images and 21 fonts at paths identical to the source tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AouJMiLwaCfZdCq9dfkvDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AouJMiLwaCfZdCq9dfkvDT)_