### PR TITLE
Fix iterator body emission to properly handle local functions and using vars

### DIFF
--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -339,6 +339,112 @@ public class Program
 }");
         }
 
+        /// <summary>
+        /// An iterator body used to be emitted statement-by-statement instead of through
+        /// <c>EmitStatements</c>, so a local function declared at the END of the body kept its
+        /// textual position — <c>var f = () =&gt; …</c> after the call — and calling it earlier hit
+        /// <c>undefined</c> ("f is not a function"). Curiosity's CSV-import column selector is
+        /// exactly this shape.
+        /// </summary>
+        [TestMethod]
+        public async Task IteratorCallsLocalFunctionDeclaredAfterItRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    static IEnumerable<string> Fields(bool match)
+    {
+        var buf = new List<string>();
+
+        if (match) SetIgnore(); else SetPleaseSelect();
+
+        Func<string> onSelected = () => { SetIgnore(); return string.Join("","", buf); };
+
+        yield return ""first:"" + string.Join("","", buf);
+        yield return ""cb:"" + onSelected();
+
+        void SetPleaseSelect() => buf.Add(""* select a field *"");
+        void SetIgnore()       => buf.Add(""Ignore column"");
+    }
+    public static void Main()
+    {
+        foreach (var s in Fields(false)) Console.WriteLine(s);
+        foreach (var s in Fields(true))  Console.WriteLine(s);
+    }
+}");
+        }
+
+        /// <summary>
+        /// The same bypass meant an iterator body never got the <c>using var</c> → try/finally
+        /// desugaring, so the resource was never disposed.
+        /// </summary>
+        [TestMethod]
+        public async Task IteratorUsingVarDisposesRunsAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Res : IDisposable
+{
+    private readonly string _n;
+    public Res(string n) { _n = n; Console.WriteLine(""open "" + n); }
+    public void Dispose() { Console.WriteLine(""close "" + _n); }
+}
+public class Program
+{
+    static IEnumerable<string> Items()
+    {
+        using var r = new Res(""r1"");
+        yield return ""a"";
+        yield return ""b"";
+    }
+    public static void Main()
+    {
+        foreach (var s in Items()) Console.WriteLine(s);
+    }
+}");
+        }
+
+        /// <summary>
+        /// A property getter with <c>yield return</c> is an iterator too. Its accessor body used to
+        /// be emitted into a plain <c>function</c>, so the bare <c>yield</c> was a JavaScript SYNTAX
+        /// error that took the whole bundle down. A local function in a normal getter had the
+        /// hoisting bug above.
+        /// </summary>
+        [TestMethod]
+        public async Task IteratorPropertyGetterAndGetterLocalFunctionRunAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    public static IEnumerable<int> Numbers
+    {
+        get
+        {
+            yield return 1;
+            yield return 2;
+        }
+    }
+    public static string Prop
+    {
+        get
+        {
+            return Fmt(""prop"");
+            string Fmt(string s) => ""<"" + s + "">"";
+        }
+    }
+    public static void Main()
+    {
+        Console.WriteLine(Prop);
+        foreach (var n in Numbers) Console.WriteLine(n);
+    }
+}");
+        }
+
         // ---- compound assignment to a collection indexer ----------------------
 
         [TestMethod]

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -142,7 +142,7 @@ public sealed partial class Emitter
                         }
                         if (staticCtor?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is ConstructorDeclarationSyntax { Body: { } body })
                         {
-                            foreach (var s in body.Statements) EmitStatement(s);
+                            EmitStatements(body.Statements);
                         }
                     });
                     _w.WriteLine();
@@ -632,7 +632,7 @@ public sealed partial class Emitter
             // A generator function can't be an arrow, so it rebinds `this`; bind it to the
             // enclosing instance so an iterator body that reads `this.field` still works.
             _w.Write("return TransposeR.iter((function* () ");
-            _w.Block(() => { foreach (var s in body.Statements) EmitStatement(s); });
+            _w.Block(() => EmitStatements(body.Statements));
             _w.WriteLine(").bind(this));");
         });
     }
@@ -910,7 +910,8 @@ public sealed partial class Emitter
         switch (syntax)
         {
             case AccessorDeclarationSyntax { Body: { } body }:
-                _w.Block(() => { foreach (var s in body.Statements) EmitStatement(s); });
+                if (IsIteratorBody(body)) EmitIteratorBody(body, accessor);
+                else _w.Block(() => EmitStatements(body.Statements));
                 break;
             case AccessorDeclarationSyntax { ExpressionBody: { } arrow }:
             case ArrowExpressionClauseSyntax arrow2 when (arrow2 = (ArrowExpressionClauseSyntax)syntax) != null:

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -958,7 +958,7 @@ public sealed partial class Emitter
                 // arrow would be invalid — a bare `yield` outside a generator is a strict-mode syntax
                 // error.
                 _w.Write("return TransposeR.iter((function* () ");
-                _w.Block(() => { foreach (var s in localFn.Body!.Statements) EmitStatement(s); });
+                _w.Block(() => EmitStatements(localFn.Body!.Statements));
                 _w.WriteLine(").bind(this));");
             }
             else


### PR DESCRIPTION
## Summary

Iterator bodies (methods with `yield return` and property getters with `yield return`) were being emitted statement-by-statement instead of through the `EmitStatements` method. This caused two critical bugs:

1. Local functions declared at the end of an iterator body retained their textual position in the generated JavaScript, causing "undefined" errors when called before their declaration
2. `using var` declarations in iterator bodies were never desugared to try/finally blocks, so resources were never disposed

Additionally, property getters with `yield return` were emitted as plain functions instead of generators, causing syntax errors.

## Key Changes

- **Emit/Emitter.Members.cs**: 
  - Fixed static constructor body emission to use `EmitStatements` instead of manual statement loop
  - Fixed iterator body emission in `EmitIteratorBody` to use `EmitStatements`
  - Added iterator detection in `EmitAccessorBody` to properly handle property getters with `yield return`

- **Emit/Emitter.Statements.cs**:
  - Fixed local function iterator body emission to use `EmitStatements`

- **Translator.Tests/EmitRegressionTests.cs**:
  - Added `IteratorCallsLocalFunctionDeclaredAfterItRunsAsync` test for the local function hoisting bug
  - Added `IteratorUsingVarDisposesRunsAsync` test for the using var disposal bug
  - Added `IteratorPropertyGetterAndGetterLocalFunctionRunAsync` test for iterator property getters and local functions in normal getters

## Implementation Details

The fix ensures that `EmitStatements` is consistently used for all iterator bodies (methods, local functions, and property accessors). This method properly handles statement hoisting and desugaring, including:
- Hoisting local function declarations to the top of their scope
- Desugaring `using var` to try/finally blocks
- Properly ordering statements for JavaScript generator semantics

https://claude.ai/code/session_017rQjj35Kuc22mBfQmxxDP8