### PR TITLE
Add Transpose.System.Text.Json

### DIFF
--- a/.devops/build-transpose-system-text-json.yml
+++ b/.devops/build-transpose-system-text-json.yml
@@ -1,0 +1,93 @@
+variables:
+  transposeSystemTextJson: '$(Build.SourcesDirectory)/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj'
+  transposeSystemTextJsonTests: '$(Build.SourcesDirectory)/Packages/Transpose.System.Text.Json.Tests/Transpose.System.Text.Json.Tests.csproj'
+  buildConfiguration: 'Release'
+  targetVersion: yy.M.$(build.buildId)
+
+pool:
+  vmImage: 'windows-latest'
+
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - Packages/Transpose.System.Text.Json/*
+    - Packages/Transpose.System.Text.Json.Tests/*
+    - .devops/build-transpose-system-text-json.yml
+
+pr: none
+
+steps:
+- checkout: self
+
+- script: |
+    echo "Commit message: $(Build.SourceVersionMessage)"
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 10.0 SDK'
+  inputs:
+    packageType: sdk
+    version: 10.x
+    includePreviewVersions: false
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- task: PowerShell@2
+  displayName: 'Create CalVer Version'
+  inputs:
+    targetType: 'inline'
+    script: |
+      $dottedDate = (Get-Date).ToString("yy.M")
+      $buildID = $($env:BUILD_BUILDID)
+      $modBuildID = [int]$buildID % 65536  # ensure fits in int16
+      $newTargetVersion = "$dottedDate.$modBuildID"
+      Write-Host "##vso[task.setvariable variable=targetVersion;]$newTargetVersion"
+      Write-Host "Updated targetVersion to '$newTargetVersion'"
+
+- task: CmdLine@2
+  displayName: 'Install Transpose compiler'
+  inputs:
+    script: 'dotnet tool install --global Transpose.Compiler'
+
+- task: DotNetCoreCLI@2
+  displayName: 'restore nuget'
+  inputs:
+    command: 'restore'
+    projects: '$(transposeSystemTextJson)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'build'
+  inputs:
+    command: 'build'
+    projects: '$(transposeSystemTextJson)'
+    arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)'
+
+# TESTS DISABLED ON CI DUE TO RESOURCE LIMITATION
+# Runs the snippets both natively (against the real System.Text.Json) and as translated JavaScript on Node,
+# and diffs the output — so a change to JsonSerializer.js is checked against System.Text.Json before it ships.
+# The Transpose.dll runtime the tests translate against comes from the Transpose.BCL package the
+# restore above put in the NuGet cache.
+# - task: DotNetCoreCLI@2
+#   displayName: 'test'
+#   inputs:
+#     command: 'test'
+#     projects: '$(transposeSystemTextJsonTests)'
+#     arguments: '-c $(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'pack nuget'
+  inputs:
+    command: 'pack'
+    packagesToPack: '$(transposeSystemTextJson)'
+    configuration: '$(buildConfiguration)'
+    versioningScheme: 'off'
+    buildProperties: 'Version="$(targetVersion)";AllowUnsafeBlocks="True";LangVersion="latest"'
+
+- task: NuGetCommand@2
+  displayName: 'push nuget'
+  inputs:
+    command: 'push'
+    packagesToPush: '**/Transpose.System.Text.Json.$(targetVersion).nupkg'
+    nuGetFeedType: 'external'
+    publishFeedCredentials: 'nuget-curiosity-org'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,16 @@ Packages/                      # Additional binding libraries (all [assembly: Ex
 ├── Transpose.Newtonsoft.Json.Tests/ # MSTest suite for it: every snippet runs natively against the
 │                              #   real Json.NET *and* as translated JS on Node, and the outputs are
 │                              #   diffed (see its README for the documented divergences)
+├── Transpose.System.Text.Json/#   package Transpose.System.Text.Json — the whole-document
+│                              #   JsonSerializer/JsonSerializerOptions surface a browser app uses.
+│                              #   Deliberately *not* the streaming (Utf8JsonReader/Writer), document
+│                              #   (JsonDocument/JsonNode) or source-generated APIs, and no converter
+│                              #   registry. Behaviour lives in Resources/Manual/JsonSerializer.js
+├── Transpose.System.Text.Json.Tests/ # MSTest suite for it, with two oracles: the real
+│                              #   System.Text.Json (it ships in the shared framework, so the same
+│                              #   snippet binds to both), and — for the Curiosity migration —
+│                              #   Transpose.Newtonsoft.Json, so every wire-format change between the
+│                              #   two packages is recorded on both sides (see its README)
 ├── Transpose.Howler/          #   package Transpose.Howler
 ├── Transpose.WebGL2/          #   package Transpose.WebGL2
 ├── Transpose.P2/              #   package Transpose.P2

