### PR TITLE
Expand [Template] method groups to apply template substitution

### DIFF
--- a/Packages/Transpose.Newtonsoft.Json.Tests/CuriosityUsageTests.cs
+++ b/Packages/Transpose.Newtonsoft.Json.Tests/CuriosityUsageTests.cs
@@ -27,6 +27,44 @@ using System.Linq;
 using Newtonsoft.Json;
 ";
 
+    /// <summary>
+    /// <c>DeserializeObject&lt;T&gt;</c> passed as a METHOD GROUP, the way AIModelSettings maps a
+    /// setting's valid values (<c>ValidValues.Select(JsonConvert.DeserializeObject&lt;AWSRegionEndpoint&gt;)</c>).
+    /// A regression: a method group of a <c>[Template]</c> method emitted a bare member reference
+    /// instead of expanding the template, so <c>{T}</c> was dropped and Select's element index landed
+    /// in the runtime's <c>type</c> slot — "type is not a constructor" at runtime.
+    /// </summary>
+    [TestMethod]
+    public async Task DeserializeObjectAsAMethodGroupCarriesItsTypeArgument()
+    {
+        var code = Header + @"
+public class AWSRegionEndpoint
+{
+    public string DisplayName { get; set; }
+    public string SystemName  { get; set; }
+}
+
+public class App
+{
+    public static void Main()
+    {
+        var validValues = new[]
+        {
+            ""{\""DisplayName\"":\""Europe (Frankfurt)\"",\""SystemName\"":\""eu-central-1\""}"",
+            ""{\""DisplayName\"":\""US East (N. Virginia)\"",\""SystemName\"":\""us-east-1\""}"",
+        };
+
+        var regions = validValues.Select(JsonConvert.DeserializeObject<AWSRegionEndpoint>).ToArray();
+        foreach (var r in regions) Console.WriteLine(r.DisplayName + "" / "" + r.SystemName);
+
+        // the same conversion held in a delegate and invoked twice
+        Func<string, AWSRegionEndpoint> parse = JsonConvert.DeserializeObject<AWSRegionEndpoint>;
+        Console.WriteLine(parse(validValues[0]).SystemName + ""|"" + parse(validValues[1]).SystemName);
+    }
+}";
+        await RunAndCompare(code);
+    }
+
     /// <summary>A search-response shaped DTO round-tripping the way an <c>API.*</c> call does.</summary>
     [TestMethod]
     public async Task TypedApiResponseRoundTrips()

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -3442,6 +3442,52 @@ public class Program
 }", waitForOutput: "<<DONE>>");
         }
 
