### PR TITLE
Let a polymorphic hierarchy be declared at run time

### DIFF
--- a/Packages/Transpose.System.Text.Json.Tests/PolymorphismTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/PolymorphismTests.cs
@@ -216,4 +216,88 @@ public sealed class PolymorphismTests : JsonTestBase
             }
         }
         """);
+
+    // ---------------------------------------------------------------------------------------------
+    // Registering a hierarchy at run time
+    // ---------------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task AHierarchyCanBeDeclaredAtRunTime() => await RunJs("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        // No [JsonDerivedType] anywhere: this is the shape a layered application is forced into when
+        // the base type sits in a project *below* the one holding its implementations, so it cannot
+        // name them at compile time.
+        public interface INote { }
+
+        public class TextNote : INote { public string Body { get; set; } }
+        public class LinkNote : INote { public string Url  { get; set; } }
+
+        public class Holder { public INote Note { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                JsonPolymorphicTypes.Register<INote>(typeof(TextNote), "text");
+                JsonPolymorphicTypes.Register<INote>(typeof(LinkNote), "link");
+
+                var json = JsonSerializer.Serialize(new Holder { Note = new LinkNote { Url = "https://x/" } });
+                Console.WriteLine(json);
+
+                var back = JsonSerializer.Deserialize<Holder>(json);
+                Console.WriteLine(back.Note.GetType().Name + "/" + ((LinkNote)back.Note).Url);
+            }
+        }
+        """,
+        expected: "{\"Note\":{\"$type\":\"link\",\"Url\":\"https://x/\"}}\nLinkNote/https://x/");
+
+    [TestMethod]
+    public async Task ARunTimeHierarchyAcceptsAnAssemblyQualifiedDiscriminatorToo() => await RunJs("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public interface INodeRendererItem { }
+        public class FieldContent : INodeRendererItem { public string Field { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                JsonPolymorphicTypes.Register<INodeRendererItem>(typeof(FieldContent), "Mosaik.Components.NodeRendering.FieldContent");
+
+                var legacy = "{\"$type\":\"Mosaik.Components.NodeRendering.FieldContent, Mosaik.Graph\",\"Field\":\"Title\"}";
+                var back   = JsonSerializer.Deserialize<INodeRendererItem>(legacy);
+
+                Console.WriteLine(back.GetType().Name + "/" + ((FieldContent)back).Field);
+            }
+        }
+        """,
+        expected: "FieldContent/Title");
+
+    [TestMethod]
+    public async Task ARunTimeRegistrationCanNameItsDiscriminatorMember() => await RunJs("""
+        using System;
+        using System.Text.Json;
+        using System.Text.Json.Serialization;
+
+        public interface IShape { }
+        public class Square : IShape { public int Side { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                JsonPolymorphicTypes.Register<IShape>(typeof(Square), "square", "kind");
+
+                var json = JsonSerializer.Serialize<IShape>(new Square { Side = 2 });
+                Console.WriteLine(json);
+                Console.WriteLine(JsonSerializer.Deserialize<IShape>(json).GetType().Name);
+            }
+        }
+        """,
+        expected: "{\"kind\":\"square\",\"Side\":2}\nSquare");
 }

--- a/Packages/Transpose.System.Text.Json.Tests/README.md
+++ b/Packages/Transpose.System.Text.Json.Tests/README.md
@@ -77,7 +77,7 @@ Requirements: **Node** on `PATH` (or `/opt/node22/bin/node`) and a `Transpose.dl
 | `AttributeTests` | `[JsonPropertyName]`, `[JsonIgnore]`, `[JsonInclude]`, `[JsonConstructor]`, `[JsonPropertyOrder]`, `[JsonNumberHandling]` |
 | `OptionsTests` | naming policies, case insensitivity, ignore conditions, read switches, `JsonSerializerDefaults.Web` |
 | `BclTypeTests` | dates, times, GUIDs, URIs, versions, byte arrays, characters, nullables, 64-bit integers |
-| `PolymorphismTests` | `[JsonPolymorphic]` / `[JsonDerivedType]`, `$type` |
+| `PolymorphismTests` | `[JsonPolymorphic]` / `[JsonDerivedType]`, `$type`, run-time registration |
 | `ErrorHandlingTests` | malformed input, type and shape mismatches, depth limit |
 | `CrossPackageTests` | this package vs `Transpose.Newtonsoft.Json` — the migration's risk register |
 | `MosaikShapeTests` | `UID128`, `LanguageDTO`, enum and renamed-member shapes from the Curiosity front-end |
@@ -102,6 +102,16 @@ deliberately stays a JSON number, because the server has no decimal-from-string 
 The last one exists so a store written by Json.NET's `TypeNameHandling` (which wrote
 `"Some.Type, Some.Assembly"` into `$type`) keeps deserializing against a hierarchy that declares the
 bare type name as its discriminator.
+
+## Declaring a hierarchy the attribute cannot reach
+
+`[JsonDerivedType]` has to name the derived types from the base type's own file, so the base must see
+them at compile time. In a layered application it often does not — an interface in a shared,
+low-level project and its implementations in the UI project that references it — and the attribute
+cannot be written at all. `JsonPolymorphicTypes.Register<TBase>(typeof(Derived), "discriminator")`
+declares the same pair at run time, from somewhere that can see both, and behaves exactly as the
+attribute would. The two can be mixed, which is what a project shared between a server (attributes)
+and a Transpose front-end (registration) needs.
 
 ## What the package deliberately does not cover
 

--- a/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
+++ b/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
@@ -631,12 +631,47 @@
                     return all.filter(function (a) { return Transpose.is(a, attributeType); });
                 },
 
+                // The run-time half of the hierarchy declaration (JsonPolymorphicTypes.Register), for
+                // the case where [JsonDerivedType] cannot be written because the base type sits below
+                // its implementations and cannot name them.
+                registerDerivedType: function (baseType, derivedType, id, discriminatorPropertyName) {
+                    var cache = System.Text.Json.JsonSerializer.getCacheByType(baseType),
+                        info  = cache.$registered;
+
+                    if (!info) {
+                        info = { discriminator: discriminatorPropertyName || "$type", unknown: 0, types: [] };
+                        cache.$registered = info;
+                    } else if (discriminatorPropertyName) {
+                        info.discriminator = discriminatorPropertyName;
+                    }
+
+                    for (var i = 0; i < info.types.length; i++) {
+                        if (info.types[i].type === derivedType) {
+                            info.types[i].id = id;
+                            return;
+                        }
+                    }
+
+                    info.types.push({ type: derivedType, id: id });
+
+                    // A hierarchy resolved earlier would have been cached as "not polymorphic".
+                    cache.$poly = undefined;
+                },
+
                 polymorphism: function (type) {
-                    if (!type || !Transpose.getMetadata(type)) {
+                    if (!type) {
                         return null;
                     }
 
                     var cache = System.Text.Json.JsonSerializer.getCacheByType(type);
+
+                    if (cache.$registered) {
+                        return cache.$registered;
+                    }
+
+                    if (!Transpose.getMetadata(type)) {
+                        return null;
+                    }
 
                     if (cache.$poly !== undefined) {
                         return cache.$poly;

--- a/Packages/Transpose.System.Text.Json/Serialization/JsonPolymorphicTypes.cs
+++ b/Packages/Transpose.System.Text.Json/Serialization/JsonPolymorphicTypes.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Declares a polymorphic hierarchy at run time, for the case where
+    /// <see cref="JsonDerivedTypeAttribute"/> cannot be written.
+    /// </summary>
+    /// <remarks>
+    /// The attribute has to name the derived types from the base type's own file, which means the
+    /// base has to see them at compile time. In a layered application the base often sits *below*
+    /// its implementations — an interface in a shared, low-level project and the concrete types in
+    /// the UI project that references it — and there is no way to write the attribute at all.
+    ///
+    /// This is the escape hatch: register the same pairs at startup, from a place that can see both.
+    /// A registration behaves exactly as the attribute would, and the two can be mixed (a type may
+    /// use the attribute in one build and this in another, which is what a project shared between a
+    /// server and a Transpose front-end typically needs).
+    ///
+    /// Register before the first serialize or deserialize of the hierarchy. A registration is
+    /// process-wide, like the attribute it stands in for.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// JsonPolymorphicTypes.Register&lt;INotification&gt;(typeof(UserJoined), "MyApp.UserJoined");
+    /// </code>
+    /// </example>
+    [Transpose.External]
+    public static class JsonPolymorphicTypes
+    {
+        /// <summary>Declares <paramref name="derivedType"/> as a member of <typeparamref name="TBase"/>'s hierarchy.</summary>
+        /// <param name="derivedType">The concrete type. It must be assignable to <typeparamref name="TBase"/>.</param>
+        /// <param name="typeDiscriminator">The value written to, and matched against, the discriminator member.</param>
+        [Transpose.Template("System.Text.Json.JsonSerializer.registerDerivedType({TBase}, {derivedType}, {typeDiscriminator}, null)")]
+        public static extern void Register<TBase>(Type derivedType, string typeDiscriminator);
+
+        /// <summary>
+        /// Declares <paramref name="derivedType"/> as a member of <typeparamref name="TBase"/>'s
+        /// hierarchy, naming the member that carries the discriminator.
+        /// </summary>
+        [Transpose.Template("System.Text.Json.JsonSerializer.registerDerivedType({TBase}, {derivedType}, {typeDiscriminator}, {discriminatorPropertyName})")]
+        public static extern void Register<TBase>(Type derivedType, string typeDiscriminator, string discriminatorPropertyName);
+
+        /// <summary>Declares <paramref name="derivedType"/> as a member of <paramref name="baseType"/>'s hierarchy.</summary>
+        [Transpose.Template("System.Text.Json.JsonSerializer.registerDerivedType({baseType}, {derivedType}, {typeDiscriminator}, null)")]
+        public static extern void Register(Type baseType, Type derivedType, string typeDiscriminator);
+    }
+}


### PR DESCRIPTION
`[JsonDerivedType]` has to name the derived types from the base type's own file, so the base has to see them at compile time. In a layered application it often cannot: an interface in a shared, low-level project with its implementations in the UI project that references it. There the attribute is not merely inconvenient, it does not compile — which is exactly the shape Curiosity's node-rendering hierarchy has, with the interfaces in `Mosaik.FrontEnd.Core` and the implementations in `Mosaik.FrontEnd` above it.

`JsonPolymorphicTypes.Register<TBase>(typeof(Derived), "discriminator")` declares the same pair from somewhere that can see both, and produces the identical wire format. Attributes and registrations can be mixed, which is what a file shared between a server (attributes, one assembly) and a Transpose front-end (registration) needs.

This follows [#116](https://github.com/curiosity-ai/transpose/pull/116), which added the package itself. The Curiosity front-end migration is blocked on it — `NodeRendererJsonTypes` registers ~30 renderer types this way — so `Transpose.System.Text.Json` needs a publish after this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7Etwmw4CCavzr2A94R8df)_