### PR TITLE
Resolve an enum value to its name through a cached map, not a scan

### DIFF
--- a/.claude/skills/transpose-runtime-and-bcl/SKILL.md
+++ b/.claude/skills/transpose-runtime-and-bcl/SKILL.md
@@ -7,8 +7,10 @@ description: >-
   C# (System.*), when adding a missing BCL method/type (e.g. a LINQ operator, a string/Task API),
   when the emitted metadata/init changes, or when adding a regression test to
   EmitRegressionTests.cs and running the suite. Triggers on "add X to the BCL", "rebuild the
-  runtime", "implement this .NET API in transpose", "add a regression test", or "run the transpose
-  tests". Pairs with transpose-debugging (inspection) and transpose-h5-audit (finding bugs).
+  runtime", "implement this .NET API in transpose", "add a regression test", "run the transpose
+  tests", or "why is my runtime change not taking effect". Covers the two ways a runtime change
+  tests green without ever being loaded (stale bundles, unset TRANSPOSE_DLL_PATH). Pairs with
+  transpose-debugging (inspection) and transpose-h5-audit (finding bugs).
 ---
 
 # Runtime, BCL changes, and regression tests
@@ -39,6 +41,45 @@ This transpiles the BCL into `Resources/.generated/*.js`, stitches the bundles p
 emits `Transpose.dll` with them embedded. Both the runners and the test suite read this DLL via
 `TRANSPOSE_DLL_PATH`. (For a **shim** change, rebuild the translator/compiler instead — the shim is
 embedded there.)
+
+## Prove you are testing the code you changed
+
+A runtime change has two ways to look tested when it is not. Both end in `Passed! - Failed: 0`
+against the *old* JavaScript, so neither announces itself:
+
+- **`dotnet build` on the BCL csproj does not rebuild the bundles.** The SDK passes `--incremental`
+  and its up-to-date check does not watch `Resources/*.js`, so editing runtime JS and running
+  `dotnet build BCL/Transpose.BCL/Transpose.BCL.csproj` prints `Build succeeded` in about a second
+  and leaves the previous JS embedded in `Transpose.dll`. Use the `--build-runtime` command above,
+  which does track them (~10s, and it says `OK — built runtime Transpose.dll`). If you must go
+  through `dotnet build`, `rm -rf BCL/Transpose.BCL/bin BCL/Transpose.BCL/obj` first.
+- **Without `TRANSPOSE_DLL_PATH`, the suite silently uses the published package.**
+  `TransposeAssemblies.Discover()` falls back to the newest `Transpose.BCL` in the NuGet cache, so
+  the tests run green against whatever was last released and never touch your build. Export it in
+  the same shell as `dotnet test` — an `export` in an earlier, separate command does not carry over.
+
+So before believing a green run on a runtime change, **break the code on purpose and watch the suite
+fail**:
+
+```bash
+# 1. sabotage the branch you edited (e.g. append + "SABOTAGE" to a return value)
+# 2. rebuild the runtime with --build-runtime
+# 3. run the relevant filter — it MUST fail
+export TRANSPOSE_DLL_PATH=$PWD/BCL/Transpose.BCL/bin/Debug/netstandard2.0/Transpose.dll
+dotnet test Transpose/Transpose.Translator.Tests/Transpose.Translator.Tests.csproj \
+  -c Debug --no-build --filter "FullyQualifiedName~Enum"
+# 4. revert the sabotage, rebuild, re-run — it MUST pass
+```
+
+If step 3 passes, your edit is not reaching the tests and everything after it is meaningless. This
+costs two minutes and is the only thing that distinguishes "my change is correct" from "my change is
+not loaded" — the failure mode is identical from the outside.
+
+It matters most for a **pure performance change**, where the before and after are behaviourally
+identical by construction: no test can tell them apart, so the suite only proves you did not break
+anything, and the sabotage run is what proves the suite is looking at your code at all. Pair it with
+a measurement of the actual improvement (see **transpose-performance**), because a green suite says
+nothing about whether the change did what you intended.
 
 ## Adding a BCL API — two paths
 