--- a/Packages/Transpose.System.Text.Json.Tests/AttributeTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/AttributeTests.cs
@@ -1,0 +1,300 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// The <c>System.Text.Json.Serialization</c> attributes: renaming, ignoring, opting in, ordering and
+/// per-member number handling.
+/// </summary>
+[TestClass]
+public sealed class AttributeTests : JsonTestBase
+{
+    // ---------------------------------------------------------------------------------------------
+    // [JsonPropertyName]
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task JsonPropertyNameRenamesOnWriteAndRead() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonPropertyName("n")]    public string Name  { get; set; }
+            [JsonPropertyName("cnt")]  public int    Count { get; set; }
+                                       public bool   Plain { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { Name = "a", Count = 2, Plain = true });
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine(back.Name + "/" + back.Count + "/" + back.Plain);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task JsonPropertyNameBeatsTheNamingPolicy() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonPropertyName("KeepMe")] public string Renamed { get; set; }
+                                         public string Other   { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+                Console.WriteLine(JsonSerializer.Serialize(new T { Renamed = "a", Other = "b" }, options));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task TheOriginalMemberNameNoLongerMatchesOnceRenamed() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T { [JsonPropertyName("n")] public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Name\":\"x\"}").Name ?? "<null>");
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // [JsonIgnore]
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task JsonIgnoreRemovesTheMemberEntirely() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            public string Kept { get; set; } = "kept";
+            [JsonIgnore] public string Dropped { get; set; } = "dropped";
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new T()));
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Dropped\":\"changed\"}").Dropped);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task JsonIgnoreWhenWritingNull() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string Maybe { get; set; }
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public int?   MaybeInt { get; set; }
+            public string Always { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new T()));
+                Console.WriteLine(JsonSerializer.Serialize(new T { Maybe = "m", MaybeInt = 0, Always = "a" }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task JsonIgnoreWhenWritingDefault() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)] public int    Count { get; set; }
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)] public bool   Flag  { get; set; }
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)] public string Name  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new T()));
+                Console.WriteLine(JsonSerializer.Serialize(new T { Count = 1, Flag = true, Name = "n" }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task JsonIgnoreNeverOverridesTheOptionsWideCondition() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonIgnore(Condition = JsonIgnoreCondition.Never)] public string Kept { get; set; }
+            public string Dropped { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+                Console.WriteLine(JsonSerializer.Serialize(new T(), options));
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // [JsonInclude]
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task JsonIncludeOptsInAPublicField() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonInclude] public string Included;
+                          public string Excluded;
+                          public string Prop { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { Included = "i", Excluded = "e", Prop = "p" });
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>("{\"Included\":\"x\",\"Excluded\":\"y\"}");
+                Console.WriteLine((back.Included ?? "<null>") + "/" + (back.Excluded ?? "<null>"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task JsonIncludeOptsInANonPublicSetter() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonInclude] public string Opted  { get; private set; } = "original";
+                          public string Closed { get; private set; } = "original";
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var back = JsonSerializer.Deserialize<T>("{\"Opted\":\"changed\",\"Closed\":\"changed\"}");
+                Console.WriteLine(back.Opted + "/" + back.Closed);
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // [JsonPropertyOrder]
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task JsonPropertyOrderPositionsMembers() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonPropertyOrder(3)]  public int Third  { get; set; }
+            [JsonPropertyOrder(1)]  public int First  { get; set; }
+            [JsonPropertyOrder(2)]  public int Second { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Serialize(new T { First = 1, Second = 2, Third = 3 }));
+        }
+        """, exactMemberOrder: true);
+
+    [TestMethod]
+    public async Task ANegativeOrderSortsBeforeTheUnordered() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            public int Unordered { get; set; }
+            [JsonPropertyOrder(-1)] public int Early { get; set; }
+            [JsonPropertyOrder(10)] public int Late  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Serialize(new T { Unordered = 1, Early = 2, Late = 3 }));
+        }
+        """, exactMemberOrder: true);
+
+    // ---------------------------------------------------------------------------------------------
+    // [JsonNumberHandling]
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task JsonNumberHandlingAllowsReadingAMemberFromAString() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)] public int Lenient { get; set; }
+            public int Strict { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Lenient\":\"7\"}").Lenient);
+
+                try
+                {
+                    Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Strict\":\"7\"}").Strict);
+                }
+                catch (JsonException)
+                {
+                    Console.WriteLine("JsonException");
+                }
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/BclTypeTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/BclTypeTests.cs
@@ -1,0 +1,292 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// The BCL values with a fixed JSON shape — dates, times, GUIDs, URIs, versions, byte arrays,
+/// characters, nullables — plus the numeric types JavaScript cannot represent exactly.
+/// </summary>
+[TestClass]
+public sealed class BclTypeTests : JsonTestBase
+{
+    [TestMethod]
+    public async Task GuidUriAndVersion() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public Guid G { get; set; } public Uri U { get; set; } public Version V { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new T
+                {
+                    G = new Guid("11111111-2222-3333-4444-555555555555"),
+                    U = new Uri("https://example.org/path?q=1"),
+                    V = new Version(1, 2, 3, 4)
+                };
+
+                var json = JsonSerializer.Serialize(value);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine(back.G + "/" + back.U + "/" + back.V);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DateTimeIsIso8601() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public DateTime Utc { get; set; } public DateTime Unspecified { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new T
+                {
+                    Utc         = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                    Unspecified = new DateTime(2021, 6, 7, 8, 9, 10, DateTimeKind.Unspecified)
+                };
+
+                var json = JsonSerializer.Serialize(value);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine(back.Utc.ToString("yyyy-MM-dd HH:mm:ss") + "/" + back.Unspecified.ToString("yyyy-MM-dd HH:mm:ss"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DateTimeWithFractionalSeconds() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public DateTime D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { D = new DateTime(2020, 1, 2, 3, 4, 5, 250, DateTimeKind.Utc) });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<T>(json).D.Millisecond);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DateTimeOffsetRoundTrips() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public DateTimeOffset D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { D = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero) });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<T>(json).D.ToString("yyyy-MM-dd HH:mm:ss"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task TimeSpanIsItsConstantString() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public TimeSpan Ts { get; set; } public TimeSpan? Nullable { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { Ts = TimeSpan.FromSeconds(90) });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<T>(json).Ts.TotalSeconds);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AByteArrayIsBase64() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public byte[] Data { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { Data = new byte[] { 1, 2, 3, 250 } });
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine(back.Data.Length + "/" + back.Data[3]);
+
+                Console.WriteLine(JsonSerializer.Serialize(new T { Data = new byte[0] }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ACharIsASingleCharacterString() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public char C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { C = 'q' });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<T>(json).C);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task NullablesRoundTrip() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public enum E { A = 1 }
+        public class T
+        {
+            public int?      I  { get; set; }
+            public bool?     B  { get; set; }
+            public double?   D  { get; set; }
+            public DateTime? Dt { get; set; }
+            public E?        En { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new T()));
+
+                var set  = new T { I = 1, B = true, D = 1.5, Dt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc), En = E.A };
+                var json = JsonSerializer.Serialize(set);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine(back.I + "/" + back.B + "/" + back.D + "/" + back.En);
+
+                var empty = JsonSerializer.Deserialize<T>("{}");
+                Console.WriteLine(empty.I.HasValue + "/" + empty.Dt.HasValue);
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Numerics JavaScript cannot hold exactly — the package's one deliberate wire difference
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task SixtyFourBitIntegersAreWrittenAsStringsWhileDecimalsStayNumbers() => await RunJs("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public long L { get; set; } public ulong U { get; set; } public decimal D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Serialize(new T { L = 9007199254740993L, U = 18446744073709551615UL, D = 1.5m }));
+        }
+        """,
+        expected:     """{"D":1.5,"L":"9007199254740993","U":"18446744073709551615"}""",
+        nativePrints: """{"L":9007199254740993,"U":18446744073709551615,"D":1.5}""");
+
+    [TestMethod]
+    public async Task SixtyFourBitIntegersRoundTripThroughTheirStringForm() => await RunJs("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public long L { get; set; } public decimal D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T { L = 9007199254740993L, D = 0.1m });
+                var back = JsonSerializer.Deserialize<T>(json);
+
+                Console.WriteLine(back.L);
+                Console.WriteLine(back.D);
+            }
+        }
+        """,
+        expected:     "9007199254740993\n0.1",
+        nativePrints: "9007199254740993\n0.1");
+
+    [TestMethod]
+    public async Task SixtyFourBitIntegersAreAlsoReadFromANumber() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public long L { get; set; } public decimal D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var back = JsonSerializer.Deserialize<T>("{\"L\":12,\"D\":1.5}");
+                Console.WriteLine(back.L + "/" + back.D);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task WholeNumberDoublesLoseTheirTrailingZero() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public double A { get; set; } public double B { get; set; } public float F { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Serialize(new T { A = 1.0, B = 1.25, F = 0.5f }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task IntegerBoundaries() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public byte   B  { get; set; }
+            public sbyte  Sb { get; set; }
+            public short  S  { get; set; }
+            public ushort Us { get; set; }
+            public int    I  { get; set; }
+            public uint   Ui { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new T { B = 255, Sb = -128, S = -32768, Us = 65535, I = -2147483648, Ui = 4294967295 };
+                var json  = JsonSerializer.Serialize(value);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine(back.B + "/" + back.Sb + "/" + back.S + "/" + back.Us + "/" + back.I + "/" + back.Ui);
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/CollectionTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/CollectionTests.cs
@@ -1,0 +1,255 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>Arrays, lists, sets, dictionaries, the collection interfaces, and nesting between them.</summary>
+[TestClass]
+public sealed class CollectionTests : JsonTestBase
+{
+    [TestMethod]
+    public async Task ArraysOfPrimitives() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new[] { 1, 2, 3 }));
+                Console.WriteLine(JsonSerializer.Serialize(new[] { "a", null, "c" }));
+                Console.WriteLine(JsonSerializer.Serialize(new[] { true, false }));
+                Console.WriteLine(JsonSerializer.Serialize(new double[] { 1.5, 2 }));
+                Console.WriteLine(JsonSerializer.Serialize(new int[0]));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ArraysRoundTrip() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var back = JsonSerializer.Deserialize<int[]>("[1,2,3]");
+                Console.WriteLine(back.Length + "/" + back[0] + "/" + back[2]);
+
+                var strings = JsonSerializer.Deserialize<string[]>("[\"a\",null]");
+                Console.WriteLine(strings.Length + "/" + (strings[1] ?? "<null>"));
+
+                Console.WriteLine(JsonSerializer.Deserialize<int[]>("[]").Length);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ListsAndSets() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new List<string> { "a", "b" }));
+                Console.WriteLine(JsonSerializer.Serialize(new HashSet<int> { 1, 2, 3 }));
+
+                var list = JsonSerializer.Deserialize<List<string>>("[\"a\",\"b\"]");
+                Console.WriteLine(list.Count + "/" + list[1]);
+
+                var set = JsonSerializer.Deserialize<HashSet<int>>("[1,2,2,3]");
+                Console.WriteLine(set.Count + "/" + set.Contains(3));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task CollectionInterfaceTargets() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Deserialize<IList<int>>("[1,2]").Count);
+                Console.WriteLine(JsonSerializer.Deserialize<ICollection<int>>("[1,2,3]").Count);
+                Console.WriteLine(JsonSerializer.Deserialize<IEnumerable<int>>("[1,2,3,4]").Count());
+                Console.WriteLine(JsonSerializer.Deserialize<IReadOnlyList<string>>("[\"a\"]").Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ACollectionValuedMemberThatIsOnlyIEnumerable() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using System.Text.Json;
+
+        public class T
+        {
+            public IEnumerable<string>     Items    { get; set; }
+            public IReadOnlyList<int>      Numbers  { get; set; }
+            public IReadOnlyCollection<int> Others  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Items\":[\"a\",\"b\"],\"Numbers\":[1,2,3],\"Others\":[9]}");
+                Console.WriteLine(t.Items.Count() + "/" + t.Numbers.Count + "/" + t.Others.Count);
+                Console.WriteLine(JsonSerializer.Serialize(t));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DictionariesWithStringKeys() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }));
+                Console.WriteLine(JsonSerializer.Serialize(new Dictionary<string, string> { ["k"] = null }));
+
+                var back = JsonSerializer.Deserialize<Dictionary<string, int>>("{\"a\":1,\"b\":2}");
+                Console.WriteLine(back.Count + "/" + back["b"]);
+
+                Console.WriteLine(JsonSerializer.Serialize(new Dictionary<string, int>()));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DictionariesWithNonStringKeys() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public enum Kind { Alpha = 1, Beta = 2 }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new Dictionary<int, string> { [3] = "x" }));
+                Console.WriteLine(JsonSerializer.Serialize(new Dictionary<Kind, string> { [Kind.Beta] = "y" }));
+
+                var ints = JsonSerializer.Deserialize<Dictionary<int, string>>("{\"3\":\"x\"}");
+                Console.WriteLine(ints[3]);
+
+                var enums = JsonSerializer.Deserialize<Dictionary<Kind, string>>("{\"Beta\":\"y\"}");
+                Console.WriteLine(enums[Kind.Beta]);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DictionaryOfObjects() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public class Item { public string Name { get; set; } public int Value { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var map = new Dictionary<string, Item>
+                {
+                    ["one"] = new Item { Name = "a", Value = 1 },
+                    ["two"] = new Item { Name = "b", Value = 2 }
+                };
+
+                var json = JsonSerializer.Serialize(map);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<Dictionary<string, Item>>(json);
+                Console.WriteLine(back.Count + "/" + back["two"].Name + "/" + back["two"].Value);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task NestedCollections() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new List<List<int>> { new List<int> { 1, 2 }, new List<int>(), new List<int> { 3 } };
+                var json  = JsonSerializer.Serialize(value);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<List<List<int>>>(json);
+                Console.WriteLine(back.Count + "/" + back[0].Count + "/" + back[1].Count + "/" + back[2][0]);
+
+                var maps = new Dictionary<string, List<string>> { ["k"] = new List<string> { "a", "b" } };
+                Console.WriteLine(JsonSerializer.Serialize(maps));
+                Console.WriteLine(JsonSerializer.Deserialize<Dictionary<string, List<string>>>(JsonSerializer.Serialize(maps))["k"][1]);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ACollectionOfObjectsRoundTrips() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public class Item { public string Name { get; set; } public int Value { get; set; } }
+        public class Holder { public List<Item> Items { get; set; } public Item[] Array { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new Holder
+                {
+                    Items = new List<Item> { new Item { Name = "a", Value = 1 }, new Item { Name = "b", Value = 2 } },
+                    Array = new[] { new Item { Name = "c", Value = 3 } }
+                };
+
+                var json = JsonSerializer.Serialize(value);
+                var back = JsonSerializer.Deserialize<Holder>(json);
+
+                Console.WriteLine(back.Items.Count + "/" + back.Items[1].Name + "/" + back.Array[0].Value);
+                Console.WriteLine(JsonSerializer.Serialize(back) == json);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ANullCollectionMemberStaysNull() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public class T { public List<int> Items { get; set; } public int[] Array { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new T());
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json);
+                Console.WriteLine((back.Items == null) + "/" + (back.Array == null));
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/CrossPackageTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/CrossPackageTests.cs
@@ -1,0 +1,378 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// <c>Transpose.Newtonsoft.Json</c> versus <c>Transpose.System.Text.Json</c>, both running in the
+/// browser. This is the migration's risk register: an <c>AssertSame</c> is a shape that can be
+/// swapped over without thinking about it, and an <c>AssertDiffers</c> is a shape whose payload or
+/// behaviour changes, recorded on both sides so it cannot drift.
+/// </summary>
+[TestClass]
+public sealed class CrossPackageTests : CrossPackageTestBase
+{
+    // =============================================================================================
+    // Transparent — the payload is identical
+    // =============================================================================================
+
+    [TestMethod]
+    public async Task PlainObjects() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public class T { public string Name { get; set; } public int Count { get; set; } public bool Flag { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(Json.Write(new T { Name = "Ada", Count = 3, Flag = true }));
+                Console.WriteLine(Json.Write(new T()));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task NestedObjectsAndCollections() => await AssertSame("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public class Inner { public string S { get; set; } }
+        public class T
+        {
+            public Inner                    One  { get; set; }
+            public List<Inner>              Many { get; set; }
+            public int[]                    Nums { get; set; }
+            public Dictionary<string, int>  Map  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(Json.Write(new T
+                {
+                    One  = new Inner { S = "a" },
+                    Many = new List<Inner> { new Inner { S = "b" } },
+                    Nums = new[] { 1, 2 },
+                    Map  = new Dictionary<string, int> { ["k"] = 1 }
+                }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task EnumsAreNumbersInBoth() => await AssertSame("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public enum Colour { Red = 0, Green = 5, Blue = 9 }
+        public class T { public Colour C { get; set; } public Colour? N { get; set; } public Colour? Missing { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(Json.Write(new T { C = Colour.Green, N = Colour.Blue }));
+                Console.WriteLine(Json.Write(new Dictionary<Colour, string> { [Colour.Blue] = "x" }));
+
+                // Both read a number, and both also accept the name the Curiosity server writes.
+                Console.WriteLine(Json.Read<T>("{\"C\":9}").C);
+                Console.WriteLine(Json.Read<T>("{\"C\":\"Green\"}").C);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task TheRenameAttribute() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public class T
+        {
+            [#PROP("n")]   public string Name  { get; set; }
+            [#PROP("cnt")] public int    Count { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = Json.Write(new T { Name = "a", Count = 1 });
+                Console.WriteLine(json);
+
+                var back = Json.Read<T>(json);
+                Console.WriteLine(back.Name + "/" + back.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task SixtyFourBitIntegersAndDecimalsAreStringsInBoth() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public class T { public long L { get; set; } public ulong U { get; set; } public decimal D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = Json.Write(new T { L = 9007199254740993L, U = 18446744073709551615UL, D = 1.5m });
+                Console.WriteLine(json);
+
+                var back = Json.Read<T>(json);
+                Console.WriteLine(back.L + "/" + back.U + "/" + back.D);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DatesGuidsUrisAndByteArrays() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public class T
+        {
+            public DateTime       Dt    { get; set; }
+            public DateTimeOffset Dto   { get; set; }
+            public TimeSpan       Ts    { get; set; }
+            public Guid           G     { get; set; }
+            public Uri            U     { get; set; }
+            public Version        V     { get; set; }
+            public byte[]         Bytes { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new T
+                {
+                    Dt    = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                    Dto   = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero),
+                    Ts    = TimeSpan.FromSeconds(90),
+                    G     = new Guid("11111111-2222-3333-4444-555555555555"),
+                    U     = new Uri("https://example.org/p"),
+                    V     = new Version(1, 2, 3),
+                    Bytes = new byte[] { 1, 2, 3 }
+                };
+
+                var json = Json.Write(value);
+                Console.WriteLine(json);
+
+                var back = Json.Read<T>(json);
+                Console.WriteLine(back.Dt.ToString("yyyy-MM-dd HH:mm:ss") + "/" + back.Ts.TotalSeconds + "/" + back.G + "/" + back.V + "/" + back.Bytes.Length);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DeserializingToObjectYieldsTheRawParsedValueInBoth() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = Json.Read<object>("{\"a\":1,\"b\":[1,2]}");
+                Console.WriteLine(Json.Write(value));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task UnknownMembersAreIgnoredInBoth() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(Json.Read<T>("{\"Nope\":1,\"Name\":\"n\",\"Deep\":{\"x\":[1]}}").Name);
+        }
+        """);
+
+    [TestMethod]
+    public async Task IndentedOutput() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public class Inner { public string S { get; set; } }
+        public class T { public Inner In { get; set; } public int[] Arr { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(Json.WriteIndented(new T { In = new Inner { S = "v" }, Arr = new[] { 1, 2 } }));
+        }
+        """);
+
+    // =============================================================================================
+    // Divergent — these are the migration's real work
+    // =============================================================================================
+
+    [TestMethod]
+    public async Task MemberMatchingBecomesCaseSensitive() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T { public string Name { get; set; } public int ItemCount { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = Json.Read<T>("{\"name\":\"n\",\"itemcount\":3}");
+                Console.WriteLine((t.Name ?? "<null>") + "/" + t.ItemCount);
+            }
+        }
+        """,
+        newtonsoft:     "n/3",
+        systemTextJson: "<null>/0");
+
+    [TestMethod]
+    public async Task PublicFieldsStopBeingSerialized() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T
+        {
+            public string Field;
+            public string Prop { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(Json.Write(new T { Field = "f", Prop = "p" }));
+                Console.WriteLine(Json.Read<T>("{\"Field\":\"f\",\"Prop\":\"p\"}").Field ?? "<null>");
+            }
+        }
+        """,
+        newtonsoft:     "{\"Field\":\"f\",\"Prop\":\"p\"}\nf",
+        systemTextJson: "{\"Prop\":\"p\"}\n<null>");
+
+    [TestMethod]
+    public async Task NonPublicSettersStopBeingPopulated() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T { public string Value { get; private set; } = "original"; }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(Json.Read<T>("{\"Value\":\"changed\"}").Value);
+        }
+        """,
+        newtonsoft:     "changed",
+        systemTextJson: "original");
+
+    [TestMethod]
+    public async Task StringsAreEscapedMuchMoreAggressively() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T { public string V { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(Json.Write(new T { V = "a+b <tag> & 'q' café" }));
+        }
+        """,
+        newtonsoft:     "{\"V\":\"a+b <tag> & 'q' café\"}",
+        systemTextJson: "{\"V\":\"a\\u002Bb \\u003Ctag\\u003E \\u0026 \\u0027q\\u0027 caf\\u00E9\"}");
+
+    [TestMethod]
+    public async Task ANullIntoANonNullableValueMemberNowThrows() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T { public int Count { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try                    { Console.WriteLine(Json.Read<T>("{\"Count\":null}").Count); }
+                catch (#JSONEX#)       { Console.WriteLine("JsonException"); }
+            }
+        }
+        """,
+        newtonsoft:     "0",
+        systemTextJson: "JsonException");
+
+    [TestMethod]
+    public async Task AShapeMismatchNowThrows() => await AssertDiffers("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            static void Try(string label, Func<string> f)
+            {
+                try              { Console.WriteLine(label + ": " + f()); }
+                catch (#JSONEX#) { Console.WriteLine(label + ": JsonException"); }
+            }
+
+            public static void Main()
+            {
+                Try("array into object", () => Json.Read<T>("[1,2]").Name ?? "<null>");
+                Try("object into list",  () => Json.Read<List<int>>("{\"a\":1}").Count.ToString());
+            }
+        }
+        """,
+        newtonsoft:     "array into object: <null>\nobject into list: 0",
+        systemTextJson: "array into object: JsonException\nobject into list: JsonException");
+
+    [TestMethod]
+    public async Task ALenientPayloadIsNoLongerAccepted() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            static void Try(string label, Func<string> f)
+            {
+                try              { Console.WriteLine(label + ": " + f()); }
+                catch (#JSONEX#) { Console.WriteLine(label + ": JsonException"); }
+            }
+
+            public static void Main()
+            {
+                Try("single quotes",  () => Json.Read<T>("{'Name':'n'}").Name);
+                Try("unquoted name",  () => Json.Read<T>("{Name:\"n\"}").Name);
+                Try("trailing comma", () => Json.Read<T>("{\"Name\":\"n\",}").Name);
+                Try("comment",        () => Json.Read<T>("{/*c*/\"Name\":\"n\"}").Name);
+            }
+        }
+        """,
+        newtonsoft:     "single quotes: n\nunquoted name: n\ntrailing comma: n\ncomment: n",
+        systemTextJson: "single quotes: JsonException\nunquoted name: JsonException\ntrailing comma: JsonException\ncomment: JsonException");
+
+    [TestMethod]
+    public async Task AnEmptyDocumentNowThrowsInsteadOfReturningDefault() => await AssertDiffers("""
+        using System;
+        #USINGS#
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try              { Console.WriteLine(Json.Read<T>("") is null ? "<null>" : "instance"); }
+                catch (#JSONEX#) { Console.WriteLine("JsonException"); }
+            }
+        }
+        """,
+        newtonsoft:     "<null>",
+        systemTextJson: "JsonException");
+}

--- a/Packages/Transpose.System.Text.Json.Tests/DeserializationTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/DeserializationTests.cs
@@ -1,0 +1,438 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// How a payload maps back onto a type: member matching (which is case-sensitive by default, unlike
+/// Json.NET), constructor binding, missing and unknown members, and primitive conversions.
+/// </summary>
+[TestClass]
+public sealed class DeserializationTests : JsonTestBase
+{
+    // ---------------------------------------------------------------------------------------------
+    // Member matching
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task MembersMatchByExactName() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Name { get; set; } public int Count { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Name\":\"n\",\"Count\":7}");
+                Console.WriteLine(t.Name + "/" + t.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task MatchingIsCaseSensitiveByDefault() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"name\":\"n\"}").Name ?? "<null>");
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"NAME\":\"n\"}").Name ?? "<null>");
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Name\":\"n\"}").Name ?? "<null>");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task PropertyNameCaseInsensitiveRelaxesMatching() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Name { get; set; } public int Count { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var t = JsonSerializer.Deserialize<T>("{\"name\":\"n\",\"COUNT\":3}", options);
+                Console.WriteLine(t.Name + "/" + t.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnUnknownMemberIsIgnored() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Nope\":1,\"Name\":\"n\",\"Also\":{\"deep\":[1,2]}}").Name);
+        }
+        """);
+
+    [TestMethod]
+    public async Task AMissingMemberKeepsWhateverTheConstructorLeft() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public string Name  { get; set; } = "default";
+            public int    Count { get; set; } = 42;
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{}");
+                Console.WriteLine(t.Name + "/" + t.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task APropertyWithANonPublicSetterIsNotWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Value { get; private set; } = "original"; }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Value\":\"changed\"}").Value);
+        }
+        """);
+
+    [TestMethod]
+    public async Task AGetOnlyPropertyIsNotWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public string Stored { get; set; } = "s";
+            public string Computed => "computed";
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Stored\":\"x\",\"Computed\":\"ignored\"}");
+                Console.WriteLine(t.Stored + "/" + t.Computed);
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Constructors
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task AParameterlessConstructorIsPreferred() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public T()                { Which = "parameterless"; }
+            public T(string name)     { Which = "parameterized"; Name = name; }
+            public string Name  { get; set; }
+            public string Which { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Name\":\"n\"}");
+                Console.WriteLine(t.Which + "/" + t.Name);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task TheSinglePublicConstructorBindsItsParameters() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public T(string name, int count) { Name = name; Count = count; }
+            public string Name  { get; }
+            public int    Count { get; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Name\":\"n\",\"Count\":5}");
+                Console.WriteLine(t.Name + "/" + t.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AConstructorParameterWithNoMatchingMemberGetsTheDefault() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public T(string name, int count) { Name = name; Count = count; }
+            public string Name  { get; }
+            public int    Count { get; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Name\":\"n\"}");
+                Console.WriteLine((t.Name ?? "<null>") + "/" + t.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task JsonConstructorSelectsTheConstructor() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            public T() { Which = "parameterless"; }
+
+            [JsonConstructor]
+            public T(string name) { Which = "attributed"; Name = name; }
+
+            public string Name  { get; set; }
+            public string Which { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"Name\":\"n\"}");
+                Console.WriteLine(t.Which + "/" + t.Name);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AConstructorParameterInheritsItsMembersJsonName() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T
+        {
+            public T(string name) { Name = name; }
+
+            [JsonPropertyName("n")]
+            public string Name { get; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"n\":\"x\"}").Name ?? "<null>");
+                Console.WriteLine(JsonSerializer.Serialize(new T("x")));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AMemberBoundThroughAConstructorIsNotWrittenTwice() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public T(string name) { Name = (name ?? "<null>") + "-viaCtor"; }
+            public string Name { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Deserialize<T>("{\"Name\":\"n\"}").Name);
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Values
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task PrimitiveMembersAreConverted() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public bool   B  { get; set; }
+            public int    I  { get; set; }
+            public double D  { get; set; }
+            public string S  { get; set; }
+            public int?   NI { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"B\":true,\"I\":-3,\"D\":1.5,\"S\":\"s\",\"NI\":null}");
+                Console.WriteLine(t.B + "/" + t.I + "/" + t.D + "/" + t.S + "/" + (t.NI.HasValue ? t.NI.ToString() : "<null>"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEnumIsReadFromItsNumber() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public enum Colour { Red = 0, Green = 5 }
+        public class T { public Colour C { get; set; } public Colour? N { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var t = JsonSerializer.Deserialize<T>("{\"C\":5,\"N\":0}");
+                Console.WriteLine(t.C + "/" + t.N);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEnumIsAlsoReadFromItsName() => await RunJs("""
+        using System;
+        using System.Text.Json;
+
+        public enum Colour { Red = 0, Green = 5 }
+        public class T { public Colour C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try
+                {
+                    Console.WriteLine(JsonSerializer.Deserialize<T>("{\"C\":\"Green\"}").C);
+                }
+                catch (JsonException)
+                {
+                    Console.WriteLine("JsonException");
+                }
+            }
+        }
+        """,
+        expected:     "Green",
+        nativePrints: "JsonException");
+
+    [TestMethod]
+    public async Task ALiteralNullDocumentReturnsNull() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Deserialize<T>("null") is null ? "<null>" : "instance");
+        }
+        """);
+
+    [TestMethod]
+    public async Task ATopLevelScalarDocument() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Deserialize<int>("42"));
+                Console.WriteLine(JsonSerializer.Deserialize<string>("\"hello\""));
+                Console.WriteLine(JsonSerializer.Deserialize<bool>("true"));
+                Console.WriteLine(JsonSerializer.Deserialize<double>("1.25"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DeserializingToObjectReturnsTheRawParsedValue() => await RunJs("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = JsonSerializer.Deserialize<object>("{\"a\":1}");
+                Console.WriteLine(value == null ? "<null>" : "value");
+                Console.WriteLine(JsonSerializer.Serialize(value));
+            }
+        }
+        """,
+        expected:     "value\n{\"a\":1}",
+        nativePrints: "value\n{\"a\":1}");
+
+    [TestMethod]
+    public async Task ARoundTripPreservesEveryMember() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public enum Kind { One = 1, Two = 2 }
+        public class Inner { public string S { get; set; } public int I { get; set; } }
+        public class T
+        {
+            public string        Name   { get; set; }
+            public int           Count  { get; set; }
+            public bool          Flag   { get; set; }
+            public double        Ratio  { get; set; }
+            public Kind          Kind   { get; set; }
+            public Inner         Inner  { get; set; }
+            public List<string>  Tags   { get; set; }
+            public int[]         Nums   { get; set; }
+            public string        Absent { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var original = new T
+                {
+                    Name  = "n", Count = 3, Flag = true, Ratio = 1.5, Kind = Kind.Two,
+                    Inner = new Inner { S = "s", I = 9 },
+                    Tags  = new List<string> { "a", "b" },
+                    Nums  = new[] { 1, 2, 3 }
+                };
+
+                var json = JsonSerializer.Serialize(original);
+                var back = JsonSerializer.Deserialize<T>(json);
+
+                Console.WriteLine(JsonSerializer.Serialize(back));
+                Console.WriteLine(JsonSerializer.Serialize(back) == json);
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/ErrorHandlingTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,148 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// What happens on bad input. System.Text.Json is markedly stricter than Json.NET here — a null into a
+/// non-nullable value type, a string where a number is expected, and a shape mismatch are all errors
+/// rather than silently-defaulted members — so these are the cases most likely to surface during a
+/// migration.
+/// </summary>
+[TestClass]
+public sealed class ErrorHandlingTests : JsonTestBase
+{
+    private const string Model = """
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public class T { public string Name { get; set; } public int Count { get; set; } }
+
+        public static class Program
+        {
+            static void Try(string label, Func<string> f)
+            {
+                try                   { Console.WriteLine(label + ": " + f()); }
+                catch (JsonException) { Console.WriteLine(label + ": JsonException"); }
+            }
+
+            public static void Main()
+            {
+        __BODY__
+            }
+        }
+        """;
+
+    private static string With(string body) => Model.Replace("__BODY__", body);
+
+    [TestMethod]
+    public async Task MalformedInput() => await RunAndCompare(With("""
+                Try("unclosed object", () => JsonSerializer.Deserialize<T>("{").Name);
+                Try("unclosed array",  () => JsonSerializer.Deserialize<int[]>("[1,2").Length.ToString());
+                Try("garbage",         () => JsonSerializer.Deserialize<T>("not json").Name);
+                Try("empty",           () => JsonSerializer.Deserialize<T>("").Name);
+                Try("whitespace",      () => JsonSerializer.Deserialize<T>("   ").Name);
+                Try("bare comma",      () => JsonSerializer.Deserialize<T>("{,}").Name);
+                Try("missing value",   () => JsonSerializer.Deserialize<T>("{\"Name\":}").Name);
+                Try("trailing junk",   () => JsonSerializer.Deserialize<T>("{} extra").Name);
+        """));
+
+    [TestMethod]
+    public async Task NullIntoANonNullableValueTypeIsAnError() => await RunAndCompare(With("""
+                Try("int",      () => JsonSerializer.Deserialize<T>("{\"Count\":null}").Count.ToString());
+                Try("string",   () => JsonSerializer.Deserialize<T>("{\"Name\":null}").Name ?? "<null>");
+        """));
+
+    [TestMethod]
+    public async Task ATypeMismatchIsAnError() => await RunAndCompare(With("""
+                Try("string into int",  () => JsonSerializer.Deserialize<T>("{\"Count\":\"7\"}").Count.ToString());
+                Try("object into int",  () => JsonSerializer.Deserialize<T>("{\"Count\":{}}").Count.ToString());
+                Try("array into int",   () => JsonSerializer.Deserialize<T>("{\"Count\":[1]}").Count.ToString());
+                Try("bool into int",    () => JsonSerializer.Deserialize<T>("{\"Count\":true}").Count.ToString());
+                Try("number into obj",  () => JsonSerializer.Deserialize<T>("5").Name ?? "<null>");
+        """));
+
+    [TestMethod]
+    public async Task AShapeMismatchIsAnError() => await RunAndCompare(With("""
+                Try("array into object", () => JsonSerializer.Deserialize<T>("[1,2]").Name ?? "<null>");
+                Try("object into list",  () => JsonSerializer.Deserialize<List<int>>("{\"a\":1}").Count.ToString());
+                Try("object into array", () => JsonSerializer.Deserialize<int[]>("{\"a\":1}").Length.ToString());
+        """));
+
+    [TestMethod]
+    public async Task AnInvalidEnumValueIsAnError() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public enum Colour { Red = 0, Green = 5 }
+        public class T { public Colour C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try                   { Console.WriteLine(JsonSerializer.Deserialize<T>("{\"C\":\"Nope\"}").C); }
+                catch (JsonException) { Console.WriteLine("JsonException"); }
+                catch (ArgumentException) { Console.WriteLine("ArgumentException"); }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnUndeclaredEnumNumberIsAccepted() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public enum Colour { Red = 0, Green = 5 }
+        public class T { public Colour C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine((int)JsonSerializer.Deserialize<T>("{\"C\":77}").C);
+        }
+        """);
+
+    [TestMethod]
+    public async Task ADeeplyNestedPayloadHitsTheDepthLimit() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Node { public Node Next { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var deep = new string('x', 0);
+                for (int i = 0; i < 70; i++) deep += "{\"Next\":";
+                deep += "null";
+                for (int i = 0; i < 70; i++) deep += "}";
+
+                try                   { Console.WriteLine(JsonSerializer.Deserialize<Node>(deep) is null ? "<null>" : "ok"); }
+                catch (JsonException) { Console.WriteLine("JsonException"); }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AJsonExceptionIsCatchableAsAnException() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try
+                {
+                    JsonSerializer.Deserialize<T>("{");
+                    Console.WriteLine("no throw");
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e is JsonException);
+                }
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/EscapingTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/EscapingTests.cs
@@ -1,0 +1,164 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// System.Text.Json escapes far more than JSON requires — everything outside a short allow-list of
+/// basic-latin characters — which is what makes its output safe to embed in an HTML
+/// <c>&lt;script&gt;</c> block. <c>JSON.stringify</c> escapes the bare minimum, so this is the area
+/// where a browser implementation is most likely to drift, and every rule is pinned here.
+/// </summary>
+[TestClass]
+public sealed class EscapingTests : JsonTestBase
+{
+    private const string Harness = """
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            static void P(string s) => Console.WriteLine(JsonSerializer.Serialize(s));
+
+            public static void Main()
+            {
+        __BODY__
+            }
+        }
+        """;
+
+    private static string With(string body) => Harness.Replace("__BODY__", body);
+
+    [TestMethod]
+    public async Task HtmlSensitiveCharactersAreEscaped() => await RunAndCompare(With("""
+                P("a+b");
+                P("<script>");
+                P("a&b");
+                P("it's");
+                P("q\"q");
+                P("back\\slash");
+                P("tick`tick");
+        """));
+
+    [TestMethod]
+    public async Task TheSafePunctuationAllowListPassesThrough() => await RunAndCompare(With("""
+                P(" !#$%()*,-./:;=?@[]^_{|}~");
+                P("abcXYZ0189");
+        """));
+
+    [TestMethod]
+    public async Task ControlCharactersUseTheirShortEscapesWhereJsonHasOne() => await RunAndCompare(With("""
+                P("a\nb");
+                P("a\tb");
+                P("a\rb");
+                P("a\bb");
+                P("a\fb");
+                P("ab");
+                P("ab");
+        """));
+
+    [TestMethod]
+    public async Task NonAsciiIsEscapedAsUppercaseHex() => await RunAndCompare(With("""
+                P("café");
+                P("—");
+                P("ünïcode");
+                P("");
+                P("");
+                P("日本語");
+        """));
+
+    [TestMethod]
+    public async Task ASurrogatePairIsEscapedAsTwoUnits() => await RunAndCompare(With("""
+                P("x\U0001F600y");
+        """));
+
+    [TestMethod]
+    public async Task MemberNamesAreEscapedTheSameWay() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var map = new Dictionary<string, int> { ["a+b<c>"] = 1, ["plain"] = 2, ["é"] = 3 };
+                Console.WriteLine(JsonSerializer.Serialize(map));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEscapedPayloadRoundTrips() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Value { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var original = "a+b <script> café 日本語 \"quoted\" \\ back\nnewline";
+                var json     = JsonSerializer.Serialize(new T { Value = original });
+                var back     = JsonSerializer.Deserialize<T>(json);
+
+                Console.WriteLine(json);
+                Console.WriteLine(back.Value == original);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEscapedDocumentIsSafeToEmbedInAScriptBlock() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Payload { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                // The self-contained page exports drop a serialized model straight into a <script>
+                // block, so no '<' may survive into the output.
+                var json = JsonSerializer.Serialize(new T { Payload = "</script><script>alert(1)</script>" });
+
+                Console.WriteLine(json);
+                Console.WriteLine(json.IndexOf('<') < 0);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task EscapesSurviveIndentedOutputToo() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Serialize(new T { A = "x+y<z>é" }, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task ReadingUnescapesEveryForm() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = "{\"A\":\"\\u002B\\u003C\\u0026\\u00E9\\n\\t\\\"\\\\\\/\"}";
+                var back = JsonSerializer.Deserialize<T>(json);
+
+                Console.WriteLine(back.A.Length);
+                Console.WriteLine(JsonSerializer.Serialize(back));
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/Infrastructure/CrossPackageTestBase.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/Infrastructure/CrossPackageTestBase.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// Runs one program twice in the browser: once against <c>Transpose.Newtonsoft.Json</c> and once
+/// against <c>Transpose.System.Text.Json</c>, so a migration can be judged call site by call site.
+///
+/// A single template is written in a small dialect and rendered into each package's API:
+/// <list type="bullet">
+///   <item><c>#USINGS#</c> — the JSON usings for that package.</item>
+///   <item><c>Json.Write(v)</c> / <c>Json.WriteIndented(v)</c> / <c>Json.Read&lt;T&gt;(s)</c> — the
+///     entry points, supplied by a per-dialect helper class appended to the program.</item>
+///   <item><c>[#PROP("n")]</c> — the rename attribute (<c>JsonProperty</c> / <c>JsonPropertyName</c>).</item>
+///   <item><c>#JSONEX#</c> — that package's exception type.</item>
+/// </list>
+/// Everything else is ordinary C# and identical in both renderings, which is the point: what differs
+/// in the output differs because the serializer differs.
+/// </summary>
+public abstract class CrossPackageTestBase
+{
+    private const string NewtonsoftShim = """
+
+        internal static class Json
+        {
+            public static string Write(object v)         => Newtonsoft.Json.JsonConvert.SerializeObject(v);
+            public static string WriteIndented(object v) => Newtonsoft.Json.JsonConvert.SerializeObject(v, Newtonsoft.Json.Formatting.Indented);
+            public static T      Read<T>(string s)       => Newtonsoft.Json.JsonConvert.DeserializeObject<T>(s);
+        }
+        """;
+
+    private const string SystemTextJsonShim = """
+
+        internal static class Json
+        {
+            public static string Write(object v)         => System.Text.Json.JsonSerializer.Serialize(v);
+            public static string WriteIndented(object v) => System.Text.Json.JsonSerializer.Serialize(v, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            public static T      Read<T>(string s)       => System.Text.Json.JsonSerializer.Deserialize<T>(s);
+        }
+        """;
+
+    protected static string RenderNewtonsoft(string template) => template
+        .Replace("#USINGS#", "using Newtonsoft.Json;\nusing Newtonsoft.Json.Serialization;")
+        .Replace("#PROP(", "JsonProperty(")
+        .Replace("#JSONEX#", "Newtonsoft.Json.JsonException")
+        + NewtonsoftShim;
+
+    protected static string RenderSystemTextJson(string template) => template
+        .Replace("#USINGS#", "using System.Text.Json;\nusing System.Text.Json.Serialization;")
+        .Replace("#PROP(", "JsonPropertyName(")
+        .Replace("#JSONEX#", "System.Text.Json.JsonException")
+        + SystemTextJsonShim;
+
+    /// <summary>
+    /// Asserts the two packages produce identical output — the migration is transparent for this shape.
+    /// </summary>
+    protected async Task AssertSame(string template)
+    {
+        var (newtonsoft, systemTextJson) = await RunBoth(template);
+
+        var a = TestOutput.CanonicalizeJson(newtonsoft);
+        var b = TestOutput.CanonicalizeJson(systemTextJson);
+
+        if (!string.Equals(a, b, StringComparison.Ordinal))
+        {
+            Assert.Fail(
+                "The two packages disagree, so migrating this shape is not transparent.\n" +
+                $"\n--- Transpose.Newtonsoft.Json ---\n{a}\n" +
+                $"\n--- Transpose.System.Text.Json ---\n{b}\n");
+        }
+    }
+
+    /// <summary>
+    /// Asserts a known, deliberate difference between the two packages, pinning both sides so the
+    /// migration note cannot rot. Member order is *not* canonicalized here — a difference is only
+    /// worth recording when it is a real one, and both packages order members alphabetically.
+    /// </summary>
+    protected async Task AssertDiffers(string template, string newtonsoft, string systemTextJson)
+    {
+        var (actualNewtonsoft, actualSystemTextJson) = await RunBoth(template);
+
+        if (!string.Equals(TestOutput.Normalize(newtonsoft), actualNewtonsoft, StringComparison.Ordinal))
+        {
+            Assert.Fail(
+                "The recorded Transpose.Newtonsoft.Json output is stale.\n" +
+                $"\n--- recorded ---\n{TestOutput.Normalize(newtonsoft)}\n" +
+                $"\n--- actual ---\n{actualNewtonsoft}\n");
+        }
+
+        if (!string.Equals(TestOutput.Normalize(systemTextJson), actualSystemTextJson, StringComparison.Ordinal))
+        {
+            Assert.Fail(
+                "The recorded Transpose.System.Text.Json output is stale.\n" +
+                $"\n--- recorded ---\n{TestOutput.Normalize(systemTextJson)}\n" +
+                $"\n--- actual ---\n{actualSystemTextJson}\n");
+        }
+
+        if (string.Equals(actualNewtonsoft, actualSystemTextJson, StringComparison.Ordinal))
+        {
+            Assert.Fail("The two packages now agree — this is no longer a divergence, so use AssertSame.");
+        }
+    }
+
+    private static async Task<(string Newtonsoft, string SystemTextJson)> RunBoth(string template)
+    {
+        // Sequentially: both runners build a package on first use and shell out to Node.
+        var newtonsoft     = await NewtonsoftPackageRunner.RunAsync(RenderNewtonsoft(template));
+        var systemTextJson = await TranslatedJsonRunner.RunAsync(RenderSystemTextJson(template));
+
+        return (newtonsoft, systemTextJson);
+    }
+}

--- a/Packages/Transpose.System.Text.Json.Tests/Infrastructure/JsonTestBase.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/Infrastructure/JsonTestBase.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>Normalizes captured console output so the two runners are comparable.</summary>
+public static class TestOutput
+{
+    public static string Normalize(string output)
+    {
+        if (string.IsNullOrEmpty(output)) return "";
+        return string.Join("\n", output.Trim()
+            .Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)
+            .Select(s => s.TrimEnd()));
+    }
+
+    /// <summary>
+    /// Rewrites every JSON document in the output with its object members sorted by name, so a
+    /// comparison tests structure and values rather than member order.
+    ///
+    /// Member order is the one systematic difference between the two implementations: System.Text.Json
+    /// writes properties in declaration order (most-derived type first, then fields), while the
+    /// binding library reads the type's Transpose reflection metadata, which lists them
+    /// alphabetically. <c>SerializationTests.MemberOrderIsAlphabetical</c> pins that down; every other
+    /// test compares canonically so it is not re-asserted a hundred times.
+    ///
+    /// Json.NET is used here purely as a JSON *parser* for the comparison — it is never the oracle,
+    /// and no snippet under test references it.
+    /// </summary>
+    public static string CanonicalizeJson(string output)
+    {
+        if (string.IsNullOrEmpty(output)) return output;
+
+        // An indented document spans several lines, so try the whole output first, then line by line.
+        if (TrySort(output, out var whole)) return whole;
+
+        return string.Join("\n", output
+            .Split('\n')
+            .Select(line => TrySort(line, out var sorted) ? sorted : line));
+    }
+
+    private static bool TrySort(string text, out string sorted)
+    {
+        sorted = text;
+        var trimmed = text.Trim();
+        if (trimmed.Length < 2 || (trimmed[0] != '{' && trimmed[0] != '[')) return false;
+
+        try
+        {
+            using var reader = new JsonTextReader(new System.IO.StringReader(trimmed))
+            {
+                DateParseHandling = DateParseHandling.None,
+                FloatParseHandling = FloatParseHandling.Decimal,
+            };
+            var token = JToken.ReadFrom(reader);
+            if (reader.Read()) return false; // trailing content: not a single document
+
+            sorted = Sort(token).ToString(Formatting.None);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static JToken Sort(JToken token)
+    {
+        switch (token)
+        {
+            case JObject obj:
+                var sorted = new JObject();
+                foreach (var property in obj.Properties().OrderBy(p => p.Name, StringComparer.Ordinal))
+                    sorted.Add(property.Name, Sort(property.Value));
+                return sorted;
+
+            case JArray array:
+                return new JArray(array.Select(Sort));
+
+            default:
+                return token;
+        }
+    }
+}
+
+/// <summary>
+/// Base class for the <c>Transpose.System.Text.Json</c> test suite.
+///
+/// Every snippet is a small C# program run twice — natively against the <b>real</b> System.Text.Json
+/// (which ships in the shared framework, so the snippet's <c>using System.Text.Json;</c> binds to it
+/// with no package involved) and as translated JavaScript against this package — and the two console
+/// outputs are diffed. The package exists to behave like System.Text.Json, so "what does
+/// System.Text.Json print" is the specification.
+///
+/// Two ways to assert, and the choice is the point of the suite:
+/// <list type="bullet">
+///   <item><see cref="RunAndCompare"/> — require the two to agree. Use this wherever the package is
+///     meant to match, which is nearly everywhere.</item>
+///   <item><see cref="RunJs(string,string,string)"/> — run only the translated JavaScript and assert
+///     its output directly. Use this for the documented divergences, passing what native prints so
+///     the note is asserted rather than just claimed.</item>
+/// </list>
+/// </summary>
+public abstract class JsonTestBase
+{
+    /// <summary>
+    /// Runs <paramref name="csharpCode"/> both natively (real System.Text.Json) and as translated
+    /// JavaScript (this package), asserting the console output matches. Returns the JavaScript output.
+    /// </summary>
+    /// <param name="exactMemberOrder">
+    /// Compare the output verbatim instead of canonicalizing JSON member order. Only useful for a
+    /// test that is *about* member order — see <see cref="TestOutput.CanonicalizeJson"/>.
+    /// </param>
+    protected async Task<string> RunAndCompare(string csharpCode, bool exactMemberOrder = false)
+    {
+        var jsOutput = await TranslatedJsonRunner.RunAsync(csharpCode);
+        var nativeOutput = NativeJsonRunner.CompileAndRun(csharpCode);
+
+        var expected = exactMemberOrder ? nativeOutput : TestOutput.CanonicalizeJson(nativeOutput);
+        var actual = exactMemberOrder ? jsOutput : TestOutput.CanonicalizeJson(jsOutput);
+
+        if (!string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            Assert.Fail(
+                "Output mismatch between the real System.Text.Json and the Transpose package.\n" +
+                $"\n--- expected (native System.Text.Json) ---\n{expected}\n" +
+                $"\n--- actual (Transpose / JS) ---\n{actual}\n");
+        }
+
+        return jsOutput;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="csharpCode"/> as translated JavaScript only and asserts its console
+    /// output verbatim. For documented divergences — pass <paramref name="nativePrints"/> to record
+    /// what the real System.Text.Json prints instead (it is asserted too, so the note cannot rot).
+    /// </summary>
+    protected async Task RunJs(string csharpCode, string expected, string? nativePrints = null)
+    {
+        var jsOutput = await TranslatedJsonRunner.RunAsync(csharpCode);
+
+        if (!string.Equals(TestOutput.Normalize(expected), jsOutput, StringComparison.Ordinal))
+        {
+            Assert.Fail(
+                "Translated JavaScript output changed.\n" +
+                $"\n--- expected ---\n{TestOutput.Normalize(expected)}\n" +
+                $"\n--- actual ---\n{jsOutput}\n");
+        }
+
+        if (nativePrints is not null)
+        {
+            var nativeOutput = NativeJsonRunner.CompileAndRun(csharpCode);
+            if (!string.Equals(TestOutput.Normalize(nativePrints), nativeOutput, StringComparison.Ordinal))
+            {
+                Assert.Fail(
+                    "The recorded native System.Text.Json output for this documented divergence is stale.\n" +
+                    $"\n--- recorded ---\n{TestOutput.Normalize(nativePrints)}\n" +
+                    $"\n--- actual (native System.Text.Json) ---\n{nativeOutput}\n");
+            }
+        }
+    }
+
+    /// <summary>Runs the snippet as translated JavaScript only, returning its output (no assertion).</summary>
+    protected Task<string> RunJs(string csharpCode) => TranslatedJsonRunner.RunAsync(csharpCode);
+
+    /// <summary>Runs the snippet natively against the real System.Text.Json, returning its output.</summary>
+    protected string RunNative(string csharpCode) => NativeJsonRunner.CompileAndRun(csharpCode);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/Infrastructure/NativeJsonRunner.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/Infrastructure/NativeJsonRunner.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// Compiles and runs a test snippet natively (Roslyn → in-memory assembly → invoke entry point)
+/// against the <b>real</b> Json.NET, capturing Console output. This is the oracle the translated
+/// JavaScript is diffed against: the binding library exists to behave like Json.NET, so "what does
+/// Json.NET print" is the definition of correct.
+///
+/// The reference set is the test host's own trusted-platform assembly list, which contains the
+/// <c>Newtonsoft.Json</c> package this project references — that is how a snippet's
+/// <c>using Newtonsoft.Json;</c> binds.
+/// </summary>
+public static class NativeJsonRunner
+{
+    public static string CompileAndRun(string source)
+    {
+        AppContext.SetSwitch("System.Globalization.Invariant", true);
+        AppContext.SetSwitch("System.TimeZoneInfo.Invariant", true);
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
+        // Define DEBUG/TRACE so native execution matches the translator's Debug-build parse options.
+        var tree = CSharpSyntaxTree.ParseText(source,
+            new CSharpParseOptions(LanguageVersion.Latest).WithPreprocessorSymbols("DEBUG", "TRACE"));
+
+        var refs = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string) ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "NativeJsonRun_" + Guid.NewGuid().ToString("N"),
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel: OptimizationLevel.Debug));
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(d => d.ToString()));
+            throw new InvalidOperationException("Native compilation failed:\n" + errors);
+        }
+
+        peStream.Seek(0, SeekOrigin.Begin);
+        var context = new AssemblyLoadContext("NativeJsonRun", isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromStream(peStream);
+            var entry = assembly.EntryPoint
+                ?? throw new InvalidOperationException("No entry point found.");
+
+            var sb = new StringBuilder();
+            var writer = new StringWriter(sb);
+            var previous = Console.Out;
+            Console.SetOut(writer);
+            try
+            {
+                var args = entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() };
+                var invokeResult = entry.Invoke(null, args);
+                if (invokeResult is System.Threading.Tasks.Task task)
+                {
+                    task.GetAwaiter().GetResult();
+                }
+            }
+            finally
+            {
+                Console.SetOut(previous);
+                writer.Flush();
+            }
+
+            return TestOutput.Normalize(sb.ToString());
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+}

--- a/Packages/Transpose.System.Text.Json.Tests/Infrastructure/NewtonsoftPackageRunner.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/Infrastructure/NewtonsoftPackageRunner.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// The same translate-and-run-on-Node pipeline as <see cref="TranslatedJsonRunner"/>, but against the
+/// sibling <c>Transpose.Newtonsoft.Json</c> package.
+///
+/// It exists for one reason: the Curiosity front-end is migrating off that package onto this one, and
+/// the question that decides how risky each call site is — "does the payload on the wire change?" —
+/// is only answerable by running the same program through both. See <c>CrossPackageTests</c>.
+/// </summary>
+public static class NewtonsoftPackageRunner
+{
+    private const string PackageAssemblyName = "Transpose.Newtonsoft.Json";
+
+    private static readonly Lazy<PackageArtifacts> _package = new(BuildPackage, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private sealed record PackageArtifacts(string ReferenceDllPath, string GlueJavascript, string JsonConvertJavascript);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+
+    public static string PackageDir => Path.Combine(RepoRoot(), "Packages", "Transpose.Newtonsoft.Json");
+
+    private static PackageArtifacts BuildPackage()
+    {
+        var packageDir = PackageDir;
+
+        var sources = Directory.EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Replace('\\', '/').Contains("/bin/") && !p.Replace('\\', '/').Contains("/obj/"))
+            .Select(p => (path: p, text: File.ReadAllText(p)))
+            .ToList();
+
+        var result = new RoslynTranslator().BuildAssembly(
+            sources,
+            PackageAssemblyName,
+            extraReferencePaths: null,
+            preprocessorSymbols: new[] { "TRANSPOSE", "TRACE" },
+            emitAssembly: true);
+
+        if (result.AssemblyBytes is null || result.Javascript is null)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Select(d => d.GetMessage()));
+            throw new InvalidOperationException($"Failed to build the Transpose.Newtonsoft.Json package:\n{errors}");
+        }
+
+        var dllPath = Path.Combine(Path.GetTempPath(), $"Transpose.Newtonsoft.Json.{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(dllPath, result.AssemblyBytes);
+
+        var jsonConvert = File.ReadAllText(Path.Combine(packageDir, "Resources", "Manual", "JsonConvert.js"));
+
+        return new PackageArtifacts(dllPath, result.Javascript, jsonConvert);
+    }
+
+    /// <summary>
+    /// Translates <paramref name="csharpCode"/> (which may use <c>Newtonsoft.Json.*</c>), runs it on
+    /// Node against that package's runtime, and returns the trimmed console output.
+    /// </summary>
+    public static async Task<string> RunAsync(string csharpCode)
+    {
+        var package = _package.Value;
+
+        var result = new RoslynTranslator().Translate(
+            new[] { ("App.cs", csharpCode) },
+            CompilationBuilder.DefaultAssemblyName,
+            extraReferencePaths: new[] { package.ReferenceDllPath },
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" });
+
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Errors.Select(d => d.GetMessage()));
+            throw new InvalidOperationException($"Translation failed:\n{errors}");
+        }
+
+        var full =
+            RoslynTranslator.LoadRuntime() + "\n" +
+            package.GlueJavascript + "\n" +
+            package.JsonConvertJavascript + "\n" +
+            "Newtonsoft.Json.$cache = Newtonsoft.Json.$cache || [];\n" +
+            result.Javascript;
+
+        if (Environment.GetEnvironmentVariable("TPS_DUMP_JS_NEWTONSOFT") is { Length: > 0 } dump)
+            File.WriteAllText(dump, full);
+
+        return TestOutput.Normalize(await NodeJsRunner.RunAsync(full));
+    }
+}

--- a/Packages/Transpose.System.Text.Json.Tests/Infrastructure/TranslatedJsonRunner.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/Infrastructure/TranslatedJsonRunner.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// Compiles and runs a C# program that uses the <c>Transpose.System.Text.Json</c> binding library as
+/// translated JavaScript on Node, so the package's runtime (JsonSerializer.js) is exercised end-to-end.
+///
+/// The package is a JavaScript binding library ([assembly: External]): its C# is a set of external
+/// type/attribute declarations, and its real behaviour lives in the hand-written
+/// <c>Resources/Manual/JsonSerializer.js</c>. To run a program against it we
+/// <list type="number">
+///   <item>compile the package's own C# once into a reference assembly (+ its emitted glue JS), so
+///     the test program can bind to <c>System.Text.Json.*</c>;</item>
+///   <item>compile the test program against that reference (reflection on, so types are
+///     reflectable — TypeNameHandling and the contract walker need metadata);</item>
+///   <item>prepend the Transpose runtime, the package glue and <c>JsonSerializer.js</c> to the program
+///     JS and run it on Node.</item>
+/// </list>
+/// </summary>
+public static class TranslatedJsonRunner
+{
+    private const string PackageAssemblyName = "Transpose.System.Text.Json";
+
+    private static readonly Lazy<PackageArtifacts> _package = new(BuildPackage, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private sealed record PackageArtifacts(string ReferenceDllPath, string GlueJavascript, string JsonSerializerJavascript);
+
+    /// <summary>Repo root, derived from this source file's compile-time path.</summary>
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+        // .../Packages/Transpose.SystemTextJson.Tests/Infrastructure/TranslatedJsonRunner.cs → repo root
+        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+
+    /// <summary>The binding library under test.</summary>
+    public static string PackageDir => Path.Combine(RepoRoot(), "Packages", "Transpose.System.Text.Json");
+
+    private static PackageArtifacts BuildPackage()
+    {
+        var packageDir = PackageDir;
+
+        // The package's C# declarations (external stubs + attributes + enums). Exclude the JS
+        // resources (they aren't C#) and any build output.
+        var sources = Directory.EnumerateFiles(packageDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Replace('\\', '/').Contains("/bin/") && !p.Replace('\\', '/').Contains("/obj/"))
+            .Select(p => (path: p, text: File.ReadAllText(p)))
+            .ToList();
+
+        var result = new RoslynTranslator().BuildAssembly(
+            sources,
+            PackageAssemblyName,
+            extraReferencePaths: null,
+            preprocessorSymbols: new[] { "TRANSPOSE", "TRACE" },
+            emitAssembly: true);
+
+        if (result.AssemblyBytes is null || result.Javascript is null)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Select(d => d.GetMessage()));
+            throw new InvalidOperationException($"Failed to build the Transpose.System.Text.Json package:\n{errors}");
+        }
+
+        var dllPath = Path.Combine(Path.GetTempPath(), $"Transpose.System.Text.Json.{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(dllPath, result.AssemblyBytes);
+
+        var jsonSerializer = File.ReadAllText(Path.Combine(packageDir, "Resources", "Manual", "JsonSerializer.js"));
+
+        return new PackageArtifacts(dllPath, result.Javascript, jsonSerializer);
+    }
+
+    /// <summary>
+    /// Translates <paramref name="csharpCode"/> (which may use <c>System.Text.Json.*</c>), runs it on
+    /// Node with the package runtime loaded, and returns the trimmed console output.
+    /// </summary>
+    public static async Task<string> RunAsync(string csharpCode)
+    {
+        var package = _package.Value;
+
+        var result = new RoslynTranslator().Translate(
+            new[] { ("App.cs", csharpCode) },
+            CompilationBuilder.DefaultAssemblyName,
+            extraReferencePaths: new[] { package.ReferenceDllPath },
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" });
+
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Errors.Select(d => d.GetMessage()));
+            throw new InvalidOperationException($"Translation failed:\n{errors}");
+        }
+
+        // Runtime + package glue (the External type/enum/attribute defines) + the hand-written
+        // JsonSerializer.js behaviour + the program. tps.js auto-runs the entry point.
+        // The package's tps.json stitches JsonSerializer.js between AssemblyBegin.js/AssemblyEnd.js;
+        // the only runtime state those add is the type cache, so initialise it here.
+        var full =
+            RoslynTranslator.LoadRuntime() + "\n" +
+            package.GlueJavascript + "\n" +
+            package.JsonSerializerJavascript + "\n" +
+            "System.Text.Json.$cache = System.Text.Json.$cache || [];\n" +
+            result.Javascript;
+
+        if (Environment.GetEnvironmentVariable("TPS_DUMP_JS") is { Length: > 0 } dump)
+            File.WriteAllText(dump, full);
+
+        var output = await NodeJsRunner.RunAsync(full);
+        return TestOutput.Normalize(output);
+    }
+}

--- a/Packages/Transpose.System.Text.Json.Tests/MosaikShapeTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/MosaikShapeTests.cs
@@ -1,0 +1,592 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// The shapes the Curiosity front-end actually puts on the wire, run through both packages.
+///
+/// These are the types that exist *because* a Transpose JSON binding has no converter registry: a
+/// wrapper whose runtime representation is a plain JavaScript string, reached only through an
+/// implicit/explicit conversion operator (<c>UID128</c>, <c>LanguageDTO</c>). Nothing about them is
+/// expressible in a native System.Text.Json snippet — they are <c>extern</c> + <c>[Template]</c> — so
+/// the only meaningful oracle is the package they are migrating away from.
+/// </summary>
+[TestClass]
+public sealed class MosaikShapeTests : CrossPackageTestBase
+{
+    // A faithful reduction of FrontEnd/Mosaik.FrontEnd.Core/src/Schema/Graph/UID128.cs: a class whose
+    // values are plain strings at runtime, with an explicit string -> UID128 and an implicit
+    // UID128 -> string operator.
+    private const string Uid128 = """
+        using System;
+        using System.Collections.Generic;
+        using Transpose;
+        #USINGS#
+
+        namespace UID
+        {
+            public sealed class UID128
+            {
+                [Template("UID.UID128.ThrowIfInvalid({value})")]
+                public extern UID128(string value);
+
+                private static string ThrowIfInvalid(string value)
+                    => LooksValid(value) ? value : throw new ArgumentException("Invalid string content specified for UID128: '" + value + "'");
+
+                public extern string Value { [Template("{this}")] get; }
+
+                public static explicit operator UID128(string value) => string.IsNullOrEmpty(value) ? null : new UID128(value);
+                public static implicit operator string(UID128 value) => value?.Value;
+
+                [Template("Transpose.getHashCode({this})")]
+                public extern override int GetHashCode();
+
+                [Template("Transpose.equals({this}, {o})")]
+                public extern override bool Equals(object o);
+
+                public static bool LooksValid(string value) => value != null && value.Length == 22;
+
+                public static UID128 Parse(string val) => new UID128(val);
+            }
+        }
+        """;
+
+    // A faithful reduction of FrontEnd/Mosaik.FrontEnd.Core/src/Schema/NLP/LanguageDTO.cs: a *struct*
+    // that is its code string at runtime, so a Language reaches the server as "de" rather than as the
+    // enum's number.
+    private const string LanguageDto = """
+        using System;
+        using Transpose;
+        #USINGS#
+
+        namespace Mosaik.Schema
+        {
+            public enum Language { Any = 0, English = 1, German = 2, Portuguese = 3 }
+
+            public static class Languages
+            {
+                public static string EnumToCode(Language value)
+                {
+                    switch (value)
+                    {
+                        case Language.English:    return "en";
+                        case Language.German:     return "de";
+                        case Language.Portuguese: return "pt";
+                        default:                  return "--";
+                    }
+                }
+
+                public static Language CodeToEnum(string code)
+                {
+                    switch (code)
+                    {
+                        case "en": return Language.English;
+                        case "de": return Language.German;
+                        case "pt": return Language.Portuguese;
+                        default:   return Language.Any;
+                    }
+                }
+            }
+
+            public struct LanguageDTO : IEquatable<LanguageDTO>
+            {
+                [Template("Mosaik.Schema.LanguageDTO.Normalize({value})")]
+                public extern LanguageDTO(string value);
+
+                public static implicit operator LanguageDTO(Language value) => new LanguageDTO(Languages.EnumToCode(value));
+                public static implicit operator Language(LanguageDTO value) => Languages.CodeToEnum(CodeOf(value));
+                public static explicit operator LanguageDTO(string languageCode) => new LanguageDTO(languageCode);
+
+                public static bool operator ==(LanguageDTO x, LanguageDTO y) => CodeOf(x) == CodeOf(y);
+                public static bool operator !=(LanguageDTO x, LanguageDTO y) => CodeOf(x) != CodeOf(y);
+
+                public bool Equals(LanguageDTO other) => this == other;
+
+                [Template("{this} === {o}")]
+                public extern override bool Equals(object o);
+
+                [Template("Transpose.getHashCode(Mosaik.Schema.LanguageDTO.CodeOf({this}))")]
+                public extern override int GetHashCode();
+
+                private static string CodeOf(LanguageDTO value)
+                    => Script.Write<string>("(typeof {0} === \"string\" ? {0} : null)", value) ?? Languages.EnumToCode(Language.Any);
+
+                private static string Normalize(string languageCode)
+                    => Languages.EnumToCode(string.IsNullOrWhiteSpace(languageCode) ? Language.English : Languages.CodeToEnum(languageCode));
+            }
+        }
+        """;
+
+    // =============================================================================================
+    // UID128
+    // =============================================================================================
+
+    [TestMethod]
+    public async Task AUid128MemberIsWrittenAsItsBareString() => await AssertSame(Uid128 + """
+
+        public class Node
+        {
+            public UID.UID128 Uid    { get; set; }
+            public UID.UID128 Parent { get; set; }
+            public string     Label  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(Json.Write(new Node
+                {
+                    Uid    = UID.UID128.Parse("1234567890123456789012"),
+                    Parent = null,
+                    Label  = "a node"
+                }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task AUid128MemberIsReadThroughItsExplicitOperator() => await AssertSame(Uid128 + """
+
+        public class Node { public UID.UID128 Uid { get; set; } public string Label { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var node = Json.Read<Node>("{\"Uid\":\"1234567890123456789012\",\"Label\":\"a node\"}");
+
+                Console.WriteLine(node.Uid.Value);
+                Console.WriteLine(node.Uid == UID.UID128.Parse("1234567890123456789012"));
+                Console.WriteLine(node.Label);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AUid128RoundTrips() => await AssertSame(Uid128 + """
+
+        public class Node { public UID.UID128 Uid { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var original = new Node { Uid = UID.UID128.Parse("1234567890123456789012") };
+                var json     = Json.Write(original);
+                var back     = Json.Read<Node>(json);
+
+                Console.WriteLine(json);
+                Console.WriteLine(Json.Write(back) == json);
+                Console.WriteLine(back.Uid.Equals(original.Uid));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEmptyStringBecomesANullUid128() => await AssertSame(Uid128 + """
+
+        public class Node { public UID.UID128 Uid { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                // The explicit operator maps "" to null on purpose: some payloads carry a blank string
+                // rather than null for "no value".
+                Console.WriteLine(Json.Read<Node>("{\"Uid\":\"\"}").Uid == null ? "<null>" : "value");
+                Console.WriteLine(Json.Read<Node>("{\"Uid\":null}").Uid == null ? "<null>" : "value");
+                Console.WriteLine(Json.Read<Node>("{}").Uid == null ? "<null>" : "value");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task Uid128sInCollectionsAndAsDictionaryKeys() => await AssertSame(Uid128 + """
+
+        public class Bag
+        {
+            public UID.UID128[]                       Ids  { get; set; }
+            public List<UID.UID128>                   More { get; set; }
+            public Dictionary<UID.UID128, string>     Map  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var a = UID.UID128.Parse("1111111111111111111111");
+                var b = UID.UID128.Parse("2222222222222222222222");
+
+                var bag = new Bag
+                {
+                    Ids  = new[] { a, b },
+                    More = new List<UID.UID128> { a },
+                    Map  = new Dictionary<UID.UID128, string> { [a] = "first" }
+                };
+
+                var json = Json.Write(bag);
+                Console.WriteLine(json);
+
+                var back = Json.Read<Bag>(json);
+                Console.WriteLine(back.Ids.Length + "/" + back.Ids[1].Value + "/" + back.More[0].Value + "/" + back.Map.Count);
+            }
+        }
+        """);
+
+    // =============================================================================================
+    // LanguageDTO
+    // =============================================================================================
+
+    [TestMethod]
+    public async Task ALanguageDtoMemberIsWrittenAsItsCodeString() => await AssertSame(LanguageDto + """
+
+        public class Request
+        {
+            public Mosaik.Schema.LanguageDTO Language { get; set; }
+            public string                    Query    { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(Json.Write(new Request { Language = Mosaik.Schema.Language.German, Query = "q" }));
+                Console.WriteLine(Json.Write(new Request { Language = Mosaik.Schema.Language.Any,    Query = "q" }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ALanguageDtoIsReadBackThroughItsOperator() => await AssertSame(LanguageDto + """
+
+        public class Request { public Mosaik.Schema.LanguageDTO Language { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var request = Json.Read<Request>("{\"Language\":\"pt\"}");
+
+                Mosaik.Schema.Language asEnum = request.Language;
+                Console.WriteLine(asEnum);
+                Console.WriteLine(request.Language == (Mosaik.Schema.LanguageDTO)Mosaik.Schema.Language.Portuguese);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ALanguageDtoRoundTrips() => await AssertSame(LanguageDto + """
+
+        public class Request { public Mosaik.Schema.LanguageDTO Language { get; set; } public int Take { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = Json.Write(new Request { Language = Mosaik.Schema.Language.English, Take = 10 });
+                var back = Json.Read<Request>(json);
+
+                Console.WriteLine(json);
+                Console.WriteLine(Json.Write(back) == json);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnUnassignedLanguageDtoIsWrittenAsAnEmptyObject() => await AssertSame(LanguageDto + """
+
+        public class Request { public Mosaik.Schema.LanguageDTO Language { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                // The documented gap in LanguageDTO: default(LanguageDTO) never ran the constructor, so
+                // it is an empty object rather than a code string. Both packages write it the same way,
+                // which is what matters for the migration.
+                Console.WriteLine(Json.Write(new Request()));
+            }
+        }
+        """);
+
+    // =============================================================================================
+    // Enums, the way the front-end DTOs use them
+    // =============================================================================================
+
+    [TestMethod]
+    public async Task EnumMembersOfEveryShape() => await AssertSame("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public enum SortMode  { Relevance = 0, DateAscending = 1, DateDescending = 2 }
+        public enum IndexType { None = 0, Text = 1, Vector = 2 }
+
+        public class SearchRequest
+        {
+            public SortMode              Sort      { get; set; }
+            public SortMode?             Fallback  { get; set; }
+            public SortMode?             Unset     { get; set; }
+            public IndexType[]           Indexes   { get; set; }
+            public List<SortMode>        Order     { get; set; }
+            public Dictionary<IndexType, int> Weights { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var request = new SearchRequest
+                {
+                    Sort     = SortMode.DateDescending,
+                    Fallback = SortMode.Relevance,
+                    Indexes  = new[] { IndexType.Text, IndexType.Vector },
+                    Order    = new List<SortMode> { SortMode.DateAscending },
+                    Weights  = new Dictionary<IndexType, int> { [IndexType.Vector] = 3 }
+                };
+
+                var json = Json.Write(request);
+                Console.WriteLine(json);
+
+                var back = Json.Read<SearchRequest>(json);
+                Console.WriteLine(back.Sort + "/" + back.Fallback + "/" + (back.Unset.HasValue ? "set" : "unset") + "/" + back.Indexes[1] + "/" + back.Order[0] + "/" + back.Weights[IndexType.Vector]);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEnumArrivesFromTheServerAsItsName() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public enum ScheduledTaskType { Import = 0, Reindex = 1, Cleanup = 2 }
+
+        public class Task { public ScheduledTaskType Type { get; set; } public ScheduledTaskType? Optional { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                // The Curiosity server registers a JsonStringEnumConverter, so an enum reaches the
+                // browser as its name. Both packages accept that as well as the numeric form.
+                var byName   = Json.Read<Task>("{\"Type\":\"Reindex\",\"Optional\":\"Cleanup\"}");
+                var byNumber = Json.Read<Task>("{\"Type\":1,\"Optional\":2}");
+
+                Console.WriteLine(byName.Type + "/" + byName.Optional);
+                Console.WriteLine(byNumber.Type + "/" + byNumber.Optional);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEnumWithExplicitValuesAndGaps() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        public enum Status { Unknown = 0, Queued = 10, Running = 20, Done = 30 }
+
+        public class T { public Status S { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(Json.Write(new T { S = Status.Running }));
+                Console.WriteLine(Json.Read<T>("{\"S\":30}").S);
+                Console.WriteLine((int)Json.Read<T>("{\"S\":99}").S);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AFlagsEnum() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        [Flags]
+        public enum Access { None = 0, Read = 1, Write = 2, Admin = 4 }
+
+        public class T { public Access A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = Json.Write(new T { A = Access.Read | Access.Admin });
+                Console.WriteLine(json);
+                Console.WriteLine(Json.Read<T>(json).A);
+            }
+        }
+        """);
+
+    // =============================================================================================
+    // Attribute handling, on the shapes the shared types use
+    // =============================================================================================
+
+    [TestMethod]
+    public async Task ShortenedMemberNamesAsTheSharedTypesUse() => await AssertSame("""
+        using System;
+        #USINGS#
+
+        // Shared/Mosaik.Shared/SharedTypes.cs and Mosaik/Core.Shared/src/ExtractorStatus.cs rename most
+        // members to one- or two-character wire names.
+        public class ExtractorProgress
+        {
+            [#PROP("S")]   public string Stage                { get; set; }
+            [#PROP("W")]   public string SubStage             { get; set; }
+            [#PROP("P")]   public float  CurrentStageProgress { get; set; }
+            [#PROP("PID")] public int    ProcessId            { get; set; }
+            [#PROP("Re")]  public int?   RequestID            { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = Json.Write(new ExtractorProgress { Stage = "extract", SubStage = "ocr", CurrentStageProgress = 0.5f, ProcessId = 42 });
+                Console.WriteLine(json);
+
+                var back = Json.Read<ExtractorProgress>(json);
+                Console.WriteLine(back.Stage + "/" + back.SubStage + "/" + back.CurrentStageProgress + "/" + back.ProcessId + "/" + (back.RequestID.HasValue ? "set" : "unset"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ARenamedMemberInsideACollection() => await AssertSame("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public class KeyValue
+        {
+            [#PROP("K")] public string Key   { get; set; }
+            [#PROP("V")] public string Value { get; set; }
+        }
+
+        public class Holder { public List<KeyValue> Pairs { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = Json.Write(new Holder { Pairs = new List<KeyValue> { new KeyValue { Key = "a", Value = "1" }, new KeyValue { Key = "b", Value = "2" } } });
+                Console.WriteLine(json);
+
+                var back = Json.Read<Holder>(json);
+                Console.WriteLine(back.Pairs.Count + "/" + back.Pairs[1].Key + "/" + back.Pairs[1].Value);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AJsonConstructorOnAGraphSchemaShape() => await AssertSame("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public class SchemaDefinition
+        {
+            [JsonConstructor]
+            public SchemaDefinition(string name, List<string> fields)
+            {
+                Name   = name;
+                Fields = fields ?? new List<string>();
+            }
+
+            public string       Name   { get; }
+            public List<string> Fields { get; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var back = Json.Read<SchemaDefinition>("{\"Name\":\"Person\",\"Fields\":[\"Title\",\"Email\"]}");
+                Console.WriteLine(back.Name + "/" + back.Fields.Count + "/" + back.Fields[1]);
+
+                var empty = Json.Read<SchemaDefinition>("{\"Name\":\"Empty\"}");
+                Console.WriteLine(empty.Name + "/" + empty.Fields.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnObjectLiteralTypeIsHandedBackAsTheParsedValue() => await AssertSame("""
+        using System;
+        using Transpose;
+        #USINGS#
+
+        // Request.cs marks its response shapes [ObjectLiteral]: they compile to direct property access
+        // on the parsed object, so neither package may walk them member by member.
+        [ObjectLiteral]
+        public class ServerStatus
+        {
+            public string Version { get; set; }
+            public bool   Ready   { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var status = Json.Read<ServerStatus>("{\"Version\":\"1.2.3\",\"Ready\":true}");
+                Console.WriteLine(status.Version + "/" + status.Ready);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ADeeplyNestedSearchResultShape() => await AssertSame("""
+        using System;
+        using System.Collections.Generic;
+        #USINGS#
+
+        public enum FacetKind { Term = 0, Range = 1 }
+
+        public class Facet
+        {
+            [#PROP("n")] public string    Name  { get; set; }
+            [#PROP("k")] public FacetKind Kind  { get; set; }
+            [#PROP("c")] public int       Count { get; set; }
+        }
+
+        public class Hit
+        {
+            [#PROP("u")] public string              Uid    { get; set; }
+            [#PROP("t")] public string              Title  { get; set; }
+            [#PROP("s")] public double              Score  { get; set; }
+            [#PROP("f")] public Dictionary<string, string> Fields { get; set; }
+        }
+
+        public class SearchResult
+        {
+            public List<Hit>   Hits   { get; set; }
+            public List<Facet> Facets { get; set; }
+            public long        Total  { get; set; }
+            public bool        More   { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var result = new SearchResult
+                {
+                    Total  = 12345678901L,
+                    More   = true,
+                    Hits   = new List<Hit>
+                    {
+                        new Hit { Uid = "1111111111111111111111", Title = "First", Score = 0.75, Fields = new Dictionary<string, string> { ["author"] = "Ada" } },
+                        new Hit { Uid = "2222222222222222222222", Title = "Second", Score = 0.5, Fields = new Dictionary<string, string>() }
+                    },
+                    Facets = new List<Facet> { new Facet { Name = "type", Kind = FacetKind.Term, Count = 3 } }
+                };
+
+                var json = Json.Write(result);
+                Console.WriteLine(json);
+
+                var back = Json.Read<SearchResult>(json);
+                Console.WriteLine(back.Hits.Count + "/" + back.Hits[0].Title + "/" + back.Hits[0].Fields["author"] + "/" + back.Facets[0].Kind + "/" + back.Total + "/" + back.More);
+                Console.WriteLine(Json.Write(back) == json);
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/OptionsTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/OptionsTests.cs
@@ -1,0 +1,324 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// <see cref="System.Text.Json.JsonSerializerOptions"/>: naming policies, case sensitivity, the
+/// options-wide ignore condition, indentation, fields, and the lenient read switches.
+/// </summary>
+[TestClass]
+public sealed class OptionsTests : JsonTestBase
+{
+    // ---------------------------------------------------------------------------------------------
+    // Naming policies
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task CamelCaseLowersTheWholeLeadingRunOfCapitals() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var policy = JsonNamingPolicy.CamelCase;
+
+                Console.WriteLine(policy.ConvertName("Name"));
+                Console.WriteLine(policy.ConvertName("ALLCAPS"));
+                Console.WriteLine(policy.ConvertName("HTTPRequest"));
+                Console.WriteLine(policy.ConvertName("A"));
+                Console.WriteLine(policy.ConvertName("alreadyCamel"));
+                Console.WriteLine(policy.ConvertName(""));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task SnakeAndKebabPolicies() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonNamingPolicy.SnakeCaseLower.ConvertName("HTTPRequestName"));
+                Console.WriteLine(JsonNamingPolicy.SnakeCaseUpper.ConvertName("HTTPRequestName"));
+                Console.WriteLine(JsonNamingPolicy.KebabCaseLower.ConvertName("HTTPRequestName"));
+                Console.WriteLine(JsonNamingPolicy.KebabCaseUpper.ConvertName("HTTPRequestName"));
+                Console.WriteLine(JsonNamingPolicy.SnakeCaseLower.ConvertName("Simple"));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ANamingPolicyAppliesOnWriteAndOnRead() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string FirstName { get; set; } public int ItemCount { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+                var json = JsonSerializer.Serialize(new T { FirstName = "Ada", ItemCount = 2 }, options);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<T>(json, options);
+                Console.WriteLine(back.FirstName + "/" + back.ItemCount);
+
+                // Without the policy the camel-cased payload no longer matches.
+                Console.WriteLine(JsonSerializer.Deserialize<T>(json).FirstName ?? "<null>");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ACustomNamingPolicyIsUsed() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public sealed class PrefixPolicy : JsonNamingPolicy
+        {
+            public override string ConvertName(string name) => "x_" + name;
+        }
+
+        public class T { public string Name { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { PropertyNamingPolicy = new PrefixPolicy() };
+
+                var json = JsonSerializer.Serialize(new T { Name = "n" }, options);
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<T>(json, options).Name);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DictionaryKeyPolicyRenamesKeysOnly() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { DictionaryKeyPolicy = JsonNamingPolicy.CamelCase };
+                Console.WriteLine(JsonSerializer.Serialize(new Dictionary<string, int> { ["FirstKey"] = 1, ["SecondKey"] = 2 }, options));
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Ignore conditions
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task DefaultIgnoreConditionWhenWritingNull() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T { public string A { get; set; } public int B { get; set; } public string C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+                Console.WriteLine(JsonSerializer.Serialize(new T { C = "c" }, options));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DefaultIgnoreConditionWhenWritingDefaultAlsoDropsNulls() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public enum E { Zero = 0, One = 1 }
+        public class T
+        {
+            public string A { get; set; }
+            public int    B { get; set; }
+            public bool   C { get; set; }
+            public double D { get; set; }
+            public E      Enum { get; set; }
+            public int    Set  { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault };
+                Console.WriteLine(JsonSerializer.Serialize(new T { Set = 5 }, options));
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Read switches
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ATrailingCommaIsRejectedUnlessAllowed() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try   { Console.WriteLine(JsonSerializer.Deserialize<T>("{\"A\":\"a\",}").A); }
+                catch (JsonException) { Console.WriteLine("JsonException"); }
+
+                var options = new JsonSerializerOptions { AllowTrailingCommas = true };
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{\"A\":\"a\",}", options).A);
+                Console.WriteLine(JsonSerializer.Deserialize<int[]>("[1,2,]", options).Length);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ACommentIsRejectedUnlessSkipped() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try   { Console.WriteLine(JsonSerializer.Deserialize<T>("{/* c */\"A\":\"a\"}").A); }
+                catch (JsonException) { Console.WriteLine("JsonException"); }
+
+                var options = new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip };
+                Console.WriteLine(JsonSerializer.Deserialize<T>("{/* c */\"A\":\"a\" // trailing\n}", options).A);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task SingleQuotesAreNeverAccepted() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { AllowTrailingCommas = true, ReadCommentHandling = JsonCommentHandling.Skip };
+
+                try   { Console.WriteLine(JsonSerializer.Deserialize<T>("{'A':'a'}", options).A); }
+                catch (JsonException) { Console.WriteLine("JsonException"); }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task NumberHandlingAllowReadingFromString() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T { public int I { get; set; } public double D { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowReadingFromString };
+                var t = JsonSerializer.Deserialize<T>("{\"I\":\"7\",\"D\":\"1.5\"}", options);
+                Console.WriteLine(t.I + "/" + t.D);
+
+                try   { Console.WriteLine(JsonSerializer.Deserialize<T>("{\"I\":\"7\"}").I); }
+                catch (JsonException) { Console.WriteLine("JsonException"); }
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Presets
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task WebDefaultsAreCamelCaseCaseInsensitiveAndLenientNumbers() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string FirstName { get; set; } public int Count { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+                Console.WriteLine(JsonSerializer.Serialize(new T { FirstName = "Ada", Count = 1 }, options));
+
+                var t = JsonSerializer.Deserialize<T>("{\"FIRSTNAME\":\"Ada\",\"count\":\"7\"}", options);
+                Console.WriteLine(t.FirstName + "/" + t.Count);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task CopyingOptionsCarriesEverySetting() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public class T { public string FirstName { get; set; } public string Empty { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var source = new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy   = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                    WriteIndented          = false
+                };
+
+                var copy = new JsonSerializerOptions(source);
+                Console.WriteLine(JsonSerializer.Serialize(new T { FirstName = "Ada" }, copy));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task OptionsAreReusableAcrossCalls() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class A { public string X { get; set; } }
+        public class B { public int Y { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+                Console.WriteLine(JsonSerializer.Serialize(new A { X = "x" }, options));
+                Console.WriteLine(JsonSerializer.Serialize(new B { Y = 1 }, options));
+                Console.WriteLine(JsonSerializer.Serialize(new A { X = "z" }, options));
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/PolymorphismTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/PolymorphismTests.cs
@@ -1,0 +1,219 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// <c>[JsonPolymorphic]</c> / <c>[JsonDerivedType]</c>: the discriminator is written first, matched on
+/// read, and the hierarchy is declared on the base type rather than inferred from a CLR type name the
+/// way Json.NET's <c>TypeNameHandling</c> did.
+/// </summary>
+[TestClass]
+public sealed class PolymorphismTests : JsonTestBase
+{
+    private const string Hierarchy = """
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        [JsonDerivedType(typeof(Dog), "dog")]
+        [JsonDerivedType(typeof(Cat), "cat")]
+        public abstract class Animal { public string Name { get; set; } }
+
+        public class Dog : Animal { public bool Fetches { get; set; } }
+        public class Cat : Animal { public int Lives { get; set; } }
+
+        public class Shelter { public Animal Resident { get; set; } public List<Animal> All { get; set; } }
+        """;
+
+    [TestMethod]
+    public async Task TheDiscriminatorIsWrittenFirst() => await RunAndCompare(Hierarchy + """
+
+        public static class Program
+        {
+            public static void Main()
+                => Console.WriteLine(JsonSerializer.Serialize<Animal>(new Dog { Name = "Rex", Fetches = true }));
+        }
+        """, exactMemberOrder: true);
+
+    [TestMethod]
+    public async Task ADerivedValueIsReadBackAsItsOwnType() => await RunAndCompare(Hierarchy + """
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize<Animal>(new Cat { Name = "Tom", Lives = 9 });
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<Animal>(json);
+                Console.WriteLine(back.GetType().Name + "/" + back.Name + "/" + ((Cat)back).Lives);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task APolymorphicMemberRoundTrips() => await RunAndCompare(Hierarchy + """
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var shelter = new Shelter
+                {
+                    Resident = new Dog { Name = "Rex", Fetches = true },
+                    All      = new List<Animal> { new Dog { Name = "Rex" }, new Cat { Name = "Tom", Lives = 7 } }
+                };
+
+                var json = JsonSerializer.Serialize(shelter);
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<Shelter>(json);
+                Console.WriteLine(back.Resident.GetType().Name + "/" + back.All.Count + "/" + back.All[1].GetType().Name);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnUnrecognisedDiscriminatorFails() => await RunAndCompare(Hierarchy + """
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                try
+                {
+                    var back = JsonSerializer.Deserialize<Animal>("{\"$type\":\"fox\",\"Name\":\"n\"}");
+                    Console.WriteLine(back.GetType().Name);
+                }
+                catch (JsonException)
+                {
+                    Console.WriteLine("JsonException");
+                }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ACustomDiscriminatorPropertyName() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        [JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+        [JsonDerivedType(typeof(Square), "square")]
+        public abstract class Shape { public string Label { get; set; } }
+        public class Square : Shape { public int Side { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize<Shape>(new Square { Label = "s", Side = 2 });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<Shape>(json).GetType().Name);
+            }
+        }
+        """, exactMemberOrder: true);
+
+    [TestMethod]
+    public async Task AnInterfaceRootedHierarchy() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        [JsonDerivedType(typeof(TextNote), "text")]
+        [JsonDerivedType(typeof(LinkNote), "link")]
+        public interface INote { }
+
+        public class TextNote : INote { public string Body { get; set; } }
+        public class LinkNote : INote { public string Url  { get; set; } }
+
+        public class Holder { public INote Note { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new Holder { Note = new LinkNote { Url = "https://x/" } });
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<Holder>(json);
+                Console.WriteLine(back.Note.GetType().Name + "/" + ((LinkNote)back.Note).Url);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task ADiscriminatorCanBeAFullTypeName() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        // Json.NET's TypeNameHandling wrote the CLR type name into $type. Declaring the same string as
+        // the discriminator is what lets a payload written that way keep deserializing.
+        [JsonDerivedType(typeof(FieldContent), "Mosaik.Components.NodeRendering.FieldContent")]
+        public interface INodeRendererItem { }
+
+        public class FieldContent : INodeRendererItem { public string Field { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize<INodeRendererItem>(new FieldContent { Field = "Title" });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<INodeRendererItem>(json).GetType().Name);
+            }
+        }
+        """, exactMemberOrder: true);
+
+    [TestMethod]
+    public async Task AnAssemblyQualifiedDiscriminatorStillMatchesTheBareName() => await RunJs("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        [JsonDerivedType(typeof(FieldContent), "Mosaik.Components.NodeRendering.FieldContent")]
+        public interface INodeRendererItem { }
+
+        public class FieldContent : INodeRendererItem { public string Field { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                // Exactly what a store written by Json.NET with TypeNameHandling.Objects contains.
+                var legacy = "{\"$type\":\"Mosaik.Components.NodeRendering.FieldContent, Mosaik.Graph\",\"Field\":\"Title\"}";
+
+                try
+                {
+                    var back = JsonSerializer.Deserialize<INodeRendererItem>(legacy);
+                    Console.WriteLine(back.GetType().Name + "/" + ((FieldContent)back).Field);
+                }
+                catch (JsonException)
+                {
+                    Console.WriteLine("JsonException");
+                }
+            }
+        }
+        """,
+        expected:     "FieldContent/Title",
+        nativePrints: "JsonException");
+
+    [TestMethod]
+    public async Task ANonPolymorphicTypeIsUnaffected() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Plain { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new Plain { A = "a" });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<Plain>("{\"$type\":\"ignored\",\"A\":\"a\"}").A);
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/README.md
+++ b/Packages/Transpose.System.Text.Json.Tests/README.md
@@ -1,0 +1,111 @@
+# Transpose.System.Text.Json.Tests
+
+End-to-end tests for the **`Transpose.System.Text.Json`** package — the `System.Text.Json.*` surface a
+Transpose app compiles against, whose behaviour lives in the hand-written
+[`Resources/Manual/JsonSerializer.js`](../Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js).
+
+## How a test works
+
+There are two kinds, and the difference is which oracle a test is diffed against.
+
+### 1. Against the real System.Text.Json (`JsonTestBase`)
+
+Each test is a small C# program run **twice**, and the console output is diffed:
+
+| | runner | what it exercises |
+| --- | --- | --- |
+| oracle | `NativeJsonRunner` | Roslyn-compiles the snippet in-process against the **real** `System.Text.Json` and invokes its entry point |
+| subject | `TranslatedJsonRunner` | translates the snippet with `Transpose.Translator` against the package's own reference assembly, prepends the Transpose runtime + the package's glue + `JsonSerializer.js`, and runs it on Node |
+
+`System.Text.Json` ships in the shared framework, so the oracle needs no package reference — the
+snippet's `using System.Text.Json;` binds to the framework copy, and the *same snippet text* binds to
+this package when translated. The package exists to behave like System.Text.Json, so "what does
+System.Text.Json print" *is* the specification.
+
+Where the package deliberately or knowingly differs, the test uses `RunJs(code, expected, nativePrints)`
+instead: it pins the JavaScript output **and** re-asserts what native prints, so a documented divergence
+cannot quietly rot into something else.
+
+JSON member **order** is canonicalized before comparing (`TestOutput.CanonicalizeJson`), because it is
+the one difference that would otherwise show up in nearly every test:
+`SerializationTests.MemberOrderIsAlphabetical` pins it down once. (Json.NET is referenced *only* as the
+parser that does this canonicalization — it is never an oracle, and no snippet references it.)
+
+### 2. Against `Transpose.Newtonsoft.Json` (`CrossPackageTestBase`)
+
+The Curiosity front-end is migrating off the Newtonsoft binding onto this package, and the question
+that decides how risky each call site is — *does the payload on the wire change?* — is only answerable
+by running the same program through both. `CrossPackageTests` and `MosaikShapeTests` do exactly that:
+
+- **`AssertSame`** — the two packages agree, so that shape can be swapped over without thinking.
+- **`AssertDiffers`** — a real behavioural change, with **both** sides recorded so neither can drift.
+
+One template is written in a small dialect and rendered into each package's API: `#USINGS#`,
+`[#PROP("n")]` (→ `JsonProperty` / `JsonPropertyName`), `#JSONEX#`, and `Json.Write` / `Json.WriteIndented`
+/ `Json.Read<T>` supplied by a per-dialect shim. Everything else is ordinary C# and identical in both
+renderings — which is the point: what differs, differs because the serializer differs.
+
+`MosaikShapeTests` covers the types that exist *because* a Transpose JSON binding has no converter
+registry — `UID128` and `LanguageDTO`, whose values are plain JavaScript strings reached only through a
+conversion operator — plus the enum and renamed-member shapes the shared DTOs use. None of those are
+expressible in a native snippet (they are `extern` + `[Template]`), so the sibling package is the only
+meaningful oracle for them.
+
+```bash
+dotnet test Packages/Transpose.System.Text.Json.Tests
+
+# see the JavaScript a test actually ran
+TPS_DUMP_JS=/tmp/out.js dotnet test Packages/Transpose.System.Text.Json.Tests --filter SimpleRoundTrip
+
+# ... and the Newtonsoft rendering of a cross-package test
+TPS_DUMP_JS_NEWTONSOFT=/tmp/nj.js dotnet test Packages/Transpose.System.Text.Json.Tests --filter CrossPackageTests
+```
+
+Requirements: **Node** on `PATH` (or `/opt/node22/bin/node`) and a `Transpose.dll` runtime — the
+`Transpose.BCL` package from the NuGet cache, or one built from this repo via
+`TRANSPOSE_DLL_PATH=…/BCL/Transpose.BCL/bin/Release/netstandard2.0/Transpose.dll`.
+
+## Layout
+
+| file | area |
+| --- | --- |
+| `SmokeTests` | the harness itself: package build, runtime glue, Node |
+| `SerializationTests` | member selection, order, nesting, indentation, enums, depth |
+| `EscapingTests` | the escaping allow-list, control characters, non-ASCII, surrogate pairs |
+| `DeserializationTests` | member matching, case sensitivity, constructors, primitives, `object` targets |
+| `CollectionTests` | arrays, lists, sets, dictionaries, collection interfaces, nesting |
+| `AttributeTests` | `[JsonPropertyName]`, `[JsonIgnore]`, `[JsonInclude]`, `[JsonConstructor]`, `[JsonPropertyOrder]`, `[JsonNumberHandling]` |
+| `OptionsTests` | naming policies, case insensitivity, ignore conditions, read switches, `JsonSerializerDefaults.Web` |
+| `BclTypeTests` | dates, times, GUIDs, URIs, versions, byte arrays, characters, nullables, 64-bit integers |
+| `PolymorphismTests` | `[JsonPolymorphic]` / `[JsonDerivedType]`, `$type` |
+| `ErrorHandlingTests` | malformed input, type and shape mismatches, depth limit |
+| `CrossPackageTests` | this package vs `Transpose.Newtonsoft.Json` — the migration's risk register |
+| `MosaikShapeTests` | `UID128`, `LanguageDTO`, enum and renamed-member shapes from the Curiosity front-end |
+
+## Known divergences from System.Text.Json
+
+Each is asserted by the test named beside it, so this list stays true.
+
+| behaviour | System.Text.Json | this package | test |
+| --- | --- | --- | --- |
+| member order | declaration order, most-derived first | alphabetical | `MemberOrderIsAlphabetical` |
+| `long` / `ulong` | JSON numbers | JSON strings (JavaScript cannot hold them exactly) | `SixtyFourBitIntegersAreWrittenAsStringsWhileDecimalsStayNumbers` |
+| enum from its **name** | needs a `JsonStringEnumConverter` | always accepted | `AnEnumIsAlsoReadFromItsName` |
+| deserializing to `object` | a `JsonElement` | the raw parsed JavaScript value | `DeserializingToObjectReturnsTheRawParsedValue` |
+| an assembly-qualified `$type` | unrecognised discriminator | also matches the bare type name | `AnAssemblyQualifiedDiscriminatorStillMatchesTheBareName` |
+
+The first two are inherited from `Transpose.Newtonsoft.Json` on purpose: the Curiosity server's
+`Long`/`ULong`-from-string converters and its `JsonStringEnumConverter` are written against exactly
+that wire shape, so matching the *server* matters more than matching the framework here. A `decimal`
+deliberately stays a JSON number, because the server has no decimal-from-string converter.
+
+The last one exists so a store written by Json.NET's `TypeNameHandling` (which wrote
+`"Some.Type, Some.Assembly"` into `$type`) keeps deserializing against a hierarchy that declares the
+bare type name as its discriminator.
+
+## What the package deliberately does not cover
+
+The streaming (`Utf8JsonReader` / `Utf8JsonWriter`), document (`JsonDocument` / `JsonNode` /
+`JsonElement`) and source-generated (`JsonSerializerContext`) APIs, and the custom-converter registry
+(`JsonConverter<T>`, `JsonStringEnumConverter`). The package covers whole-document
+`Serialize` / `Deserialize` over a `JsonSerializerOptions`, which is the surface a browser app uses.

--- a/Packages/Transpose.System.Text.Json.Tests/SerializationTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/SerializationTests.cs
@@ -1,0 +1,352 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// What ends up in the payload and in what shape: which members are picked, how they are ordered,
+/// nesting, indentation, enums, and the depth guard.
+/// </summary>
+[TestClass]
+public sealed class SerializationTests : JsonTestBase
+{
+    // ---------------------------------------------------------------------------------------------
+    // Member selection
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task PublicPropertiesAreWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } public int B { get; set; } public bool C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T { A = "a", B = 2, C = true }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task PublicFieldsAreSkippedUnlessIncludeFieldsIsSet() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Field; public string Prop { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new T { Field = "f", Prop = "p" };
+                Console.WriteLine(JsonSerializer.Serialize(value));
+                Console.WriteLine(JsonSerializer.Serialize(value, new JsonSerializerOptions { IncludeFields = true }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task PrivateAndInternalMembersAreSkipped() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public   string Public   { get; set; } = "yes";
+            internal string Internal { get; set; } = "no";
+            private  string Private  { get; set; } = "no";
+            protected string Protected { get; set; } = "no";
+        }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T()));
+        }
+        """);
+
+    [TestMethod]
+    public async Task AGetOnlyPropertyIsWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public string Stored { get; set; } = "s";
+            public string Computed => Stored + "!";
+        }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T()));
+        }
+        """);
+
+    [TestMethod]
+    public async Task APropertyWithANonPublicSetterIsStillWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string Value { get; private set; } = "v"; }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T()));
+        }
+        """);
+
+    [TestMethod]
+    public async Task StaticMembersAreSkipped() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public static string Shared { get; set; } = "no";
+            public        string Own    { get; set; } = "yes";
+        }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T()));
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnIndexerIsSkipped() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public string Name { get; set; } = "n";
+            public string this[int i] => i.ToString();
+        }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T()));
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Order — the one systematic divergence, pinned once here so every other test can canonicalize
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task MemberOrderIsAlphabetical() => await RunJs("""
+        using System;
+        using System.Text.Json;
+
+        public class T
+        {
+            public int Zebra  { get; set; }
+            public int Apple  { get; set; }
+            public int Middle { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T { Zebra = 1, Apple = 2, Middle = 3 }));
+        }
+        """,
+        expected:     """{"Apple":2,"Middle":3,"Zebra":1}""",
+        nativePrints: """{"Zebra":1,"Apple":2,"Middle":3}""");
+
+    [TestMethod]
+    public async Task NullsAreWrittenByDefault() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } public string B { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T { A = null, B = "b" }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task ANullRootIsWrittenAsNull() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize<T>(null));
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Nesting and formatting
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task NestedObjectsAndArrays() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public class Inner { public string S { get; set; } }
+        public class Outer
+        {
+            public Inner        One  { get; set; }
+            public List<Inner>  Many { get; set; }
+            public int[]        Nums { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new Outer
+                {
+                    One  = new Inner { S = "a" },
+                    Many = new List<Inner> { new Inner { S = "b" }, new Inner { S = "c" } },
+                    Nums = new[] { 1, 2, 3 }
+                };
+
+                Console.WriteLine(JsonSerializer.Serialize(value));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task WriteIndentedUsesTwoSpacesAndAColonSpace() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Inner { public string S { get; set; } }
+        public class Outer { public Inner In { get; set; } public int[] Arr { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new Outer { In = new Inner { S = "v" }, Arr = new[] { 1, 2 } };
+                Console.WriteLine(JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnEmptyArrayAndAnEmptyObjectStayOnOneLineWhenIndented() => await RunAndCompare("""
+        using System;
+        using System.Collections.Generic;
+        using System.Text.Json;
+
+        public class Empty { }
+        public class T { public int[] Arr { get; set; } public List<int> List { get; set; } public Empty Obj { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var value = new T { Arr = new int[0], List = new List<int>(), Obj = new Empty() };
+                Console.WriteLine(JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true }));
+            }
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Enums
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task EnumsAreWrittenAsNumbers() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public enum Colour { Red = 0, Green = 5, Blue = 9 }
+        public class T { public Colour C { get; set; } public Colour? N { get; set; } public Colour? Missing { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T { C = Colour.Green, N = Colour.Blue }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnUndeclaredEnumValueIsWrittenAsItsNumber() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public enum Colour { Red = 0, Green = 5 }
+        public class T { public Colour C { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new T { C = (Colour)42 }));
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Polymorphic-shaped writes without a declared hierarchy
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ADerivedValueBoxedAsObjectIsWrittenWithItsOwnMembers() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class T { public string A { get; set; } public int B { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize<object>(new T { A = "a", B = 1 }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task InheritedMembersAreWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Base    { public int FromBase { get; set; } }
+        public class Derived : Base { public int FromDerived { get; set; } }
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new Derived { FromBase = 1, FromDerived = 2 }));
+        }
+        """);
+
+    [TestMethod]
+    public async Task AnAnonymousTypeIsWritten() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            public static void Main() => Console.WriteLine(JsonSerializer.Serialize(new { X = 1, Y = "s", Z = true }));
+        }
+        """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Depth / cycles
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ASelfReferencingObjectFailsRatherThanLooping() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Node { public string Name { get; set; } public Node Next { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var node = new Node { Name = "a" };
+                node.Next = node;
+
+                try
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(node));
+                }
+                catch (JsonException)
+                {
+                    Console.WriteLine("JsonException");
+                }
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/SmokeTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/SmokeTests.cs
@@ -1,0 +1,73 @@
+namespace Transpose.SystemTextJson.Tests;
+
+/// <summary>
+/// The narrowest end-to-end checks: if these fail, the harness itself (package build, runtime glue,
+/// Node) is broken rather than any particular behaviour.
+/// </summary>
+[TestClass]
+public sealed class SmokeTests : JsonTestBase
+{
+    [TestMethod]
+    public async Task SerializeASimpleObject() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new Person { Name = "Ada", Age = 36 }));
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task DeserializeASimpleObject() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var p = JsonSerializer.Deserialize<Person>("{\"Name\":\"Ada\",\"Age\":36}");
+                Console.WriteLine(p.Name + " / " + p.Age);
+            }
+        }
+        """);
+
+    [TestMethod]
+    public async Task RoundTrip() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public bool Active { get; set; }
+        }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                var json = JsonSerializer.Serialize(new Person { Name = "Ada", Age = 36, Active = true });
+                var back = JsonSerializer.Deserialize<Person>(json);
+                Console.WriteLine(JsonSerializer.Serialize(back));
+            }
+        }
+        """);
+}

--- a/Packages/Transpose.System.Text.Json.Tests/Transpose.System.Text.Json.Tests.csproj
+++ b/Packages/Transpose.System.Text.Json.Tests/Transpose.System.Text.Json.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <InvariantTimezone>true</InvariantTimezone>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
+    <!-- The oracle is the real System.Text.Json, which ships in the shared framework and so needs
+         no package reference: NativeJsonRunner compiles each snippet against the test host's own
+         trusted-platform assemblies. Json.NET is referenced only to canonicalize JSON member order
+         before comparing. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+    <Using Include="Transpose.Translator" />
+    <!-- The namespace of the linked NodeJsRunner below. -->
+    <Using Include="Transpose.Translator.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Transpose\Transpose.Translator\Transpose.Translator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Shared with the translator test suite so both resolve Node the same way. -->
+    <Compile Include="..\..\Transpose\Transpose.Translator.Tests\Infrastructure\NodeJsRunner.cs" Link="Infrastructure\NodeJsRunner.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Packages/Transpose.System.Text.Json/Json/JsonCommentHandling.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonCommentHandling.cs
@@ -1,0 +1,18 @@
+namespace System.Text.Json
+{
+    /// <summary>How a comment in the payload is treated on read.</summary>
+    public enum JsonCommentHandling : byte
+    {
+        /// <summary>A comment is a syntax error. This is the default.</summary>
+        Disallow = 0,
+
+        /// <summary>A comment is skipped over.</summary>
+        Skip = 1,
+
+        /// <summary>
+        /// A comment is surfaced as a token. The whole-document serializer never surfaces tokens, so
+        /// this behaves as <see cref="Skip"/> here.
+        /// </summary>
+        Allow = 2
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Json/JsonException.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonException.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace System.Text.Json
+{
+    /// <summary>The exception thrown when JSON is invalid or cannot be mapped onto a .NET type.</summary>
+    public class JsonException : Exception
+    {
+        /// <summary>Initializes a new instance.</summary>
+        public JsonException()
+        {
+        }
+
+        /// <summary>Initializes a new instance with the given message.</summary>
+        public JsonException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>Initializes a new instance with the given message and inner exception.</summary>
+        public JsonException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>The path to the member where the error occurred, when one is known.</summary>
+        public string Path { get; internal set; }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Json/JsonNamingPolicy.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonNamingPolicy.cs
@@ -1,0 +1,97 @@
+namespace System.Text.Json
+{
+    /// <summary>
+    /// Renames a .NET member for the JSON payload. Derive from this to supply your own policy.
+    /// </summary>
+    public abstract class JsonNamingPolicy
+    {
+        /// <summary>Initializes a new instance.</summary>
+        protected JsonNamingPolicy()
+        {
+        }
+
+        /// <summary>The built-in policy that converts <c>PascalCase</c> to <c>camelCase</c>.</summary>
+        public static JsonNamingPolicy CamelCase { get; } = new CamelCaseNamingPolicy();
+
+        /// <summary>The built-in policy that converts to <c>snake_case</c>.</summary>
+        public static JsonNamingPolicy SnakeCaseLower { get; } = new SnakeCaseNamingPolicy("_", false);
+
+        /// <summary>The built-in policy that converts to <c>SNAKE_CASE</c>.</summary>
+        public static JsonNamingPolicy SnakeCaseUpper { get; } = new SnakeCaseNamingPolicy("_", true);
+
+        /// <summary>The built-in policy that converts to <c>kebab-case</c>.</summary>
+        public static JsonNamingPolicy KebabCaseLower { get; } = new SnakeCaseNamingPolicy("-", false);
+
+        /// <summary>The built-in policy that converts to <c>KEBAB-CASE</c>.</summary>
+        public static JsonNamingPolicy KebabCaseUpper { get; } = new SnakeCaseNamingPolicy("-", true);
+
+        /// <summary>Returns the JSON name for <paramref name="name"/>.</summary>
+        public abstract string ConvertName(string name);
+    }
+
+    /// <summary>
+    /// Lower-cases the leading run of capitals rather than only the first character, so
+    /// <c>ALLCAPS</c> becomes <c>allcaps</c> and <c>HTTPRequest</c> becomes <c>httpRequest</c> —
+    /// what System.Text.Json itself does.
+    /// </summary>
+    internal sealed class CamelCaseNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name)
+        {
+            if (string.IsNullOrEmpty(name) || !char.IsUpper(name[0])) return name;
+
+            var chars = name.ToCharArray();
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (i > 0 && i + 1 < chars.Length && !char.IsUpper(chars[i + 1])) break;
+                if (!char.IsUpper(chars[i])) break;
+
+                chars[i] = char.ToLower(chars[i]);
+            }
+
+            return new string(chars);
+        }
+    }
+
+    /// <summary>Separates word boundaries with <c>separator</c>, optionally upper-casing the result.</summary>
+    internal sealed class SnakeCaseNamingPolicy : JsonNamingPolicy
+    {
+        private readonly string _separator;
+        private readonly bool   _upper;
+
+        public SnakeCaseNamingPolicy(string separator, bool upper)
+        {
+            _separator = separator;
+            _upper     = upper;
+        }
+
+        public override string ConvertName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+
+            var sb = new System.Text.StringBuilder();
+
+            for (int i = 0; i < name.Length; i++)
+            {
+                var c = name[i];
+
+                if (char.IsUpper(c))
+                {
+                    var previousIsLower = i > 0 && !char.IsUpper(name[i - 1]) && name[i - 1] != '_';
+                    var nextIsLower     = i + 1 < name.Length && !char.IsUpper(name[i + 1]);
+
+                    if (i > 0 && (previousIsLower || nextIsLower)) sb.Append(_separator);
+
+                    sb.Append(_upper ? char.ToUpper(c) : char.ToLower(c));
+                }
+                else
+                {
+                    sb.Append(_upper ? char.ToUpper(c) : c);
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Json/JsonSerializer.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonSerializer.cs
@@ -1,0 +1,66 @@
+using System;
+using Transpose;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// Converts .NET values to and from JSON.
+    /// </summary>
+    /// <remarks>
+    /// This is the Transpose binding onto the hand-written runtime in
+    /// <c>Resources/Manual/JsonSerializer.js</c>. It covers the surface a browser app actually uses —
+    /// whole-document <see cref="Serialize(object)"/> / <see cref="Deserialize{TValue}(string)"/> over
+    /// a <see cref="JsonSerializerOptions"/> — and deliberately not the streaming
+    /// (<c>Utf8JsonReader</c> / <c>Utf8JsonWriter</c>), document (<c>JsonDocument</c> /
+    /// <c>JsonNode</c>) or source-generated (<c>JsonSerializerContext</c>) APIs.
+    /// </remarks>
+    [External]
+    public static class JsonSerializer
+    {
+        /// <summary>Converts the value to a JSON string.</summary>
+        [Unbox(false)]
+        [Template("System.Text.Json.JsonSerializer.Serialize({value}, null, false, {TValue})")]
+        public static extern string Serialize<TValue>(TValue value);
+
+        /// <summary>Converts the value to a JSON string, using the supplied options.</summary>
+        [Unbox(false)]
+        [Template("System.Text.Json.JsonSerializer.Serialize({value}, {options}, false, {TValue})")]
+        public static extern string Serialize<TValue>(TValue value, JsonSerializerOptions options);
+
+        /// <summary>Converts the value to a JSON string.</summary>
+        [Unbox(false)]
+        [Template("System.Text.Json.JsonSerializer.Serialize({value}, null, false, null)")]
+        public static extern string Serialize(object value);
+
+        /// <summary>Converts the value to a JSON string, using the supplied options.</summary>
+        [Unbox(false)]
+        [Template("System.Text.Json.JsonSerializer.Serialize({value}, {options}, false, null)")]
+        public static extern string Serialize(object value, JsonSerializerOptions options);
+
+        /// <summary>Converts the value to a JSON string, treating it as <paramref name="inputType"/>.</summary>
+        [Unbox(false)]
+        [Template("System.Text.Json.JsonSerializer.Serialize({value}, null, false, {inputType})")]
+        public static extern string Serialize(object value, Type inputType);
+
+        /// <summary>Converts the value to a JSON string, treating it as <paramref name="inputType"/>.</summary>
+        [Unbox(false)]
+        [Template("System.Text.Json.JsonSerializer.Serialize({value}, {options}, false, {inputType})")]
+        public static extern string Serialize(object value, Type inputType, JsonSerializerOptions options);
+
+        /// <summary>Parses the JSON string into a <typeparamref name="TValue"/>.</summary>
+        [Template("System.Text.Json.JsonSerializer.Deserialize({json}, {TValue}, null)")]
+        public static extern TValue Deserialize<TValue>(string json);
+
+        /// <summary>Parses the JSON string into a <typeparamref name="TValue"/>, using the supplied options.</summary>
+        [Template("System.Text.Json.JsonSerializer.Deserialize({json}, {TValue}, {options})")]
+        public static extern TValue Deserialize<TValue>(string json, JsonSerializerOptions options);
+
+        /// <summary>Parses the JSON string into a <paramref name="returnType"/>.</summary>
+        [Template("System.Text.Json.JsonSerializer.Deserialize({json}, {returnType}, null)")]
+        public static extern object Deserialize(string json, Type returnType);
+
+        /// <summary>Parses the JSON string into a <paramref name="returnType"/>, using the supplied options.</summary>
+        [Template("System.Text.Json.JsonSerializer.Deserialize({json}, {returnType}, {options})")]
+        public static extern object Deserialize(string json, Type returnType, JsonSerializerOptions options);
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Json/JsonSerializerDefaults.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonSerializerDefaults.cs
@@ -1,0 +1,15 @@
+namespace System.Text.Json
+{
+    /// <summary>Preset groups of <see cref="JsonSerializerOptions"/> values.</summary>
+    public enum JsonSerializerDefaults
+    {
+        /// <summary>The library defaults: case-sensitive matching and member names as declared.</summary>
+        General = 0,
+
+        /// <summary>
+        /// What ASP.NET Core uses: camel-cased member names, case-insensitive matching and numbers
+        /// readable from JSON strings.
+        /// </summary>
+        Web = 1
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Json/JsonSerializerOptions.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonSerializerOptions.cs
@@ -1,0 +1,85 @@
+using System.Text.Json.Serialization;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// Options that control how <see cref="JsonSerializer"/> reads and writes JSON.
+    /// </summary>
+    public sealed class JsonSerializerOptions
+    {
+        /// <summary>A read-only instance carrying the library defaults.</summary>
+        public static JsonSerializerOptions Default { get; } = new JsonSerializerOptions();
+
+        /// <summary>Initializes options with the library defaults.</summary>
+        public JsonSerializerOptions()
+        {
+        }
+
+        /// <summary>Initializes options with the presets of <paramref name="defaults"/>.</summary>
+        public JsonSerializerOptions(JsonSerializerDefaults defaults)
+        {
+            if (defaults == JsonSerializerDefaults.Web)
+            {
+                PropertyNameCaseInsensitive = true;
+                PropertyNamingPolicy        = JsonNamingPolicy.CamelCase;
+                NumberHandling              = JsonNumberHandling.AllowReadingFromString;
+            }
+        }
+
+        /// <summary>Copies the settings of <paramref name="options"/>.</summary>
+        public JsonSerializerOptions(JsonSerializerOptions options)
+        {
+            if (options is null) return;
+
+            WriteIndented               = options.WriteIndented;
+            PropertyNamingPolicy        = options.PropertyNamingPolicy;
+            DictionaryKeyPolicy         = options.DictionaryKeyPolicy;
+            PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive;
+            DefaultIgnoreCondition      = options.DefaultIgnoreCondition;
+            NumberHandling              = options.NumberHandling;
+            AllowTrailingCommas         = options.AllowTrailingCommas;
+            ReadCommentHandling         = options.ReadCommentHandling;
+            IncludeFields               = options.IncludeFields;
+            MaxDepth                    = options.MaxDepth;
+        }
+
+        /// <summary>Whether the written JSON is pretty-printed. Defaults to <c>false</c>.</summary>
+        public bool WriteIndented { get; set; }
+
+        /// <summary>
+        /// Renames members on write and matches them on read. <c>null</c> (the default) uses the
+        /// member name as declared.
+        /// </summary>
+        public JsonNamingPolicy PropertyNamingPolicy { get; set; }
+
+        /// <summary>Renames dictionary keys on write. <c>null</c> (the default) leaves them as-is.</summary>
+        public JsonNamingPolicy DictionaryKeyPolicy { get; set; }
+
+        /// <summary>
+        /// Whether a JSON member name matches a .NET member ignoring case. Defaults to <c>false</c> —
+        /// System.Text.Json is case-sensitive where Json.NET was not.
+        /// </summary>
+        public bool PropertyNameCaseInsensitive { get; set; }
+
+        /// <summary>When a member is skipped on write. Defaults to <see cref="JsonIgnoreCondition.Never"/>.</summary>
+        public JsonIgnoreCondition DefaultIgnoreCondition { get; set; } = JsonIgnoreCondition.Never;
+
+        /// <summary>
+        /// Whether numbers may be read from (and written as) JSON strings. Defaults to
+        /// <see cref="JsonNumberHandling.Strict"/>.
+        /// </summary>
+        public JsonNumberHandling NumberHandling { get; set; } = JsonNumberHandling.Strict;
+
+        /// <summary>Whether a trailing comma is accepted on read. Defaults to <c>false</c>.</summary>
+        public bool AllowTrailingCommas { get; set; }
+
+        /// <summary>How comments are treated on read. Defaults to <see cref="JsonCommentHandling.Disallow"/>.</summary>
+        public JsonCommentHandling ReadCommentHandling { get; set; } = JsonCommentHandling.Disallow;
+
+        /// <summary>Whether public fields take part in serialization. Defaults to <c>false</c>.</summary>
+        public bool IncludeFields { get; set; }
+
+        /// <summary>The maximum nesting depth. <c>0</c> (the default) means 64.</summary>
+        public int MaxDepth { get; set; }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/LICENSE.md
+++ b/Packages/Transpose.System.Text.Json/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2008-2017 Object.NET, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Packages/Transpose.System.Text.Json/Resources/.auxiliary/AssemblyBegin.js
+++ b/Packages/Transpose.System.Text.Json/Resources/.auxiliary/AssemblyBegin.js
@@ -1,0 +1,2 @@
+Transpose.assembly("System.Text.Json", function ($asm, globals) {
+    "use strict";

--- a/Packages/Transpose.System.Text.Json/Resources/.auxiliary/AssemblyEnd.js
+++ b/Packages/Transpose.System.Text.Json/Resources/.auxiliary/AssemblyEnd.js
@@ -1,0 +1,2 @@
+    System.Text.Json.$cache = [];
+});

--- a/Packages/Transpose.System.Text.Json/Resources/.auxiliary/Header.js
+++ b/Packages/Transpose.System.Text.Json/Resources/.auxiliary/Header.js
@@ -1,0 +1,5 @@
+/*
+ * @version   : {version} - The Transpose implementation of System.Text.Json
+ * @copyright : Copyright (c) 2019-{year}, Curiosity GmbH. All rights reserved.
+ * @license   : See LICENSE.md and https://github.com/curiosity-ai/transpose/blob/master/LICENSE
+ */

--- a/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
+++ b/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
@@ -1,0 +1,1474 @@
+    Transpose.define("System.Text.Json.JsonSerializer", {
+        statics: {
+            methods: {
+                // ----------------------------------------------------------------------------------
+                // Options
+                // ----------------------------------------------------------------------------------
+
+                // Every entry point normalises its JsonSerializerOptions into a plain object once, so
+                // the recursive walk below reads flat fields instead of re-checking a C# object on
+                // every member. A null options argument means "the library defaults", which is what
+                // System.Text.Json's own parameterless overloads use.
+                opts: function (options) {
+                    if (options && options.$tps) {
+                        return options;
+                    }
+
+                    var o = options || {};
+
+                    return {
+                        $tps:      true,
+                        indent:    !!o.WriteIndented,
+                        naming:    o.PropertyNamingPolicy || null,
+                        dictNaming: o.DictionaryKeyPolicy || null,
+                        ci:        !!o.PropertyNameCaseInsensitive,
+                        ignore:    o.DefaultIgnoreCondition || 0,
+                        numbers:   o.NumberHandling || 0,
+                        commas:    !!o.AllowTrailingCommas,
+                        comments:  o.ReadCommentHandling || 0,
+                        fields:    !!o.IncludeFields,
+                        maxDepth:  o.MaxDepth > 0 ? o.MaxDepth : 64
+                    };
+                },
+
+                fail: function (message) {
+                    throw new System.Text.Json.JsonException.$ctor1(message);
+                },
+
+                // A [JsonNumberHandling] on a member applies to that member only, so the walk below it
+                // runs against a copy of the options carrying it. Cached on the member config, since
+                // the same member is read on every element of a collection.
+                forMember: function (o, cfg) {
+                    if (cfg.numbers == null || cfg.numbers === o.numbers) {
+                        return o;
+                    }
+
+                    if (cfg.$opts && cfg.$opts.$from === o) {
+                        return cfg.$opts;
+                    }
+
+                    var copy = {};
+
+                    for (var key in o) {
+                        if (o.hasOwnProperty(key)) copy[key] = o[key];
+                    }
+
+                    copy.numbers = cfg.numbers;
+                    copy.$from   = o;
+                    cfg.$opts    = copy;
+
+                    return copy;
+                },
+
+                convertName: function (policy, name) {
+                    if (!policy) {
+                        return name;
+                    }
+
+                    return policy.ConvertName(name);
+                },
+
+                // ----------------------------------------------------------------------------------
+                // Writing
+                // ----------------------------------------------------------------------------------
+
+                // System.Text.Json escapes far more than JSON requires: everything outside the basic
+                // latin alphanumerics and a short punctuation allow-list, so `+ < > & ' " \` and the
+                // backtick come out as \uXXXX and any non-ASCII character does too. That is what makes
+                // its output safe to drop inside an HTML <script> block, which is exactly what the
+                // self-contained page exports do, so the package reproduces it rather than leaning on
+                // JSON.stringify's minimal escaping.
+                //
+                // The allow-list, verbatim from JavaScriptEncoder.Default:
+                //   space ! # $ % ( ) * , - . / : ; = ? @ [ ] ^ _ { | } ~  and  0-9 A-Z a-z
+                needsEscape: function (code) {
+                    if (code < 0x20 || code > 0x7E) {
+                        return true;
+                    }
+
+                    // 0-9, A-Z, a-z
+                    if ((code >= 0x30 && code <= 0x39) || (code >= 0x41 && code <= 0x5A) || (code >= 0x61 && code <= 0x7A)) {
+                        return false;
+                    }
+
+                    switch (code) {
+                        case 0x20: // space
+                        case 0x21: // !
+                        case 0x23: // #
+                        case 0x24: // $
+                        case 0x25: // %
+                        case 0x28: // (
+                        case 0x29: // )
+                        case 0x2A: // *
+                        case 0x2C: // ,
+                        case 0x2D: // -
+                        case 0x2E: // .
+                        case 0x2F: // /
+                        case 0x3A: // :
+                        case 0x3B: // ;
+                        case 0x3D: // =
+                        case 0x3F: // ?
+                        case 0x40: // @
+                        case 0x5B: // [
+                        case 0x5D: // ]
+                        case 0x5E: // ^
+                        case 0x5F: // _
+                        case 0x7B: // {
+                        case 0x7C: // |
+                        case 0x7D: // }
+                        case 0x7E: // ~
+                            return false;
+                        default:
+                            return true;
+                    }
+                },
+
+                escapeString: function (value) {
+                    var out = '"';
+
+                    for (var i = 0; i < value.length; i++) {
+                        var code = value.charCodeAt(i);
+
+                        if (!System.Text.Json.JsonSerializer.needsEscape(code)) {
+                            out += value.charAt(i);
+                            continue;
+                        }
+
+                        switch (code) {
+                            case 0x08: out += "\\b"; break;
+                            case 0x09: out += "\\t"; break;
+                            case 0x0A: out += "\\n"; break;
+                            case 0x0C: out += "\\f"; break;
+                            case 0x0D: out += "\\r"; break;
+                            case 0x5C: out += "\\\\"; break;
+                            default:
+                                var hex = code.toString(16).toUpperCase();
+                                out += "\\u" + "0000".substring(hex.length) + hex;
+                                break;
+                        }
+                    }
+
+                    return out + '"';
+                },
+
+                // The raw tree the serializer builds is plain JavaScript, so this writer decides the
+                // final text: two-space indentation, ": " after a member name, and an empty array or
+                // object staying on one line — all as System.Text.Json writes them.
+                write: function (value, indent, depth) {
+                    if (value === null || value === undefined) {
+                        return "null";
+                    }
+
+                    var t = typeof value;
+
+                    if (t === "string") {
+                        return System.Text.Json.JsonSerializer.escapeString(value);
+                    }
+
+                    if (t === "boolean") {
+                        return value ? "true" : "false";
+                    }
+
+                    if (t === "number") {
+                        if (!isFinite(value)) {
+                            System.Text.Json.JsonSerializer.fail("'" + value + "' is not a valid JSON number.");
+                        }
+
+                        return String(value);
+                    }
+
+                    var pad    = indent ? new Array(depth + 2).join("  ") : "",
+                        padEnd = indent ? new Array(depth + 1).join("  ") : "",
+                        nl     = indent ? "\n" : "",
+                        sep    = indent ? ": " : ":",
+                        parts  = [],
+                        i;
+
+                    if (Object.prototype.toString.call(value) === "[object Array]") {
+                        if (value.length === 0) {
+                            return "[]";
+                        }
+
+                        for (i = 0; i < value.length; i++) {
+                            parts.push(pad + System.Text.Json.JsonSerializer.write(value[i], indent, depth + 1));
+                        }
+
+                        return "[" + nl + parts.join("," + nl) + nl + padEnd + "]";
+                    }
+
+                    var keys = Object.keys(value);
+
+                    if (keys.length === 0) {
+                        return "{}";
+                    }
+
+                    for (i = 0; i < keys.length; i++) {
+                        parts.push(pad + System.Text.Json.JsonSerializer.escapeString(keys[i]) + sep + System.Text.Json.JsonSerializer.write(value[keys[i]], indent, depth + 1));
+                    }
+
+                    return "{" + nl + parts.join("," + nl) + nl + padEnd + "}";
+                },
+
+                // ----------------------------------------------------------------------------------
+                // Reading
+                // ----------------------------------------------------------------------------------
+
+                // JSON.parse is the strict reader System.Text.Json defaults to. The two read options a
+                // browser app actually sets — AllowTrailingCommas and ReadCommentHandling.Skip — are
+                // not expressible through it, so a payload that fails strict parsing is retried
+                // through the hand-written reader below, which accepts exactly those two extensions
+                // and nothing else. A conforming document therefore never pays for the fallback.
+                //
+                // The fallback is a real reader rather than a call into the JavaScript evaluator:
+                // evaluating a payload executes whatever it contains, and a Content-Security-Policy
+                // without 'unsafe-eval' blocks it outright.
+                parse: function (text, o) {
+                    try {
+                        return JSON.parse(text);
+                    } catch (e) {
+                        if (!(e instanceof SyntaxError)) {
+                            throw e;
+                        }
+
+                        if (!o.commas && o.comments === 0) {
+                            System.Text.Json.JsonSerializer.fail(e.message);
+                        }
+
+                        try {
+                            return System.Text.Json.JsonSerializer.parseRelaxed(text, o);
+                        } catch (relaxedError) {
+                            System.Text.Json.JsonSerializer.fail(relaxedError.message);
+                        }
+                    }
+                },
+
+                parseRelaxed: function (text, o) {
+                    if (typeof text !== "string") {
+                        throw new SyntaxError("Cannot parse a non-string value as JSON.");
+                    }
+
+                    var state = { text: text, i: 0, commas: o.commas, comments: o.comments !== 0 };
+
+                    System.Text.Json.JsonSerializer.skipTrivia(state);
+                    var value = System.Text.Json.JsonSerializer.readValue(state);
+                    System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                    if (state.i < text.length) {
+                        System.Text.Json.JsonSerializer.syntaxError(state, "Unexpected content after the JSON value");
+                    }
+
+                    return value;
+                },
+
+                syntaxError: function (state, message) {
+                    throw new SyntaxError(message + " at position " + state.i + ".");
+                },
+
+                skipTrivia: function (state) {
+                    while (state.i < state.text.length) {
+                        var c = state.text.charAt(state.i);
+
+                        if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+                            state.i++;
+                            continue;
+                        }
+
+                        if (c === "/" && state.comments) {
+                            var next = state.text.charAt(state.i + 1);
+
+                            if (next === "/") {
+                                state.i += 2;
+                                while (state.i < state.text.length && state.text.charAt(state.i) !== "\n") state.i++;
+                                continue;
+                            }
+
+                            if (next === "*") {
+                                state.i += 2;
+                                var end = state.text.indexOf("*/", state.i);
+                                if (end < 0) System.Text.Json.JsonSerializer.syntaxError(state, "Unterminated comment");
+                                state.i = end + 2;
+                                continue;
+                            }
+                        }
+
+                        break;
+                    }
+                },
+
+                readValue: function (state) {
+                    if (state.i >= state.text.length) {
+                        System.Text.Json.JsonSerializer.syntaxError(state, "Unexpected end of input");
+                    }
+
+                    var c = state.text.charAt(state.i);
+
+                    if (c === "{") return System.Text.Json.JsonSerializer.readObject(state);
+                    if (c === "[") return System.Text.Json.JsonSerializer.readArray(state);
+                    if (c === '"') return System.Text.Json.JsonSerializer.readString(state);
+
+                    return System.Text.Json.JsonSerializer.readLiteral(state);
+                },
+
+                readObject: function (state) {
+                    var result = {};
+                    state.i++; // {
+                    System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                    if (state.text.charAt(state.i) === "}") {
+                        state.i++;
+                        return result;
+                    }
+
+                    while (true) {
+                        System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                        if (state.text.charAt(state.i) === "}" && state.commas) {
+                            state.i++;
+                            return result;
+                        }
+
+                        if (state.text.charAt(state.i) !== '"') {
+                            System.Text.Json.JsonSerializer.syntaxError(state, "Expected a member name");
+                        }
+
+                        var name = System.Text.Json.JsonSerializer.readString(state);
+
+                        System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                        if (state.text.charAt(state.i) !== ":") {
+                            System.Text.Json.JsonSerializer.syntaxError(state, "Expected ':' after the member name");
+                        }
+
+                        state.i++;
+                        System.Text.Json.JsonSerializer.skipTrivia(state);
+                        result[name] = System.Text.Json.JsonSerializer.readValue(state);
+                        System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                        var c = state.text.charAt(state.i);
+
+                        if (c === ",") {
+                            state.i++;
+                            continue;
+                        }
+
+                        if (c === "}") {
+                            state.i++;
+                            return result;
+                        }
+
+                        System.Text.Json.JsonSerializer.syntaxError(state, "Expected ',' or '}'");
+                    }
+                },
+
+                readArray: function (state) {
+                    var result = [];
+                    state.i++; // [
+                    System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                    if (state.text.charAt(state.i) === "]") {
+                        state.i++;
+                        return result;
+                    }
+
+                    while (true) {
+                        System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                        if (state.text.charAt(state.i) === "]" && state.commas) {
+                            state.i++;
+                            return result;
+                        }
+
+                        result.push(System.Text.Json.JsonSerializer.readValue(state));
+                        System.Text.Json.JsonSerializer.skipTrivia(state);
+
+                        var c = state.text.charAt(state.i);
+
+                        if (c === ",") {
+                            state.i++;
+                            continue;
+                        }
+
+                        if (c === "]") {
+                            state.i++;
+                            return result;
+                        }
+
+                        System.Text.Json.JsonSerializer.syntaxError(state, "Expected ',' or ']'");
+                    }
+                },
+
+                readString: function (state) {
+                    state.i++; // opening quote
+                    var out = "";
+
+                    while (state.i < state.text.length) {
+                        var c = state.text.charAt(state.i);
+
+                        if (c === '"') {
+                            state.i++;
+                            return out;
+                        }
+
+                        if (c === "\\") {
+                            state.i++;
+                            var e = state.text.charAt(state.i);
+
+                            if (e === '"')      out += '"';
+                            else if (e === "\\") out += "\\";
+                            else if (e === "/")  out += "/";
+                            else if (e === "b")  out += "\b";
+                            else if (e === "f")  out += "\f";
+                            else if (e === "n")  out += "\n";
+                            else if (e === "r")  out += "\r";
+                            else if (e === "t")  out += "\t";
+                            else if (e === "u") {
+                                var hex = state.text.substr(state.i + 1, 4);
+                                if (!/^[0-9a-fA-F]{4}$/.test(hex)) System.Text.Json.JsonSerializer.syntaxError(state, "Invalid \\u escape");
+                                out += String.fromCharCode(parseInt(hex, 16));
+                                state.i += 4;
+                            }
+                            else System.Text.Json.JsonSerializer.syntaxError(state, "Invalid escape sequence");
+
+                            state.i++;
+                            continue;
+                        }
+
+                        out += c;
+                        state.i++;
+                    }
+
+                    System.Text.Json.JsonSerializer.syntaxError(state, "Unterminated string");
+                },
+
+                readLiteral: function (state) {
+                    var start = state.i;
+
+                    while (state.i < state.text.length && !/[\s,}\]]/.test(state.text.charAt(state.i))) {
+                        state.i++;
+                    }
+
+                    var token = state.text.substring(start, state.i);
+
+                    if (token === "true")  return true;
+                    if (token === "false") return false;
+                    if (token === "null")  return null;
+
+                    // The strict grammar only — the relaxed reader exists for commas and comments, not
+                    // to become more permissive about values than the server is.
+                    if (/^-?(0|[1-9][0-9]*)([.][0-9]+)?([eE][-+]?[0-9]+)?$/.test(token)) {
+                        return parseFloat(token);
+                    }
+
+                    state.i = start;
+                    System.Text.Json.JsonSerializer.syntaxError(state, "Unexpected token '" + token + "'");
+                },
+
+                // ----------------------------------------------------------------------------------
+                // Contract discovery
+                // ----------------------------------------------------------------------------------
+
+                getCacheByType: function (type) {
+                    for (var i = 0; i < System.Text.Json.$cache.length; i++) {
+                        if (System.Text.Json.$cache[i].type === type) {
+                            return System.Text.Json.$cache[i];
+                        }
+                    }
+
+                    var cfg = { type: type };
+                    System.Text.Json.$cache.push(cfg);
+                    return cfg;
+                },
+
+                validateReflectable: function (type) {
+                    do {
+                        var ignoreMetaData = type === System.Object || type === Object || type.$literal || type.$kind === "anonymous",
+                            nometa         = !Transpose.getMetadata(type);
+
+                        if (!ignoreMetaData && nometa) {
+                            if (Transpose.$stjGuard) {
+                                delete Transpose.$stjGuard;
+                            }
+
+                            throw new System.InvalidOperationException.$ctor1(Transpose.getTypeName(type) + " is not reflectable and cannot be serialized.");
+                        }
+
+                        type = ignoreMetaData ? null : Transpose.Reflection.getBaseType(type);
+                    } while (!ignoreMetaData && type != null)
+                },
+
+                attr: function (member, attributeType) {
+                    var found = System.Attribute.getCustomAttributes(member, attributeType);
+                    return found && found.length > 0 ? found[0] : null;
+                },
+
+                // The member model System.Text.Json applies, which differs from Json.NET's in three
+                // ways that matter: a public field takes part only under IncludeFields (or an explicit
+                // [JsonInclude]), a non-public setter is not written to unless [JsonInclude] opts it
+                // in, and [JsonPropertyOrder] rather than declaration order decides the layout.
+                //
+                // The cache key carries the naming policy, because the policy decides the JSON name
+                // and two different option objects may walk the same type.
+                getMembers: function (type, memberCode, o) {
+                    var cache = System.Text.Json.JsonSerializer.getCacheByType(type),
+                        key   = memberCode + "|" + (o.naming ? Transpose.getTypeName(Transpose.getType(o.naming)) : "") + "|" + (o.fields ? "f" : "");
+
+                    if (cache[key]) {
+                        return cache[key];
+                    }
+
+                    var isField = memberCode === 4,
+                        members = Transpose.Reflection.getMembers(type, memberCode, 52),
+                        result  = [];
+
+                    for (var i = 0; i < members.length; i++) {
+                        var m       = members[i],
+                            include = System.Text.Json.JsonSerializer.attr(m, System.Text.Json.Serialization.JsonIncludeAttribute) != null,
+                            ignore  = System.Text.Json.JsonSerializer.attr(m, System.Text.Json.Serialization.JsonIgnoreAttribute);
+
+                        // A compiler-generated backing field is not a member of the contract.
+                        if (m.backing) {
+                            continue;
+                        }
+
+                        if (ignore && ignore.Condition === 1) {
+                            continue;
+                        }
+
+                        var canRead, canWrite;
+
+                        if (isField) {
+                            if (m.a !== 2 || !(o.fields || include)) {
+                                continue;
+                            }
+
+                            canRead  = true;
+                            canWrite = !m.ro;
+                        } else {
+                            if (m.a !== 2 || m.i) {
+                                continue; // non-public, or an indexer
+                            }
+
+                            canRead  = !!m.g && (m.g.a === 2 || include);
+                            canWrite = !!m.s && (m.s.a === 2 || include);
+
+                            if (!canRead && !canWrite) {
+                                continue;
+                            }
+                        }
+
+                        var nameAttr  = System.Text.Json.JsonSerializer.attr(m, System.Text.Json.Serialization.JsonPropertyNameAttribute),
+                            orderAttr = System.Text.Json.JsonSerializer.attr(m, System.Text.Json.Serialization.JsonPropertyOrderAttribute),
+                            numAttr   = System.Text.Json.JsonSerializer.attr(m, System.Text.Json.Serialization.JsonNumberHandlingAttribute);
+
+                        result.push({
+                            member:   m,
+                            name:     nameAttr ? nameAttr.Name : System.Text.Json.JsonSerializer.convertName(o.naming, m.n),
+                            order:    orderAttr ? orderAttr.Order : 0,
+                            ignore:   ignore ? ignore.Condition : null,
+                            numbers:  numAttr ? numAttr.Handling : null,
+                            canRead:  canRead,
+                            canWrite: canWrite,
+                            isField:  isField
+                        });
+                    }
+
+                    if (result.length > 1) {
+                        // A stable sort: only [JsonPropertyOrder] moves a member, everything else keeps
+                        // the order reflection handed us.
+                        for (var j = 0; j < result.length; j++) {
+                            result[j].$i = j;
+                        }
+
+                        result.sort(function (a, b) {
+                            return a.order !== b.order ? a.order - b.order : a.$i - b.$i;
+                        });
+                    }
+
+                    cache[key] = result;
+                    return result;
+                },
+
+                // Whether a member is skipped on write. A [JsonIgnore(Condition = ...)] on the member
+                // overrides the options-wide DefaultIgnoreCondition.
+                skipOnWrite: function (cfg, value, o) {
+                    var condition = cfg.ignore != null ? cfg.ignore : o.ignore;
+
+                    if (condition === 0 || condition == null) {
+                        return false;
+                    }
+
+                    if (condition === 3) {
+                        return value == null;
+                    }
+
+                    if (condition === 2) {
+                        if (value == null) {
+                            return true;
+                        }
+
+                        var unboxed = Transpose.unbox(value, true),
+                            def     = Transpose.getDefaultValue(cfg.member.rt);
+
+                        return def != null && Transpose.equals(unboxed, def);
+                    }
+
+                    return false;
+                },
+
+                // ----------------------------------------------------------------------------------
+                // Polymorphism
+                // ----------------------------------------------------------------------------------
+
+                // [JsonPolymorphic] / [JsonDerivedType] declare the hierarchy on the base type, so the
+                // discriminator is a string the author chose rather than a CLR type name. Both are
+                // resolved from the *declared* type, which is what System.Text.Json keys off too.
+                // A type's attributes live in its metadata rather than on a member info, so
+                // System.Attribute.getCustomAttributes (which reads `element.at`) does not reach them.
+                typeAttributes: function (type, attributeType) {
+                    var meta = Transpose.getMetadata(type),
+                        all  = (meta && meta.at) || [];
+
+                    return all.filter(function (a) { return Transpose.is(a, attributeType); });
+                },
+
+                polymorphism: function (type) {
+                    if (!type || !Transpose.getMetadata(type)) {
+                        return null;
+                    }
+
+                    var cache = System.Text.Json.JsonSerializer.getCacheByType(type);
+
+                    if (cache.$poly !== undefined) {
+                        return cache.$poly;
+                    }
+
+                    var derived = System.Text.Json.JsonSerializer.typeAttributes(type, System.Text.Json.Serialization.JsonDerivedTypeAttribute),
+                        poly    = System.Text.Json.JsonSerializer.typeAttributes(type, System.Text.Json.Serialization.JsonPolymorphicAttribute),
+                        result  = null;
+
+                    if (derived && derived.length > 0) {
+                        result = {
+                            discriminator: poly && poly.length > 0 && poly[0].TypeDiscriminatorPropertyName ? poly[0].TypeDiscriminatorPropertyName : "$type",
+                            unknown:       poly && poly.length > 0 ? poly[0].UnknownDerivedTypeHandling : 0,
+                            types:         []
+                        };
+
+                        for (var i = 0; i < derived.length; i++) {
+                            result.types.push({ type: derived[i].DerivedType, id: derived[i].TypeDiscriminator });
+                        }
+                    }
+
+                    cache.$poly = result;
+                    return result;
+                },
+
+                discriminatorFor: function (info, runtimeType) {
+                    for (var i = 0; i < info.types.length; i++) {
+                        if (info.types[i].type === runtimeType) {
+                            return info.types[i].id;
+                        }
+                    }
+
+                    return null;
+                },
+
+                typeForDiscriminator: function (info, id) {
+                    var i;
+
+                    for (i = 0; i < info.types.length; i++) {
+                        if (info.types[i].id === id) {
+                            return info.types[i].type;
+                        }
+                    }
+
+                    // A payload written by Json.NET's TypeNameHandling carries an assembly-qualified
+                    // name ("Some.Namespace.Type, Some.Assembly") where the same hierarchy declares the
+                    // bare type name. Matching the part before the comma lets a store written before a
+                    // migration keep deserializing, and costs nothing for a discriminator that never
+                    // contains one.
+                    if (typeof id === "string" && id.indexOf(",") > 0) {
+                        var bare = System.String.trim(id.substring(0, id.indexOf(",")));
+
+                        for (i = 0; i < info.types.length; i++) {
+                            if (info.types[i].id === bare) {
+                                return info.types[i].type;
+                            }
+                        }
+                    }
+
+                    return null;
+                },
+
+                // ----------------------------------------------------------------------------------
+                // Serialize
+                // ----------------------------------------------------------------------------------
+
+                Serialize: function (value, options, returnRaw, declaredType, depth) {
+                    var o = System.Text.Json.JsonSerializer.opts(options);
+
+                    if (!returnRaw) {
+                        var raw = System.Text.Json.JsonSerializer.Serialize(value, o, true, declaredType, 0);
+                        return System.Text.Json.JsonSerializer.write(raw, o.indent, 0);
+                    }
+
+                    depth = depth || 0;
+
+                    if (depth > o.maxDepth) {
+                        System.Text.Json.JsonSerializer.fail("A possible object cycle was detected, or the object depth is larger than the maximum allowed depth of " + o.maxDepth + ".");
+                    }
+
+                    if (value == null) {
+                        return null;
+                    }
+
+                    // Reflection hands a value-typed member back boxed (the accessor metadata carries a
+                    // `box` function), so unwrap before anything looks at `typeof`. The box remembers
+                    // the declared type, which is the only thing that still says "char" once the value
+                    // is a bare JavaScript number.
+                    if (typeof value === "object" && value.$boxed) {
+                        var boxedType = value.type;
+                        value = Transpose.unbox(value, true);
+
+                        if (!declaredType && boxedType) {
+                            declaredType = boxedType;
+                        }
+                    }
+
+                    var runtimeType = Transpose.getType(value),
+                        type        = declaredType || runtimeType;
+
+                    if (type && type.$nullable) {
+                        type = type.$nullableType;
+                    }
+
+                    if (typeof value === "function") {
+                        return Transpose.getTypeName(value);
+                    }
+
+                    // A primitive JavaScript models directly. The *declared* type decides the shape
+                    // here and the widening below is deliberately not applied first: a char is a JS
+                    // number at runtime, so widening to its runtime type would write 113 where
+                    // System.Text.Json writes "q".
+                    if (typeof value !== "object") {
+                        if (type === System.Char) {
+                            return String.fromCharCode(value);
+                        }
+
+                        return value;
+                    }
+
+                    // A declared base (or interface) holding a more derived value: the runtime type is
+                    // what carries the members, so serialize as that. System.Text.Json does the same
+                    // for a polymorphic hierarchy and for `object`.
+                    if (runtimeType && type !== runtimeType && (type === System.Object || type.$kind === "interface" || Transpose.Reflection.isAssignableFrom(type, runtimeType))) {
+                        type = runtimeType;
+                    }
+
+                    return System.Text.Json.JsonSerializer.serializeObject(value, type, declaredType, o, depth);
+                },
+
+                serializeObject: function (value, type, declaredType, o, depth) {
+                    var i, arr;
+
+                    // --- BCL values with a fixed JSON shape -----------------------------------------
+                    if (type === System.Guid)                 return Transpose.toString(value);
+                    if (type === System.Uri)                  return value.getAbsoluteUri();
+                    if (type === System.Version)              return Transpose.toString(value);
+                    if (type === System.Globalization.CultureInfo) return value.name;
+                    if (type === System.TimeSpan)             return Transpose.toString(value);
+                    if (type === System.Char)                 return String.fromCharCode(value);
+
+                    // A JavaScript number cannot hold a 64-bit integer exactly, so `toJSON` writes
+                    // those as JSON strings where System.Text.Json writes numbers; a decimal stays a
+                    // number. This matches Transpose.Newtonsoft.Json exactly, which is what the
+                    // Curiosity server's converters are written against.
+                    if (type === System.Int64 || type === System.UInt64 || type === System.Decimal) {
+                        return value.toJSON();
+                    }
+
+                    if (type === System.DateTime) {
+                        return System.DateTime.format(value, "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK");
+                    }
+
+                    if (type === System.DateTimeOffset) {
+                        return value.ToString$1("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK");
+                    }
+
+                    if (Transpose.Reflection.isEnum(type)) {
+                        return value;
+                    }
+
+                    // --- Collections ---------------------------------------------------------------
+                    if (Transpose.isArray(null, type)) {
+                        if (type.$elementType === System.Byte) {
+                            return System.Convert.toBase64String(value);
+                        }
+
+                        arr = [];
+
+                        for (i = 0; i < value.length; i++) {
+                            arr.push(System.Text.Json.JsonSerializer.Serialize(value[i], o, true, type.$elementType, depth + 1));
+                        }
+
+                        return arr;
+                    }
+
+                    if (Transpose.Reflection.isAssignableFrom(System.Collections.IDictionary, type)) {
+                        var generic  = System.Collections.Generic.Dictionary$2.getTypeParameters(type),
+                            keyType   = generic[0],
+                            valueType = generic[1],
+                            dict      = {},
+                            entries   = Transpose.getEnumerator(value);
+
+                        while (entries.moveNext()) {
+                            var entry = entries.Current,
+                                name  = System.Text.Json.JsonSerializer.dictionaryKey(entry.key, keyType, o);
+
+                            dict[name] = System.Text.Json.JsonSerializer.Serialize(entry.value, o, true, valueType, depth + 1);
+                        }
+
+                        return dict;
+                    }
+
+                    if (Transpose.Reflection.isAssignableFrom(System.Collections.IEnumerable, type)) {
+                        var elementType = System.Text.Json.JsonSerializer.getEnumerableElementType(type),
+                            enumerator  = Transpose.getEnumerator(value, elementType);
+
+                        arr = [];
+
+                        while (enumerator.moveNext()) {
+                            arr.push(System.Text.Json.JsonSerializer.Serialize(enumerator.Current, o, true, elementType, depth + 1));
+                        }
+
+                        return arr;
+                    }
+
+                    // --- Objects -------------------------------------------------------------------
+                    return System.Text.Json.JsonSerializer.serializeMembers(value, type, declaredType, o, depth);
+                },
+
+                dictionaryKey: function (key, keyType, o) {
+                    if (keyType && Transpose.Reflection.isEnum(keyType)) {
+                        return System.Enum.getName(keyType, key);
+                    }
+
+                    var raw = System.Text.Json.JsonSerializer.Serialize(key, o, true, keyType, 0);
+
+                    if (raw === null || typeof raw === "object") {
+                        raw = Transpose.toString(key);
+                    } else if (typeof raw !== "string") {
+                        raw = String(raw);
+                    }
+
+                    return System.Text.Json.JsonSerializer.convertName(o.dictNaming, raw);
+                },
+
+                getEnumerableElementType: function (type) {
+                    var interfaceType;
+
+                    if (System.String.startsWith(type.$$name, "System.Collections.Generic.IEnumerable")) {
+                        interfaceType = type;
+                    } else {
+                        var interfaces = Transpose.Reflection.getInterfaces(type);
+
+                        for (var j = 0; j < interfaces.length; j++) {
+                            if (System.String.startsWith(interfaces[j].$$name, "System.Collections.Generic.IEnumerable")) {
+                                interfaceType = interfaces[j];
+                                break;
+                            }
+                        }
+                    }
+
+                    return interfaceType ? Transpose.Reflection.getGenericArguments(interfaceType)[0] : null;
+                },
+
+                serializeMembers: function (value, type, declaredType, o, depth) {
+                    var raw = {};
+
+                    System.Text.Json.JsonSerializer.validateReflectable(type);
+
+                    // The discriminator is declared on the base type and must be written first —
+                    // System.Text.Json's reader requires it before any other member.
+                    var info = System.Text.Json.JsonSerializer.polymorphism(declaredType) ||
+                               System.Text.Json.JsonSerializer.polymorphism(type);
+
+                    if (info) {
+                        var id = System.Text.Json.JsonSerializer.discriminatorFor(info, type);
+
+                        if (id != null) {
+                            raw[info.discriminator] = id;
+                        } else if (info.unknown === 0 && declaredType && declaredType !== type) {
+                            System.Text.Json.JsonSerializer.fail("Runtime type '" + Transpose.getTypeName(type) + "' is not supported by polymorphic type '" + Transpose.getTypeName(declaredType) + "'.");
+                        }
+                    }
+
+                    // An anonymous or [ObjectLiteral] type has no reflection contract to walk: it is a
+                    // plain JavaScript object, so every own property is a member.
+                    if (!Transpose.getMetadata(type) || type.$literal || type.$kind === "anonymous") {
+                        if (value.toJSON) {
+                            return value.toJSON();
+                        }
+
+                        for (var key in value) {
+                            if (value.hasOwnProperty(key)) {
+                                raw[System.Text.Json.JsonSerializer.convertName(o.naming, key)] = System.Text.Json.JsonSerializer.Serialize(value[key], o, true, null, depth + 1);
+                            }
+                        }
+
+                        return raw;
+                    }
+
+                    var properties = System.Text.Json.JsonSerializer.getMembers(type, 16, o),
+                        fields     = System.Text.Json.JsonSerializer.getMembers(type, 4, o),
+                        i, cfg, member, current;
+
+                    for (i = 0; i < properties.length; i++) {
+                        cfg    = properties[i];
+                        member = cfg.member;
+
+                        if (!cfg.canRead) continue;
+
+                        current = Transpose.Reflection.midel(member.g, value)();
+
+                        if (System.Text.Json.JsonSerializer.skipOnWrite(cfg, current, o)) continue;
+
+                        raw[cfg.name] = System.Text.Json.JsonSerializer.Serialize(current, o, true, member.rt, depth + 1);
+                    }
+
+                    for (i = 0; i < fields.length; i++) {
+                        cfg    = fields[i];
+                        member = cfg.member;
+                        current = Transpose.Reflection.fieldAccess(member, value);
+
+                        if (System.Text.Json.JsonSerializer.skipOnWrite(cfg, current, o)) continue;
+
+                        raw[cfg.name] = System.Text.Json.JsonSerializer.Serialize(current, o, true, member.rt, depth + 1);
+                    }
+
+                    return raw;
+                },
+
+                // ----------------------------------------------------------------------------------
+                // Deserialize
+                // ----------------------------------------------------------------------------------
+
+                Deserialize: function (json, type, options) {
+                    var o = System.Text.Json.JsonSerializer.opts(options);
+
+                    if (typeof json !== "string") {
+                        System.Text.Json.JsonSerializer.fail("The input does not contain any JSON tokens.");
+                    }
+
+                    if (json.length === 0 || System.String.trim(json).length === 0) {
+                        System.Text.Json.JsonSerializer.fail("The input does not contain any JSON tokens.");
+                    }
+
+                    return System.Text.Json.JsonSerializer.read(System.Text.Json.JsonSerializer.parse(json, o), type, o, null, 0);
+                },
+
+                // Reads an already-parsed JavaScript value into `type`.
+                read: function (raw, type, o, instance, depth) {
+                    depth = depth || 0;
+
+                    if (depth > o.maxDepth) {
+                        System.Text.Json.JsonSerializer.fail("The maximum configured depth of " + o.maxDepth + " has been exceeded.");
+                    }
+
+                    if (type.$kind === "interface") {
+                        type = System.Text.Json.JsonSerializer.concreteCollectionType(type);
+                    }
+
+                    var isObjectTarget = type === Object || type === System.Object,
+                        def            = Transpose.getDefaultValue(type);
+
+                    if (raw === null || raw === undefined) {
+                        if (type.$nullable || def === null || isObjectTarget) {
+                            return isObjectTarget ? null : def;
+                        }
+
+                        // System.Text.Json rejects a JSON null for a non-nullable value type where
+                        // Json.NET quietly left the default in place.
+                        System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                    }
+
+                    if (type.$nullable) {
+                        type = type.$nullableType;
+                    }
+
+                    // Deserializing to `object` hands back the parsed JavaScript value. System.Text.Json
+                    // produces a JsonElement, which this package does not model.
+                    if (isObjectTarget) {
+                        return raw;
+                    }
+
+                    // An [ObjectLiteral] type compiles to direct property access on a plain JavaScript
+                    // object, so it is the parsed value — walking it member by member would deep-convert
+                    // typed slots that have no conversion and throw.
+                    if (type.$literal) {
+                        return Transpose.merge(instance || Transpose.createInstance(type), raw);
+                    }
+
+                    var t = typeof raw;
+
+                    if (t === "boolean")  return System.Text.Json.JsonSerializer.readBoolean(raw, type);
+                    if (t === "number")   return System.Text.Json.JsonSerializer.readNumber(raw, type, o);
+                    if (t === "string")   return System.Text.Json.JsonSerializer.readString2(raw, type, o);
+
+                    if (Object.prototype.toString.call(raw) === "[object Array]") {
+                        return System.Text.Json.JsonSerializer.readArrayInto(raw, type, o, instance, depth);
+                    }
+
+                    return System.Text.Json.JsonSerializer.readObjectInto(raw, type, o, instance, depth);
+                },
+
+                concreteCollectionType: function (type) {
+                    if (type === System.Collections.IDictionary) {
+                        return System.Collections.Generic.Dictionary$2(System.Object, System.Object);
+                    }
+
+                    if (Transpose.Reflection.isGenericType(type) && Transpose.Reflection.isAssignableFrom(System.Collections.Generic.IDictionary$2, Transpose.Reflection.getGenericTypeDefinition(type))) {
+                        var p = System.Collections.Generic.Dictionary$2.getTypeParameters(type);
+                        return System.Collections.Generic.Dictionary$2(p[0] || System.Object, p[1] || System.Object);
+                    }
+
+                    if (type === System.Collections.IList || type === System.Collections.ICollection) {
+                        return System.Collections.Generic.List$1(System.Object);
+                    }
+
+                    if (Transpose.Reflection.isGenericType(type) && (
+                        Transpose.Reflection.isAssignableFrom(System.Collections.Generic.IList$1, Transpose.Reflection.getGenericTypeDefinition(type)) ||
+                        Transpose.Reflection.isAssignableFrom(System.Collections.Generic.ICollection$1, Transpose.Reflection.getGenericTypeDefinition(type)) ||
+                        Transpose.Reflection.isAssignableFrom(System.Collections.Generic.IEnumerable$1, Transpose.Reflection.getGenericTypeDefinition(type)))) {
+                        return System.Collections.Generic.List$1(System.Collections.Generic.List$1.getElementType(type) || System.Object);
+                    }
+
+                    return type;
+                },
+
+                readBoolean: function (raw, type) {
+                    if (type === System.Boolean) return raw;
+                    if (type === System.String)  return raw ? "true" : "false";
+
+                    var cast = System.Text.Json.JsonSerializer.castOperator(raw, type);
+                    if (cast) return cast(raw);
+
+                    System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                },
+
+                readNumber: function (raw, type, o) {
+                    if (Transpose.Reflection.isEnum(type))  return Transpose.unbox(System.Enum.parse(type, raw));
+                    if (type === System.SByte)              return raw | 0;
+                    if (type === System.Byte)               return raw >>> 0;
+                    if (type === System.Int16)              return raw | 0;
+                    if (type === System.UInt16)             return raw >>> 0;
+                    if (type === System.Int32)              return raw | 0;
+                    if (type === System.UInt32)             return raw >>> 0;
+                    if (type === System.Int64)              return System.Int64(raw);
+                    if (type === System.UInt64)             return System.UInt64(raw);
+                    if (type === System.Single)             return raw;
+                    if (type === System.Double)             return raw;
+                    if (type === System.Decimal)            return System.Decimal(raw);
+                    if (type === System.Char)               return raw | 0;
+                    if (type === System.TimeSpan)           return System.TimeSpan.fromTicks(raw);
+
+                    var cast = System.Text.Json.JsonSerializer.castOperator(raw, type);
+                    if (cast) return cast(raw);
+
+                    System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                },
+
+                readString2: function (raw, type, o) {
+                    if (type === System.String)                    return raw;
+                    if (type === Function || type === System.Type) return Transpose.Reflection.getType(raw);
+                    if (type === System.Globalization.CultureInfo) return new System.Globalization.CultureInfo(raw);
+                    if (type === System.Uri)                       return new System.Uri(raw);
+                    if (type === System.Version)                   return System.Version.parse(raw);
+                    if (type === System.Guid)                      return System.Guid.Parse(raw);
+                    if (type === System.TimeSpan)                  return System.TimeSpan.parse(raw);
+                    if (type === System.Array.type(System.Byte, 1)) return System.Convert.fromBase64String(raw);
+
+                    if (type === System.DateTime || type === System.DateTimeOffset) {
+                        var isUtc  = System.String.endsWith(raw, "Z"),
+                            format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF" + (isUtc ? "'Z'" : "K"),
+                            d      = System.DateTime.parseExact(raw, format, null, true, true);
+
+                        d = d != null ? d : System.DateTime.parse(raw, undefined, true);
+
+                        if (d == null) {
+                            System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                        }
+
+                        if (isUtc && d.kind !== 1) {
+                            d = System.DateTime.specifyKind(d, 1);
+                        }
+
+                        return type === System.DateTime ? d : new System.DateTimeOffset.$ctor1(d);
+                    }
+
+                    // 64-bit integers and decimals are written as JSON strings by this package (see
+                    // serializeObject), so reading them back from one is not a relaxation of
+                    // NumberHandling — it is what round-tripping our own output requires.
+                    if (type === System.Int64 || type === System.UInt64 || type === System.Decimal) {
+                        var parsed = { };
+
+                        if (type === System.Decimal ? !type.tryParse(raw, null, parsed) : !type.tryParse(raw, parsed)) {
+                            System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                        }
+
+                        // Named rather than called through `type`, because these constructors read
+                        // `this` and lose it when invoked through a variable.
+                        if (type === System.Decimal) return System.Decimal(raw);
+                        if (type === System.Int64)   return System.Int64(raw);
+
+                        return System.UInt64(raw);
+                    }
+
+                    if (Transpose.Reflection.isEnum(type)) {
+                        // System.Text.Json needs a JsonStringEnumConverter to read an enum from its
+                        // name. A Transpose app has no converter registry, and the Curiosity server
+                        // writes enums as names, so the name form is always accepted here.
+                        try {
+                            return Transpose.unbox(System.Enum.parse(type, raw));
+                        } catch (parseError) {
+                            System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                        }
+                    }
+
+                    if (type === System.Char) {
+                        return raw.length === 0 ? 0 : raw.charCodeAt(0);
+                    }
+
+                    if (type === System.Boolean) {
+                        if (raw === "true")  return true;
+                        if (raw === "false") return false;
+
+                        System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to System.Boolean.");
+                    }
+
+                    if (type.$number) {
+                        if ((o.numbers & 1) === 0) {
+                            System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                        }
+
+                        var n = parseFloat(raw);
+
+                        if (isNaN(n)) {
+                            System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                        }
+
+                        return System.Text.Json.JsonSerializer.readNumber(n, type, o);
+                    }
+
+                    var cast = System.Text.Json.JsonSerializer.castOperator(raw, type);
+                    if (cast) return cast(raw);
+
+                    System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                },
+
+                // An implicit/explicit conversion operator from the JSON primitive is how a wrapper
+                // type such as UID128 round-trips through its string form.
+                castOperator: function (raw, type) {
+                    if (raw === null) {
+                        return null;
+                    }
+
+                    var candidates;
+
+                    if (typeof raw === "boolean" || typeof raw === "string") {
+                        candidates = [Transpose.getType(raw)];
+                    } else if (typeof raw === "number") {
+                        candidates = [System.Double, System.Int64];
+                    } else {
+                        return null;
+                    }
+
+                    for (var i = 0; i < candidates.length; i++) {
+                        var explicitOp = Transpose.Reflection.getMembers(type, 8, 284, "op_Explicit", [candidates[i]]);
+                        if (explicitOp) {
+                            return function (value) { return Transpose.Reflection.midel(explicitOp, null)(value); };
+                        }
+
+                        var implicitOp = Transpose.Reflection.getMembers(type, 8, 284, "op_Implicit", [candidates[i]]);
+                        if (implicitOp) {
+                            return function (value) { return Transpose.Reflection.midel(implicitOp, null)(value); };
+                        }
+                    }
+
+                    return null;
+                },
+
+                readArrayInto: function (raw, type, o, instance, depth) {
+                    if (Transpose.isArray(null, type)) {
+                        var arr = new Array();
+                        System.Array.type(type.$elementType, type.$rank || 1, arr);
+
+                        for (var i = 0; i < raw.length; i++) {
+                            arr[i] = System.Text.Json.JsonSerializer.read(raw[i], type.$elementType, o, null, depth + 1);
+                        }
+
+                        return arr;
+                    }
+
+                    if (Transpose.Reflection.isAssignableFrom(System.Collections.IList, type) ||
+                        (Transpose.Reflection.isGenericType(type) && Transpose.Reflection.isAssignableFrom(System.Collections.Generic.HashSet$1, Transpose.Reflection.getGenericTypeDefinition(type)))) {
+
+                        var elementType = System.Collections.Generic.List$1.getElementType(type) ||
+                                          Transpose.Reflection.getGenericArguments(type)[0] ||
+                                          System.Object,
+                            list        = instance || Transpose.createInstance(type);
+
+                        for (var j = 0; j < raw.length; j++) {
+                            list.add(System.Text.Json.JsonSerializer.read(raw[j], elementType, o, null, depth + 1));
+                        }
+
+                        return list;
+                    }
+
+                    // An IEnumerable<T>-only target that is a plain JavaScript array at runtime — a
+                    // ReadOnlyArray<T>, or an IEnumerable<T> / IReadOnlyList<T> member. None of the
+                    // branches above match it, and falling through to object deserialization would
+                    // leave it null.
+                    var enumerableElement = System.Text.Json.JsonSerializer.getEnumerableElementType(type);
+
+                    if (enumerableElement != null) {
+                        var materialized = new Array();
+
+                        for (var k = 0; k < raw.length; k++) {
+                            materialized[k] = System.Text.Json.JsonSerializer.read(raw[k], enumerableElement, o, null, depth + 1);
+                        }
+
+                        return materialized;
+                    }
+
+                    System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                },
+
+                readObjectInto: function (raw, type, o, instance, depth) {
+                    // Resolve the runtime type before anything else, so the contract walked below is
+                    // the derived one.
+                    var info = System.Text.Json.JsonSerializer.polymorphism(type);
+
+                    if (info) {
+                        var id = raw[info.discriminator];
+
+                        if (id === undefined) {
+                            if (type.$kind === "interface") {
+                                System.Text.Json.JsonSerializer.fail("The JSON payload for polymorphic type '" + Transpose.getTypeName(type) + "' must specify a type discriminator.");
+                            }
+                        } else {
+                            var resolved = System.Text.Json.JsonSerializer.typeForDiscriminator(info, id);
+
+                            if (resolved == null) {
+                                System.Text.Json.JsonSerializer.fail("Read unrecognized type discriminator id '" + id + "'.");
+                            }
+
+                            type = resolved;
+                        }
+                    }
+
+                    if (Transpose.Reflection.isAssignableFrom(System.Collections.IDictionary, type)) {
+                        var generic   = System.Collections.Generic.Dictionary$2.getTypeParameters(type),
+                            keyType   = generic[0] || System.Object,
+                            valueType = generic[1] || System.Object,
+                            dict      = instance || Transpose.createInstance(type),
+                            keys      = Object.keys(raw);
+
+                        for (var d = 0; d < keys.length; d++) {
+                            dict.add(System.Text.Json.JsonSerializer.readDictionaryKey(keys[d], keyType, o),
+                                     System.Text.Json.JsonSerializer.read(raw[keys[d]], valueType, o, null, depth + 1));
+                        }
+
+                        return dict;
+                    }
+
+                    // A JSON object can never become a scalar or a sequence. Report that as a
+                    // conversion failure rather than letting the contract walker below complain that
+                    // System.Int32 carries no reflection metadata.
+                    if (Transpose.isArray(null, type) ||
+                        Transpose.Reflection.isAssignableFrom(System.Collections.IList, type) ||
+                        System.Text.Json.JsonSerializer.isScalarType(type)) {
+                        System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(type) + ".");
+                    }
+
+                    System.Text.Json.JsonSerializer.validateReflectable(type);
+
+                    var built  = instance ? { value: instance, consumed: [] } : System.Text.Json.JsonSerializer.construct(type, raw, o, depth),
+                        target = built.value;
+
+                    if (target == null) {
+                        return target;
+                    }
+
+                    var properties = System.Text.Json.JsonSerializer.getMembers(type, 16, o),
+                        fields     = System.Text.Json.JsonSerializer.getMembers(type, 4, o),
+                        i, cfg;
+
+                    for (i = 0; i < properties.length; i++) {
+                        cfg = properties[i];
+
+                        if (!cfg.canWrite || built.consumed.indexOf(cfg.name) >= 0) continue;
+
+                        var pv = System.Text.Json.JsonSerializer.lookup(raw, cfg.name, o);
+
+                        if (pv.found) {
+                            Transpose.Reflection.midel(cfg.member.s, target)(System.Text.Json.JsonSerializer.read(pv.value, cfg.member.rt, System.Text.Json.JsonSerializer.forMember(o, cfg), null, depth + 1));
+                        }
+                    }
+
+                    for (i = 0; i < fields.length; i++) {
+                        cfg = fields[i];
+
+                        if (!cfg.canWrite || built.consumed.indexOf(cfg.name) >= 0) continue;
+
+                        var fv = System.Text.Json.JsonSerializer.lookup(raw, cfg.name, o);
+
+                        if (fv.found) {
+                            Transpose.Reflection.fieldAccess(cfg.member, target, System.Text.Json.JsonSerializer.read(fv.value, cfg.member.rt, System.Text.Json.JsonSerializer.forMember(o, cfg), null, depth + 1));
+                        }
+                    }
+
+                    return target;
+                },
+
+                // A JSON member name is always a string, so a non-string key type is parsed from it
+                // whatever NumberHandling says — that switch is about member *values*.
+                isScalarType: function (type) {
+                    return !!type.$number ||
+                           type === System.String ||
+                           type === System.Boolean ||
+                           type === System.Char ||
+                           type === System.Guid ||
+                           type === System.Uri ||
+                           type === System.Version ||
+                           type === System.DateTime ||
+                           type === System.DateTimeOffset ||
+                           type === System.TimeSpan ||
+                           Transpose.Reflection.isEnum(type);
+                },
+
+                readDictionaryKey: function (key, keyType, o) {
+                    if (keyType === System.String || keyType === System.Object) {
+                        return key;
+                    }
+
+                    if (keyType.$number && keyType !== System.Int64 && keyType !== System.UInt64 && keyType !== System.Decimal) {
+                        var n = parseFloat(key);
+
+                        if (isNaN(n)) {
+                            System.Text.Json.JsonSerializer.fail("The JSON value could not be converted to " + Transpose.getTypeName(keyType) + ".");
+                        }
+
+                        return System.Text.Json.JsonSerializer.readNumber(n, keyType, o);
+                    }
+
+                    return System.Text.Json.JsonSerializer.readString2(key, keyType, o);
+                },
+
+                // Member matching is case-sensitive unless PropertyNameCaseInsensitive is set — the
+                // one place System.Text.Json is stricter than Json.NET by default.
+                lookup: function (raw, name, o) {
+                    if (Object.prototype.hasOwnProperty.call(raw, name)) {
+                        return { found: true, value: raw[name] };
+                    }
+
+                    if (o.ci) {
+                        var lower = name.toLowerCase(),
+                            keys  = Object.keys(raw);
+
+                        for (var i = 0; i < keys.length; i++) {
+                            if (keys[i].toLowerCase() === lower) {
+                                return { found: true, value: raw[keys[i]] };
+                            }
+                        }
+                    }
+
+                    return { found: false };
+                },
+
+                // System.Text.Json prefers a public parameterless constructor; failing that it uses the
+                // single public constructor, binding each parameter to the JSON member of the same
+                // name. [JsonConstructor] overrides both. A member bound through a parameter is not
+                // written again afterwards, which is what `consumed` records.
+                construct: function (type, raw, o, depth) {
+                    var ctors     = Transpose.Reflection.getMembers(type, 1, 54) || [],
+                        chosen    = null,
+                        publics   = [],
+                        declared  = 0,
+                        hasEmpty  = false;
+
+                    for (var i = 0; i < ctors.length; i++) {
+                        var c = ctors[i];
+
+                        // A synthetic constructor is the compiler's, not the author's — it is the
+                        // parameterless one, and it is what createInstance already calls.
+                        if (c.isSynthetic) continue;
+
+                        declared++;
+
+                        if ((c.pi || []).length === 0) {
+                            hasEmpty = true;
+                        }
+
+                        if (System.Text.Json.JsonSerializer.attr(c, System.Text.Json.Serialization.JsonConstructorAttribute) != null) {
+                            chosen = c;
+                        }
+
+                        if (c.a === 2) {
+                            publics.push(c);
+                        }
+                    }
+
+                    if (chosen == null && (hasEmpty || declared === 0)) {
+                        return { value: Transpose.createInstance(type), consumed: [] };
+                    }
+
+                    if (chosen == null && publics.length === 1 && (publics[0].pi || []).length > 0) {
+                        chosen = publics[0];
+                    }
+
+                    if (chosen == null) {
+                        if (type.$kind === "struct") {
+                            return { value: Transpose.createInstance(type), consumed: [] };
+                        }
+
+                        System.Text.Json.JsonSerializer.fail("Each parameter in the deserialization constructor on type '" + Transpose.getTypeName(type) + "' must bind to an object property or field on deserialization.");
+                    }
+
+                    var params   = chosen.pi || [],
+                        args     = [],
+                        consumed = [];
+
+                    for (var p = 0; p < params.length; p++) {
+                        var prm  = params[p],
+                            name = System.Text.Json.JsonSerializer.parameterName(type, prm, o),
+                            hit  = System.Text.Json.JsonSerializer.lookup(raw, name, o);
+
+                        if (hit.found) {
+                            args[p] = System.Text.Json.JsonSerializer.read(hit.value, prm.pt, o, null, (depth || 0) + 1);
+                            consumed.push(name);
+                        } else {
+                            args[p] = Transpose.getDefaultValue(prm.pt);
+                        }
+                    }
+
+                    return { value: Transpose.Reflection.invokeCI(chosen, args), consumed: consumed };
+                },
+
+                // A constructor parameter binds to the member of the same name, so it inherits that
+                // member's JSON name — its [JsonPropertyName] and the naming policy alike.
+                parameterName: function (type, parameter, o) {
+                    var raw        = parameter.sn || parameter.n,
+                        properties = System.Text.Json.JsonSerializer.getMembers(type, 16, o),
+                        lower      = raw.toLowerCase();
+
+                    for (var i = 0; i < properties.length; i++) {
+                        if (properties[i].member.n.toLowerCase() === lower) {
+                            return properties[i].name;
+                        }
+                    }
+
+                    return System.Text.Json.JsonSerializer.convertName(o.naming, raw);
+                }
+            }
+        }
+    });

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonConstructorAttribute.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonConstructorAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>Selects the constructor the deserializer calls.</summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    public sealed class JsonConstructorAttribute : Attribute
+    {
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonIgnoreAttribute.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonIgnoreAttribute.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>Keeps the member out of the JSON payload, always or under a condition.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class JsonIgnoreAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance that ignores the member unconditionally.</summary>
+        public JsonIgnoreAttribute()
+        {
+        }
+
+        /// <summary>When the member is ignored. Defaults to <see cref="JsonIgnoreCondition.Always"/>.</summary>
+        public JsonIgnoreCondition Condition { get; set; } = JsonIgnoreCondition.Always;
+    }
+
+    /// <summary>When a member is left out of the JSON payload.</summary>
+    public enum JsonIgnoreCondition
+    {
+        /// <summary>The member is always written and always read.</summary>
+        Never = 0,
+
+        /// <summary>The member is never written and never read.</summary>
+        Always = 1,
+
+        /// <summary>The member is skipped on write when it holds its type's default value.</summary>
+        WhenWritingDefault = 2,
+
+        /// <summary>The member is skipped on write when it is <c>null</c>.</summary>
+        WhenWritingNull = 3
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonIncludeAttribute.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonIncludeAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Opts a member in that the default rules leave out — a public field when
+    /// <see cref="JsonSerializerOptions.IncludeFields"/> is off, or a property whose setter is
+    /// non-public.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class JsonIncludeAttribute : Attribute
+    {
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonNumberHandling.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonNumberHandling.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>How numbers are read from and written to JSON.</summary>
+    [Flags]
+    public enum JsonNumberHandling
+    {
+        /// <summary>Numbers are read from and written as JSON numbers only. This is the default.</summary>
+        Strict = 0,
+
+        /// <summary>A number may also be read from a JSON string.</summary>
+        AllowReadingFromString = 1,
+
+        /// <summary>Numbers are written as JSON strings.</summary>
+        WriteAsString = 2,
+
+        /// <summary><c>NaN</c>, <c>Infinity</c> and <c>-Infinity</c> may be read from and written as strings.</summary>
+        AllowNamedFloatingPointLiterals = 4
+    }
+
+    /// <summary>Sets <see cref="JsonNumberHandling"/> for one member, type or assembly.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
+    public sealed class JsonNumberHandlingAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance with the handling to apply.</summary>
+        public JsonNumberHandlingAttribute(JsonNumberHandling handling)
+        {
+            Handling = handling;
+        }
+
+        /// <summary>The handling to apply.</summary>
+        public JsonNumberHandling Handling { get; }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonPolymorphicAttribute.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonPolymorphicAttribute.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>Configures how a hierarchy rooted at this type is written and read.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
+    public sealed class JsonPolymorphicAttribute : Attribute
+    {
+        /// <summary>
+        /// The member carrying the discriminator. Defaults to <c>$type</c>, which is what Json.NET
+        /// used for <c>TypeNameHandling</c> as well.
+        /// </summary>
+        public string TypeDiscriminatorPropertyName { get; set; } = "$type";
+
+        /// <summary>What to do with a runtime type the hierarchy does not declare.</summary>
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; set; } = JsonUnknownDerivedTypeHandling.FailSerialization;
+
+        /// <summary>Whether an unrecognised JSON member is allowed to reach the extension data.</summary>
+        public bool IgnoreUnrecognizedTypeDiscriminators { get; set; }
+    }
+
+    /// <summary>What the serializer does with a runtime type the hierarchy does not declare.</summary>
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        /// <summary>Throw. This is the default.</summary>
+        FailSerialization = 0,
+
+        /// <summary>Write it as its nearest declared ancestor.</summary>
+        FallBackToBaseType = 1,
+
+        /// <summary>Write it as the nearest declared ancestor, without a discriminator.</summary>
+        FallBackToNearestAncestor = 2
+    }
+
+    /// <summary>Declares one member of a polymorphic hierarchy and the discriminator that names it.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
+    public sealed class JsonDerivedTypeAttribute : Attribute
+    {
+        /// <summary>Declares a derived type that carries no discriminator.</summary>
+        public JsonDerivedTypeAttribute(Type derivedType)
+        {
+            DerivedType = derivedType;
+        }
+
+        /// <summary>Declares a derived type identified by a string discriminator.</summary>
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminator)
+        {
+            DerivedType       = derivedType;
+            TypeDiscriminator = typeDiscriminator;
+        }
+
+        /// <summary>Declares a derived type identified by an integer discriminator.</summary>
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminator)
+        {
+            DerivedType       = derivedType;
+            TypeDiscriminator = typeDiscriminator;
+        }
+
+        /// <summary>The derived type.</summary>
+        public Type DerivedType { get; }
+
+        /// <summary>The discriminator written for, and matched against, <see cref="DerivedType"/>.</summary>
+        public object TypeDiscriminator { get; }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonPropertyNameAttribute.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonPropertyNameAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>Gives the member a fixed JSON name, overriding any naming policy.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class JsonPropertyNameAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance with the JSON name to use.</summary>
+        public JsonPropertyNameAttribute(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>The JSON name of the member.</summary>
+        public string Name { get; }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonPropertyOrderAttribute.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonPropertyOrderAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Positions the member in the written payload. Members carrying no order sort as <c>0</c> and
+    /// keep their declaration order relative to one another.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class JsonPropertyOrderAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance with the member's position.</summary>
+        public JsonPropertyOrderAttribute(int order)
+        {
+            Order = order;
+        }
+
+        /// <summary>The member's position. Lower sorts earlier; negatives are allowed.</summary>
+        public int Order { get; }
+    }
+}

--- a/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
+++ b/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Transpose.Build.Target/26.7.3049">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>Transpose.System.Text.Json</AssemblyName>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\logo\transpose.png" Link="transpose.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <IncludeSymbols>false</IncludeSymbols>
+    <PackageIcon>transpose.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <LangVersion>7.2</LangVersion>
+    <PackageId>Transpose.System.Text.Json</PackageId>
+    <Authors>Curiosity GmbH</Authors>
+    <Company>Curiosity GmbH</Company>
+    <Description>System.Text.Json for the C# to JavaScript compiler 🚀</Description>
+    <Copyright>Copyright (c) 2019-2026, Curiosity GmbH. All rights reserved.</Copyright>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Version>0.0.1</Version>
+    <IncludeReferencedProjects>true</IncludeReferencedProjects>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>true</IsPackable>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/curiosity-ai/transpose</PackageProjectUrl>
+  </PropertyGroup>
+
+</Project>

--- a/Packages/Transpose.System.Text.Json/tps.json
+++ b/Packages/Transpose.System.Text.Json/tps.json
@@ -1,0 +1,45 @@
+{
+  "output": "Resources/.generated",
+  "cleanOutputFolderBeforeBuild": true,
+  "outputFormatting": "Formatted",
+  "outputBy": "ClassPath",
+  "generateDocumentation": "None",
+  "logging": {
+    "level": "None"
+  },
+  "html": {
+    "disabled": true
+  },
+  "assembly": {
+    "disableInitAssembly": true,
+    "enableReservedNamespaces": true
+  },
+  "fileName": "generated.js",
+  "combineScripts": false,
+  "resources": [
+    {
+      "name": "tps.js",
+      "extract": false
+    },
+    {
+      "name": "tps.meta.js",
+      "extract": false
+    },
+    {
+      "name": "tps.console.js",
+      "extract": false
+    },
+    {
+      // File paths relative to project root
+      "name": "system.text.json.js",
+      "header": "Resources/.auxiliary/Header.js",
+      "remark": "\n\n// @source @{name}\n",
+      "files": [
+        "Resources/.auxiliary/AssemblyBegin.js",
+        "Resources/.generated/generated.js",
+        "Resources/Manual/JsonSerializer.js",
+        "Resources/.auxiliary/AssemblyEnd.js"
+      ]
+    }
+  ]
+}

--- a/Transpose.slnx
+++ b/Transpose.slnx
@@ -29,6 +29,8 @@
     <Project Path="Packages/Transpose.Newtonsoft.Json.Tests/Transpose.Newtonsoft.Json.Tests.csproj" />
     <Project Path="Packages/Transpose.P2/Transpose.P2.csproj" />
     <Project Path="Packages/Transpose.Placeholders/Transpose.Placeholders.csproj" />
+    <Project Path="Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj" />
+    <Project Path="Packages/Transpose.System.Text.Json.Tests/Transpose.System.Text.Json.Tests.csproj" />
     <Project Path="Packages/Transpose.WebGL2/Transpose.WebGL2.csproj" />
   </Folder>
 </Solution>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -82,6 +82,7 @@ transpile() {
 
 transpile BCL/Transpose.Core/Transpose.Core.csproj
 transpile Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+transpile Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
 transpile Packages/Transpose.Howler/Transpose.Howler.csproj        Transpose.Core
 transpile Packages/Transpose.WebGL2/Transpose.WebGL2.csproj        Transpose.Core
 transpile Packages/Transpose.P2/Transpose.P2.csproj                Transpose.Core


### PR DESCRIPTION
A second JSON binding library, added **alongside** `Transpose.Newtonsoft.Json` rather than replacing it, so the Curiosity front-end can migrate off Json.NET onto `System.Text.Json` — which is already what the server speaks (`AddJsonOptions` in `MosaikStartup`, not `AddNewtonsoftJson`).

Publishing this package is the prerequisite for the mosaik-side migration.

## Scope

The surface a browser app actually uses:

- `JsonSerializer.Serialize` / `Deserialize`, whole-document, over a `JsonSerializerOptions`
- `JsonSerializerOptions` — `WriteIndented`, `PropertyNamingPolicy`, `DictionaryKeyPolicy`, `PropertyNameCaseInsensitive`, `DefaultIgnoreCondition`, `NumberHandling`, `AllowTrailingCommas`, `ReadCommentHandling`, `IncludeFields`, `MaxDepth`, plus `JsonSerializerDefaults.Web`
- `JsonNamingPolicy` (camel / snake / kebab, and subclassable — the server's `KeepAsIsNamingPolicy` is one)
- `[JsonPropertyName]`, `[JsonIgnore(Condition)]`, `[JsonInclude]`, `[JsonConstructor]`, `[JsonPropertyOrder]`, `[JsonNumberHandling]`, `[JsonPolymorphic]` / `[JsonDerivedType]`
- `JsonException`

Deliberately **not** in scope: the streaming (`Utf8JsonReader`/`Writer`), document (`JsonDocument`/`JsonNode`/`JsonElement`) and source-generated (`JsonSerializerContext`) APIs, and the custom-converter registry.

## Behaviour

The behaviour lives in the hand-written `Resources/Manual/JsonSerializer.js`, which reproduces System.Text.Json rather than leaning on `JSON.stringify` where the two differ:

- **Escaping.** Everything outside a short basic-latin allow-list is written as `\uXXXX` — `+ < > & ' "` and backtick included, and every non-ASCII character. That is what makes the output safe to drop straight into an HTML `<script>` block, which is exactly what the self-contained page exports do. (`SchemaGraphPageExport` currently hand-patches `<` after serializing; it no longer needs to.)
- **Reading is strict**, with `AllowTrailingCommas` and `ReadCommentHandling.Skip` served by a hand-written reader that runs only after `JSON.parse` has failed — never the JavaScript evaluator, which a CSP without `'unsafe-eval'` blocks outright.
- **Member matching is case-sensitive** by default, as the framework is.

## Deliberate divergences

Each is pinned by a test, so the list cannot rot:

| behaviour | System.Text.Json | this package | why |
| --- | --- | --- | --- |
| member order | declaration order | alphabetical | what Transpose reflection metadata gives |
| `long` / `ulong` | JSON numbers | JSON strings | a JavaScript number cannot hold them; the server's `LongToStringConverter` expects this shape. `decimal` stays a **number**, because the server has no decimal-from-string converter |
| enum from its name | needs a `JsonStringEnumConverter` | always accepted | the server registers one, so enums arrive as names; there is no registry here to register |
| deserializing to `object` | `JsonElement` | the raw parsed value | `JsonElement` is not modelled |
| assembly-qualified `$type` | unrecognised | also matches the bare type name | lets a store written by Json.NET's `TypeNameHandling` keep deserializing |

## Tests

154, in `Packages/Transpose.System.Text.Json.Tests`, against **two** oracles.

**The real System.Text.Json.** It ships in the shared framework, so the *same snippet text* compiles natively against it and translates against this package, and the two console outputs are diffed. Covers serialization, escaping, deserialization, collections, attributes, options, BCL types, polymorphism and error handling.

**`Transpose.Newtonsoft.Json`.** Because the front-end is migrating between the two, a second harness runs one program through both packages and records what changes. One template renders into each package's API (`#USINGS#`, `[#PROP("n")]`, `Json.Write` / `Json.Read<T>`), so what differs, differs because the serializer differs:

- `AssertSame` — transparent: plain objects, nesting, enums, renames, dates/GUIDs/URIs/byte arrays, 64-bit integers, indentation, unknown members, `object` targets.
- `AssertDiffers` — the migration's real work, both sides recorded: case-sensitive matching, public fields no longer serialized, non-public setters no longer populated, much heavier escaping, `null` into a non-nullable value member now throwing, shape mismatches now throwing, lenient payloads (single quotes, unquoted names, trailing commas, comments) rejected, and an empty document throwing instead of returning `default`.

`MosaikShapeTests` covers the front-end types that exist *because* a Transpose JSON binding has no converter registry — `UID128` and `LanguageDTO`, whose values are plain JavaScript strings reached only through a conversion operator — plus the enum and short-wire-name shapes the shared DTOs use. None are expressible in a native snippet (`extern` + `[Template]`), so the sibling package is the only meaningful oracle. **All 18 pass as `AssertSame`**: those shapes migrate unchanged.

## Also

- registered in `Transpose.slnx` and `bootstrap.sh` (it transpiles cleanly with `tps`)
- `.devops/build-transpose-system-text-json.yml`, mirroring the JSON pipeline, with the test step present but commented out per the repo convention
- `CLAUDE.md` repository layout updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7Etwmw4CCavzr2A94R8df

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7Etwmw4CCavzr2A94R8df)_