+        // ---- a method group of a [Template] method expands its template ---------------------
+        //
+        // A [Template] method with no `Fn` fell through to a bare mangled member reference, which either
+        // does not exist ([External], so no body is emitted) or is a differently-shaped runtime function.
+        // The reported case was `values.Select(JsonConvert.DeserializeObject<T>)`, whose template
+        // "…DeserializeObject({value}, {T})" was dropped entirely: the emitted reference landed Select's
+        // element INDEX in the runtime's `type` slot and threw "type is not a constructor". `Task.FromResult`
+        // below is the BCL analogue of that shape (a static generic templated method with a {TResult} slot);
+        // the rest cover the non-generic static, the instance and the enumerated forms. A method group now
+        // wraps the same expansion a direct call emits, with an instance receiver bound once — so `Recv()`
+        // runs exactly once no matter how often the delegate is called, as C# specifies.
+
+        [TestMethod]
+        public async Task TemplateMethodGroupExpandsItsTemplate()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+public class Program
+{
+    static int _calls;
+    static string Recv() { _calls++; return ""a,b,c""; }
+
+    public static void Main()
+    {
+        Func<int, Task<int>> mk = Task.FromResult;                    // static generic templated group
+        Console.WriteLine(mk(7).Result);
+
+        Func<string, bool> e = string.IsNullOrEmpty;                  // static templated group
+        Console.WriteLine(e("""") + ""/"" + e(""x""));
+        Console.WriteLine(string.Join("","", new[] { """", ""ab"", ""c"" }.Select(string.IsNullOrEmpty)));
+
+        Console.WriteLine(new string(""abc"".ToCharArray().Select(char.ToUpper).ToArray()));
+
+        Func<char, int> idx = Recv().IndexOf;                         // instance templated group
+        Console.WriteLine(idx('b') + ""/"" + idx('c') + ""/calls="" + _calls);
+
+        Func<string, string> fmt = new DateTime(2020, 3, 4).ToString;
+        Console.WriteLine(fmt(""yyyy-MM-dd""));
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
         // ---- a plain struct has value equality and value hashing ----------------------------
         //
         // .NET gives every value type field-wise Equals/GetHashCode via ValueType, which is what makes

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -915,6 +915,19 @@ public sealed partial class Emitter
             return;
         }
 
+        // A [Template] method with no `Fn` form still has to expand its template when referenced as a
+        // method group: the bare member reference either points at nothing (an [External] method has no
+        // emitted body) or at a runtime function whose signature is not the template's — e.g.
+        // `values.Select(JsonConvert.DeserializeObject<T>)` emitted
+        // `Newtonsoft.Json.JsonConvert.DeserializeObject`, dropping `{T}` and landing Select's element
+        // INDEX in the runtime's `type` slot. Wrap the expansion in a function whose parameters feed the
+        // template's argument slots.
+        if ((TransposeNaming.GetTemplate(method.OriginalDefinition) ?? TransposeNaming.GetTemplate(method)) is { } template)
+        {
+            EmitTemplateMethodGroup(method, template, thisTarget);
+            return;
+        }
+
         // A generic method that threads its type arguments takes them as LEADING parameters, so a
         // method group has to bind them into the delegate. Without this the delegate's first VALUE
         // argument landed in the T slot: `new[]{1,2}.Select(Show)` called Show(1, undefined), so
@@ -935,6 +948,52 @@ public sealed partial class Emitter
             _w.Write($").{TransposeNaming.MemberJsName(method)}.bind(");
             EmitReceiverExpr(thisTarget);
             _w.Write($"{boundTypeArgs})");
+        }
+    }
+
+    /// <summary>
+    /// Emits a method group over a <c>[Template]</c> method as a function whose parameters are the
+    /// template's argument slots — <c>function ($a0) { return Newtonsoft.Json.JsonConvert.DeserializeObject($a0, Foo); }</c>
+    /// — so the delegate applies the same expansion a direct call would. An instance (or extension)
+    /// receiver is bound with <c>.bind(null, recv)</c> as the leading parameter, which evaluates the
+    /// receiver once, where the method group is written, exactly as C# does.
+    /// </summary>
+    private void EmitTemplateMethodGroup(IMethodSymbol method, string template, ExpressionSyntax? thisTarget)
+    {
+        var reduced   = method is { IsExtensionMethod: true, ReducedFrom: { } r } ? r : null;
+        var argNames  = method.Parameters.Select((_, i) => "$a" + i).ToList();
+        var bindsRecv = !method.IsStatic || reduced is not null;
+        var receiver  = bindsRecv ? "$this" : null;
+
+        var byName    = new Dictionary<string, string>();
+        var byPos     = new List<string>(argNames);
+
+        // Reduced extension method: the receiver binds to the original first parameter (e.g. {source}),
+        // the delegate's own arguments to the remaining ones — mirroring the invocation path.
+        if (reduced is not null)
+        {
+            byName[reduced.Parameters[0].Name] = receiver!;
+            for (var i = 0; i < argNames.Count && i + 1 < reduced.Parameters.Length; i++)
+                byName[reduced.Parameters[i + 1].Name] = argNames[i];
+            byPos = new List<string> { receiver! }.Concat(argNames).ToList();
+            AddTypeArguments(byName, reduced, method);
+        }
+        else
+        {
+            for (var i = 0; i < method.Parameters.Length; i++) byName[method.Parameters[i].Name] = argNames[i];
+            AddTypeArguments(byName, method.OriginalDefinition, method);
+        }
+
+        var body = Capture(() => WriteTemplate(template, method.IsStatic && reduced is null, reduced is not null, receiver, byName, byPos));
+        var ps   = bindsRecv ? new List<string> { receiver! }.Concat(argNames) : argNames;
+
+        _w.Write($"(function ({string.Join(", ", ps)}) {{ return {body}; }})");
+
+        if (bindsRecv)
+        {
+            _w.Write(".bind(null, ");
+            EmitReceiverExpr(thisTarget);
+            _w.Write(")");
         }
     }
 


### PR DESCRIPTION
## Summary

Fix method groups of `[Template]` methods to properly expand their templates instead of emitting bare member references. This resolves a regression where passing a generic templated method as a delegate (e.g., `values.Select(JsonConvert.DeserializeObject<T>)`) would drop the template expansion and cause runtime errors.

## Problem

When a `[Template]` method with no `Fn` form was referenced as a method group, the emitter would emit a bare mangled member reference. This either:
- Points to nothing (for `[External]` methods with no emitted body), or
- Points to a runtime function with a different signature than the template expects

For example, `JsonConvert.DeserializeObject<T>` passed to `Select()` would drop the `{T}` template slot, causing the element index to land in the runtime's `type` parameter slot, resulting in "type is not a constructor" at runtime.

## Solution

- **New method `EmitTemplateMethodGroup()`**: Wraps the template expansion in a function whose parameters correspond to the template's argument slots, mirroring what a direct call would emit
- **Receiver binding**: Instance (or extension) receivers are bound once using `.bind(null, recv)`, ensuring the receiver expression evaluates exactly once, matching C# semantics
- **Parameter mapping**: Correctly handles both regular methods and reduced extension methods, mapping parameters and type arguments to the template's slots
- **Early return**: Added check in `EmitMethodGroup()` to detect `[Template]` methods and delegate to the new handler before other method group logic

## Test Coverage

- **EmitRegressionTests**: New `TemplateMethodGroupExpandsItsTemplate()` test covering static generic templated, static templated, instance templated, and instance method groups
- **CuriosityUsageTests**: New `DeserializeObjectAsAMethodGroupCarriesItsTypeArgument()` test with the real-world Newtonsoft.Json scenario that triggered the regression

https://claude.ai/code/session_01BBC3NjM7qdQgffc63kyWdY