@@ -88,7 +129,8 @@ Harness gotchas:
   run, while Node drains its queue — so a native-comparison test flakes. Use `skipRoslyn: true` and
   assert on the JS output sequence instead.
 - Tests use the DEBUG translator (project reference) and read the runtime via `TRANSPOSE_DLL_PATH` —
-  rebuild the runtime first if your change touched it.
+  rebuild the runtime first if your change touched it, and see "Prove you are testing the code you
+  changed" above for the two ways this goes silently wrong.
 
 Run the suite:
 

--- a/BCL/Transpose.BCL/Resources/Enum.js
+++ b/BCL/Transpose.BCL/Resources/Enum.js
@@ -27,6 +27,48 @@
             return name;
         },
 
+        // The declared names of an enum, without the defensive copy getNames() hands to callers.
+        // getNames() is on the hot path of toString()/getName(), and copying $names there means
+        // every single conversion allocates an array as long as the enum.
+        namesOf: function (enumType) {
+            return enumType.$names || System.Enum.getNames(enumType);
+        },
+
+        // value -> name, built once per enum type and cached on the type object. An enum's members
+        // are fixed when Transpose.define() runs, so the map can never go stale. Without it every
+        // ToString() walks the whole name list looking for its value, which is O(n) in the size of
+        // the *enum* — invisible on a hand-written enum, but generated ones (icon sets, error code
+        // tables, unicode categories) run to thousands of members and pay it on every conversion.
+        //
+        // Returns null for a 64-bit enum: those values are Long objects, so they are compared with
+        // .eq() rather than by identity and cannot key a Map. Callers fall back to the scan.
+        valueNames: function (enumType) {
+            if (enumType.$valueNames !== undefined) {
+                return enumType.$valueNames;
+            }
+
+            var names = enumMethods.namesOf(enumType),
+                map = new Map();
+
+            for (var i = 0; i < names.length; i++) {
+                var value = enumType[names[i]];
+
+                if (System.Int64.is64Bit(value)) {
+                    map = null;
+                    break;
+                }
+
+                // First declaration wins, matching the order the linear scan resolved aliases in.
+                if (!map.has(value)) {
+                    map.set(value, names[i]);
+                }
+            }
+
+            enumType.$valueNames = map;
+
+            return map;
+        },
+
         toObject: function (enumType, value) {
             value = Transpose.unbox(value, true);
 
@@ -51,7 +93,7 @@
                     return Transpose.box(intValue.v, enumType, function (obj) { return System.Enum.toString(enumType, obj); });
                 }
 
-                var names = System.Enum.getNames(enumType),
+                var names = enumMethods.namesOf(enumType),
                     values = enumType;
 
                 if (!enumType.prototype || !enumType.prototype.$flags) {
@@ -126,10 +168,21 @@
             System.Enum.checkEnumType(enumType);
 
             var values = enumType,
-                names = System.Enum.getNames(enumType),
                 isLong = System.Int64.is64Bit(value);
 
             if (((!enumType.prototype || !enumType.prototype.$flags) && forceFlags !== true) || (value === 0)) {
+                var map = enumMethods.valueNames(enumType);
+
+                if (map !== null) {
+                    // A Long value against a non-Long enum matches nothing, exactly as the scan below
+                    // would conclude, and Map lookup agrees with === on every value an enum can hold.
+                    var mapped = map.get(value);
+
+                    return mapped !== undefined ? enumMethods.toName(mapped) : value.toString();
+                }
+
+                var names = enumMethods.namesOf(enumType);
+
                 for (var i = 0; i < names.length; i++) {
                     var name = names[i];
 
@@ -188,7 +241,7 @@
             System.Enum.checkEnumType(enumType);
 
             var parts = [],
-                names = System.Enum.getNames(enumType),
+                names = enumMethods.namesOf(enumType),
                 values = enumType;
 
             for (var i = 0; i < names.length; i++) {
@@ -204,7 +257,7 @@
             System.Enum.checkEnumType(enumType);
 
             var parts = [],
-                names = System.Enum.getNames(enumType),
+                names = enumMethods.namesOf(enumType),
                 values = enumType;
 
             for (var i = 0; i < names.length; i++) {
@@ -283,7 +336,19 @@
 
             System.Enum.checkEnumType(enumType);
 
-            var names = System.Enum.getNames(enumType),
+            // Only for a plain numeric value: this scan compares with value.eq(...) whenever the
+            // *value* is a Long, which coerces the enum's number members, and Map lookup would not.
+            if (!isLong) {
+                var map = enumMethods.valueNames(enumType);
+
+                if (map !== null) {
+                    var mapped = map.get(value);
+
+                    return mapped !== undefined ? mapped : null;
+                }
+            }
+
+            var names = enumMethods.namesOf(enumType),
                 values = enumType;
 
             for (var i = 0; i < names.length; i++) {
@@ -310,7 +375,7 @@
             System.Enum.checkEnumType(enumType);
 
             var values = enumType,
-                names = System.Enum.getNames(enumType),
+                names = enumMethods.namesOf(enumType),
                 isString = Transpose.isString(value),
                 isLong = System.Int64.is64Bit(value);
 


### PR DESCRIPTION
System.Enum.toString walked the whole name list looking for the value it was given, and called getNames() to get that list — which hands back a copy of $names. Every enum-to-string conversion was therefore two O(n) operations in the size of the *enum*, and the language routes a lot through it: ToString(), string interpolation, string.Format, Enum.GetName, and any [Enum(Emit.StringName)] value the emitter round-trips.

On a hand-written enum that is invisible. Generated ones are not hand-written: an icon set, an error-code table, a unicode-category map runs to thousands of members, and the cost is proportional to where the member sits in the declaration. Measured in Chromium against a 5,372-member enum:

  member #0                  10.0µs -> 0.075µs
  member #4799               84.8µs -> 0.075µs
  last member                89.8µs -> 0.050µs
  value not in the enum      93.8µs -> 0.085µs
  1,120-member enum           0.5µs -> 0.040µs
  8-member enum              0.25µs -> 0.025µs

The map is built once per enum type and cached on the type object as $valueNames. An enum's members are fixed when Transpose.define() runs, so it can never go stale, and getNames()'s "$" key filter already hides the field from callers. 64-bit enums keep the scan: their values are Long objects compared with .eq(), so they cannot key a Map — valueNames() returns null and every caller falls back. Enum.getName() takes the map only for a plain numeric value, because its scan compares with value.eq(...) whenever the *value* is a Long, which coerces the enum's number members in a way Map lookup would not.

Alias resolution is unchanged: where two members share a value the map keeps the first in $names order, which is the one the scan returned. The internal read-only name walks (parse, getValues, getValuesAndNames, isDefined) now go through namesOf(), which skips getNames()'s defensive copy; the public getNames() still copies.

Verified: the value paths return byte-identical strings to the previous implementation across first/middle/last/absent members on enums of 8, 1,120 and 5,372 members. Translator suite 868 passed / 0 failed, Newtonsoft.Json 141/0, System.Text.Json 157/0 — each run with TRANSPOSE_DLL_PATH pointed at a --build-runtime rebuild, and confirmed to be exercising the new code by watching a deliberately sabotaged build fail 16 of them first.

The skill note is the other half of that: transpose-runtime-and-bcl now documents the two ways a runtime change tests green without ever being loaded (a dotnet-build that leaves stale bundles embedded, and an unset TRANSPOSE_DLL_PATH falling back to the published package), and the sabotage check that catches both.


Claude-Session: https://claude.ai/code/session_013pZshy4pcGVs6kzLKnsDWr