### PR TITLE
Lazily-loaded JavaScript modules: outputBy "Module"

### DIFF
--- a/BCL/Transpose.BCL/Resources/Class.js
+++ b/BCL/Transpose.BCL/Resources/Class.js
@@ -886,10 +886,11 @@
                 // import of another chunk — ESM evaluates it directly and the loader never sees it.
                 if (exists.$stub && exists.$$name === className && Transpose.Modules) {
                     Transpose.Modules.$replaceStub(className);
-                    exists = scope[name];
                 }
 
-                if (exists && exists.$$name === className) {
+                // A retired stub keeps its $$name (callers holding it still resolve by name), so the
+                // redefinition check has to look past it rather than at the name alone.
+                if (exists.$$name === className && !exists.$retiredStub) {
                     throw "Class '" + className + "' is already defined";
                 }
             }

--- a/BCL/Transpose.BCL/Resources/Class.js
+++ b/BCL/Transpose.BCL/Resources/Class.js
@@ -818,6 +818,12 @@
                 Transpose.$currentAssembly.$types[className] = cls;
                 cls.$assembly = Transpose.$currentAssembly;
             }
+
+            // If this type was standing in as a module stub until now, hand its metadata (and any
+            // nested types registered onto it) over to the real class.
+            if (Transpose.Modules) {
+                Transpose.Modules.$stubReplaced(className, cls);
+            }
         },
 
         addExtend: function (cls, extend) {
@@ -874,9 +880,21 @@
             exists = scope[name];
 
             if (exists) {
-                if (exists.$$name === className) {
+                // A module-mode stub standing in for this very type: the real definition has just
+                // arrived, so step aside for it. This has to happen here rather than only in
+                // Transpose.Modules.load, because a chunk can also be pulled in as a plain static
+                // import of another chunk — ESM evaluates it directly and the loader never sees it.
+                if (exists.$stub && exists.$$name === className && Transpose.Modules) {
+                    Transpose.Modules.$replaceStub(className);
+                    exists = scope[name];
+                }
+
+                if (exists && exists.$$name === className) {
                     throw "Class '" + className + "' is already defined";
                 }
+            }
+
+            if (exists) {
 
                 for (key in exists) {
                     var o = exists[key];

--- a/BCL/Transpose.BCL/Resources/Core.js
+++ b/BCL/Transpose.BCL/Resources/Core.js
@@ -516,6 +516,17 @@
                 nonPublic = false;
             }
 
+            // A stub stands in for a type whose module has not been fetched (see Modules.js). It
+            // carries enough for reflection to enumerate and test it, but not the constructor, and
+            // fetching is asynchronous — so say so here rather than failing deeper in with a
+            // "not a constructor" that names nothing.
+            if (type && type.$stub) {
+                throw new System.InvalidOperationException.$ctor1(
+                    "Cannot create an instance of '" + type.$$name + "' synchronously: it lives in module '" +
+                    type.$module + "', which has not been loaded. Use Activator.CreateInstanceAsync, " +
+                    "or await Transpose.Modules.Load(type) first.");
+            }
+
             if (type === System.Decimal) {
                 return System.Decimal.Zero;
             }

--- a/BCL/Transpose.BCL/Resources/Modules.js
+++ b/BCL/Transpose.BCL/Resources/Modules.js
@@ -164,6 +164,41 @@
             return modules.$import(url);
         },
 
+        /// Steps a stub aside so the real Transpose.define can take its place, remembering what has
+        /// to be carried over. Called from Class.js at define time, which catches every route a
+        /// chunk can arrive by — the loader below, or a plain static import from another chunk.
+        $replaceStub: function (name) {
+            var saved = modules.$evict(name);
+            if (saved) modules.$adoptPending[name] = saved;
+        },
+
+        /// Hands the stub's metadata and any nested types to the real type. Called right after the
+        /// define registered it.
+        $stubReplaced: function (name, real) {
+            if (!real || real.$stub) return;
+            var saved = modules.$adoptPending[name];
+            if (saved) {
+                for (var k in saved.carry) {
+                    if (real[k] === undefined) real[k] = saved.carry[k];
+                }
+                delete modules.$adoptPending[name];
+            }
+            // The metadata comes from the name-keyed record rather than the evicted stub: the stub
+            // may have been taken out by a different route than the one replacing it now.
+            if (!real.$metadata && modules.$metaFor[name]) {
+                real.$metadata = modules.$metaFor[name];
+                real.$getMetadata = Transpose.Reflection.getMetadata;
+                delete modules.$metaFor[name];
+            }
+            delete modules.$manifest[name];
+            delete modules.$stubs[name];
+        },
+
+        $adoptPending: {},
+
+        /// Metadata captured while a type was a stub, keyed by type name (see Reflection.setMetadata).
+        $metaFor: {},
+
         $makeStub: function (name, info) {
             var fn = function () {
                 throw new System.InvalidOperationException.$ctor1(
@@ -228,6 +263,9 @@
 
         $adopt: function (name, saved) {
             var real = Transpose.unroll(name);
+            // Class.js may already have swapped the stub out at define time and carried everything
+            // over; nothing left to do then.
+            if (real && !real.$stub && !modules.$adoptPending[name] && !modules.$manifest[name]) return;
             if (!real || real.$stub) {
                 // The module did not actually define it — leave the stub in place so the error the
                 // caller eventually sees still names the module.
@@ -249,6 +287,16 @@
     };
 
     Transpose.Modules = modules;
+
+    /// Names the assembly that a bare Transpose.define registers into. A single-bundle build gets
+    /// this from the Transpose.assembly(...) wrapper it is emitted inside; a per-chunk module has no
+    /// wrapper, so it names its assembly itself before defining anything.
+    Transpose.$useAssembly = function (name) {
+        var asm = System.Reflection.Assembly.assemblies[name];
+        if (!asm) asm = new System.Reflection.Assembly(name, {});
+        Transpose.$currentAssembly = asm;
+        return asm;
+    };
 
     /// Activator.CreateInstance's asynchronous form: loads the type's module if it is still a stub,
     /// then constructs. This is the only way to instantiate a type a build deferred, because

--- a/BCL/Transpose.BCL/Resources/Modules.js
+++ b/BCL/Transpose.BCL/Resources/Modules.js
@@ -1,0 +1,260 @@
+    // ---- lazily-loaded modules -------------------------------------------------------------
+    //
+    // A build that emits its types as separate JavaScript modules registers a manifest here. Every
+    // type it did not load up front gets a *stub* standing in its place, at the same global path
+    // and in the same assembly $types map a real Transpose.define would use. That keeps reflection
+    // whole while the code stays unfetched: Assembly.GetTypes(), Type.Name, IsInterface,
+    // IsAssignableFrom and the eagerly-emitted reflection metadata all see the type.
+    //
+    // Actually *using* the type is what forces the fetch, and fetching a module is asynchronous, so
+    // it is only reachable through the async API — Transpose.Modules.load /
+    // Transpose.createInstanceAsync, surfaced in C# as Transpose.Modules and
+    // Activator.CreateInstanceAsync. A synchronous Activator.CreateInstance on a stub throws naming
+    // the module rather than failing obscurely somewhere inside the constructor.
+
+    var modules = {
+        // type name -> { m: module url, k: kind, a: assembly name, i: [base/interface type names] }
+        $manifest: {},
+        $stubs: {},
+        // module url -> the in-flight (or settled) load, so concurrent loads share one fetch
+        $pending: {},
+        $loader: null,
+
+        /// Replaces how a module url is fetched. The default uses a dynamic import(); a host that
+        /// serves its chunks another way (a test, a bundler runtime, a non-ESM page) sets its own.
+        setLoader: function (loader) {
+            modules.$loader = loader;
+        },
+
+        /// Declares the types that live in not-yet-loaded modules. Safe to call more than once —
+        /// each assembly's chunk manifest registers itself as it is read.
+        register: function (manifest) {
+            // Outermost first: a nested type is placed *onto* its container, so the container's
+            // stub has to exist before it. Placing the nested one first would create a plain object
+            // at the container's path that the container's own stub then overwrites, silently
+            // losing the nested type.
+            var names = [];
+            for (var n in manifest) {
+                if (Object.prototype.hasOwnProperty.call(manifest, n)) names.push(n);
+            }
+            names.sort(function (a, b) { return a.split(".").length - b.split(".").length; });
+
+            var added = [];
+            for (var i = 0; i < names.length; i++) {
+                var name = names[i];
+                if (modules.$stubs[name] || Transpose.unroll(name)) continue;   // already real, or already stubbed
+                var info = manifest[name];
+                modules.$manifest[name] = info;
+                var stub = modules.$makeStub(name, info);
+                modules.$stubs[name] = stub;
+                modules.$place(name, stub);
+                var asm = System.Reflection.Assembly.assemblies[info.a];
+                if (!asm) asm = new System.Reflection.Assembly(info.a, {});
+                asm.$types[name] = stub;
+                added.push(name);
+            }
+
+            // Resolve the inheritance chains only once every stub exists — a stub may extend
+            // another stub. IsAssignableFrom walks $$inherits, so this is what makes a
+            // GetTypes().Where(t => typeof(IFoo).IsAssignableFrom(t)) scan work unloaded.
+            for (var j = 0; j < added.length; j++) {
+                var s = modules.$stubs[added[j]], list = [], ifaces = [];
+                var bases = modules.$manifest[added[j]].i || [];
+                for (var k = 0; k < bases.length; k++) {
+                    var b = Transpose.unroll(bases[k]);
+                    if (!b) continue;
+                    list.push(b);
+                    if (b.$isInterface) ifaces.push(b);
+                    if (b.$interfaces) ifaces = ifaces.concat(b.$interfaces);
+                    if (b.$$inherits) {
+                        for (var q = 0; q < b.$$inherits.length; q++) {
+                            if (b.$$inherits[q].$isInterface) ifaces.push(b.$$inherits[q]);
+                        }
+                    }
+                }
+                s.$$inherits = list;
+                s.$interfaces = ifaces;
+            }
+
+            // Metadata registered before the stub existed was deferred; give it another chance.
+            Transpose.init();
+        },
+
+        isStub: function (type) {
+            return !!(type && type.$stub);
+        },
+
+        /// True when the type's code is present — either it was never lazy, or its module has been
+        /// loaded. False only for a stub.
+        isLoaded: function (type) {
+            if (typeof type === "string") type = Transpose.unroll(type);
+            return !!type && !type.$stub;
+        },
+
+        /// Fetches the module holding <c>type</c> if it is still a stub, and resolves with the real
+        /// type. Resolving with an already-loaded type is a no-op, so this is safe to await
+        /// unconditionally.
+        load: function (type) {
+            var name = typeof type === "string" ? type : (type && type.$$name);
+            var info = name && modules.$manifest[name];
+            if (!info) {
+                // Either never deferred, or its module has already been loaded. Resolve by NAME so
+                // a caller still holding the stub it got from Type.GetType() before the load is
+                // handed the live type, rather than its own stale stub back.
+                var already = name ? Transpose.unroll(name) : null;
+                return Promise.resolve(already || (typeof type === "string" ? null : type));
+            }
+            return modules.$loadModule(info.m).then(function () {
+                return Transpose.unroll(name);
+            });
+        },
+
+        $loadModule: function (url) {
+            if (modules.$pending[url]) return modules.$pending[url];
+
+            // Every type this module owns has to give up its global slot before the module's
+            // Transpose.define calls run, or define reports "Class X is already defined".
+            var owned = [], saved = {};
+            for (var n in modules.$manifest) {
+                if (modules.$manifest[n].m === url) owned.push(n);
+            }
+            for (var i = 0; i < owned.length; i++) saved[owned[i]] = modules.$evict(owned[i]);
+
+            var loader = modules.$loader || modules.$defaultLoader;
+            var p;
+            try {
+                // toPromise takes whatever the loader hands back — a native Promise, a C# Task, or
+                // nothing at all for a loader that resolved synchronously.
+                p = Promise.resolve(Transpose.toPromise(loader(url)));
+            } catch (e) {
+                p = Promise.reject(e);
+            }
+
+            p = p.then(function () {
+                // The module's types are defined now; run the queued static initializers and let
+                // any metadata that was deferred while they were stubs attach to the real types.
+                Transpose.init();
+                for (var k = 0; k < owned.length; k++) modules.$adopt(owned[k], saved[owned[k]]);
+                return true;
+            }, function (err) {
+                // A failed fetch must not leave the type missing: put the stubs back and let the
+                // next attempt try again.
+                for (var k = 0; k < owned.length; k++) modules.$restore(owned[k], saved[owned[k]]);
+                delete modules.$pending[url];
+                throw err;
+            });
+
+            modules.$pending[url] = p;
+            return p;
+        },
+
+        $defaultLoader: function (url) {
+            // Built with new Function so the dynamic import() is only ever compiled in an engine
+            // that is actually asked to load a module — tps.js itself stays parseable everywhere.
+            if (!modules.$import) {
+                try {
+                    modules.$import = new Function("u", "return import(u);");
+                } catch (e) {
+                    modules.$import = function () {
+                        return Promise.reject(new System.NotSupportedException.$ctor1(
+                            "This JavaScript engine cannot import() a module; set Transpose.Modules.setLoader."));
+                    };
+                }
+            }
+            return modules.$import(url);
+        },
+
+        $makeStub: function (name, info) {
+            var fn = function () {
+                throw new System.InvalidOperationException.$ctor1(
+                    "Type '" + name + "' lives in module '" + info.m + "', which has not been loaded. " +
+                    "Await Transpose.Modules.Load(type) or Activator.CreateInstanceAsync(type) first.");
+            };
+            fn.$$name = name;
+            fn.$stub = true;
+            fn.$module = info.m;
+            fn.$kind = info.k || "class";
+            if (fn.$kind === "interface") fn.$isInterface = true;
+            fn.prototype = { constructor: fn };
+            fn.$assembly = System.Reflection.Assembly.assemblies[info.a];
+            return fn;
+        },
+
+        $place: function (name, value) {
+            var parts = name.split("."), scope = Transpose.global;
+            for (var i = 0; i < parts.length - 1; i++) {
+                scope = scope[parts[i]] || (scope[parts[i]] = {});
+            }
+            var leaf = parts[parts.length - 1];
+            var existing = scope[leaf];
+            if (typeof existing === "function") return;             // a real type already lives here
+            if (existing) {                                          // carry over nested types placed earlier
+                for (var k in existing) {
+                    if (Object.prototype.hasOwnProperty.call(existing, k)) value[k] = existing[k];
+                }
+            }
+            scope[leaf] = value;
+        },
+
+        $slot: function (name) {
+            var parts = name.split("."), scope = Transpose.global;
+            for (var i = 0; i < parts.length - 1 && scope; i++) scope = scope[parts[i]];
+            return { scope: scope, leaf: parts[parts.length - 1] };
+        },
+
+        $evict: function (name) {
+            var at = modules.$slot(name);
+            var stub = at.scope && at.scope[at.leaf];
+            if (!stub || !stub.$stub) return null;
+            // Anything hung off the stub (nested types registered onto it) has to survive onto the
+            // real type, and so does the metadata that attached while it stood in.
+            var carry = {};
+            for (var k in stub) {
+                if (Object.prototype.hasOwnProperty.call(stub, k) && k.charAt(0) !== "$") carry[k] = stub[k];
+            }
+            delete at.scope[at.leaf];
+            var asm = System.Reflection.Assembly.assemblies[modules.$manifest[name].a];
+            if (asm) delete asm.$types[name];
+            return { stub: stub, carry: carry, metadata: stub.$metadata, getMetadata: stub.$getMetadata };
+        },
+
+        $restore: function (name, saved) {
+            if (!saved) return;
+            var at = modules.$slot(name);
+            if (at.scope && !at.scope[at.leaf]) at.scope[at.leaf] = saved.stub;
+            var asm = System.Reflection.Assembly.assemblies[modules.$manifest[name].a];
+            if (asm) asm.$types[name] = saved.stub;
+        },
+
+        $adopt: function (name, saved) {
+            var real = Transpose.unroll(name);
+            if (!real || real.$stub) {
+                // The module did not actually define it — leave the stub in place so the error the
+                // caller eventually sees still names the module.
+                modules.$restore(name, saved);
+                return;
+            }
+            if (saved) {
+                for (var k in saved.carry) {
+                    if (real[k] === undefined) real[k] = saved.carry[k];
+                }
+                if (!real.$metadata && saved.metadata) {
+                    real.$metadata = saved.metadata;
+                    real.$getMetadata = saved.getMetadata || Transpose.Reflection.getMetadata;
+                }
+            }
+            delete modules.$manifest[name];
+            delete modules.$stubs[name];
+        }
+    };
+
+    Transpose.Modules = modules;
+
+    /// Activator.CreateInstance's asynchronous form: loads the type's module if it is still a stub,
+    /// then constructs. This is the only way to instantiate a type a build deferred, because
+    /// fetching a module cannot be made synchronous.
+    Transpose.createInstanceAsync = function (type, nonPublic, args) {
+        return modules.load(type).then(function (real) {
+            return Transpose.createInstance(real || type, nonPublic, args);
+        });
+    };

--- a/BCL/Transpose.BCL/Resources/Modules.js
+++ b/BCL/Transpose.BCL/Resources/Modules.js
@@ -13,9 +13,12 @@
     // the module rather than failing obscurely somewhere inside the constructor.
 
     var modules = {
-        // type name -> { m: module url, k: kind, a: assembly name, i: [base/interface type names] }
+        // type name -> { m: module url, k: kind, a: assembly name, i: [base/interface specs] }
         $manifest: {},
         $stubs: {},
+        // type name -> the `i` specs, kept so a stub's bases can be resolved on demand rather than
+        // at registration (see $defineLazyBases)
+        $baseSpecs: {},
         // module url -> the in-flight (or settled) load, so concurrent loads share one fetch
         $pending: {},
         $loader: null,
@@ -45,6 +48,7 @@
                 if (modules.$stubs[name] || Transpose.unroll(name)) continue;   // already real, or already stubbed
                 var info = manifest[name];
                 modules.$manifest[name] = info;
+                modules.$baseSpecs[name] = info.i || [];
                 var stub = modules.$makeStub(name, info);
                 modules.$stubs[name] = stub;
                 modules.$place(name, stub);
@@ -54,30 +58,100 @@
                 added.push(name);
             }
 
-            // Resolve the inheritance chains only once every stub exists — a stub may extend
-            // another stub. IsAssignableFrom walks $$inherits, so this is what makes a
-            // GetTypes().Where(t => typeof(IFoo).IsAssignableFrom(t)) scan work unloaded.
+            // The inheritance chains resolve on FIRST READ rather than here. Two reasons: a base may
+            // be another stub whose own bases are not registered yet (this loop used to run second
+            // to work around that), and a CONSTRUCTED generic base cannot be built at all until its
+            // definition's module has arrived — applying a stub throws. IsAssignableFrom walks
+            // $$inherits, so deferring the resolution is what lets a
+            // GetTypes().Where(t => typeof(IFoo<Bar>).IsAssignableFrom(t)) scan answer correctly.
             for (var j = 0; j < added.length; j++) {
-                var s = modules.$stubs[added[j]], list = [], ifaces = [];
-                var bases = modules.$manifest[added[j]].i || [];
-                for (var k = 0; k < bases.length; k++) {
-                    var b = Transpose.unroll(bases[k]);
-                    if (!b) continue;
-                    list.push(b);
-                    if (b.$isInterface) ifaces.push(b);
-                    if (b.$interfaces) ifaces = ifaces.concat(b.$interfaces);
-                    if (b.$$inherits) {
-                        for (var q = 0; q < b.$$inherits.length; q++) {
-                            if (b.$$inherits[q].$isInterface) ifaces.push(b.$$inherits[q]);
-                        }
-                    }
-                }
-                s.$$inherits = list;
-                s.$interfaces = ifaces;
+                modules.$defineLazyBases(modules.$stubs[added[j]], added[j]);
             }
 
             // Metadata registered before the stub existed was deferred; give it another chance.
             Transpose.init();
+        },
+
+        /// Gives a stub its $$inherits / $interfaces / $allInterfaces, computed the first time
+        /// anything reads one and frozen only once every base resolved. A partial answer is never
+        /// cached: a base whose module has not arrived resolves to nothing now and to the real type
+        /// later, so the next question has to recompute rather than see a stale list.
+        ///
+        /// Non-enumerable on purpose. Class.set walks `for (key in exists)` when a real define takes
+        /// a retired stub's slot, and an enumerable accessor would be invoked by that walk — forcing
+        /// the resolution at exactly the moment the type is mid-definition.
+        $defineLazyBases: function (stub, name) {
+            var resolve = function (wantInterfaces) {
+                var r = modules.$resolveBases(name);
+                if (r.complete) {
+                    modules.$freeze(stub, "$$inherits", r.inherits);
+                    modules.$freeze(stub, "$interfaces", r.interfaces);
+                    modules.$freeze(stub, "$allInterfaces", r.interfaces);
+                }
+                return wantInterfaces ? r.interfaces : r.inherits;
+            };
+            modules.$lazy(stub, "$$inherits", function () { return resolve(false); });
+            modules.$lazy(stub, "$interfaces", function () { return resolve(true); });
+            // getInterfaces() reads $allInterfaces and answers [] without it, so Type.GetInterfaces()
+            // on a deferred type reported nothing at all before this.
+            modules.$lazy(stub, "$allInterfaces", function () { return resolve(true); });
+        },
+
+        $lazy: function (obj, prop, get) {
+            Object.defineProperty(obj, prop, { get: get, configurable: true, enumerable: false });
+        },
+
+        $freeze: function (obj, prop, value) {
+            Object.defineProperty(obj, prop, { value: value, configurable: true, enumerable: false });
+        },
+
+        /// The base class and interfaces a stub reports, resolved from its manifest specs.
+        /// <c>complete</c> is false when any of them could not be resolved yet.
+        $resolveBases: function (name) {
+            var specs = modules.$baseSpecs[name] || [], inherits = [], ifaces = [], complete = true;
+
+            var push = function (list, t) { if (t && list.indexOf(t) < 0) list.push(t); };
+
+            for (var i = 0; i < specs.length; i++) {
+                var b = modules.$resolveType(specs[i]);
+                if (!b) { complete = false; continue; }
+                push(inherits, b);
+                if (b.$isInterface) push(ifaces, b);
+                // A base's own interfaces come along — reading them may resolve ANOTHER stub's
+                // bases, which terminates because an inheritance graph has no cycles.
+                var bi = b.$interfaces || [];
+                for (var k = 0; k < bi.length; k++) push(ifaces, bi[k]);
+                var bh = b.$$inherits || [];
+                for (var q = 0; q < bh.length; q++) {
+                    if (bh[q].$isInterface) push(ifaces, bh[q]);
+                }
+            }
+            return { inherits: inherits, interfaces: ifaces, complete: complete };
+        },
+
+        /// Resolves one manifest spec: a dotted name, or [definition, ...arguments] for a
+        /// constructed generic. Null when it cannot be resolved *yet*, which the caller treats as
+        /// "ask again later" rather than "no such type".
+        $resolveType: function (spec) {
+            if (typeof spec === "string") return Transpose.unroll(spec) || null;
+            if (!spec || !spec.length) return null;
+
+            var def = Transpose.unroll(spec[0]);
+            // A constructed generic is built by APPLYING its definition, and a stub throws when
+            // applied — so this one stays unresolved until that definition's module arrives. (A
+            // caller able to ask about the instantiation at all has already loaded it: writing
+            // typeof(IFoo<Bar>) emits the same application.)
+            if (!def || def.$stub || !Transpose.isFunction(def)) return null;
+            if (spec.length === 1) return def;
+            if (!def.$isGenericTypeDefinition) return def;
+
+            var args = [];
+            for (var i = 1; i < spec.length; i++) {
+                var a = modules.$resolveType(spec[i]);
+                if (!a) return null;
+                args.push(a);
+            }
+            return def.apply(null, args);
         },
 
         isStub: function (type) {
@@ -190,6 +264,7 @@
             }
             delete modules.$manifest[name];
             delete modules.$stubs[name];
+            delete modules.$baseSpecs[name];
         },
 
         /// Metadata captured while a type was a stub, keyed by type name (see Reflection.setMetadata).

--- a/BCL/Transpose.BCL/Resources/Modules.js
+++ b/BCL/Transpose.BCL/Resources/Modules.js
@@ -112,14 +112,6 @@
         $loadModule: function (url) {
             if (modules.$pending[url]) return modules.$pending[url];
 
-            // Every type this module owns has to give up its global slot before the module's
-            // Transpose.define calls run, or define reports "Class X is already defined".
-            var owned = [], saved = {};
-            for (var n in modules.$manifest) {
-                if (modules.$manifest[n].m === url) owned.push(n);
-            }
-            for (var i = 0; i < owned.length; i++) saved[owned[i]] = modules.$evict(owned[i]);
-
             var loader = modules.$loader || modules.$defaultLoader;
             var p;
             try {
@@ -131,15 +123,14 @@
             }
 
             p = p.then(function () {
-                // The module's types are defined now; run the queued static initializers and let
-                // any metadata that was deferred while they were stubs attach to the real types.
+                // The module's types are defined now — each retired its own stub as it was defined.
+                // Run the queued static initializers and let any metadata that was deferred while
+                // they were stubs attach to the real types.
                 Transpose.init();
-                for (var k = 0; k < owned.length; k++) modules.$adopt(owned[k], saved[owned[k]]);
                 return true;
             }, function (err) {
-                // A failed fetch must not leave the type missing: put the stubs back and let the
-                // next attempt try again.
-                for (var k = 0; k < owned.length; k++) modules.$restore(owned[k], saved[owned[k]]);
+                // Nothing was evicted, so a failed fetch leaves the stubs exactly as they were and
+                // the type stays visible; just allow another attempt.
                 delete modules.$pending[url];
                 throw err;
             });
@@ -164,27 +155,34 @@
             return modules.$import(url);
         },
 
-        /// Steps a stub aside so the real Transpose.define can take its place, remembering what has
-        /// to be carried over. Called from Class.js at define time, which catches every route a
-        /// chunk can arrive by — the loader below, or a plain static import from another chunk.
+        /// Retires the stub occupying <c>name</c> so the real Transpose.define can take the slot.
+        ///
+        /// The stub object is left in place rather than deleted: Class.set copies the members of
+        /// whatever previously occupied the slot onto the new class, which is how a nested type
+        /// registered onto the stub survives — and it has to survive *before* the define resolves
+        /// `inherits`, which a delete-then-restore-later could not manage (a type whose own base
+        /// mentions its nested type, e.g. Nav : ...&lt;Nav.NavLink&gt;, would see it undefined).
+        /// Only the identity markers are cleared, so the "already defined" check does not fire.
         $replaceStub: function (name) {
-            var saved = modules.$evict(name);
-            if (saved) modules.$adoptPending[name] = saved;
+            var at = modules.$slot(name);
+            var stub = at.scope && at.scope[at.leaf];
+            if (!stub || !stub.$stub) return;
+            // $$name is deliberately kept: a caller that grabbed this stub from Type.GetType() before
+            // the load still has to be resolvable by name afterwards (Modules.load hands them the live
+            // type). Only the stub markers are cleared, plus a flag telling Class.set to step aside.
+            stub.$stub = false;
+            stub.$retiredStub = true;
+            var info = modules.$manifest[name];
+            var asm = info && System.Reflection.Assembly.assemblies[info.a];
+            if (asm) delete asm.$types[name];
         },
 
-        /// Hands the stub's metadata and any nested types to the real type. Called right after the
-        /// define registered it.
+        /// Hands the metadata the stub was holding to the real type, once the define registered it.
         $stubReplaced: function (name, real) {
             if (!real || real.$stub) return;
-            var saved = modules.$adoptPending[name];
-            if (saved) {
-                for (var k in saved.carry) {
-                    if (real[k] === undefined) real[k] = saved.carry[k];
-                }
-                delete modules.$adoptPending[name];
-            }
-            // The metadata comes from the name-keyed record rather than the evicted stub: the stub
-            // may have been taken out by a different route than the one replacing it now.
+            // Keyed by NAME rather than taken off the stub: the stub may have been retired by a
+            // different route than the one replacing it now (the loader, or a plain static import
+            // of the chunk from another chunk).
             if (!real.$metadata && modules.$metaFor[name]) {
                 real.$metadata = modules.$metaFor[name];
                 real.$getMetadata = Transpose.Reflection.getMetadata;
@@ -193,8 +191,6 @@
             delete modules.$manifest[name];
             delete modules.$stubs[name];
         },
-
-        $adoptPending: {},
 
         /// Metadata captured while a type was a stub, keyed by type name (see Reflection.setMetadata).
         $metaFor: {},
@@ -235,54 +231,6 @@
             var parts = name.split("."), scope = Transpose.global;
             for (var i = 0; i < parts.length - 1 && scope; i++) scope = scope[parts[i]];
             return { scope: scope, leaf: parts[parts.length - 1] };
-        },
-
-        $evict: function (name) {
-            var at = modules.$slot(name);
-            var stub = at.scope && at.scope[at.leaf];
-            if (!stub || !stub.$stub) return null;
-            // Anything hung off the stub (nested types registered onto it) has to survive onto the
-            // real type, and so does the metadata that attached while it stood in.
-            var carry = {};
-            for (var k in stub) {
-                if (Object.prototype.hasOwnProperty.call(stub, k) && k.charAt(0) !== "$") carry[k] = stub[k];
-            }
-            delete at.scope[at.leaf];
-            var asm = System.Reflection.Assembly.assemblies[modules.$manifest[name].a];
-            if (asm) delete asm.$types[name];
-            return { stub: stub, carry: carry, metadata: stub.$metadata, getMetadata: stub.$getMetadata };
-        },
-
-        $restore: function (name, saved) {
-            if (!saved) return;
-            var at = modules.$slot(name);
-            if (at.scope && !at.scope[at.leaf]) at.scope[at.leaf] = saved.stub;
-            var asm = System.Reflection.Assembly.assemblies[modules.$manifest[name].a];
-            if (asm) asm.$types[name] = saved.stub;
-        },
-
-        $adopt: function (name, saved) {
-            var real = Transpose.unroll(name);
-            // Class.js may already have swapped the stub out at define time and carried everything
-            // over; nothing left to do then.
-            if (real && !real.$stub && !modules.$adoptPending[name] && !modules.$manifest[name]) return;
-            if (!real || real.$stub) {
-                // The module did not actually define it — leave the stub in place so the error the
-                // caller eventually sees still names the module.
-                modules.$restore(name, saved);
-                return;
-            }
-            if (saved) {
-                for (var k in saved.carry) {
-                    if (real[k] === undefined) real[k] = saved.carry[k];
-                }
-                if (!real.$metadata && saved.metadata) {
-                    real.$metadata = saved.metadata;
-                    real.$getMetadata = saved.getMetadata || Transpose.Reflection.getMetadata;
-                }
-            }
-            delete modules.$manifest[name];
-            delete modules.$stubs[name];
         }
     };
 

--- a/BCL/Transpose.BCL/Resources/Modules.js
+++ b/BCL/Transpose.BCL/Resources/Modules.js
@@ -113,7 +113,7 @@
             var push = function (list, t) { if (t && list.indexOf(t) < 0) list.push(t); };
 
             for (var i = 0; i < specs.length; i++) {
-                var b = modules.$resolveType(specs[i]);
+                var b = modules.$resolveType(specs[i], true);
                 if (!b) { complete = false; continue; }
                 push(inherits, b);
                 if (b.$isInterface) push(ifaces, b);
@@ -132,8 +132,22 @@
         /// Resolves one manifest spec: a dotted name, or [definition, ...arguments] for a
         /// constructed generic. Null when it cannot be resolved *yet*, which the caller treats as
         /// "ask again later" rather than "no such type".
-        $resolveType: function (spec) {
-            if (typeof spec === "string") return Transpose.unroll(spec) || null;
+        $resolveType: function (spec, basePosition) {
+            if (typeof spec === "string") {
+                var named = Transpose.unroll(spec) || null;
+                // A generic base named WITHOUT arguments is an OPEN one — `class Relay<T> :
+                // IHandler<T>`, where there is no T to write down until the definition is applied,
+                // so the manifest can only carry the definition's name. The loaded form is not the
+                // definition either: $staticInit applies it to placeholder type parameters, so a
+                // stub has to do the same or it answers differently from the type it stands in for
+                // (IsAssignableFrom(IFoo<>, ...) would match on the bare definition, and
+                // GetInterfaces() would skip it — a definition object carries $kind "class"
+                // whether or not it defines an interface).
+                if (basePosition && named && !named.$stub && named.$isGenericTypeDefinition) {
+                    return modules.$applyOpen(named) || named;
+                }
+                return named;
+            }
             if (!spec || !spec.length) return null;
 
             var def = Transpose.unroll(spec[0]);
@@ -152,6 +166,19 @@
                 args.push(a);
             }
             return def.apply(null, args);
+        },
+
+        /// Applies a generic definition to its own placeholder type parameters, which is the shape
+        /// a loaded type records for an open base. $typeArguments is what $staticInit builds (from
+        /// Reflection.createTypeParams, reading the definition function's parameter names); reading
+        /// the definition through Transpose.unroll normally triggers that, so this only forces it
+        /// when something reached the definition another way. Null when it cannot be produced, and
+        /// the caller then falls back to the bare definition rather than dropping the base.
+        $applyOpen: function (def) {
+            if (!def.$typeArguments && def.$staticInit) def.$staticInit();
+            var params = def.$typeArguments;
+            if (!params || !params.length) return null;
+            return def.apply(null, params);
         },
 
         isStub: function (type) {

--- a/BCL/Transpose.BCL/Resources/Reflection.js
+++ b/BCL/Transpose.BCL/Resources/Reflection.js
@@ -15,6 +15,14 @@
             ns = Transpose.unroll(ns);
             type.$getMetadata = Transpose.Reflection.getMetadata;
             type.$metadata = metadata;
+
+            // A module-mode stub holds the metadata for a type whose code has not arrived. Remember
+            // it against the type NAME as well, so whichever route eventually replaces the stub —
+            // the module loader, or a plain static import evaluating the chunk directly — the real
+            // class gets its metadata back. Keying on the stub object alone was not enough.
+            if (type.$stub && Transpose.Modules) {
+                Transpose.Modules.$metaFor[type.$$name] = metadata;
+            }
         },
 
         initMetaData: function (type, metadata) {

--- a/BCL/Transpose.BCL/System/Activator.cs
+++ b/BCL/Transpose.BCL/System/Activator.cs
@@ -19,5 +19,34 @@ namespace System
 
         [Transpose.Template("Transpose.createInstance({T})")]
         public static extern T CreateInstance<T>();
+
+        // ---- asynchronous creation, for a type whose module may not be loaded -------------------
+        //
+        // A build that splits its output into JavaScript modules leaves the types it deferred as
+        // stubs (see Transpose.Modules): reflection still sees them, but their constructors are not
+        // there, and fetching a module is asynchronous. The synchronous CreateInstance above throws
+        // on a stub naming the module; these overloads load it first and then construct. Awaiting
+        // one for an already-loaded type just constructs, so a call site that might see either can
+        // use the async form unconditionally.
+
+        /// <summary>Creates an instance of <paramref name="type"/>, first loading its module if it
+        /// has not been loaded yet.</summary>
+        [Transpose.Template("System.Threading.Tasks.Task.fromPromise(Transpose.createInstanceAsync({type}), 0)")]
+        public static extern System.Threading.Tasks.Task<object> CreateInstanceAsync(Type type);
+
+        /// <summary>Creates an instance of <paramref name="type"/> with the given constructor
+        /// arguments, first loading its module if it has not been loaded yet.</summary>
+        [Transpose.Template("System.Threading.Tasks.Task.fromPromise(Transpose.createInstanceAsync({type}, false, {arguments:array}), 0)")]
+        public static extern System.Threading.Tasks.Task<object> CreateInstanceAsync(Type type, params object[] arguments);
+
+        /// <summary>Creates an instance of <paramref name="type"/>, optionally matching a
+        /// non-public constructor, first loading its module if it has not been loaded yet.</summary>
+        [Transpose.Template("System.Threading.Tasks.Task.fromPromise(Transpose.createInstanceAsync({type}, {nonPublic}), 0)")]
+        public static extern System.Threading.Tasks.Task<object> CreateInstanceAsync(Type type, bool nonPublic);
+
+        /// <summary>Creates an instance of <typeparamref name="T"/>, first loading its module if it
+        /// has not been loaded yet.</summary>
+        [Transpose.Template("System.Threading.Tasks.Task.fromPromise(Transpose.createInstanceAsync({T}), 0)")]
+        public static extern System.Threading.Tasks.Task<T> CreateInstanceAsync<T>();
     }
 }

--- a/BCL/Transpose.BCL/Transpose/Modules.cs
+++ b/BCL/Transpose.BCL/Transpose/Modules.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Transpose
+{
+    /// <summary>
+    /// The registry for types whose JavaScript lives in a module that has not been loaded.
+    ///
+    /// A build that splits its output into modules registers a manifest of what it deferred; every
+    /// such type gets a stub standing in its place, so reflection keeps working over it —
+    /// <c>Assembly.GetTypes()</c>, <c>Type.Name</c>, <c>Type.IsInterface</c>,
+    /// <c>Type.IsAssignableFrom</c> and the reflection metadata all see the type while its code is
+    /// still unfetched.
+    ///
+    /// What a stub cannot do is run. Fetching a module is asynchronous and C# construction is not,
+    /// so instantiating a deferred type goes through <see cref="Activator.CreateInstanceAsync(Type)"/>
+    /// or an explicit <see cref="LoadAsync(Type)"/>; a synchronous
+    /// <see cref="Activator.CreateInstance(Type)"/> on a stub throws and names the module.
+    /// </summary>
+    [External]
+    [Name("Transpose.Modules")]
+    public static class Modules
+    {
+        /// <summary>
+        /// Declares the types that live in not-yet-loaded modules. The argument is the manifest
+        /// object the build emitted: type name → <c>{ m: module url, k: kind, a: assembly,
+        /// i: [base type names] }</c>. Calling it more than once is safe; each assembly registers
+        /// its own chunk manifest.
+        /// </summary>
+        [Template("Transpose.Modules.register({manifest})")]
+        public static extern void Register(object manifest);
+
+        /// <summary>
+        /// Replaces how a module url is fetched. The default uses a dynamic <c>import()</c>; a host
+        /// that serves its chunks another way — a bundler runtime, a non-ESM page, a test — supplies
+        /// its own. The loader is handed the url and returns a task that completes once the module
+        /// has been evaluated.
+        /// </summary>
+        [Template("Transpose.Modules.setLoader({loader})")]
+        public static extern void SetLoader(Func<string, Task> loader);
+
+        /// <summary>
+        /// True when the type's code is present — either it was never deferred, or its module has
+        /// been loaded. False only while it is still a stub.
+        /// </summary>
+        [Template("Transpose.Modules.isLoaded({type})")]
+        public static extern bool IsLoaded(Type type);
+
+        /// <summary>True while <paramref name="type"/> is a stub for an unloaded module.</summary>
+        [Template("Transpose.Modules.isStub({type})")]
+        public static extern bool IsStub(Type type);
+
+        /// <summary>
+        /// Fetches the module holding <paramref name="type"/> and completes with the real type.
+        /// Awaiting an already-loaded type is a no-op, so this is safe to call unconditionally.
+        /// </summary>
+        [Template("System.Threading.Tasks.Task.fromPromise(Transpose.Modules.load({type}), 0)")]
+        public static extern Task<Type> LoadAsync(Type type);
+
+        /// <summary>
+        /// Fetches the module holding the type named <paramref name="typeName"/> (its full name, as
+        /// the manifest declares it) and completes with the real type, or <c>null</c> if no such
+        /// type is known.
+        /// </summary>
+        [Template("System.Threading.Tasks.Task.fromPromise(Transpose.Modules.load({typeName}), 0)")]
+        public static extern Task<Type> LoadAsync(string typeName);
+    }
+}

--- a/BCL/Transpose.BCL/tps.json
+++ b/BCL/Transpose.BCL/tps.json
@@ -147,6 +147,9 @@
             "Resources/.generated/System/CharEnumerator.js",
 
             "Resources/Task.js",
+            // After Task.js: the module loader resolves with Promises the Task layer adapts, and
+            // after Reflection/Class so its stubs can register into an assembly's $types map.
+            "Resources/Modules.js",
             "Resources/Validation.js",
             "Resources/Attribute.js",
             "Resources/.generated/System/SerializableAttribute.js",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,7 +497,31 @@ The short version:
   package, which does not pack `None` items. Curiosity.FrontEnd did exactly that, so every application
   built against the package was missing 243 icons/illustrations, both variable-font families and the
   favicon.
-- **Lazily-loaded modules: the runtime half is done, the emitter half is not.** `Resources/Modules.js`
+- **Lazily-loaded modules (done).** `outputBy: "Module"` in a project's `tps.json` makes a site build
+  emit one ES module per chunk (`chunks/cN.mjs`) plus an entry module, and index.html carries a single
+  `<script type="module">`. A **chunk is a strongly-connected component of the reference graph**
+  `TypeRef` records while emitting each type — the smallest sound unit, because `Transpose.define`
+  resolves `inherits` eagerly, so a per-class split cannot order a reference cycle. Components come
+  out of Tarjan in reverse-topological order, so numbering them yields a DAG in which every import
+  points at a lower index, which also makes the output deterministic. A `typeof` operand is the one
+  reference that is *not* a dependency: it wants a Type object, which a stub answers for. Chunks
+  reachable from the entry point are imported by the entry module; the rest are declared to
+  `Transpose.Modules`. See `Emitter.Modules.cs`, `ModuleEmitTests`, and **`TODO.modules.md`** §7a for
+  what it measures (Tesserae's sample gallery: the app's initial payload 1,109 KB → 164 KB raw, all
+  140 samples rendering identically).
+
+  Three things are load-bearing and were found by running it, not by reasoning: the entry module
+  emits its **reflection metadata before the manifest** (`Modules.register` ends with a
+  `Transpose.init()`, and `init` runs `Main` — anything after it would not exist yet); the stub
+  swap lives in **`Transpose.define` itself** (`Class.set`), because a chunk can also be evaluated as
+  a plain static import from another chunk, which never passes through the loader; and the metadata
+  hand-off is keyed by type **name** (`Modules.$metaFor`) rather than held on the stub object, for the
+  same reason.
+
+  Still single-bundle: `--emit-package` (a package embeds one bundle, so a *library* cannot be split
+  yet), `--incremental` (chunk assignment is a whole-program property — do not combine them yet),
+  minification of chunk files, and watch mode.
+- **The module runtime.** `Resources/Modules.js`
   provides `Transpose.Modules` — a registry of types whose JavaScript lives in a module that has not
   been fetched. `Modules.Register(manifest)` stubs each such type at the same global path and in the
   same assembly `$types` map a real `Transpose.define` would use, so `Assembly.GetTypes()`,
@@ -509,9 +533,8 @@ The short version:
   construction is not — so `Transpose.createInstance` carries a stub guard that throws naming the
   module rather than failing obscurely. Covered by `LazyModuleActivatorTests`.
 
-  Nothing emits chunks or a manifest yet, so a host registers them itself. The emitter work — chunking
-  by strongly-connected component of the hard-reference graph, and why a per-class split is unsound —
-  is measured and specified in **`TODO.modules.md`**.
+  A host can also drive this itself — `Modules.Register` takes a manifest from anywhere — which is how
+  it was validated before the emitter half existed.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 - **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
   reuses the previous build of a project: nothing at all is compiled when every input hashes the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,6 +497,21 @@ The short version:
   package, which does not pack `None` items. Curiosity.FrontEnd did exactly that, so every application
   built against the package was missing 243 icons/illustrations, both variable-font families and the
   favicon.
+- **Lazily-loaded modules: the runtime half is done, the emitter half is not.** `Resources/Modules.js`
+  provides `Transpose.Modules` — a registry of types whose JavaScript lives in a module that has not
+  been fetched. `Modules.Register(manifest)` stubs each such type at the same global path and in the
+  same assembly `$types` map a real `Transpose.define` would use, so `Assembly.GetTypes()`,
+  `Type.Name`, `IsInterface`, `IsAssignableFrom` and the reflection metadata all keep working while
+  the code is absent. `Modules.LoadAsync(type)` fetches it (default loader: a dynamic `import()`,
+  built via `new Function` so `tps.js` stays parseable where one cannot be compiled;
+  `Modules.SetLoader` substitutes another), and `Activator.CreateInstanceAsync` loads-then-constructs.
+  **Using a deferred type synchronously cannot work** — fetching a module is asynchronous and C#
+  construction is not — so `Transpose.createInstance` carries a stub guard that throws naming the
+  module rather than failing obscurely. Covered by `LazyModuleActivatorTests`.
+
+  Nothing emits chunks or a manifest yet, so a host registers them itself. The emitter work — chunking
+  by strongly-connected component of the hard-reference graph, and why a per-class split is unsound —
+  is measured and specified in **`TODO.modules.md`**.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 - **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
   reuses the previous build of a project: nothing at all is compiled when every input hashes the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,7 +504,10 @@ The short version:
   resolves `inherits` eagerly, so a per-class split cannot order a reference cycle. Components come
   out of Tarjan in reverse-topological order, so numbering them yields a DAG in which every import
   points at a lower index, which also makes the output deterministic. A `typeof` operand is the one
-  reference that is *not* a dependency: it wants a Type object, which a stub answers for. Chunks
+  reference that is *not* a dependency: it wants a Type object, which a stub answers for — **unless it
+  is a constructed generic**, which has no object to point at (it is built by *applying* its
+  definition, and applying a stub throws), so `typeof(Foo<Bar>)` records the definition and its
+  arguments as hard references while `typeof(Foo)` and unbound `typeof(Foo<>)` stay soft. Chunks
   reachable from the entry point are imported by the entry module; the rest are declared to
   `Transpose.Modules`. See `Emitter.Modules.cs`, `ModuleEmitTests`, and **`TODO.modules.md`** §7a for
   what it measures (Tesserae's sample gallery: the app's initial payload 1,109 KB → 164 KB raw, all
@@ -535,6 +538,18 @@ The short version:
   object where it is, keeping `$$name` (a caller holding the stub must still resolve by name) and
   setting `$retiredStub` for the redefinition check to look past.
 
+  **A stub answers for a constructed generic too.** A base or interface reaches the manifest as either
+  a name or `[definition, ...arguments]` (`["tss.CB$2", "tss.Avatar", "HTMLElement"]`), and the runtime
+  *applies* the definition on the first read of the stub's `$$inherits`/`$interfaces`/`$allInterfaces`
+  — never at `register` time, because a base may itself be a stub, and never caching a partial
+  resolution, so a base whose module arrives later is picked up on the next question. Flattening it to
+  `Foo$1` (all a `Transpose.unroll` path walk can express — a constructed generic deliberately gets no
+  global slot) made `IsAssignableFrom(IFoo<Bar>, stub)` answer false, silently. This is *not*
+  interface-only: a generic base class flattens the same way, and is the more common case
+  (`ComponentBase<Self, THTML>`). An **open** base — `class Relay<T> : IHandler<T>` — still reports
+  only the definition; there is no `T` to write down until the definition is applied. `TODO.modules.md`
+  §7c has the details, `LazyModuleActivatorTests` the coverage.
+
   Still single-bundle: `--incremental` (chunk assignment is a whole-program property — do not combine
   them yet), minification (a module entry and its chunks are emitted formatted only, since they carry
   `import` syntax `JsMinifier` does not handle), and watch mode.
@@ -542,8 +557,8 @@ The short version:
   provides `Transpose.Modules` — a registry of types whose JavaScript lives in a module that has not
   been fetched. `Modules.Register(manifest)` stubs each such type at the same global path and in the
   same assembly `$types` map a real `Transpose.define` would use, so `Assembly.GetTypes()`,
-  `Type.Name`, `IsInterface`, `IsAssignableFrom` and the reflection metadata all keep working while
-  the code is absent. `Modules.LoadAsync(type)` fetches it (default loader: a dynamic `import()`,
+  `Type.Name`, `IsInterface`, `IsAssignableFrom`, `GetInterfaces` and the reflection metadata all keep
+  working while the code is absent. `Modules.LoadAsync(type)` fetches it (default loader: a dynamic `import()`,
   built via `new Function` so `tps.js` stays parseable where one cannot be compiled;
   `Modules.SetLoader` substitutes another), and `Activator.CreateInstanceAsync` loads-then-constructs.
   **Using a deferred type synchronously cannot work** — fetching a module is asynchronous and C#

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,9 +518,26 @@ The short version:
   hand-off is keyed by type **name** (`Modules.$metaFor`) rather than held on the stub object, for the
   same reason.
 
-  Still single-bundle: `--emit-package` (a package embeds one bundle, so a *library* cannot be split
-  yet), `--incremental` (chunk assignment is a whole-program property — do not combine them yet),
-  minification of chunk files, and watch mode.
+  **A package splits too.** `--emit-package` emits chunks as well; a library has no entry point to be
+  lazy relative to, so it defers everything (its eager set is just the chunks holding `[Ready]`
+  handlers) and publishes a chunk map — emitted type name → chunk file — embedded as
+  `Transpose.Modules.json` (embedded but *not* listed in `Transpose.Resources.json`, like the
+  `BuildStamp`, so nothing extracts it into a site). A consuming build merges its references' maps
+  (`ModuleMap.Read`) and emits `import '../<lib>/cN.mjs'` from whichever of its own chunks reaches
+  into a library type — without that the reference would land on the library's stub, which cannot be
+  resolved synchronously. Covered by `ModulePackageTests`.
+
+  A fourth load-bearing detail, found the same way as the three above: **a stub is retired in place,
+  never deleted.** `Class.set` already copies the members of whatever previously occupied a type's
+  global slot onto the new class — that is how a nested type registered onto a stub survives — and it
+  has to survive *before* the define resolves `inherits`, because a type's own base can mention its
+  nested type (`Nav : …<Nav.NavLink>`). So `$replaceStub` clears the stub markers and leaves the
+  object where it is, keeping `$$name` (a caller holding the stub must still resolve by name) and
+  setting `$retiredStub` for the redefinition check to look past.
+
+  Still single-bundle: `--incremental` (chunk assignment is a whole-program property — do not combine
+  them yet), minification (a module entry and its chunks are emitted formatted only, since they carry
+  `import` syntax `JsMinifier` does not handle), and watch mode.
 - **The module runtime.** `Resources/Modules.js`
   provides `Transpose.Modules` — a registry of types whose JavaScript lives in a module that has not
   been fetched. `Modules.Register(manifest)` stubs each such type at the same global path and in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,9 +546,11 @@ The short version:
   `Foo$1` (all a `Transpose.unroll` path walk can express — a constructed generic deliberately gets no
   global slot) made `IsAssignableFrom(IFoo<Bar>, stub)` answer false, silently. This is *not*
   interface-only: a generic base class flattens the same way, and is the more common case
-  (`ComponentBase<Self, THTML>`). An **open** base — `class Relay<T> : IHandler<T>` — still reports
-  only the definition; there is no `T` to write down until the definition is applied. `TODO.modules.md`
-  §7c has the details, `LazyModuleActivatorTests` the coverage.
+  (`ComponentBase<Self, THTML>`). An **open** base — `class Relay<T> : IHandler<T>` — has no argument
+  to write down, so the spec is the bare definition and the runtime applies it to placeholder type
+  parameters (`$applyOpen`), which is the shape a loaded type records: reporting the definition itself
+  instead both over-matched an unbound `typeof(IFoo<>)` and left `GetInterfaces()` empty.
+  `TODO.modules.md` §7c has the details, `LazyModuleActivatorTests` the coverage.
 
   Still single-bundle: `--incremental` (chunk assignment is a whole-program property — do not combine
   them yet), minification (a module entry and its chunks are emitted formatted only, since they carry

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -5,9 +5,11 @@ one per *cluster* of classes — that the page loads on demand, instead of the s
 today. Measured end to end against **Tesserae** (`Tesserae.Tests`, the sample gallery), with the
 rendered page diffed against an unmodified build.
 
-Status: **no compiler change has been made.** This is the feasibility report and the evidence behind
-it. The prototype was built by mechanically re-chunking an already-emitted site, which is enough to
-answer every runtime question without touching the emitter.
+Status: **the runtime/BCL half is implemented** (§5a — `Transpose.Modules`,
+`Activator.CreateInstanceAsync`, type stubs, the synchronous-use guard); **the emitter still emits one
+bundle**. Everything below is the feasibility report and the evidence behind it — the measurements
+were made by mechanically re-chunking an already-emitted site, which answered every runtime question
+without touching the emitter.
 
 ---
 
@@ -19,7 +21,7 @@ answer every runtime question without touching the emitter.
 | Does the page still render correctly? | **Yes** — 140/140 Tesserae samples structurally identical to the baseline, zero console errors. |
 | Can modules be loaded on demand? | **Yes**, if the chunk boundary is an SCC of the reference graph. Validated. |
 | Does reflection survive? | **Yes**, with eager metadata plus registered *type stubs*. `GetTypes` / `IsAssignableFrom` / `GetCustomAttributes` / `Name` all work against unloaded types. |
-| Can reflection auto-load a module? | **Only asynchronously.** `Activator.CreateInstance` is synchronous C#; there is no sound synchronous ESM load. This is the one hard blocker. |
+| Can reflection auto-load a module? | **Only asynchronously** — and that half is now **implemented**: `Transpose.Modules` + `Activator.CreateInstanceAsync` (§5a). `Activator.CreateInstance` stays synchronous and now fails with a message naming the module. |
 | Is it worth it for Tesserae? | **~14% off the initial page** (gzipped). Less than it sounds, and for reasons that are structural — see §6. |
 
 The single most surprising number: **reflection metadata is 25% of the gzipped payload** of the
@@ -161,6 +163,42 @@ Two things the stubs need care with, both found the hard way:
 - Carry `$metadata` across when the real class replaces the stub, and evict the stub from the global
   path first, or `Transpose.define` reports *"Class X is already defined"*.
 
+### 5a. The runtime half, implemented
+
+`Resources/Modules.js` and the `Transpose.Modules` / `Activator.CreateInstanceAsync` bindings now
+ship in the BCL. This is the part that does not depend on the emitter, so it landed first:
+
+- `Modules.Register(manifest)` — declares the types a build deferred (`type name -> { m: module url,
+  k: kind, a: assembly, i: [base type names] }`) and stubs each one, outermost-first, at its global
+  path and in its assembly's `$types`. Resolves the `$$inherits`/`$interfaces` chains afterwards, so
+  a stub may extend another stub, then calls `Transpose.init()` so metadata deferred while the type
+  was missing attaches.
+- `Modules.LoadAsync(type)` / `LoadAsync(name)` — fetches the module and completes with the **real**
+  type. Concurrent calls share one fetch; awaiting a type that was never deferred is a no-op, so a
+  call site can await unconditionally. A caller still holding the stub it got from `Type.GetType()`
+  before the load is handed the live type rather than its own stale reference.
+- `Modules.IsLoaded` / `IsStub`, and `Modules.SetLoader(url => Task)` — the default loader is a
+  dynamic `import()`, built through `new Function` so `tps.js` stays parseable in an engine that
+  cannot compile one; a host that serves chunks another way substitutes its own.
+- `Activator.CreateInstanceAsync(type[, args | nonPublic])` and `CreateInstanceAsync<T>()` — load,
+  then construct.
+- `Transpose.createInstance` gains a stub guard, so the **synchronous** path fails with
+  *"Cannot create an instance of 'X' synchronously: it lives in module 'Y', which has not been
+  loaded"* instead of a `not a constructor` deeper in. The silent-degradation failure mode that
+  experiment B hit is gone.
+- A failed fetch restores the stubs and clears the memoised promise, so reflection still sees the
+  type and a retry is allowed.
+
+Covered by `LazyModuleActivatorTests` (7 tests): a stub is visible to `Type.GetType`, `Name`,
+`IsInterface`, `IsAssignableFrom` and `Assembly.GetTypes()` before its module loads; the synchronous
+path throws naming the module; `CreateInstanceAsync` loads once and returns a working instance;
+`LoadAsync` is idempotent; and a failed load is recoverable. They run with `skipRoslyn: true` — there
+is no native .NET counterpart to diff against — and substitute a loader that defines the type from
+C#, so no test touches the network or a real ESM import.
+
+What is still missing is the *producer*: nothing emits chunks or a manifest yet, so today a host has
+to call `Modules.Register` itself. That is the emitter work in §7.
+
 **The one thing that cannot work synchronously is using the type.** `Activator.CreateInstance(t)`,
 `new X()`, a static call — these are synchronous C#, and `import()` is asynchronous. The prototype
 bridged it with a synchronous `XMLHttpRequest` + `eval`, which is how it reaches 0 errors; that is
@@ -200,6 +238,8 @@ splitting metadata per type alongside the chunks and accepting an async `GetType
 Ordered by how much of it already exists.
 
 **Already there**
+- The whole runtime/BCL half: `Resources/Modules.js`, `Transpose.Modules`,
+  `Activator.CreateInstanceAsync`, the stub guard in `Transpose.createInstance` (§5a).
 - Per-class emission: `Emitter.EmitClassPath()`, currently gated to the base library.
 - Per-file packaging: `EmbeddedItem` (`ResourceEmbedder.cs:9`) already carries an `Output`
   subdirectory and a `Load` flag for "write it, but do not put a `<script>` in index.html" — exactly
@@ -228,9 +268,7 @@ Ordered by how much of it already exists.
 
 **New, in the runtime (`Transpose.BCL/Resources`)**
 - `Transpose.$useAssembly(name)` — name the ambient assembly for a bare `define` outside a wrapper.
-- Stub registration, eviction and metadata hand-off.
-- An async `Transpose.loadChunk(url)` and the BCL surface (`Modules.Load<T>()`) that exposes it.
-- A clear error when a stub is used synchronously — the failure today is silent, which is worse.
+  The only runtime piece still outstanding; everything else in this section is done (§5a).
 
 **Interactions to check that this investigation did not**
 - `--incremental`: the chunk assignment is a *whole-program* property, so a body-only edit that today
@@ -251,7 +289,8 @@ Sequence it as:
    heuristic. This is the whole technical core, and it is measurable on its own.
 2. **An explicit `[LazyModule]`-style boundary** plus `await Modules.Load<T>()`. Without it, lazy
    loading is only reachable through reflection, and only asynchronously.
-3. **Stubs + eager metadata** in the runtime, so reflection keeps working across the boundary.
+3. ~~**Stubs + eager metadata** in the runtime, so reflection keeps working across the boundary.~~
+   **Done** — see §5a.
 4. Only then, packaging across assembly boundaries.
 
 And separately, ahead of all of it, look at the **metadata**: it is a quarter of the gzipped payload,

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -1,0 +1,273 @@
+# TODO.modules — emitting JavaScript modules per class / per cluster
+
+Investigation into adding an output mode where `tps` emits ES modules (`.mjs`) — one per class, or
+one per *cluster* of classes — that the page loads on demand, instead of the single bundle it emits
+today. Measured end to end against **Tesserae** (`Tesserae.Tests`, the sample gallery), with the
+rendered page diffed against an unmodified build.
+
+Status: **no compiler change has been made.** This is the feasibility report and the evidence behind
+it. The prototype was built by mechanically re-chunking an already-emitted site, which is enough to
+answer every runtime question without touching the emitter.
+
+---
+
+## 1. The short version
+
+| Question | Answer |
+| --- | --- |
+| Can the emitted code be split into ES modules at all? | **Yes**, and cheaply. The output format needs no change beyond a wrapper. |
+| Does the page still render correctly? | **Yes** — 140/140 Tesserae samples structurally identical to the baseline, zero console errors. |
+| Can modules be loaded on demand? | **Yes**, if the chunk boundary is an SCC of the reference graph. Validated. |
+| Does reflection survive? | **Yes**, with eager metadata plus registered *type stubs*. `GetTypes` / `IsAssignableFrom` / `GetCustomAttributes` / `Name` all work against unloaded types. |
+| Can reflection auto-load a module? | **Only asynchronously.** `Activator.CreateInstance` is synchronous C#; there is no sound synchronous ESM load. This is the one hard blocker. |
+| Is it worth it for Tesserae? | **~14% off the initial page** (gzipped). Less than it sounds, and for reasons that are structural — see §6. |
+
+The single most surprising number: **reflection metadata is 25% of the gzipped payload** of the
+Tesserae sample app (274 KB of 1.10 MB) and module splitting does not touch it. There is a much
+cheaper win available there than in code splitting.
+
+---
+
+## 2. Why splitting is easy: the emitted code has no imports to rewrite
+
+Three properties of the current output make this far less work than it would be for a typical
+compiler:
+
+1. **Every type reference is a dotted global.** `TypeRef` (`Emitter.Types.cs:66`) emits
+   `tss.Button`, `System.Collections.Generic.List$1(T)` — never a lexical binding. Splitting a
+   bundle into files therefore requires **no import/export rewriting at all**; a module only has to
+   be *evaluated* before the reference is read.
+2. **Type bodies never touch the assembly wrapper.** `Transpose.assembly("tss", function ($asm, globals) {…})`
+   binds `$asm` and `globals`, and across all 688 types in `tss.js` + `app.js` there is exactly one
+   occurrence of each — the signature itself. A per-type file needs only to name its assembly
+   (one line) so the bare `Transpose.define` registers into the right `$types` map.
+3. **`Emitter.EmitClassPath()` already emits one bare `Transpose.define` per type**, at a
+   `<ns>/<Type>.js` path. That is how `Transpose.BCL` is built. The emit half of "one file per class"
+   exists; it is gated to the base library (`ProjectBuild.cs:250`) and produces plain scripts rather
+   than modules.
+
+So the per-class file layout is a small change. Everything hard is in *load ordering* and
+*reflection*.
+
+## 3. What must be loaded before what
+
+`Transpose.define` resolves `inherits` **eagerly** — `Class.js:471` does `extend = extend()` inside
+`define`, so the lazy-looking `inherits: function () { return [Base]; }` thunk runs immediately. Base
+classes and interfaces must therefore be defined before the type that extends them.
+
+That splits every reference into two kinds:
+
+- **Hard** — the emitted code reaches *into* the type: `new X()`, a static member read, `inherits`,
+  and (non-obviously) **a generic type argument**, because `Foo$1(X)` builds a generic instance whose
+  base class can be `X` itself. A hard reference must be an `import`.
+- **Soft** — a bare mention: `typeof(X)`, an `is`/cast operand, a metadata reference. These only need
+  a *Type object*, which a stub provides (§5). They need not be imports.
+
+ES modules give the ordering guarantee for free: a side-effect `import './Base.mjs';` at the top of a
+module is fully evaluated before the importer's body runs. No name rewriting, no loader.
+
+**But only if the import graph is acyclic.** With a cycle A↔B, whichever module is entered first runs
+its body while the other is still initialising, and a `inherits` reference across the cycle throws.
+The inheritance graph alone is acyclic (measured: every SCC over `inherits` edges is a single type),
+but the *full* reference graph is not, and a purely inheritance-based import graph is unsound —
+proven, see §4.
+
+**The rule that works: a chunk is a strongly-connected component of the hard-reference graph.** The
+condensation of an SCC graph is a DAG, so chunk-level side-effect imports are always safe, and inside
+a chunk the emitter's existing dependency-depth ordering already satisfies `inherits`.
+
+## 4. What was measured
+
+Baseline: `Tesserae.Tests` built with `tps` at `8abfab4`, Debug, into
+`bin/Debug/netstandard2.0/tps/`. 688 source types (526 in `tss.js`, 162 in `app.js`). Correctness
+oracle: headless Chromium loads the page, records the sidebar, clicks all 140 samples and
+fingerprints each rendered pane (element count + text length), plus every console error.
+
+Four chunkings were built by re-chunking that emitted site and re-run through the same oracle:
+
+| Experiment | Chunks | Initial load | Result |
+| --- | --- | --- | --- |
+| **A** one module per type, all imported eagerly | 688 | 3140 KB | **140/140 samples identical, 0 errors** |
+| **B** one module per type, only the entry closure eager | 404 eager | 2058 KB | Renders, but only **3 of 140** samples — reflection cannot see unloaded types, and it fails *silently* |
+| **C** as B + metadata-backed type stubs + sync fault-in | 404 eager | 2058 KB | Full 140-item sidebar restored; **27 errors** — static calls into stubs |
+| **D** chunk = SCC of the full reference graph | 366 (211 eager) | 2053 KB | **140/140 samples identical, 0 errors** |
+
+Experiment A proves the split itself is sound. D is the working design.
+
+Experiment C is the interesting failure: with per-type modules whose imports are only the `inherits`
+edges, a lazily-loaded sample calls `tss.Bind.Bind$2(...)` — a static method on a type that is still
+a stub. There is no interception point for a plain property read on a global, so the chunk boundary
+*must* be closed over hard references. That is what D does.
+
+A fifth experiment (E) refined D by classifying references as hard/soft to break up the chunks. It
+improves granularity on paper — 366 → 499 chunks, eager 2053 → 1979 KB — but the classifier here works
+on *emitted text* and could not be made sound; it kept mis-filing edges (a generic type argument that
+becomes a base class; a second `inherits` inside a `Transpose.definei` block). A real implementation
+classifies on Roslyn symbols at the point `TypeRef` is called and would not have this problem. Left as
+the main open question, because it is where the remaining upside is.
+
+### Compression
+
+Splitting costs bytes. Measured over the same content:
+
+```
+366 chunks, gzipped individually   598 KB
+the same bytes as one file, gzip   519 KB     -> per-file split costs +15%
+```
+
+Small files lose the shared compression dictionary. This is real and must be stated in any pitch.
+
+### Payload, gzipped, for the Tesserae sample app
+
+```
+tps.js        278 KB      the runtime                     not splittable by this work
+tps.meta.js    57 KB      BCL reflection metadata         stays eager
+tss.js        365 KB      Tesserae                        splittable
+tss.meta.js   217 KB      Tesserae reflection metadata    stays eager
+app.js        183 KB      the sample app (incl. 11% inline metadata)   splittable
+              -------
+             1102 KB total initial page
+
+with the SCC split:  eager chunks 376 KB + boot 19 KB  (was 548 KB)
+                     949 KB total initial page  ->  -14%
+```
+
+## 5. Reflection
+
+This was the part flagged as "to be checked", and it resolved better than expected.
+
+**Metadata can stay entirely eager and does not need the code.** `Transpose.setMetadata`
+(`Reflection.js:4`) already defers an entry whose type is not yet defined, and `Transpose.init()`
+re-defers it if the type is still missing. So the whole `$m(...)` block can ship up front and attach
+to each type as its module arrives.
+
+**Type stubs make unloaded types visible to reflection.** Registering, for each unloaded type, a
+function carrying `$$name`, `$kind`, `$isInterface`, `$$inherits`, `$interfaces` and `$assembly` — at
+its global path *and* in the assembly's `$types` map, which is exactly where `Transpose.define` would
+put the real class (`Class.js:818`) — makes all of this work with the code absent:
+
+- `Assembly.GetTypes()` (`getAssemblyTypes` enumerates `$types`)
+- `IsAssignableFrom` (walks `$$inherits`)
+- `IsInterface`, `Name`
+- `GetCustomAttributes(...)`, including *constructing* the attribute instances
+
+Tesserae's sample gallery is discovered entirely through those four calls
+(`Tesserae.Tests/src/App.cs:116`), and it rebuilds its full 140-item sidebar off stubs alone.
+
+Two things the stubs need care with, both found the hard way:
+
+- Register outermost-first. Placing a nested type creates a plain `{}` at its container's path, which
+  the container's own stub then overwrites, silently losing the nested type.
+- Carry `$metadata` across when the real class replaces the stub, and evict the stub from the global
+  path first, or `Transpose.define` reports *"Class X is already defined"*.
+
+**The one thing that cannot work synchronously is using the type.** `Activator.CreateInstance(t)`,
+`new X()`, a static call — these are synchronous C#, and `import()` is asynchronous. The prototype
+bridged it with a synchronous `XMLHttpRequest` + `eval`, which is how it reaches 0 errors; that is
+acceptable for a dev mode and not for production (it blocks the main thread and is deprecated).
+
+So the production answer has to be an **explicit asynchronous boundary** — an attribute marking a
+lazily-loadable type and an `await` at the point the app crosses into it. A `Task<T>`-returning
+`Modules.Load<T>()` fits the existing `Task`→`Promise` mapping. Automatic per-class lazy loading
+cannot be sound for synchronous C# semantics; this is a language-surface change, not just a codegen
+one.
+
+## 6. Why the win is smaller than it looks
+
+Two structural facts, both visible in the chunking:
+
+**The library's own shape sets the floor.** The largest chunk is **1538 KB raw, 192 types** — the
+Tesserae component core. `tss.UI` is a static facade that references every component, and the
+components reference `UI` back, so the entire component library is one strongly-connected component
+and can never be split by any sound automatic rule. That chunk alone is 75% of the eager payload. The
+fix is not in the compiler: it is breaking the `UI` facade cycle in Tesserae.
+
+**Cross-references fuse unrelated code.** 122 of the 131 sample types landed in one 760 KB chunk,
+because each sample's "See Also" list is `typeof(OtherSample)` — emitted as
+`System.Array.init([Tesserae.Tests.Samples.ButtonSample, …])`. Those are *soft* references that a stub
+satisfies, so the hard/soft classification of §3 is what unlocks this; without it the median cost of
+opening one sample is 913 KB, i.e. nearly the whole lazy set.
+
+And a third, which is about where the bytes actually are: **metadata is 25% of the payload**
+(274 KB gz) and 37% of the raw bytes. `tss.meta.js` alone is 2.58 MB raw — the largest single file in
+the site, larger than `tss.js`. It must stay eager for reflection to work over unloaded types, so
+module splitting cannot reduce it. Emitting only the metadata a project actually reflects over, or
+splitting metadata per type alongside the chunks and accepting an async `GetTypes()`, is a
+*separate* and probably higher-value piece of work.
+
+## 7. What the compiler change would be
+
+Ordered by how much of it already exists.
+
+**Already there**
+- Per-class emission: `Emitter.EmitClassPath()`, currently gated to the base library.
+- Per-file packaging: `EmbeddedItem` (`ResourceEmbedder.cs:9`) already carries an `Output`
+  subdirectory and a `Load` flag for "write it, but do not put a `<script>` in index.html" — exactly
+  what N chunk files plus one boot module need.
+- Deferred metadata attachment in the runtime (`Reflection.js`).
+
+**New, in the translator**
+- A **reference-kind classifier**. All 82 `TypeRef(...)` call sites funnel through the single
+  `TypeRef(ITypeSymbol)` in `Emitter.Types.cs:66`, so *recording* an edge is a one-place change; but
+  classifying it hard vs soft needs the calling context, so either those sites pass a kind, or a
+  separate analysis pass walks the symbols. A separate pass is preferable — it keeps the emitter's
+  output byte-identical, which is the standing correctness gate, and `TreeModel` already caches the
+  semantic models it would need.
+- **SCC + condensation** over the hard-reference graph, then a chunk-merge heuristic (a 200-byte
+  chunk per type is worse than useless — see the +15% compression cost).
+- A **chunk manifest**: type → chunk, chunk → chunk deps, plus each type's kind and inherits list so
+  the boot module can build stubs.
+
+**New, in the compiler core**
+- An `outputBy: Module` / `--modules` mode in `TransposeJson` + `ProjectBuild`, writing chunk files
+  and a boot module instead of one bundle.
+- `OutputBuilder`: script-tag only the boot module; write chunks as unlinked files.
+- Package builds: a library must embed its chunks *and* its manifest, and a consuming site build must
+  merge the manifests of every referenced package. This is the fiddliest part — it is a new
+  cross-assembly protocol, versioned by the `BuildStamp` minimum-compiler check.
+
+**New, in the runtime (`Transpose.BCL/Resources`)**
+- `Transpose.$useAssembly(name)` — name the ambient assembly for a bare `define` outside a wrapper.
+- Stub registration, eviction and metadata hand-off.
+- An async `Transpose.loadChunk(url)` and the BCL surface (`Modules.Load<T>()`) that exposes it.
+- A clear error when a stub is used synchronously — the failure today is silent, which is worse.
+
+**Interactions to check that this investigation did not**
+- `--incremental`: the chunk assignment is a *whole-program* property, so a body-only edit that today
+  reuses cached per-type JS could still reshuffle chunks. `TODO.incremental.md`'s guarantee of
+  byte-identical output needs re-examining.
+- `--watch`: a rebuild that moves a type between chunks must invalidate both.
+- Minification: chunks minify independently, so `JsMinifier`'s local-variable renaming stays safe, but
+  the `.js`/`.min.js` variant switch now applies to N files.
+
+## 8. Recommendation
+
+Worth doing, but not as "modules per class" — that granularity is what the measurements argue
+against, on both compression (+15%) and the fact that the largest SCC is 192 types regardless.
+
+Sequence it as:
+
+1. **Hard/soft reference classification on Roslyn symbols**, with SCC chunking and a merge
+   heuristic. This is the whole technical core, and it is measurable on its own.
+2. **An explicit `[LazyModule]`-style boundary** plus `await Modules.Load<T>()`. Without it, lazy
+   loading is only reachable through reflection, and only asynchronously.
+3. **Stubs + eager metadata** in the runtime, so reflection keeps working across the boundary.
+4. Only then, packaging across assembly boundaries.
+
+And separately, ahead of all of it, look at the **metadata**: it is a quarter of the gzipped payload,
+every project pays for it whether it reflects or not, and reducing it needs none of the machinery
+above.
+
+---
+
+### Reproducing
+
+The harness is in `docs/experiments/js-modules/` — see its README. It works on an emitted site, so it
+needs no compiler changes:
+
+```bash
+cd /path/to/tesserae && dotnet build Tesserae.sln -c Debug        # with tps on PATH
+node graph.js  <site>                    # reachability + SCC statistics
+node split3.js <site> out-scc            # the working SCC chunking (experiment D)
+node probe.js  out-scc report            # render, click all 140 samples, fingerprint
+```

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -255,7 +255,9 @@ tps/
   types each type's body reaches into, so an edge exists exactly when a reference was emitted. A
   `typeof` operand is the one *soft* position: it wants a Type object, which a stub already answers
   for, so it is not recorded. That distinction is what stops a "see also" list of `typeof(...)` from
-  fusing every type it names into one chunk.
+  fusing every type it names into one chunk. A *constructed* generic is the exception and stays hard
+  even inside a `typeof` — it has no object to point at, it is built by applying its definition, and
+  applying a stub throws (§7c).
 - Iterative Tarjan over that graph; each SCC is a chunk. Components come out in reverse-topological
   order, so numbering them gives a DAG in which every import points at a lower index — which makes
   the import lists and the file names deterministic (`OutputIsDeterministic` guards it).
@@ -377,9 +379,59 @@ from the noise floor above. Reflection still enumerates all 528 + 162 types. Zer
 - **Watch mode** with module output.
 - **Minification** — a module entry and its chunks are emitted formatted only (they carry `import`
   syntax `JsMinifier` is not set up for), and a module-mode package embeds no `.min.js` sibling.
-- Generic base types reach the manifest as their definition name (`Foo$1`), which is all
-  `Transpose.unroll` can express, so `IsAssignableFrom` against a *constructed* generic interface is
-  not answered from a stub.
+- An **open** generic base — `class Relay<T> : IHandler<T>` — reaches the manifest as the bare
+  definition (`IHandler$1`), because there is no `T` to write down until the definition is applied.
+  The definition-level relationship is reported; a question about one instantiation still needs the
+  module. Same for an argument that is an array, or a base nested inside a generic. See §7c for the
+  constructed case, which is answered.
+
+### 7c. Constructed generics from a stub
+
+The first cut flattened every generic base to its definition name (`Foo$1`) because the manifest was
+resolved with `Transpose.unroll`, a dotted-path walk over globals — and a constructed generic
+deliberately has no global path. `Transpose.define` places only the *definition*; the instantiation
+lives in `fn.$cache`, keyed by the argument objects, reachable only by **applying** the definition.
+So a stub reported `IHandler$1` where the caller asked about `IHandler<Order>`, and
+`varianceAssignable` — which matches on `$genericTypeDefinition` + `$typeArguments`, neither of which
+a definition object carries — answered false. Silently: indistinguishable from a real false.
+
+It is **not** interface-specific. `ManifestBaseNames` ran the base class through the same flattening,
+and in Tesserae the most common generic base is a class: 133 of the library's 528 deferred types name
+one, 63 of them `ComponentBase<Self, THTML>`.
+
+Two changes fix it.
+
+- **The manifest carries the arguments.** A base is now either a name (as before) or
+  `[definition, ...arguments]`, nesting for `IFoo<IBar<int>>`:
+  `i: [["tss.CB$2", "tss.Avatar", "HTMLElement"], "tss.IC", …]`. 228 of Tesserae's specs take the
+  array form.
+- **The runtime applies it lazily.** `Modules.$resolveType` builds the instantiation on the *first
+  read* of a stub's `$$inherits`/`$interfaces`/`$allInterfaces`, not at `register` time — because a
+  base may itself be a stub, and applying a stub throws. A partial resolution is never cached, so a
+  base whose module arrives later is picked up on the next question.
+
+Lazy is not just cheaper, it is what makes the eager alternative unnecessary. Forcing every generic
+definition into the eager set (so the manifest could emit a real application) looked attractive —
+only 20 distinct definitions in the library — but it is not needed: **to ask about `IFoo<Bar>` at all
+you must already have the definition**, since `typeof(IFoo<Bar>)` emits the same application. At query
+time it is loaded by construction.
+
+That invariant only holds because of the second half of this change: `typeof` was treated as a soft
+reference, and a soft reference is satisfiable by a stub — but a constructed generic has no object to
+point at, it is *built* by applying the definition, and a stub throws when applied. So
+`typeof(IFoo<Bar>)` on a definition in an unimported chunk was a latent runtime throw, not a wrong
+answer. `RecordConstructedTypeRefs` now records the definition and its arguments as hard references
+from inside a `typeof`; a plain `typeof(X)` and an unbound `typeof(Foo<>)` (which emits the definition
+object, no application) stay soft, so a "see also" list still does not fuse chunks.
+
+`$allInterfaces` was a third, smaller hole found on the way: `getInterfaces` reads it and answers `[]`
+without it, so `Type.GetInterfaces()` on any deferred type — generic or not — reported nothing at all.
+
+Measured on the live gallery: for a still-deferred `tss.Avatar`,
+`IsAssignableFrom(ComponentBase<Avatar, HTMLElement>, …)` is true, `GetInterfaces()` returns 4 rather
+than 0, and the type is still a stub afterwards — the answer came from the manifest, not from a load.
+The eager payload grows 8 KB raw / 2 KB gzipped (a bigger `tps.js` plus the longer specs), and the
+chunk assignment is unchanged at 628/212.
 
 ## 7. What the compiler change would be
 

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -5,11 +5,14 @@ one per *cluster* of classes — that the page loads on demand, instead of the s
 today. Measured end to end against **Tesserae** (`Tesserae.Tests`, the sample gallery), with the
 rendered page diffed against an unmodified build.
 
-Status: **the runtime/BCL half is implemented** (§5a — `Transpose.Modules`,
-`Activator.CreateInstanceAsync`, type stubs, the synchronous-use guard); **the emitter still emits one
-bundle**. Everything below is the feasibility report and the evidence behind it — the measurements
-were made by mechanically re-chunking an already-emitted site, which answered every runtime question
-without touching the emitter.
+Status: **implemented, end to end.** `outputBy: "Module"` in a project's `tps.json` makes `tps` emit
+one ES module per chunk plus an entry module, and the runtime (`Transpose.Modules`,
+`Activator.CreateInstanceAsync`) loads the deferred ones on demand. See §5a for the runtime half and
+§7a for the emitter half and what it measures on Tesserae.
+
+The report below is the original feasibility investigation, kept because it is the reasoning the
+implementation follows and it records what was rejected and why. Its measurements were made by
+mechanically re-chunking an already-emitted site; §7a has the numbers from the real compiler.
 
 ---
 
@@ -232,6 +235,88 @@ the site, larger than `tss.js`. It must stay eager for reflection to work over u
 module splitting cannot reduce it. Emitting only the metadata a project actually reflects over, or
 splitting metadata per type alongside the chunks and accepting an async `GetTypes()`, is a
 *separate* and probably higher-value piece of work.
+
+## 7a. What was built
+
+`outputBy: "Module"` in `tps.json`. One `<script type="module">` in index.html; everything else is
+imports.
+
+```
+tps/
+  app.js            entry module: imports the eager chunks, the reflection metadata for every type,
+                    the manifest of what was deferred, Transpose.init()
+  chunks/c0.mjs …   one file per chunk: side-effect imports of the chunks it references, then the
+                    Transpose.define of each of its types
+```
+
+**Translator** (`Emitter.Modules.cs`, ~300 lines):
+
+- `TypeRef` — the single choke point every emitted type reference goes through — records the source
+  types each type's body reaches into, so an edge exists exactly when a reference was emitted. A
+  `typeof` operand is the one *soft* position: it wants a Type object, which a stub already answers
+  for, so it is not recorded. That distinction is what stops a "see also" list of `typeof(...)` from
+  fusing every type it names into one chunk.
+- Iterative Tarjan over that graph; each SCC is a chunk. Components come out in reverse-topological
+  order, so numbering them gives a DAG in which every import points at a lower index — which makes
+  the import lists and the file names deterministic (`OutputIsDeterministic` guards it).
+- Inside a chunk the emitter's existing dependency-depth ordering is kept, so `inherits` is satisfied
+  without any extra work.
+- Eager set = the entry point's chunk plus its transitive chunk dependencies. A project with no entry
+  point (a library) keeps everything eager — there is nothing to be lazy relative to.
+
+**Runtime** — beyond §5a, two things the prototype had not needed:
+
+- `Transpose.$useAssembly(name)`, so a bare `define` outside the `Transpose.assembly(...)` wrapper
+  registers into the right assembly.
+- **Stub replacement moved into `Transpose.define` itself.** A chunk can be evaluated by two routes:
+  the loader, or a plain static `import` from another chunk that ESM resolves directly. Only the
+  first went through `Modules.load`, so a type arriving by the second hit *"Class X is already
+  defined"* against its own stub. Doing the swap in `Class.set` covers both. For the same reason the
+  metadata hand-off is keyed by type **name** (`Modules.$metaFor`, populated from
+  `Reflection.setMetadata`) rather than held on the stub object — the stub may be taken out by a
+  different route than the one replacing it. Both were found by the Tesserae run, not by reasoning.
+
+**Entry-module ordering is load-bearing.** Metadata is emitted *before* the manifest, because
+`Modules.register` ends with a `Transpose.init()` and `init` runs the entry point — anything emitted
+after it would not exist yet when `Main` runs. That is what keeps `[SampleDetails]` readable off the
+stubs; with the order reversed, Tesserae's whole sidebar collapsed into one "Others" group.
+
+### Measured on the Tesserae sample gallery
+
+Same sources built both ways, both rendered in headless Chromium, all 140 samples clicked:
+
+| | initial JS payload (the app's own) |
+| --- | --- |
+| single bundle | 1,109 KB raw / 183 KB gz |
+| `outputBy: Module` | **164 KB raw / 19 KB gz** |
+
+160 chunks: 5 loaded up front, 155 on demand (157 of 162 types deferred). **All 140 samples render
+with identical element and text counts, and the sidebar is identical, with zero console errors** —
+including the reflection-driven discovery, which reads names, interfaces and attributes off stubs.
+
+That ratio is the best case: a gallery of independent samples is exactly the shape module splitting
+suits. It also required a two-line change in the app, because instantiating a deferred type is
+asynchronous:
+
+```csharp
+// Sample.cs   Func<IComponent>  ->  Func<Task<IComponent>>
+() => Activator.CreateInstance(t) as IComponent
+async () => await Activator.CreateInstanceAsync(t) as IComponent   // and DeferSync -> Defer
+```
+
+### Not done
+
+- **Packages.** Only a site build emits modules; `--emit-package` still embeds one bundle, so
+  Tesserae itself (`tss.js`, 2.4 MB) is unsplit. Splitting a package means embedding chunk files plus
+  a manifest and merging the manifests of every reference — a new cross-assembly protocol.
+- **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today
+  reuses cached per-type JavaScript could still reshuffle chunks. Module mode has not been checked
+  against the cache and the two should not be combined yet.
+- **Minification** of chunk files, and the `.js`/`.min.js` variant switch across N files.
+- **Watch mode** with module output.
+- Generic base types reach the manifest as their definition name (`Foo$1`), which is all
+  `Transpose.unroll` can express, so `IsAssignableFrom` against a *constructed* generic interface is
+  not answered from a stub.
 
 ## 7. What the compiler change would be
 

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -348,6 +348,26 @@ entry modules, almost all of it the `$m` blocks that used to be `tss.meta.js`. I
 for reflection to see deferred types at all, which is the same conclusion §1 reached from the other
 direction — metadata, not code, is what the split cannot touch.
 
+### Re-measured with the library's reflection turned off
+
+Tesserae subsequently set `reflection.disabled: true` in its own `tps.json` (the library does not
+need to be reflectable; the app still is), which deletes the 2.5 MB `tss.meta.js` the paragraph above
+identified as the floor. Same 628 chunks, same code, re-measured:
+
+| | tss + app JavaScript | whole page |
+| --- | --- | --- |
+| single bundle | 3,473 KB raw / 534 KB gz | 6,938 KB raw / 1,105 KB gz |
+| both as modules | **1,750 KB raw / 323 KB gz** | **5,215 KB raw / 893 KB gz** |
+
+212 chunks eager (207 library, 5 app), 416 on demand; the entry modules are 60 KB (`tss.js`) and
+149 KB (`app.js`). So the split's own contribution went from 29% raw / 31% gz to **50% raw / 40% gz**
+— not because the splitter improved, but because with the metadata gone what remains eager is code,
+and code is what it can move. The two changes compose: eager metadata was the larger of the two
+costs, and neither removes the other's.
+
+139 of 140 samples fingerprint identically; the one that differs (`Avatar`) is the randomised sample
+from the noise floor above. Reflection still enumerates all 528 + 162 types. Zero console errors.
+
 ### Not done
 
 - **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -379,11 +379,10 @@ from the noise floor above. Reflection still enumerates all 528 + 162 types. Zer
 - **Watch mode** with module output.
 - **Minification** — a module entry and its chunks are emitted formatted only (they carry `import`
   syntax `JsMinifier` is not set up for), and a module-mode package embeds no `.min.js` sibling.
-- An **open** generic base — `class Relay<T> : IHandler<T>` — reaches the manifest as the bare
-  definition (`IHandler$1`), because there is no `T` to write down until the definition is applied.
-  The definition-level relationship is reported; a question about one instantiation still needs the
-  module. Same for an argument that is an array, or a base nested inside a generic. See §7c for the
-  constructed case, which is answered.
+- Nothing outstanding on the generic front: §7c covers the constructed case and the open one. A base
+  whose arguments cannot be *named* (an open `IHandler<T>`, an array argument, a base nested inside a
+  generic) reaches the manifest as the bare definition and the runtime applies it to placeholder type
+  parameters, which is the same shape the loaded type records.
 
 ### 7c. Constructed generics from a stub
 
@@ -409,6 +408,30 @@ Two changes fix it.
   read* of a stub's `$$inherits`/`$interfaces`/`$allInterfaces`, not at `register` time — because a
   base may itself be a stub, and applying a stub throws. A partial resolution is never cached, so a
   base whose module arrives later is picked up on the next question.
+
+#### The open case
+
+`class Relay<T> : IHandler<T>` has no argument to write down — `T` does not exist until the definition
+is applied — so the spec is the bare definition name. Reporting it *bare* is wrong, though, because a
+loaded definition does not record `IHandler$1` either: `$staticInit` applies it to placeholder type
+parameters built by `Reflection.createTypeParams`, so the real `$$inherits` holds `IHandler$1(T)`. A
+stub that reported the definition answered differently from the type it stands in for, in two
+directions at once (measured against a genuinely loaded `Relay<T>`):
+
+| question | loaded | bare definition | applied to placeholders |
+| --- | --- | --- | --- |
+| `IsAssignableFrom(IHandler<Order>, X)` | false | false | false |
+| `IsAssignableFrom(IHandler<>, X)` | false | **true** | false |
+| `GetInterfaces(X).Length` | 1 | **0** | 1 |
+
+Over-matching an unbound `typeof` (the bare definition is identity-equal to it, the real
+instantiation is not) and under-reporting `GetInterfaces` (a definition object carries
+`$kind: "class"` whether or not it defines an interface, so it never lands in the interface list).
+`Modules.$applyOpen` closes both by applying the definition to its own `$typeArguments`. The
+placeholder is not the same object the deferred type would have used — it comes from the *base's*
+parameter names rather than the deriving type's — but nothing compares placeholders across types, and
+every question above lands on the loaded answer. That also makes the idiomatic .NET test,
+`GetInterfaces().Any(i => i.GetGenericTypeDefinition() == typeof(IFoo<>))`, work unloaded.
 
 Lazy is not just cheaper, it is what makes the eager alternative unnecessary. Forcing every generic
 definition into the eager set (so the manifest could emit a real application) looked attractive —

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -304,16 +304,59 @@ asynchronous:
 async () => await Activator.CreateInstanceAsync(t) as IComponent   // and DeferSync -> Defer
 ```
 
+### Packages split too (§7b)
+
+`--emit-package` emits chunks as well, so a *library* splits. Two pieces make that work across the
+assembly boundary:
+
+- **A library defers everything.** It has no entry point to be lazy relative to, so its eager set is
+  just the chunks holding its `[Ready]` handlers (usually none). Its entry module imports nothing and
+  registers the whole manifest as stubs.
+- **It publishes a chunk map** — emitted type name → chunk file — embedded as `Transpose.Modules.json`
+  (embedded but *not* listed in `Transpose.Resources.json`, like the `BuildStamp`, so no consumer
+  extracts it into a site). A consuming build reads the maps of all its references (`ModuleMap.Read`)
+  and, wherever its own code reaches into a library type, emits `import '../<lib>/cN.mjs'` from the
+  chunk that uses it. Without that the reference would land on the library's stub, and a stub cannot
+  be resolved synchronously.
+
+`RecordRef` therefore records two sets: source types (chunked here) and referenced-assembly types
+(chunked over there). BCL types are recorded in neither — they live in `tps.js`, which always loads.
+
+The one non-obvious bug this surfaced: **a stub must be retired in place, not deleted.** `Class.set`
+already copies the members of whatever previously occupied a type's global slot onto the new class,
+which is how a nested type registered onto a stub survives — and it has to survive *before* the
+define resolves `inherits`, because a type's own base can mention its nested type
+(`Nav : ...<Nav.NavLink>`). Deleting the stub and restoring later left `Nav.NavLink` undefined at
+exactly that moment. So `$replaceStub` now clears the stub markers and leaves the object in place,
+keeping `$$name` (a caller holding the stub still has to resolve by name afterwards) and setting
+`$retiredStub` for the redefinition check to look past.
+
+### Measured with both Tesserae and the app split
+
+| | initial JS payload |
+| --- | --- |
+| single bundle (tss.js + tss.meta.js + app.js) | 5,968 KB raw / 762 KB gz |
+| both as modules | **4,235 KB raw / 527 KB gz** |
+
+628 chunks (468 library, 160 app); 210 chunks load up front, 418 on demand. 137 of 140 samples
+fingerprint identically; the other 3 (`Searchable List`, `Searchable Grouped List`, `Avatar`) differ
+run-to-run in the *single-bundle* build too — virtualized list windows and randomised avatars — so
+they are the measurement's noise floor rather than a regression. Zero console errors.
+
+The eager remainder is dominated by **reflection metadata**: 2,708 KB raw of the 4,235 is the two
+entry modules, almost all of it the `$m` blocks that used to be `tss.meta.js`. It has to stay eager
+for reflection to see deferred types at all, which is the same conclusion §1 reached from the other
+direction — metadata, not code, is what the split cannot touch.
+
 ### Not done
 
-- **Packages.** Only a site build emits modules; `--emit-package` still embeds one bundle, so
-  Tesserae itself (`tss.js`, 2.4 MB) is unsplit. Splitting a package means embedding chunk files plus
-  a manifest and merging the manifests of every reference — a new cross-assembly protocol.
 - **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today
   reuses cached per-type JavaScript could still reshuffle chunks. Module mode has not been checked
   against the cache and the two should not be combined yet.
 - **Minification** of chunk files, and the `.js`/`.min.js` variant switch across N files.
 - **Watch mode** with module output.
+- **Minification** — a module entry and its chunks are emitted formatted only (they carry `import`
+  syntax `JsMinifier` is not set up for), and a module-mode package embeds no `.min.js` sibling.
 - Generic base types reach the manifest as their definition name (`Foo$1`), which is all
   `Transpose.unroll` can express, so `IsAssignableFrom` against a *constructed* generic interface is
   not answered from a stub.

--- a/Transpose/Transpose.Compiler.Core/ModuleMap.cs
+++ b/Transpose/Transpose.Compiler.Core/ModuleMap.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace Transpose.Compiler;
+
+/// <summary>
+/// Reads the chunk maps that module-mode packages publish (<c>Transpose.Modules.json</c>, embedded
+/// by <see cref="ResourceEmbedder"/>) and merges them into the single lookup the translator needs:
+/// emitted type name → site-relative chunk file.
+///
+/// A consuming build uses it to turn a reference to a library type into an <c>import</c> of the
+/// chunk that defines it. Without that the reference would resolve to the library's stub, and a stub
+/// cannot be resolved synchronously — which is exactly the failure the module runtime is designed to
+/// report loudly rather than paper over.
+/// </summary>
+internal static class ModuleMap
+{
+    /// <summary>Merges the chunk maps of every reference that has one. A later reference never
+    /// overwrites an earlier entry: two assemblies claiming the same type name would be a name
+    /// collision the compiler cannot resolve, and the first (dependency-order) reference wins,
+    /// matching how the site build orders their JavaScript.</summary>
+    public static Dictionary<string, string> Read(IEnumerable<string> referencePaths)
+    {
+        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var dll in referencePaths)
+        {
+            var json = TryReadResource(dll, ResourceEmbedder.ModuleMapName);
+            if (json is null) continue;
+            try
+            {
+                var map = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                if (map is null) continue;
+                foreach (var kv in map) merged.TryAdd(kv.Key, kv.Value);
+            }
+            catch (JsonException) { /* a malformed map is not worth failing a build over */ }
+        }
+        return merged;
+    }
+
+    private static string? TryReadResource(string dllPath, string name)
+    {
+        try
+        {
+            // Read through Cecil, never Assembly.LoadFrom: loading would lock the file for the
+            // process's lifetime and break the next rebuild of a referenced project.
+            using var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(dllPath);
+            foreach (var r in asm.MainModule.Resources)
+            {
+                if (r is not Mono.Cecil.EmbeddedResource e || e.Name != name) continue;
+                using var s = e.GetResourceStream();
+                using var sr = new StreamReader(s);
+                return sr.ReadToEnd();
+            }
+        }
+        catch { /* not a readable assembly, or no such resource */ }
+        return null;
+    }
+}

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -59,6 +59,10 @@ internal static class OutputBuilder
         public string? MinifiedPath;
         public bool IsEmpty;
         public bool IsMinified;
+        /// <summary>Scripted as &lt;script type="module"&gt; rather than a classic deferred script.
+        /// Only the entry file of an <c>outputBy: Module</c> build sets this; the chunk files are
+        /// reached through its imports and are never scripted at all.</summary>
+        public bool IsModule;
     }
 
     /// <summary>The outcome of assembling a site: the directory it was written to, and every stale
@@ -81,7 +85,7 @@ internal static class OutputBuilder
     /// </summary>
     public readonly record struct CssResource(string OutputRelativePath, IReadOnlyList<string> SourceFiles, bool Concatenated);
 
-    public static SiteBuildResult Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, string configuration, string? metadataJavascript = null, string? liveReloadScript = null)
+    public static SiteBuildResult Build(ResolvedProject project, TransposeJson config, string javascript, string outputDir, string configuration, string? metadataJavascript = null, string? liveReloadScript = null, Translator.Emitter.ModuleOutput? modules = null)
     {
         Directory.CreateDirectory(outputDir);
 
@@ -112,9 +116,9 @@ internal static class OutputBuilder
 
         // A per-project compiler output (the app bundle, its reflection metadata, the shim): there
         // is no pre-built variant to reuse, so minify at compile time per outputFormatting.
-        void EmitCompilerJs(string rel, string content)
+        void EmitCompilerJs(string rel, string content, bool isModule = false)
         {
-            var o = new JsOut { Path = rel };
+            var o = new JsOut { Path = rel, IsModule = isModule };
             if (wantFormatted) WriteText(rel, content); else o.IsEmpty = true;
             if (wantMinified)
             {
@@ -212,7 +216,21 @@ internal static class OutputBuilder
         }
 
         // 3. The compiled bundle — loads last, after runtime + library deps are in place.
-        EmitCompilerJs(config.FileName, javascript);
+        // outputBy: Module — the chunk files are written but never scripted; the entry module
+        // imports the ones it needs and declares the rest to Transpose.Modules, which fetches them
+        // on demand. index.html therefore carries exactly one <script type="module">.
+        if (modules is not null)
+        {
+            foreach (var (rel, chunkJs) in modules.Chunks)
+            {
+                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                File.WriteAllText(dest, chunkJs, utf8);
+                written.Add(Path.GetFullPath(dest));
+            }
+        }
+
+        EmitCompilerJs(config.FileName, javascript, isModule: modules is not null);
 
         // 3b. Reflection metadata as a separate file (reflection.target: "file") — loads right
         //     after the bundle whose types it describes, matching the existing compiler.
@@ -981,7 +999,7 @@ internal static class OutputBuilder
             {
                 // A standalone minified resource — minified HTML only.
                 if (minSeen.Add(o.Path))
-                    jsMin.Append("\n    ").Append($"<script src=\"{o.Path}\" defer></script>");
+                    jsMin.Append("\n    ").Append(ScriptTag(o.Path, o.IsModule));
                 continue;
             }
 
@@ -989,7 +1007,7 @@ internal static class OutputBuilder
             // formatted one was not written (Minified mode) — mirrors the legacy GetOutputPath().
             var formattedPath = o.IsEmpty ? o.MinifiedPath : o.Path;
             if (formattedPath is not null)
-                js.Append("\n    ").Append($"<script src=\"{formattedPath}\" defer></script>");
+                js.Append("\n    ").Append(ScriptTag(formattedPath, o.IsModule));
 
             // Minified HTML links the minified sibling, falling back to the formatted path when no
             // minified variant exists. (The legacy compiler dropped such files from the minified
@@ -997,8 +1015,14 @@ internal static class OutputBuilder
             // load in a Release build. Transpose keeps it: a missing .min just loads the plain file.)
             var minifiedPath = o.MinifiedPath ?? (o.IsEmpty ? null : o.Path);
             if (minifiedPath is not null && minSeen.Add(minifiedPath))
-                jsMin.Append("\n    ").Append($"<script src=\"{minifiedPath}\" defer></script>");
+                jsMin.Append("\n    ").Append(ScriptTag(minifiedPath, o.IsModule));
         }
+
+        // A module script is deferred by definition and executes in document order alongside the
+        // classic `defer` ones, so the entry module still runs after the runtime scripts above it.
+        static string ScriptTag(string path, bool isModule) => isModule
+            ? $"<script type=\"module\" src=\"{path}\"></script>"
+            : $"<script src=\"{path}\" defer></script>";
 
         string? htmlName = (js.Length > 0 || css.Length > 0) ? "index.html" : null;
         string? htmlMinName = jsMin.Length > 0 ? (htmlName is null ? "index.html" : "index.min.html") : null;

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -119,8 +119,11 @@ internal static class OutputBuilder
         void EmitCompilerJs(string rel, string content, bool isModule = false)
         {
             var o = new JsOut { Path = rel, IsModule = isModule };
-            if (wantFormatted) WriteText(rel, content); else o.IsEmpty = true;
-            if (wantMinified)
+            // A module entry is always written formatted: it carries `import` statements, and
+            // minifying ES module syntax is not something JsMinifier is set up for yet. The chunk
+            // files are likewise copied through as authored.
+            if (wantFormatted || isModule) WriteText(rel, content); else o.IsEmpty = true;
+            if (wantMinified && !isModule)
             {
                 var minRel = ToMinName(rel);
                 WriteText(minRel, JsMinifier.Minify(content, Path.GetFileName(rel), minifyLocals));
@@ -162,14 +165,14 @@ internal static class OutputBuilder
                     // A standalone .min.js is still a Release-only script as far as index.html goes,
                     // matching how the same group routes from disk. A .dontload resource is on disk
                     // (above) but never injected into either HTML.
-                    if (f.Load) jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = IsMinifiedName(f.FileName) });
+                    if (f.Load) jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = IsMinifiedName(f.FileName), IsModule = f.Module });
                     continue;
                 }
 
                 // The minified half of a pair is written below, by its formatted sibling.
                 if (IsMinifiedName(f.FileName)) continue;
 
-                var o = new JsOut { Path = f.Rel };
+                var o = new JsOut { Path = f.Rel, IsModule = f.Module };
                 if (wantFormatted) WriteText(f.Rel, f.Text); else o.IsEmpty = true;
                 if (wantMinified)
                 {
@@ -219,6 +222,9 @@ internal static class OutputBuilder
         // outputBy: Module — the chunk files are written but never scripted; the entry module
         // imports the ones it needs and declares the rest to Transpose.Modules, which fetches them
         // on demand. index.html therefore carries exactly one <script type="module">.
+        // A module entry and its chunks are embedded formatted only — they carry `import` syntax,
+        // which the minifier is not set up for — so no .min.js sibling is produced for them and the
+        // consumer's formatted/minified switch simply copies them through.
         if (modules is not null)
         {
             foreach (var (rel, chunkJs) in modules.Chunks)
@@ -267,10 +273,29 @@ internal static class OutputBuilder
     /// </summary>
     public static List<EmbeddedItem> CollectEmbeddableItems(
         string projectDir, TransposeJson config, string mainJsName, string javascript, string? metadataJavascript,
-        bool minifyLocalVariables = false)
+        bool minifyLocalVariables = false, Translator.Emitter.ModuleOutput? modules = null)
     {
         var items = new List<EmbeddedItem>();
         var utf8 = new UTF8Encoding(false);
+
+        // outputBy: Module — the chunk files travel alongside the entry. They are Load=false (never
+        // scripted; the entry imports the ones it needs and Transpose.Modules fetches the rest) and
+        // .mjs, so the consumer copies them through verbatim rather than routing them as bundles.
+        // A module entry and its chunks are embedded formatted only — they carry `import` syntax,
+        // which the minifier is not set up for — so no .min.js sibling is produced for them and the
+        // consumer's formatted/minified switch simply copies them through.
+        if (modules is not null)
+        {
+            foreach (var (rel, chunkJs) in modules.Chunks)
+            {
+                var slash = rel.LastIndexOf('/');
+                items.Add(new EmbeddedItem(
+                    Name: rel.Substring(slash + 1),
+                    Content: utf8.GetBytes(chunkJs),
+                    Output: slash < 0 ? null : rel.Substring(0, slash),
+                    Load: false));
+            }
+        }
         var metaName = metadataJavascript is not null
             ? Path.GetFileNameWithoutExtension(mainJsName) + ".meta.js"
             : null;
@@ -355,8 +380,10 @@ internal static class OutputBuilder
         var defaults = new List<EmbeddedItem>();
         if (!mainDeclared)
         {
-            defaults.Add(new EmbeddedItem(mainJsName, utf8.GetBytes(javascript), null));
-            if (config.OutputFormatting != JsOutputFormatting.Formatted)
+            defaults.Add(new EmbeddedItem(mainJsName, utf8.GetBytes(javascript), null, Module: modules is not null));
+            // No minified sibling for a module entry: it carries `import` syntax the minifier is not
+            // set up for, and with only one variant the consumer copies it through in both configs.
+            if (config.OutputFormatting != JsOutputFormatting.Formatted && modules is null)
                 defaults.Add(new EmbeddedItem(ToMinName(mainJsName), utf8.GetBytes(JsMinifier.Minify(javascript, mainJsName, minifyLocalVariables)), null));
         }
         if (metaName is not null && !metaDeclared)
@@ -386,7 +413,7 @@ internal static class OutputBuilder
     /// <summary>A JavaScript resource loaded from a package (a runtime bundle or embedded library
     /// code), with its file name (for pairing a formatted variant with its <c>.min.js</c>), the
     /// output-relative path it extracts to, and its text.</summary>
-    private readonly record struct EmbeddedJs(string FileName, string Rel, string Text, bool Load = true);
+    private readonly record struct EmbeddedJs(string FileName, string Rel, string Text, bool Load = true, bool Module = false);
 
     /// <summary>
     /// Read-only access to one assembly's embedded resources, opened and closed around the extraction —
@@ -453,7 +480,7 @@ internal static class OutputBuilder
         var manifestName = names.FirstOrDefault(n => n.EndsWith("Transpose.Resources.json", StringComparison.OrdinalIgnoreCase));
         if (manifestName is null) return jsFiles;
 
-        List<(string fileName, string? path, bool load)> entries;
+        List<(string fileName, string? path, bool load, bool module)> entries;
         using (var ms = asm.Open(manifestName))
         using (var sr = new StreamReader(ms))
         using (var doc = JsonDocument.Parse(sr.ReadToEnd(), new JsonDocumentOptions { AllowTrailingCommas = true }))
@@ -462,9 +489,10 @@ internal static class OutputBuilder
                 .Select(e => (
                     fileName: e.TryGetProperty("FileName", out var f) ? f.GetString() : null,
                     path: e.TryGetProperty("Path", out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null,
-                    load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False))   // absent → true
+                    load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False,   // absent → true
+                    module: e.TryGetProperty("Module", out var mo) && mo.ValueKind == JsonValueKind.True))
                 .Where(x => !string.IsNullOrEmpty(x.fileName))
-                .Select(x => (x.fileName!, x.path, x.load))
+                .Select(x => (x.fileName!, x.path, x.load, x.module))
                 .ToList();
         }
 
@@ -474,7 +502,7 @@ internal static class OutputBuilder
         string Rel(string fileName, string? path)
             => string.IsNullOrEmpty(path) ? Path.GetFileName(fileName) : path!.Replace('\\', '/').TrimEnd('/') + "/" + Path.GetFileName(fileName);
 
-        foreach (var (fileName, path, load) in entries)
+        foreach (var (fileName, path, load, module) in entries)
         {
             var resName = names.FirstOrDefault(n => n.Equals(fileName, StringComparison.OrdinalIgnoreCase))
                           ?? names.FirstOrDefault(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
@@ -486,7 +514,7 @@ internal static class OutputBuilder
             {
                 using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
-                jsFiles.Add(new EmbeddedJs(Path.GetFileName(fileName), rel, reader.ReadToEnd(), load));
+                jsFiles.Add(new EmbeddedJs(Path.GetFileName(fileName), rel, reader.ReadToEnd(), load, module));
             }
             else
             {
@@ -842,7 +870,7 @@ internal static class OutputBuilder
         // (Path — null/empty means the site root), and whether it is injected into index.html (Load).
         // A package without a manifest (the base runtime) surfaces only its .js/.css resources at the
         // site root — other resource types can't be identified, nor their output path recovered, without it.
-        List<(string fileName, string? path, bool load)> entries;
+        List<(string fileName, string? path, bool load, bool module)> entries;
         if (manifest is not null)
         {
             using var ms = asm.Open(manifest);
@@ -852,9 +880,10 @@ internal static class OutputBuilder
                 .Select(e => (
                     fileName: e.TryGetProperty("FileName", out var f) ? f.GetString() : null,
                     path: e.TryGetProperty("Path", out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null,
-                    load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False))   // absent → true
+                    load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False,   // absent → true
+                    module: e.TryGetProperty("Module", out var mo) && mo.ValueKind == JsonValueKind.True))
                 .Where(x => !string.IsNullOrEmpty(x.fileName))
-                .Select(x => (x.fileName!, x.path, x.load))
+                .Select(x => (x.fileName!, x.path, x.load, x.module))
                 .ToList();
         }
         else
@@ -862,11 +891,11 @@ internal static class OutputBuilder
             entries = resourceNames
                 .Where(n => n.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
                             || n.EndsWith(".css", StringComparison.OrdinalIgnoreCase))
-                .Select(n => (n, (string?)null, true))
+                .Select(n => (n, (string?)null, true, false))
                 .ToList();
         }
 
-        foreach (var (fileName, path, load) in entries)
+        foreach (var (fileName, path, load, module) in entries)
         {
             var resName = resourceNames.FirstOrDefault(n => n.Equals(fileName, StringComparison.OrdinalIgnoreCase))
                           ?? resourceNames.FirstOrDefault(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
@@ -882,7 +911,7 @@ internal static class OutputBuilder
             {
                 using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
-                jsFiles.Add(new EmbeddedJs(leaf, rel, reader.ReadToEnd(), load));   // JS: placed/minified by RoutePackageJs
+                jsFiles.Add(new EmbeddedJs(leaf, rel, reader.ReadToEnd(), load, module));   // JS: placed/minified by RoutePackageJs
             }
             else
             {

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -344,7 +344,10 @@ internal static class ProjectBuild
                 assemblyVersion: options.AssemblyVersion,
                 emitDebugInformation: project.EmitDebugInformation,
                 metadataOnlyAssembly: metadataOnly,
-                incremental: plan);
+                incremental: plan,
+                // Only a site build can emit modules: a package DLL embeds one bundle for its
+                // consumer to extract, and there is no place in that protocol for chunk files yet.
+                emitModules: isSiteBuild && tpscfg is { OutputByModule: true });
         }
         catch (Exception ex)
         {
@@ -398,11 +401,14 @@ internal static class ProjectBuild
 
             var outDir = SiteDirectory(options, config, project);
             var siteResult = PhaseTimings.Measure("write site (minify + resources + html)", () =>
-                OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript, options.LiveReloadScript));
+                OutputBuilder.Build(project, config, js, outDir, configuration, result.MetadataJavascript, options.LiveReloadScript, result.Modules));
             // Every file in the site counts as an output: a rebuild must notice if any of them was
             // deleted or edited, otherwise "up to date" would leave a broken site in place.
             SaveCache(cache, plan, result, SiteOutputs(outDir, dllPath));
             log.Info($"\nOK — built site in {outDir} ({js.Length:N0} bytes of {config.FileName}) in {sw.ElapsedMilliseconds} ms.");
+            if (result.Modules is { } mods)
+                log.Info($"  modules:    {mods.Chunks.Count} chunk(s) — {mods.EagerChunkCount} loaded up front, " +
+                         $"{mods.LazyChunkCount} on demand ({mods.LazyTypeCount} type(s) deferred)");
             log.Info($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
             if (dllPath is not null) log.Info($"  dll:        {dllPath}");
             if (siteResult.RemovedStaleFiles.Count > 0)

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -328,6 +328,12 @@ internal static class ProjectBuild
 
         var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
 
+        // Module mode applies to a site build AND to a package (--emit-package): a library emits its
+        // chunks and publishes the map, and its consumer imports the chunks behind the types it uses.
+        var wantsModules = tpscfg is { OutputByModule: true } && (isSiteBuild || options.EmitPackage);
+        // Every referenced assembly that was itself built as modules contributes its type → chunk map.
+        var externalChunks = wantsModules ? ModuleMap.Read(project.ReferencePaths) : null;
+
         var translator = new RoslynTranslator();
         AssemblyBuildResult result;
         try
@@ -345,9 +351,13 @@ internal static class ProjectBuild
                 emitDebugInformation: project.EmitDebugInformation,
                 metadataOnlyAssembly: metadataOnly,
                 incremental: plan,
-                // Only a site build can emit modules: a package DLL embeds one bundle for its
-                // consumer to extract, and there is no place in that protocol for chunk files yet.
-                emitModules: isSiteBuild && tpscfg is { OutputByModule: true });
+                emitModules: wantsModules,
+                // Per assembly, so two module-mode assemblies in one site cannot collide.
+                chunkDirectory: "chunks/" + project.AssemblyName,
+                externalChunks: externalChunks,
+                // A library has no entry point to be lazy relative to: nothing is eager beyond its
+                // [Ready] handlers, and its consumers pull in what they actually use.
+                packageModules: options.EmitPackage);
         }
         catch (Exception ex)
         {
@@ -380,6 +390,9 @@ internal static class ProjectBuild
             SaveCache(cache, plan, result, new[] { dllPath });
             log.Info($"\nOK — built package {project.AssemblyName}.dll ({result.AssemblyBytes!.Length:N0} bytes) with {items.Count} embedded resource(s) in {sw.ElapsedMilliseconds} ms.");
             log.Info($"  dll:      {dllPath}");
+            if (result.Modules is { } pkgMods)
+                log.Info($"  modules:    {pkgMods.Chunks.Count} chunk(s) — {pkgMods.EagerChunkCount} loaded up front, " +
+                         $"{pkgMods.LazyChunkCount} on demand ({pkgMods.LazyTypeCount} type(s) deferred)");
             log.Info($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
             return BuildOutcome.NoSite(0, result.Diagnostics);
         }
@@ -784,7 +797,14 @@ internal static class ProjectBuild
                 assemblyVersion: assemblyVersion,
                 emitDebugInformation: project.EmitDebugInformation,
                 metadataOnlyAssembly: metadataOnly,
-                incremental: plan);
+                incremental: plan,
+                // A referenced project is always built as a package, and it declares module output
+                // the same way a root project does. Without this the dependency would be rebuilt as
+                // a single bundle here, silently replacing the chunked DLL its own build produced.
+                emitModules: tpscfg is { OutputByModule: true },
+                chunkDirectory: "chunks/" + project.AssemblyName,
+                externalChunks: tpscfg is { OutputByModule: true } ? ModuleMap.Read(project.ReferencePaths) : null,
+                packageModules: true);
         }
         catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex, log); return false; }
 
@@ -826,8 +846,17 @@ internal static class ProjectBuild
         Directory.CreateDirectory(Path.GetDirectoryName(dllPath)!);
 
         var items = PhaseTimings.Measure("collect package resources (minify + read files)", () => config is not null
-            ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables)
+            ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables, result.Modules)
             : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) });
+
+        // A module-mode package's entry file is an ES module (it imports its eager chunks), so the
+        // consumer has to script it as one rather than as a classic deferred script.
+        if (result.Modules is not null)
+        {
+            for (var i = 0; i < items.Count; i++)
+                if (string.Equals(items[i].Name, mainJsName, StringComparison.OrdinalIgnoreCase))
+                    items[i] = items[i] with { Module = true };
+        }
         // Cecil re-serializes the assembly's metadata when embedding the resources; encoding a
         // parameter's default value whose type lives in a referenced assembly (e.g. a Tesserae enum)
         // makes it resolve that assembly. Seed the resolver with the reference directories so those
@@ -835,7 +864,7 @@ internal static class ProjectBuild
         // next to this DLL).
         // Writes the DLL — the emitted assembly plus the embedded resources — in one pass.
         PhaseTimings.Measure("embed resources into DLL (Cecil)",
-            () => ResourceEmbedder.Embed(dllPath, result.AssemblyBytes!, items, project.ReferencePaths));
+            () => ResourceEmbedder.Embed(dllPath, result.AssemblyBytes!, items, project.ReferencePaths, result.Modules?.TypeToChunk));
         // Record what a consumer's compilation actually depends on — this assembly's metadata — so a
         // rebuild of this project does not force a rebuild of everything referencing it when only its
         // method bodies moved. Cecil restamps the DLL's MVID on every embed, so its bytes cannot serve.

--- a/Transpose/Transpose.Compiler.Core/ResourceEmbedder.cs
+++ b/Transpose/Transpose.Compiler.Core/ResourceEmbedder.cs
@@ -6,7 +6,7 @@ namespace Transpose.Compiler;
 
 /// <summary>One embedded Transpose resource: the file bytes plus its manifest entry. <see cref="Output"/>
 /// is the output subdirectory a consumer extracts it to (null for a top-level script).</summary>
-internal sealed record EmbeddedItem(string Name, byte[] Content, string? Output, bool Load = true);
+internal sealed record EmbeddedItem(string Name, byte[] Content, string? Output, bool Load = true, bool Module = false);
 
 /// <summary>
 /// Embeds the compiled JavaScript (and tps.json resource files) into a .NET assembly as private
@@ -22,6 +22,17 @@ internal sealed record EmbeddedItem(string Name, byte[] Content, string? Output,
 internal static class ResourceEmbedder
 {
     private const string ManifestName = "Transpose.Resources.json";
+
+    /// <summary>
+    /// The chunk map a module-mode package publishes: emitted type name → the site-relative chunk
+    /// file that defines it. A consuming build reads this so its own chunks can import the chunk
+    /// behind a library type they use — without it the reference would land on the library's stub,
+    /// and a stub cannot be resolved synchronously.
+    ///
+    /// Embedded but deliberately NOT listed in <see cref="ManifestName"/>: it is build metadata for
+    /// the next compiler, not a web resource, so no consumer extracts it into a site.
+    /// </summary>
+    public const string ModuleMapName = "Transpose.Modules.json";
     private static readonly UTF8Encoding Utf8NoBom = new(false);
 
     /// <summary>True if the assembly already carries the embedded Transpose resource manifest — i.e. it
@@ -45,10 +56,10 @@ internal static class ResourceEmbedder
     /// with the JS, CSS and fonts embedded, a package DLL runs to tens of megabytes, and writing it
     /// once and then reading it straight back only to rewrite it was pure I/O.
     /// </summary>
-    public static void Embed(string assemblyPath, byte[] assemblyBytes, IReadOnlyList<EmbeddedItem> items, IEnumerable<string>? referencePaths = null)
+    public static void Embed(string assemblyPath, byte[] assemblyBytes, IReadOnlyList<EmbeddedItem> items, IEnumerable<string>? referencePaths = null, IReadOnlyDictionary<string, string>? moduleMap = null)
     {
         using var output = File.Create(assemblyPath);
-        Embed(output, assemblyBytes, items, referencePaths, contextDirectory: Path.GetDirectoryName(Path.GetFullPath(assemblyPath)));
+        Embed(output, assemblyBytes, items, referencePaths, contextDirectory: Path.GetDirectoryName(Path.GetFullPath(assemblyPath)), moduleMap: moduleMap);
     }
 
     /// <summary>
@@ -60,7 +71,8 @@ internal static class ResourceEmbedder
     /// path (a copy-local referenced assembly can sit there); pass null when there is no such directory.
     /// </summary>
     public static void Embed(Stream output, byte[] assemblyBytes, IReadOnlyList<EmbeddedItem> items,
-        IEnumerable<string>? referencePaths = null, string? contextDirectory = null)
+        IEnumerable<string>? referencePaths = null, string? contextDirectory = null,
+        IReadOnlyDictionary<string, string>? moduleMap = null)
     {
         // Cecil resolves referenced assemblies when it re-serializes metadata on Write() — e.g. to
         // determine the underlying type of a parameter's default value whose type is a referenced
@@ -86,6 +98,10 @@ internal static class ResourceEmbedder
         var manifest = items.Select(i => new
         {
             FileName = i.Name,
+            // Module: the consumer scripts this file as <script type="module"> instead of a classic
+            // deferred script. Only a module-mode package's entry file sets it; its chunk files are
+            // Load=false and are reached through that entry's imports.
+            Module = i.Module ? (bool?)true : null,
             Name = i.Name,
             Path = i.Output,
             Parts = (object?)null,
@@ -98,6 +114,9 @@ internal static class ResourceEmbedder
         // type-level remarks). Replace rather than add, so re-embedding an assembly that already
         // carries one restamps it instead of leaving two.
         Replace(BuildStamp.ResourceName, BuildStamp.ForCurrentCompiler().ToJsonBytes());
+
+        if (moduleMap is { Count: > 0 })
+            Replace(ModuleMapName, Utf8NoBom.GetBytes(JsonSerializer.Serialize(moduleMap)));
 
         asm.Write(output);
     }

--- a/Transpose/Transpose.Compiler.Core/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler.Core/TransposeJson.cs
@@ -56,6 +56,10 @@ internal sealed class TransposeJson
     /// </summary>
     public string? OutputBy { get; init; }
 
+    /// <summary>True when <c>outputBy</c> asks for the ES-module layout: one file per chunk plus an
+    /// entry module, instead of a single bundle. See TODO.modules.md.</summary>
+    public bool OutputByModule => string.Equals(OutputBy, "Module", System.StringComparison.OrdinalIgnoreCase);
+
     /// <summary>
     /// <c>cleanOutputFolder</c> — prune stale files from the site output folder after a build:
     /// any file left over from a previous build that <em>this</em> build did not (re)write is

--- a/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
@@ -393,5 +393,66 @@ public class Program
             StringAssert.Contains(output, "after: 1");
             StringAssert.Contains(output, "<<DONE>>");
         }
+
+        /// <summary>An OPEN generic base — `class Relay&lt;T&gt; : IHandler&lt;T&gt;` — has no
+        /// argument to write into the manifest, so the spec is the bare definition name. The stub
+        /// still has to answer exactly what the loaded definition answers, which means applying that
+        /// definition to its own placeholder type parameters rather than reporting it bare.</summary>
+        private const string OpenBasePreamble = @"
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Transpose;
+
+public interface IHandler<T> { void Handle(T item); }
+public class Order { public int Id; }
+public class Relay<T> : IHandler<T> { public void Handle(T item) { } }
+
+public static class OpenChunk
+{
+    public static void Register()
+    {
+        Modules.Register(Script.Write<object>(
+            @""{ 'StubRelay$1': { m: 'chunk-5.mjs', k: 'class', a: 'App', i: ['IHandler$1'] } }""));
+    }
+}
+";
+
+        [TestMethod]
+        public async Task AnOpenGenericBaseAnswersAsTheLoadedDefinitionDoesAsync()
+        {
+            var output = await RunTest(OpenBasePreamble + @"
+public class Program
+{
+    public static void Main()
+    {
+        OpenChunk.Register();
+
+        // Relay<T> is really here; StubRelay<T> is the same shape, deferred.
+        var loaded = typeof(Relay<>);
+        var stub   = Type.GetType(""StubRelay$1"");
+
+        Console.WriteLine(""constructed: "" + typeof(IHandler<Order>).IsAssignableFrom(loaded)
+                                             + ""/"" + typeof(IHandler<Order>).IsAssignableFrom(stub));
+        Console.WriteLine(""open: "" + typeof(IHandler<>).IsAssignableFrom(loaded)
+                                     + ""/"" + typeof(IHandler<>).IsAssignableFrom(stub));
+        Console.WriteLine(""ifaces: "" + loaded.GetInterfaces().Length + ""/"" + stub.GetInterfaces().Length);
+        Console.WriteLine(""stillStub: "" + Modules.IsStub(stub));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            // Every answer is the loaded one. Reporting the bare definition instead made the middle
+            // row True/False — a stub matching an unbound typeof that the real type does not match —
+            // and left GetInterfaces() empty, because a definition object carries $kind "class"
+            // whether or not it defines an interface.
+            StringAssert.Contains(output, "constructed: False/False");
+            StringAssert.Contains(output, "open: False/False");
+            StringAssert.Contains(output, "ifaces: 1/1");
+            StringAssert.Contains(output, "stillStub: True");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
@@ -299,5 +299,99 @@ public class Program
             StringAssert.Contains(output, "attempts: 2");
             StringAssert.Contains(output, "<<DONE>>");
         }
+
+        /// <summary>A deferred type whose base class AND interface are CONSTRUCTED generics — the
+        /// manifest carries them as [definition, ...arguments] rather than a flattened name, because
+        /// a constructed generic is a distinct runtime object built by applying the definition.</summary>
+        private const string GenericPreamble = @"
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Transpose;
+
+public interface IHandler<T> { void Handle(T item); }
+public class Order { public int Id; }
+public class Repo<T> { public T Get() { return default(T); } }
+
+public class EagerHandler : IHandler<Order> { public void Handle(Order item) { } }
+
+public static class GenericChunk
+{
+    // What a module build emits for a deferred `class LazyHandler : Repo<Order>, IHandler<Order>`.
+    public static void Register()
+    {
+        Modules.Register(Script.Write<object>(
+            @""{ 'LazyHandler': { m: 'chunk-2.mjs', k: 'class', a: 'App', i: [['Repo$1', 'Order'], ['IHandler$1', 'Order']] } }""));
+    }
+}
+";
+
+        [TestMethod]
+        public async Task IsAssignableFromAConstructedGenericAnswersFromAStubAsync()
+        {
+            var output = await RunTest(GenericPreamble + @"
+public class Program
+{
+    public static void Main()
+    {
+        GenericChunk.Register();
+        var t = Type.GetType(""LazyHandler"");
+
+        Console.WriteLine(""iface: "" + typeof(IHandler<Order>).IsAssignableFrom(t));
+        Console.WriteLine(""baseClass: "" + typeof(Repo<Order>).IsAssignableFrom(t));
+        Console.WriteLine(""ifaceCount: "" + t.GetInterfaces().Length);
+        Console.WriteLine(""stillStub: "" + Modules.IsStub(t));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            // Applying the definition is what produces the object varianceAssignable compares
+            // against: it matches on $genericTypeDefinition + $typeArguments, and a bare definition
+            // object carries neither, so a flattened `IHandler$1` in the manifest answered False.
+            StringAssert.Contains(output, "iface: True");
+            StringAssert.Contains(output, "baseClass: True");
+            // getInterfaces() reads $allInterfaces, which a stub did not set at all — so
+            // Type.GetInterfaces() on a deferred type used to report nothing.
+            StringAssert.Contains(output, "ifaceCount: 1");
+            // None of this loaded the module: the answer comes from the manifest.
+            StringAssert.Contains(output, "stillStub: True");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task AnUnresolvableBaseIsRetriedRatherThanCachedAsync()
+        {
+            var output = await RunTest(GenericPreamble + @"
+public class Program
+{
+    public static void Main()
+    {
+        // Both the generic definition AND a type built on top of it are deferred. The base cannot
+        // be built while its own definition is a stub — applying a stub throws — so the answer has
+        // to stay open rather than being frozen as 'no bases'.
+        Modules.Register(Script.Write<object>(@""{
+            'DeferredBase$1': { m: 'chunk-3.mjs', k: 'class', a: 'App', i: [] },
+            'UsesDeferred':   { m: 'chunk-4.mjs', k: 'class', a: 'App', i: [['DeferredBase$1', 'Order']] }
+        }""));
+
+        Console.WriteLine(""before: "" + Script.Write<int>(
+            @""(Transpose.unroll('UsesDeferred').$$inherits || []).length""));
+
+        // The definition's chunk arrives and defines it for real, retiring its stub.
+        Script.Write(@""Transpose.define('DeferredBase$1', function (T) { return { }; });"");
+
+        Console.WriteLine(""after: "" + Script.Write<int>(
+            @""(Transpose.unroll('UsesDeferred').$$inherits || []).length""));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "before: 0");
+            StringAssert.Contains(output, "after: 1");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
@@ -1,0 +1,303 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The lazily-loaded module surface: <c>Transpose.Modules</c> (Resources/Modules.js) and
+    /// <c>Activator.CreateInstanceAsync</c>.
+    ///
+    /// A build that splits its output into JavaScript modules leaves the types it deferred as
+    /// *stubs*: registered at the same global path and in the same assembly <c>$types</c> map a real
+    /// <c>Transpose.define</c> would use, so reflection still enumerates and tests them, but with no
+    /// constructor behind them. Fetching the module is asynchronous, so instantiating such a type
+    /// cannot go through the synchronous <c>Activator.CreateInstance</c> — that throws and names the
+    /// module — and goes through <c>CreateInstanceAsync</c> instead.
+    ///
+    /// Every test runs with <c>skipRoslyn: true</c>: <c>CreateInstanceAsync</c> and
+    /// <c>Transpose.Modules</c> have no native .NET counterpart to diff against, so the assertions
+    /// are on the JS output. The loader is replaced with one that defines the type from C#, which
+    /// keeps the tests free of a real network fetch or a real ESM import.
+    /// </summary>
+    [TestClass]
+    public class LazyModuleActivatorTests : TranslatorTestBase
+    {
+        /// <summary>Shared preamble: a real interface + a real type, then a manifest declaring a
+        /// *second* type that only exists inside "chunk-1.mjs", with a loader that defines it.</summary>
+        private const string Preamble = @"
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Transpose;
+
+public interface IWidget { string Describe(); }
+
+public class EagerWidget : IWidget
+{
+    public string Describe() => ""eager"";
+}
+
+public static class Chunk
+{
+    public static int LoadCount;
+
+    // Stands in for a module the build deferred: registering the manifest creates a stub, and the
+    // loader is what a real build would satisfy with a dynamic import() of the chunk file.
+    public static void Register()
+    {
+        Modules.Register(Script.Write<object>(
+            @""{ 'LazyWidget': { m: 'chunk-1.mjs', k: 'class', a: 'App', i: ['IWidget'] } }""));
+    }
+
+    public static void InstallLoader()
+    {
+        Modules.SetLoader(url =>
+        {
+            LoadCount++;
+            // What the fetched chunk would have executed.
+            Script.Write(@""Transpose.define('LazyWidget', { inherits: [IWidget], alias: ['Describe', 'IWidget$Describe'], methods: { Describe: function () { return 'lazy'; } } });"");
+            return Task.CompletedTask;
+        });
+    }
+}
+";
+
+        [TestMethod]
+        public async Task StubIsVisibleToReflectionBeforeItsModuleLoadsAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static void Main()
+    {
+        Chunk.Register();
+
+        var t = Type.GetType(""LazyWidget"");
+        Console.WriteLine(""found: "" + (t != null));
+        Console.WriteLine(""name: "" + t.Name);
+        Console.WriteLine(""isInterface: "" + t.IsInterface);
+        Console.WriteLine(""assignable: "" + typeof(IWidget).IsAssignableFrom(t));
+        Console.WriteLine(""isLoaded: "" + Modules.IsLoaded(t));
+        Console.WriteLine(""isStub: "" + Modules.IsStub(t));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "found: True");
+            StringAssert.Contains(output, "name: LazyWidget");
+            StringAssert.Contains(output, "isInterface: False");
+            // The point of a stub: an interface scan finds the type while its code is absent.
+            StringAssert.Contains(output, "assignable: True");
+            StringAssert.Contains(output, "isLoaded: False");
+            StringAssert.Contains(output, "isStub: True");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task AssemblyGetTypesSeesAStubbedTypeAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static void Main()
+    {
+        var before = typeof(EagerWidget).Assembly.GetTypes()
+            .Count(x => typeof(IWidget).IsAssignableFrom(x) && !x.IsInterface);
+        Chunk.Register();
+        var after = typeof(EagerWidget).Assembly.GetTypes()
+            .Count(x => typeof(IWidget).IsAssignableFrom(x) && !x.IsInterface);
+
+        Console.WriteLine(""before: "" + before);
+        Console.WriteLine(""after: "" + after);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            // This is exactly how Tesserae's sample gallery discovers its samples, and the reason a
+            // module split must not hide a deferred type from Assembly.GetTypes().
+            StringAssert.Contains(output, "before: 1");
+            StringAssert.Contains(output, "after: 2");
+        }
+
+        [TestMethod]
+        public async Task SynchronousCreateInstanceOnAStubThrowsNamingTheModuleAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static void Main()
+    {
+        Chunk.Register();
+        var t = Type.GetType(""LazyWidget"");
+        try
+        {
+            Activator.CreateInstance(t);
+            Console.WriteLine(""no throw"");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(""threw: "" + ex.Message);
+        }
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            // A silent or obscure failure here is the trap: the sync path must say what is wrong.
+            StringAssert.Contains(output, "threw: ");
+            StringAssert.Contains(output, "LazyWidget");
+            StringAssert.Contains(output, "chunk-1.mjs");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task CreateInstanceAsyncLoadsTheModuleAndConstructsAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Chunk.Register();
+        Chunk.InstallLoader();
+
+        var t = Type.GetType(""LazyWidget"");
+        Console.WriteLine(""before isLoaded: "" + Modules.IsLoaded(t));
+
+        var instance = await Activator.CreateInstanceAsync(t);
+        Console.WriteLine(""loads: "" + Chunk.LoadCount);
+        Console.WriteLine(""instance null: "" + (instance == null));
+        Console.WriteLine(""describe: "" + ((IWidget)instance).Describe());
+        Console.WriteLine(""after isLoaded: "" + Modules.IsLoaded(Type.GetType(""LazyWidget"")));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "before isLoaded: False");
+            StringAssert.Contains(output, "loads: 1");
+            StringAssert.Contains(output, "instance null: False");
+            // The real class replaced the stub, and the instance behaves like the real type.
+            StringAssert.Contains(output, "describe: lazy");
+            StringAssert.Contains(output, "after isLoaded: True");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task LoadAsyncIsIdempotentAndFetchesOnceAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Chunk.Register();
+        Chunk.InstallLoader();
+
+        var t = Type.GetType(""LazyWidget"");
+        var a = await Modules.LoadAsync(t);
+        var b = await Modules.LoadAsync(t);
+        var c = await Modules.LoadAsync(""LazyWidget"");
+
+        Console.WriteLine(""loads: "" + Chunk.LoadCount);
+        Console.WriteLine(""same: "" + (a == b && b == c));
+        Console.WriteLine(""stub now: "" + Modules.IsStub(a));
+
+        // Awaiting a type that was never deferred is a no-op, so a call site can await
+        // unconditionally without knowing whether the type was split out.
+        var eager = await Modules.LoadAsync(typeof(EagerWidget));
+        Console.WriteLine(""eager: "" + (eager == typeof(EagerWidget)));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "loads: 1");
+            StringAssert.Contains(output, "same: True");
+            StringAssert.Contains(output, "stub now: False");
+            StringAssert.Contains(output, "eager: True");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task CreateInstanceAsyncOnAnAlreadyLoadedTypeJustConstructsAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Chunk.InstallLoader();
+        var instance = await Activator.CreateInstanceAsync(typeof(EagerWidget));
+        Console.WriteLine(""describe: "" + ((IWidget)instance).Describe());
+        Console.WriteLine(""loads: "" + Chunk.LoadCount);
+
+        var generic = await Activator.CreateInstanceAsync<EagerWidget>();
+        Console.WriteLine(""generic: "" + generic.Describe());
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "describe: eager");
+            // No module was registered for it, so nothing was fetched.
+            StringAssert.Contains(output, "loads: 0");
+            StringAssert.Contains(output, "generic: eager");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        [TestMethod]
+        public async Task AFailedLoadRestoresTheStubAndCanBeRetriedAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Chunk.Register();
+
+        var attempts = 0;
+        Modules.SetLoader(url =>
+        {
+            attempts++;
+            if (attempts == 1) throw new InvalidOperationException(""network down"");
+            Script.Write(@""Transpose.define('LazyWidget', { inherits: [IWidget], alias: ['Describe', 'IWidget$Describe'], methods: { Describe: function () { return 'lazy'; } } });"");
+            return Task.CompletedTask;
+        });
+
+        try
+        {
+            await Activator.CreateInstanceAsync(Type.GetType(""LazyWidget""));
+            Console.WriteLine(""no throw"");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(""first threw: "" + ex.Message);
+        }
+
+        // The failure must not have erased the type: reflection still sees the stub, and a retry
+        // is allowed rather than being memoised as permanently failed.
+        var t = Type.GetType(""LazyWidget"");
+        Console.WriteLine(""still found: "" + (t != null));
+        Console.WriteLine(""still stub: "" + Modules.IsStub(t));
+
+        var instance = await Activator.CreateInstanceAsync(t);
+        Console.WriteLine(""retry describe: "" + ((IWidget)instance).Describe());
+        Console.WriteLine(""attempts: "" + attempts);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "first threw: ");
+            StringAssert.Contains(output, "still found: True");
+            StringAssert.Contains(output, "still stub: True");
+            StringAssert.Contains(output, "retry describe: lazy");
+            StringAssert.Contains(output, "attempts: 2");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -19,12 +19,17 @@ namespace Transpose.Translator.Tests
     [TestClass]
     public class ModuleEmitTests : TranslatorTestBase
     {
-        private static Emitter.ModuleOutput Emit(string source)
+        private static Emitter.ModuleOutput Emit(
+            string source,
+            bool packageModules = false,
+            IReadOnlyDictionary<string, string>? externalChunks = null,
+            string chunkDirectory = "chunks")
         {
             var result = new RoslynTranslator().BuildAssembly(
                 new[] { ("App.cs", source) }, CompilationBuilder.DefaultAssemblyName,
                 extraReferencePaths: null, preprocessorSymbols: new[] { "DEBUG", "TRACE" },
-                emitAssembly: false, emitModules: true);
+                emitAssembly: false, emitModules: true,
+                chunkDirectory: chunkDirectory, externalChunks: externalChunks, packageModules: packageModules);
             if (!result.Success)
                 Assert.Fail("translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));
             return result.Modules!;
@@ -203,6 +208,74 @@ public class Program { public static void Main() { Console.WriteLine(new One().T
             Assert.AreEqual(a.EntryJs, b.EntryJs);
             CollectionAssert.AreEqual(a.Chunks.Select(c => c.relPath).ToList(), b.Chunks.Select(c => c.relPath).ToList());
             for (var i = 0; i < a.Chunks.Count; i++) Assert.AreEqual(a.Chunks[i].js, b.Chunks[i].js);
+        }
+
+        // ---- packages -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void ALibraryDefersEverythingItDoesNotHaveToRun()
+        {
+            var m = Emit(@"
+public class Widget { public int N; }
+public class Gadget { public Widget W = new Widget(); }
+", packageModules: true);
+
+            // A library has no entry point to be lazy relative to, so nothing is eager: its consumer's
+            // chunks import what they actually use, and the rest waits to be asked for. Making it all
+            // eager instead would produce chunk files that always load, which is strictly worse than
+            // one bundle.
+            Assert.AreEqual(0, m.EagerChunkCount);
+            Assert.AreEqual(m.Chunks.Count, m.LazyChunkCount);
+            StringAssert.Contains(m.EntryJs, "Transpose.Modules.register({");
+            Assert.IsFalse(m.EntryJs.Contains("import './chunks/"), "a library entry imports nothing");
+        }
+
+        [TestMethod]
+        public void ALibraryKeepsItsReadyHandlersEager()
+        {
+            var m = Emit(@"
+public class Widget { public int N; }
+public static class Boot
+{
+    [Transpose.Ready]
+    public static void Start() { System.Console.WriteLine(""up""); }
+}
+", packageModules: true);
+
+            // A [Ready] handler runs on load, so it cannot be deferred — its chunk (and whatever that
+            // chunk needs) is the library's eager set.
+            Assert.IsTrue(m.EagerChunkCount >= 1, "the [Ready] handler's chunk must load up front");
+            StringAssert.Contains(m.EntryJs, "import './chunks/");
+            StringAssert.Contains(m.EntryJs, "Transpose.ready(");
+        }
+
+        [TestMethod]
+        public void EveryEmittedTypeIsInThePublishedChunkMap()
+        {
+            var m = Emit(@"
+public class Alpha { public int N; }
+public class Beta { public Alpha A = new Alpha(); }
+public class Program { public static void Main() { System.Console.WriteLine(new Beta().A.N); } }
+");
+            // This map is what a package embeds for its consumers; a type missing from it would make
+            // the consumer emit no import and hit the library's stub at runtime.
+            foreach (var t in new[] { "Alpha", "Beta", "Program" })
+            {
+                Assert.IsTrue(m.TypeToChunk.ContainsKey(t), $"{t} is missing from the chunk map");
+                Assert.IsTrue(m.Chunks.Any(c => c.relPath == m.TypeToChunk[t]), $"{t} maps to a chunk that was not emitted");
+            }
+        }
+
+        /// <summary>The specifier a chunk uses to reach another chunk, possibly in a different
+        /// assembly's folder. <see cref="ModulePackageTests"/> covers the cross-assembly protocol
+        /// end to end; this pins the path arithmetic it depends on.</summary>
+        [TestMethod]
+        public void RelativeImportWalksBetweenChunkFolders()
+        {
+            Assert.AreEqual("./c2.mjs", Emitter.RelativeImport("chunks/app/c1.mjs", "chunks/app/c2.mjs"));
+            Assert.AreEqual("../lib/c9.mjs", Emitter.RelativeImport("chunks/app/c1.mjs", "chunks/lib/c9.mjs"));
+            Assert.AreEqual("./chunks/app/c1.mjs", Emitter.RelativeImport("app.js", "chunks/app/c1.mjs"));
+            Assert.AreEqual("../../top.mjs", Emitter.RelativeImport("chunks/app/c1.mjs", "top.mjs"));
         }
 
         [TestMethod]

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <c>outputBy: Module</c> — the emitter half of lazily-loaded modules (Emitter.Modules.cs).
+    ///
+    /// A chunk is a strongly-connected component of the reference graph, so the chunk graph is a DAG
+    /// and a chunk can pull in what it references with a side-effect <c>import</c>. Chunks reachable
+    /// from the entry point are imported by the entry module; the rest are declared to
+    /// <c>Transpose.Modules</c> and fetched on demand (see <see cref="LazyModuleActivatorTests"/> for
+    /// the runtime side).
+    /// </summary>
+    [TestClass]
+    public class ModuleEmitTests : TranslatorTestBase
+    {
+        private static Emitter.ModuleOutput Emit(string source)
+        {
+            var result = new RoslynTranslator().BuildAssembly(
+                new[] { ("App.cs", source) }, CompilationBuilder.DefaultAssemblyName,
+                extraReferencePaths: null, preprocessorSymbols: new[] { "DEBUG", "TRACE" },
+                emitAssembly: false, emitModules: true);
+            if (!result.Success)
+                Assert.Fail("translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));
+            return result.Modules!;
+        }
+
+        /// <summary>The chunk a type's <c>Transpose.define</c> was emitted into.</summary>
+        private static string ChunkOf(Emitter.ModuleOutput m, string typeName) =>
+            m.Chunks.First(c => Regex.IsMatch(c.js, @"Transpose\.definei?\(""" + Regex.Escape(typeName) + @"""")).relPath;
+
+        private static IEnumerable<string> ImportsOf(string js) =>
+            Regex.Matches(js, @"^import '\./(c\d+\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
+
+        [TestMethod]
+        public void MutuallyReferencingTypesShareOneChunk()
+        {
+            var m = Emit(@"
+public class Ping { public Pong Make() { return new Pong(); } }
+public class Pong { public Ping Make() { return new Ping(); } }
+public class Lonely { public int N; }
+public class Program { public static void Main() { System.Console.WriteLine(new Ping().Make()); } }
+");
+            // Ping <-> Pong is a cycle, so no import order could satisfy both: they have to be one
+            // chunk. This is the whole reason a chunk is an SCC rather than a single class.
+            Assert.AreEqual(ChunkOf(m, "Ping"), ChunkOf(m, "Pong"), "Ping and Pong must share a chunk");
+            Assert.AreNotEqual(ChunkOf(m, "Ping"), ChunkOf(m, "Lonely"), "an unrelated type must not be fused in");
+        }
+
+        [TestMethod]
+        public void ABaseTypeIsImportedByTheChunkThatExtendsIt()
+        {
+            var m = Emit(@"
+public class Animal { public virtual string Speak() { return ""...""; } }
+public class Dog : Animal { public override string Speak() { return ""woof""; } }
+public class Program { public static void Main() { System.Console.WriteLine(new Dog().Speak()); } }
+");
+            var baseChunk = ChunkOf(m, "Animal");
+            var derived = m.Chunks.First(c => c.relPath == ChunkOf(m, "Dog"));
+            Assert.AreNotEqual(baseChunk, derived.relPath, "a base and its subclass need not share a chunk");
+            // Transpose.define resolves `inherits` eagerly, so the base must already be defined.
+            CollectionAssert.Contains(ImportsOf(derived.js).ToList(),
+                System.IO.Path.GetFileName(baseChunk), "the derived chunk must import its base's chunk");
+        }
+
+        [TestMethod]
+        public void TypeofDoesNotCreateADependency()
+        {
+            var m = Emit(@"
+using System;
+public class Other { public int N; }
+public class Holder { public Type What() { return typeof(Other); } }
+public class Program { public static void Main() { Console.WriteLine(new Holder().What()); } }
+");
+            // typeof wants a Type object, which a Transpose.Modules stub already answers for. Making
+            // it a dependency would fuse together every type a `see also`-style list mentions.
+            var holder = m.Chunks.First(c => c.relPath == ChunkOf(m, "Holder"));
+            Assert.AreNotEqual(ChunkOf(m, "Other"), holder.relPath);
+            CollectionAssert.DoesNotContain(ImportsOf(holder.js).ToList(),
+                System.IO.Path.GetFileName(ChunkOf(m, "Other")));
+        }
+
+        [TestMethod]
+        public void ConstructionAndStaticAccessDoCreateADependency()
+        {
+            var m = Emit(@"
+using System;
+public class Made { public int N = 7; }
+public class Helper { public static int Twice(int n) { return n * 2; } }
+public class UsesBoth
+{
+    public int Go() { return Helper.Twice(new Made().N); }
+}
+public class Program { public static void Main() { Console.WriteLine(new UsesBoth().Go()); } }
+");
+            var user = m.Chunks.First(c => c.relPath == ChunkOf(m, "UsesBoth"));
+            var imports = ImportsOf(user.js).ToList();
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Made")), "new Made() is a dependency");
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Helper")), "a static call is a dependency");
+        }
+
+        [TestMethod]
+        public void TheChunkGraphIsADagInFileOrder()
+        {
+            var m = Emit(@"
+using System;
+public interface IShape { double Area(); }
+public class Square : IShape { public double S; public double Area() { return S * S; } }
+public class Circle : IShape { public double R; public double Area() { return R * R * 3.14; } }
+public class Pair { public Square A = new Square(); public Circle B = new Circle(); }
+public class Program { public static void Main() { Console.WriteLine(new Pair().A.Area()); } }
+");
+            // Chunks are numbered in topological order, so every import points at a LOWER index.
+            // That is what makes the side-effect imports sound and the file names deterministic.
+            foreach (var (relPath, js) in m.Chunks)
+            {
+                var self = int.Parse(Regex.Match(relPath, @"c(\d+)\.mjs").Groups[1].Value);
+                foreach (var dep in ImportsOf(js))
+                {
+                    var to = int.Parse(Regex.Match(dep, @"c(\d+)\.mjs").Groups[1].Value);
+                    Assert.IsTrue(to < self, $"{relPath} imports {dep}, which is not earlier in the order");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void OnlyTheEntryClosureIsImportedAndTheRestIsDeclared()
+        {
+            var m = Emit(@"
+using System;
+public interface IPlugin { string Run(); }
+public class Used : IPlugin { public string Run() { return ""used""; } }
+public class NeverReferenced : IPlugin { public string Run() { return ""lazy""; } }
+public class Program { public static void Main() { Console.WriteLine(new Used().Run()); } }
+");
+            Assert.IsTrue(m.LazyChunkCount > 0, "a type nothing references should have been deferred");
+            StringAssert.Contains(m.EntryJs, "Transpose.Modules.register({");
+            StringAssert.Contains(m.EntryJs, "\"NeverReferenced\": { m: \"./chunks/");
+            // ...and its declared base list is what lets IsAssignableFrom work while it is a stub.
+            StringAssert.Contains(m.EntryJs, "i: [\"IPlugin\"]");
+            // The entry never imports the deferred chunk.
+            var lazyChunk = System.IO.Path.GetFileName(ChunkOf(m, "NeverReferenced"));
+            Assert.IsFalse(m.EntryJs.Contains($"import './chunks/{lazyChunk}'"),
+                "the entry module must not statically import a deferred chunk");
+            Assert.IsTrue(m.EntryJs.Contains($"import './chunks/{System.IO.Path.GetFileName(ChunkOf(m, "Used"))}'"),
+                "the entry module must import what it reaches");
+        }
+
+        [TestMethod]
+        public void MetadataIsEmittedBeforeTheManifest()
+        {
+            var m = Emit(@"
+using System;
+public interface IPlugin { string Run(); }
+public class Deferred : IPlugin { public string Run() { return ""x""; } }
+public class Program { public static void Main() { Console.WriteLine(typeof(IPlugin)); } }
+");
+            var meta = m.EntryJs.IndexOf("var $m = Transpose.setMetadata", StringComparison.Ordinal);
+            var reg = m.EntryJs.IndexOf("Transpose.Modules.register(", StringComparison.Ordinal);
+            var init = m.EntryJs.IndexOf("Transpose.init();", StringComparison.Ordinal);
+            Assert.IsTrue(meta >= 0 && reg >= 0 && init >= 0, "entry module is missing one of its sections");
+            // register() ends with a Transpose.init(), and init runs the entry point — so metadata
+            // emitted after it would not exist yet when Main runs. This ordering is load-bearing:
+            // it is what kept Tesserae's [SampleDetails] attributes readable off the stubs.
+            Assert.IsTrue(meta < reg, "reflection metadata must be emitted before the manifest");
+            Assert.IsTrue(reg < init, "the manifest must be registered before the final init");
+        }
+
+        [TestMethod]
+        public void EveryTypeIsEmittedExactlyOnce()
+        {
+            var m = Emit(@"
+using System;
+public class A { public B B = new B(); }
+public class B { public C C = new C(); }
+public class C { public int N; }
+public class Program { public static void Main() { Console.WriteLine(new A().B.C.N); } }
+");
+            var defines = m.Chunks
+                .SelectMany(c => Regex.Matches(c.js, @"Transpose\.definei?\(""([^""]+)""").Select(x => x.Groups[1].Value))
+                .ToList();
+            CollectionAssert.AllItemsAreUnique(defines, "a type must not be emitted into two chunks");
+            foreach (var t in new[] { "A", "B", "C", "Program" }) CollectionAssert.Contains(defines, t);
+        }
+
+        [TestMethod]
+        public void OutputIsDeterministic()
+        {
+            const string src = @"
+using System;
+public class One { public Two T = new Two(); }
+public class Two { public One O; }
+public class Three { public int N; }
+public class Program { public static void Main() { Console.WriteLine(new One().T); } }
+";
+            var a = Emit(src);
+            var b = Emit(src);
+            Assert.AreEqual(a.EntryJs, b.EntryJs);
+            CollectionAssert.AreEqual(a.Chunks.Select(c => c.relPath).ToList(), b.Chunks.Select(c => c.relPath).ToList());
+            for (var i = 0; i < a.Chunks.Count; i++) Assert.AreEqual(a.Chunks[i].js, b.Chunks[i].js);
+        }
+
+        [TestMethod]
+        public async Task TheEmittedChunksRunAsync()
+        {
+            const string src = @"
+using System;
+public abstract class Shape { public abstract double Area(); }
+public class Square : Shape { public double S = 3; public override double Area() { return S * S; } }
+public class Program
+{
+    public static void Main()
+    {
+        Shape s = new Square();
+        Console.WriteLine(s.Area());
+        Console.WriteLine(typeof(Square).Name);
+    }
+}
+";
+            var m = Emit(src);
+
+            // Chunk indices are a topological order, so concatenating them in that order — with the
+            // side-effect imports stripped — reproduces exactly the evaluation order ES modules
+            // would give. That lets the emitted chunks run on plain Node.
+            var flat = string.Join("\n", m.Chunks.Select(c => Regex.Replace(c.js, @"^import '[^']+';$", "", RegexOptions.Multiline)));
+            var entry = Regex.Replace(m.EntryJs, @"^import '[^']+';$", "", RegexOptions.Multiline);
+            var full = RoslynTranslator.LoadRuntime() + "\n" + flat + "\n" + entry;
+
+            var output = (await NodeJsRunner.RunAsync(full)).Trim();
+            StringAssert.Contains(output, "9");
+            StringAssert.Contains(output, "Square");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -91,6 +91,77 @@ public class Program { public static void Main() { Console.WriteLine(new Holder(
         }
 
         [TestMethod]
+        public void TypeofAConstructedGenericDoesCreateADependency()
+        {
+            var m = Emit(@"
+using System;
+public class Box<T> { public T Value; }
+public class Item { public int N; }
+public class Holder { public Type What() { return typeof(Box<Item>); } }
+public class Program { public static void Main() { Console.WriteLine(new Holder().What()); } }
+");
+            // typeof is soft because a stub object satisfies it — but a CONSTRUCTED generic has no
+            // object to point at: TypeRefCore emits Box$1(Item), an application of the definition,
+            // and applying a stub throws. So both the definition and the argument are real
+            // dependencies, exactly as they are outside a typeof.
+            var holder = m.Chunks.First(c => c.relPath == ChunkOf(m, "Holder"));
+            var imports = ImportsOf(holder.js).ToList();
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Box$1")),
+                "typeof(Box<Item>) applies Box$1, so its chunk has to be imported");
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Item")),
+                "the type argument is applied to the definition, so it is a dependency too");
+        }
+
+        [TestMethod]
+        public void TypeofAnUnboundGenericStaysSoft()
+        {
+            var m = Emit(@"
+using System;
+public class Box<T> { public T Value; }
+public class Holder { public Type What() { return typeof(Box<>); } }
+public class Program { public static void Main() { Console.WriteLine(new Holder().What()); } }
+");
+            // An UNBOUND typeof emits the definition object itself, never an application, so a stub
+            // answers it and the soft-reference exemption still holds.
+            var holder = m.Chunks.First(c => c.relPath == ChunkOf(m, "Holder"));
+            Assert.AreNotEqual(ChunkOf(m, "Box$1"), holder.relPath);
+            CollectionAssert.DoesNotContain(ImportsOf(holder.js).ToList(),
+                System.IO.Path.GetFileName(ChunkOf(m, "Box$1")));
+        }
+
+        [TestMethod]
+        public void AConstructedGenericBaseKeepsItsTypeArgumentsInTheManifest()
+        {
+            var m = Emit(@"
+using System;
+public interface IHandler<T> { void Handle(T item); }
+public class Order { public int Id; }
+public class OrderHandler : IHandler<Order> { public void Handle(Order item) { } }
+public class Program { public static void Main() { Console.WriteLine(""hi""); } }
+");
+            // The stub has to report IHandler<Order>, not the bare definition IHandler$1: a
+            // constructed generic is a distinct runtime object, and varianceAssignable matches on
+            // $genericTypeDefinition + $typeArguments, which a definition object does not carry.
+            // The array form is what the runtime applies (Modules.$resolveType).
+            StringAssert.Contains(m.EntryJs, "i: [[\"IHandler$1\", \"Order\"]]");
+        }
+
+        [TestMethod]
+        public void AnOpenGenericBaseFallsBackToTheDefinitionName()
+        {
+            var m = Emit(@"
+using System;
+public interface IHandler<T> { void Handle(T item); }
+public class Relay<T> : IHandler<T> { public void Handle(T item) { } }
+public class Program { public static void Main() { Console.WriteLine(""hi""); } }
+");
+            // `Relay<T> : IHandler<T>` has no argument to write down — T does not exist until the
+            // definition is applied — so the manifest reports the definition-level relationship and
+            // a question about one instantiation still needs the module.
+            StringAssert.Contains(m.EntryJs, "i: [\"IHandler$1\"]");
+        }
+
+        [TestMethod]
         public void ConstructionAndStaticAccessDoCreateADependency()
         {
             var m = Emit(@"

--- a/Transpose/Transpose.Translator.Tests/ModulePackageTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModulePackageTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// The cross-assembly half of <c>outputBy: Module</c>: what a module-mode <em>package</em> embeds,
+/// and what a consuming site build does with it.
+///
+/// A library has no entry point to be lazy relative to, so it defers everything and publishes a chunk
+/// map — emitted type name → the chunk file that defines it. Its consumer reads that map and, for
+/// every library type its own code reaches into, imports the chunk behind it. Without that the
+/// reference would resolve to the library's stub, and a stub cannot be resolved synchronously.
+/// </summary>
+[TestClass]
+public sealed class ModulePackageTests
+{
+    private string _root = "", _appDir = "", _outputDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-modpkg-" + Guid.NewGuid().ToString("N"));
+        _appDir = Path.Combine(_root, "app");
+        _outputDir = Path.Combine(_root, "site");
+        Directory.CreateDirectory(_appDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [TestMethod]
+    public void APackagesChunksAreCopiedThroughAndItsEntryIsScriptedAsAModule()
+    {
+        var dll = LibraryPackage(out _);
+        var html = BuildSite(dll);
+
+        // The entry is the only thing index.html scripts, and it is scripted as a module because it
+        // carries `import` statements.
+        StringAssert.Contains(html, "<script type=\"module\" src=\"Lib.js\"></script>");
+        // The chunks are on disk for those imports (and for Transpose.Modules) to fetch...
+        AssertInOutput("chunks/Lib/c0.mjs");
+        AssertInOutput("chunks/Lib/c1.mjs");
+        // ...but are never scripted: a chunk that loaded itself would defeat the split.
+        Assert.IsFalse(html.Contains("c0.mjs"), "a chunk file must not be referenced from index.html");
+        Assert.IsFalse(html.Contains("c1.mjs"), "a chunk file must not be referenced from index.html");
+    }
+
+    [TestMethod]
+    public void APackagePublishesItsChunkMapForConsumersToImportFrom()
+    {
+        var dll = LibraryPackage(out var map);
+
+        // Read back exactly the way a consuming build does.
+        var read = ModuleMap.Read(new[] { dll });
+        CollectionAssert.AreEquivalent(map.Keys.ToList(), read.Keys.ToList());
+        foreach (var kv in map) Assert.AreEqual(kv.Value, read[kv.Key]);
+    }
+
+    [TestMethod]
+    public void TheChunkMapIsNotExtractedIntoTheSite()
+    {
+        var dll = LibraryPackage(out _);
+        BuildSite(dll);
+
+        // It is build metadata for the next compiler, not a web resource — like the BuildStamp, it is
+        // embedded but deliberately absent from Transpose.Resources.json, so nothing extracts it.
+        AssertNotInOutput("Transpose.Modules.json");
+        AssertNotInOutput("chunks/Lib/Transpose.Modules.json");
+    }
+
+    [TestMethod]
+    public void AReferenceWithNoChunkMapContributesNothing()
+    {
+        // An ordinary single-bundle package: reading its (absent) map must be empty rather than
+        // throwing, so a site can mix module-mode and single-bundle references.
+        var plain = PackageDll("Plain", new List<EmbeddedItem> { new("Plain.js", System.Text.Encoding.UTF8.GetBytes("var p = 1;"), null) }, moduleMap: null);
+        Assert.AreEqual(0, ModuleMap.Read(new[] { plain }).Count);
+    }
+
+    [TestMethod]
+    public void MapsFromSeveralReferencesMerge()
+    {
+        var a = PackageDll("A", new List<EmbeddedItem>(), new Dictionary<string, string> { ["A.One"] = "chunks/A/c0.mjs" });
+        var b = PackageDll("B", new List<EmbeddedItem>(), new Dictionary<string, string> { ["B.Two"] = "chunks/B/c3.mjs" });
+
+        var merged = ModuleMap.Read(new[] { a, b });
+        Assert.AreEqual(2, merged.Count);
+        Assert.AreEqual("chunks/A/c0.mjs", merged["A.One"]);
+        Assert.AreEqual("chunks/B/c3.mjs", merged["B.Two"]);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>A library package shaped exactly like one <c>tps --emit-package</c> produces in module
+    /// mode: two chunk files under its own per-assembly folder (never scripted), a module entry, and
+    /// the chunk map.</summary>
+    private string LibraryPackage(out Dictionary<string, string> map)
+    {
+        var utf8 = new System.Text.UTF8Encoding(false);
+        map = new Dictionary<string, string>
+        {
+            ["Lib.Widget"] = "chunks/Lib/c0.mjs",
+            ["Lib.Gadget"] = "chunks/Lib/c1.mjs",
+        };
+        var items = new List<EmbeddedItem>
+        {
+            new("c0.mjs", utf8.GetBytes("Transpose.$useAssembly(\"Lib\");\nTranspose.define(\"Lib.Widget\", {});\n"), "chunks/Lib", Load: false),
+            new("c1.mjs", utf8.GetBytes("import './c0.mjs';\nTranspose.$useAssembly(\"Lib\");\nTranspose.define(\"Lib.Gadget\", {});\n"), "chunks/Lib", Load: false),
+            new("Lib.js", utf8.GetBytes("Transpose.Modules.register({});\nTranspose.init();\n"), null, Load: true, Module: true),
+        };
+        return PackageDll("Lib", items, map);
+    }
+
+    private string PackageDll(string assemblyName, IReadOnlyList<EmbeddedItem> items, IReadOnlyDictionary<string, string>? moduleMap)
+    {
+        byte[] bytes;
+        using (var asm = AssemblyDefinition.CreateAssembly(
+                   new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)), assemblyName, ModuleKind.Dll))
+        using (var ms = new MemoryStream())
+        {
+            asm.Write(ms);
+            bytes = ms.ToArray();
+        }
+
+        var path = Path.Combine(_root, "packages", assemblyName + ".dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        ResourceEmbedder.Embed(path, bytes, items, referencePaths: null, moduleMap: moduleMap);
+        return path;
+    }
+
+    private string BuildSite(string packageDll)
+    {
+        File.WriteAllText(Path.Combine(_appDir, "tps.json"), @"{ ""fileName"": ""app.js"" }");
+        var config = TransposeJson.TryLoad(_appDir, "Debug");
+        Assert.IsNotNull(config);
+
+        var project = new ResolvedProject
+        {
+            CsprojPath = Path.Combine(_appDir, "App.csproj"),
+            ProjectDir = _appDir,
+            AssemblyName = "App",
+            TargetFramework = "netstandard2.0",
+            Sources = new List<(string, string)>(),
+            ReferencePaths = new List<string> { packageDll },
+            DefineConstants = new List<string>(),
+            LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+            ProjectDirs = new List<string> { _appDir },
+        };
+
+        OutputBuilder.Build(project, config!, "var app = 1;", _outputDir, "Debug");
+        var html = Path.Combine(_outputDir, "index.html");
+        Assert.IsTrue(File.Exists(html), "the build must generate index.html");
+        return File.ReadAllText(html);
+    }
+
+    private void AssertInOutput(string rel) => Assert.IsTrue(
+        File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))), rel + " should be in the site");
+
+    private void AssertNotInOutput(string rel) => Assert.IsFalse(
+        File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))), rel + " should NOT be in the site");
+}

--- a/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
+++ b/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
@@ -32,6 +32,13 @@ public sealed class AssemblyBuildResult
     /// </summary>
     public IReadOnlyDictionary<string, string>? DeclarationHashes { get; init; }
 
+    /// <summary>
+    /// The ES-module form of the same output, when the build asked for it (<c>outputBy: Module</c>).
+    /// <see cref="Javascript"/> then holds the entry module rather than a single bundle, and this
+    /// carries the chunk files alongside it. Null for an ordinary single-bundle build.
+    /// </summary>
+    public Emitter.ModuleOutput? Modules { get; init; }
+
     public IEnumerable<Diagnostic> Errors => Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
     public bool Success => Javascript is not null && !Errors.Any();
 }

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -84,7 +84,9 @@ public sealed class RoslynTranslator
         string? assemblyVersion = null,
         bool emitDebugInformation = true,
         bool metadataOnlyAssembly = false,
-        IncrementalPlan? incremental = null)
+        IncrementalPlan? incremental = null,
+        bool emitModules = false,
+        string chunkDirectory = "chunks")
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -205,6 +207,7 @@ public sealed class RoslynTranslator
             return new AssemblyBuildResult(null, null, null, diagnostics);
 
         string? js = null, metadataJs = null;
+        Emitter.ModuleOutput? moduleOutput = null;
         TranslationException? emitterFailure = null;
         try
         {
@@ -214,9 +217,21 @@ public sealed class RoslynTranslator
                 MetadataTarget = metadataTarget,
                 AssemblyVersion = string.IsNullOrWhiteSpace(assemblyVersion) ? "1.0.0.0" : assemblyVersion!,
             };
-            CompileProgress.Report("emitting JavaScript");
-            js = PhaseTimings.Measure("emit JavaScript", () => emitter.Emit());
-            metadataJs = emitter.MetadataScript;
+            if (emitModules)
+            {
+                // Module mode carries its reflection metadata inside the entry module (it has to be
+                // eager and cover every type, including the deferred ones), so there is no separate
+                // metadata script and the "javascript" of this build is the entry module.
+                CompileProgress.Report("emitting JavaScript modules");
+                moduleOutput = PhaseTimings.Measure("emit JavaScript (modules)", () => emitter.EmitModules(chunkDirectory));
+                js = moduleOutput.EntryJs;
+            }
+            else
+            {
+                CompileProgress.Report("emitting JavaScript");
+                js = PhaseTimings.Measure("emit JavaScript", () => emitter.Emit());
+                metadataJs = emitter.MetadataScript;
+            }
         }
         catch (TranslationException ex)
         {
@@ -263,6 +278,7 @@ public sealed class RoslynTranslator
         return new AssemblyBuildResult(js, metadataJs, assemblyBytes, diagnostics)
         {
             DeclarationHashes = declarationHashes,
+            Modules = moduleOutput,
         };
     }
 

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -86,7 +86,9 @@ public sealed class RoslynTranslator
         bool metadataOnlyAssembly = false,
         IncrementalPlan? incremental = null,
         bool emitModules = false,
-        string chunkDirectory = "chunks")
+        string chunkDirectory = "chunks",
+        IReadOnlyDictionary<string, string>? externalChunks = null,
+        bool packageModules = false)
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -223,7 +225,8 @@ public sealed class RoslynTranslator
                 // eager and cover every type, including the deferred ones), so there is no separate
                 // metadata script and the "javascript" of this build is the entry module.
                 CompileProgress.Report("emitting JavaScript modules");
-                moduleOutput = PhaseTimings.Measure("emit JavaScript (modules)", () => emitter.EmitModules(chunkDirectory));
+                moduleOutput = PhaseTimings.Measure("emit JavaScript (modules)",
+                    () => emitter.EmitModules(chunkDirectory, externalChunks, packageModules));
                 js = moduleOutput.EntryJs;
             }
             else

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -253,8 +253,16 @@ public sealed partial class Emitter
                 // Name/IsInterface/IsAssignableFrom/attributes just as well. Not treating it as a
                 // dependency is what keeps a "see also" list of typeof(...) from fusing every one
                 // of those types into a single chunk.
+                //
+                // A CONSTRUCTED generic is the exception, and it is not soft: it has no Type object
+                // to point at, it is BUILT by calling its definition — `Foo$1(Bar)` — and a stub
+                // throws when called. So the definition (and, per RecordRef, the arguments it is
+                // applied to) are real dependencies even here. RecordConstructedTypeRefs records
+                // exactly the pieces TypeRefCore will emit as a call.
+                var typeOfType = _model.GetTypeInfo(typeOf.Type).Type!;
+                RecordConstructedTypeRefs(typeOfType);
                 _softRefDepth++;
-                try { _w.Write(TypeRef(_model.GetTypeInfo(typeOf.Type).Type!)); }
+                try { _w.Write(TypeRef(typeOfType)); }
                 finally { _softRefDepth--; }
                 break;
             case IsPatternExpressionSyntax isPattern:

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -249,7 +249,13 @@ public sealed partial class Emitter
                 EmitConditionalAccess(condAccess);
                 break;
             case TypeOfExpressionSyntax typeOf:
-                _w.Write(TypeRef(_model.GetTypeInfo(typeOf.Type).Type!));
+                // `typeof(X)` wants the Type object, never X's code — a module-mode stub answers
+                // Name/IsInterface/IsAssignableFrom/attributes just as well. Not treating it as a
+                // dependency is what keeps a "see also" list of typeof(...) from fusing every one
+                // of those types into a single chunk.
+                _softRefDepth++;
+                try { _w.Write(TypeRef(_model.GetTypeInfo(typeOf.Type).Type!)); }
+                finally { _softRefDepth--; }
                 break;
             case IsPatternExpressionSyntax isPattern:
                 EmitIsPattern(isPattern);

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -25,6 +25,12 @@ public sealed partial class Emitter
         public int EagerChunkCount { get; init; }
         public int LazyChunkCount { get; init; }
         public int LazyTypeCount { get; init; }
+
+        /// <summary>Every emitted type's define name → the site-relative chunk file holding it. A
+        /// package embeds this so a consuming build can import the chunk behind a type it uses;
+        /// without it the consumer's reference would land on a stub it cannot resolve synchronously.
+        /// </summary>
+        public Dictionary<string, string> TypeToChunk { get; } = new(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -44,7 +50,17 @@ public sealed partial class Emitter
     /// unfetched, and are loaded on demand. A project with no entry point (a library) keeps
     /// everything eager — there is nothing to be lazy relative to.
     /// </summary>
-    public ModuleOutput EmitModules(string chunkDirectory = "chunks")
+    /// <param name="chunkDirectory">Site-relative folder the chunk files go in. Per assembly, so two
+    /// module-mode assemblies in one site cannot collide.</param>
+    /// <param name="externalChunks">Define name → site-relative chunk file, merged from every
+    /// referenced assembly that was itself built as modules.</param>
+    /// <param name="packageMode">A library: nothing is eager beyond what its own [Ready] handlers
+    /// need, because there is no entry point to be lazy relative to — the consumer's chunks import
+    /// what they use, and everything else stays a stub until something asks for it.</param>
+    public ModuleOutput EmitModules(
+        string chunkDirectory = "chunks",
+        IReadOnlyDictionary<string, string>? externalChunks = null,
+        bool packageMode = false)
     {
         var types = PhaseTimings.Measure("  ├ collect + order types", CollectTypes);
         var order = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
@@ -53,15 +69,18 @@ public sealed partial class Emitter
         // Emit every type once, recording what it references as we go.
         var bodies = new ConcurrentDictionary<INamedTypeSymbol, string>(SymbolEqualityComparer.Default);
         var refs = new ConcurrentDictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+        var extRefs = new ConcurrentDictionary<INamedTypeSymbol, HashSet<string>>(SymbolEqualityComparer.Default);
         try
         {
             PhaseTimings.Measure("  ├ emit type bodies (parallel)", () =>
                 Parallel.ForEach(types, type =>
                 {
                     var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-                    bodies[type] = EmitOnlyType(this, type, seen).ToString();
+                    var ext = externalChunks is null ? null : new HashSet<string>(StringComparer.Ordinal);
+                    bodies[type] = EmitOnlyType(this, type, seen, ext).ToString();
                     seen.Remove(type);
                     refs[type] = seen;
+                    if (ext is not null) extRefs[type] = ext;
                 }));
         }
         catch (AggregateException ex) when (ex.Flatten().InnerExceptions.OfType<TranslationException>().FirstOrDefault() is { } te)
@@ -72,14 +91,31 @@ public sealed partial class Emitter
         var chunks = PhaseTimings.Measure("  ├ chunk (strongly-connected components)",
             () => Chunk(types, refs, order));
 
-        // Eager set: the chunk holding the entry point, plus every chunk it transitively references.
-        var entry = _compilation.GetEntryPoint(default)?.ContainingType?.OriginalDefinition as INamedTypeSymbol;
+        // Eager set: the chunks the entry module has to import, closed over chunk dependencies.
+        //
+        //  - an application: the chunk holding Main;
+        //  - a library (packageMode): only the chunks holding [Ready] handlers, which run on load and
+        //    so cannot be deferred. Everything else waits to be imported by a consumer's chunk or
+        //    fetched on demand — a library has no entry point to be lazy relative to, and making it
+        //    all eager would defeat the split entirely;
+        //  - neither (a site build with no Main): everything, since nothing can be deferred safely.
+        var roots = new List<INamedTypeSymbol>();
+        if (packageMode)
+        {
+            roots.AddRange(types.Where(t => t.GetMembers().OfType<IMethodSymbol>()
+                .Any(m => m.IsStatic && m.GetAttributes().Any(a => TransposeNaming.AttrIs(a, TransposeNaming.ReadyAttr)))));
+        }
+        else if (_compilation.GetEntryPoint(default)?.ContainingType?.OriginalDefinition is INamedTypeSymbol main)
+        {
+            roots.Add(main);
+        }
+
         var eager = new HashSet<int>();
-        if (entry is not null && chunks.IndexOf.TryGetValue(entry, out var entryChunk))
+        if (roots.Count > 0 || packageMode)
         {
             var stack = new Stack<int>();
-            eager.Add(entryChunk);
-            stack.Push(entryChunk);
+            foreach (var r in roots)
+                if (chunks.IndexOf.TryGetValue(r, out var c) && eager.Add(c)) stack.Push(c);
             while (stack.Count > 0)
                 foreach (var d in chunks.Deps[stack.Pop()])
                     if (eager.Add(d)) stack.Push(d);
@@ -100,6 +136,19 @@ public sealed partial class Emitter
             // two builds of the same sources produce byte-identical files.
             foreach (var d in chunks.Deps[i].OrderBy(x => x))
                 w.Append("import '").Append(RelativeImport(ChunkFile(i), ChunkFile(d))).Append("';\n");
+            // Cross-assembly: a referenced module-mode assembly's chunk holding a type this one uses.
+            // Without it the reference would resolve to that assembly's stub, and a stub cannot be
+            // resolved synchronously.
+            if (externalChunks is not null)
+            {
+                var wanted = new SortedSet<string>(StringComparer.Ordinal);
+                foreach (var t in chunks.Members[i])
+                    if (extRefs.TryGetValue(t, out var names))
+                        foreach (var n in names)
+                            if (externalChunks.TryGetValue(n, out var file)) wanted.Add(file);
+                foreach (var file in wanted)
+                    w.Append("import '").Append(RelativeImport(ChunkFile(i), file)).Append("';\n");
+            }
             // A bare Transpose.define outside the Transpose.assembly(...) wrapper has no ambient
             // assembly, so each chunk names its own before defining anything.
             w.Append("Transpose.$useAssembly(\"").Append(_assemblyName).Append("\");\n");
@@ -115,13 +164,15 @@ public sealed partial class Emitter
         for (var i = 0; i < chunks.Members.Count; i++)
             if (!eager.Contains(i)) lazyTypes.AddRange(chunks.Members[i]);
 
-        return new ModuleOutput
+        var result = new ModuleOutput
         {
             EntryJs = BuildEntryModule(types, chunks, eager, lazyTypes, ChunkFile),
             EagerChunkCount = eager.Count,
             LazyChunkCount = chunks.Members.Count - eager.Count,
             LazyTypeCount = lazyTypes.Count,
         }.With(output);
+        foreach (var t in types) result.TypeToChunk[MetaTypeDefName(t)] = ChunkFile(chunks.IndexOf[t]);
+        return result;
     }
 
     private sealed record ChunkGraph(
@@ -316,14 +367,22 @@ public sealed partial class Emitter
         return string.Join("\n", lines);
     }
 
-    /// <summary>A relative specifier from one chunk file to another. Both live in the same folder in
-    /// every layout emitted today, so this is just <c>./name</c>, but it is computed rather than
-    /// assumed so a nested chunk directory keeps working.</summary>
-    private static string RelativeImport(string from, string to)
+    /// <summary>
+    /// An ES module specifier from one site-relative file to another. Both may sit in different
+    /// per-assembly chunk folders (a consumer importing a library's chunk), so this walks up with
+    /// <c>../</c> as needed. Always explicitly relative — a bare name would be a bare specifier,
+    /// which the browser resolves through the import map rather than as a path.
+    /// </summary>
+    internal static string RelativeImport(string from, string to)
     {
-        var fromDir = from.Contains('/') ? from.Substring(0, from.LastIndexOf('/')) : "";
-        var toDir = to.Contains('/') ? to.Substring(0, to.LastIndexOf('/')) : "";
-        return fromDir == toDir ? "./" + to.Substring(toDir.Length == 0 ? 0 : toDir.Length + 1) : "./" + to;
+        var fromParts = from.Split('/');
+        var toParts = to.Split('/');
+        var common = 0;
+        while (common < fromParts.Length - 1 && common < toParts.Length - 1
+               && string.Equals(fromParts[common], toParts[common], StringComparison.Ordinal)) common++;
+        var up = fromParts.Length - 1 - common;
+        var prefix = up == 0 ? "./" : string.Concat(Enumerable.Repeat("../", up));
+        return prefix + string.Join("/", toParts.Skip(common));
     }
 }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Transpose.Translator;
+
+public sealed partial class Emitter
+{
+    /// <summary>
+    /// The result of an <c>outputBy: Module</c> emission: one ES module per chunk, plus the entry
+    /// module that imports the eagerly-needed ones and registers the rest.
+    /// </summary>
+    public sealed class ModuleOutput
+    {
+        /// <summary>Chunk files, output-relative path → JavaScript.</summary>
+        public List<(string relPath, string js)> Chunks { get; } = new();
+
+        /// <summary>The entry module: eager imports, the reflection metadata, the manifest of what
+        /// was deferred, and the runtime init. This is the only file index.html scripts.</summary>
+        public string EntryJs { get; init; } = "";
+
+        public int EagerChunkCount { get; init; }
+        public int LazyChunkCount { get; init; }
+        public int LazyTypeCount { get; init; }
+    }
+
+    /// <summary>
+    /// Emits the assembly as ES modules instead of one bundle.
+    ///
+    /// A chunk is a <b>strongly-connected component of the reference graph</b> — the graph
+    /// <see cref="TypeRef"/> recorded while emitting each type's body. That is the smallest sound
+    /// unit: <c>Transpose.define</c> resolves <c>inherits</c> eagerly (Class.js), so a type's bases
+    /// must already be defined when its define runs, and a per-class split cannot guarantee that in
+    /// the presence of a reference cycle. The condensation of an SCC graph is a DAG, so a chunk can
+    /// pull in every chunk it references with a side-effect <c>import</c> and the evaluation order
+    /// is always correct — no name rewriting, because every emitted type reference is already a
+    /// dotted global.
+    ///
+    /// Chunks reachable from the entry point are imported by the entry module; the rest are declared
+    /// to <c>Transpose.Modules</c> so reflection still sees their types while their code stays
+    /// unfetched, and are loaded on demand. A project with no entry point (a library) keeps
+    /// everything eager — there is nothing to be lazy relative to.
+    /// </summary>
+    public ModuleOutput EmitModules(string chunkDirectory = "chunks")
+    {
+        var types = PhaseTimings.Measure("  ├ collect + order types", CollectTypes);
+        var order = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        for (var i = 0; i < types.Count; i++) order[types[i]] = i;
+
+        // Emit every type once, recording what it references as we go.
+        var bodies = new ConcurrentDictionary<INamedTypeSymbol, string>(SymbolEqualityComparer.Default);
+        var refs = new ConcurrentDictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+        try
+        {
+            PhaseTimings.Measure("  ├ emit type bodies (parallel)", () =>
+                Parallel.ForEach(types, type =>
+                {
+                    var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+                    bodies[type] = EmitOnlyType(this, type, seen).ToString();
+                    seen.Remove(type);
+                    refs[type] = seen;
+                }));
+        }
+        catch (AggregateException ex) when (ex.Flatten().InnerExceptions.OfType<TranslationException>().FirstOrDefault() is { } te)
+        {
+            throw te;
+        }
+
+        var chunks = PhaseTimings.Measure("  ├ chunk (strongly-connected components)",
+            () => Chunk(types, refs, order));
+
+        // Eager set: the chunk holding the entry point, plus every chunk it transitively references.
+        var entry = _compilation.GetEntryPoint(default)?.ContainingType?.OriginalDefinition as INamedTypeSymbol;
+        var eager = new HashSet<int>();
+        if (entry is not null && chunks.IndexOf.TryGetValue(entry, out var entryChunk))
+        {
+            var stack = new Stack<int>();
+            eager.Add(entryChunk);
+            stack.Push(entryChunk);
+            while (stack.Count > 0)
+                foreach (var d in chunks.Deps[stack.Pop()])
+                    if (eager.Add(d)) stack.Push(d);
+        }
+        else
+        {
+            for (var i = 0; i < chunks.Members.Count; i++) eager.Add(i);
+        }
+
+        var dir = string.IsNullOrEmpty(chunkDirectory) ? "" : chunkDirectory.TrimEnd('/') + "/";
+        string ChunkFile(int i) => $"{dir}c{i}.mjs";
+
+        var output = new List<(string, string)>();
+        for (var i = 0; i < chunks.Members.Count; i++)
+        {
+            var w = new StringBuilder();
+            // Import order is the chunk index, which is the topological order Chunk() assigned, so
+            // two builds of the same sources produce byte-identical files.
+            foreach (var d in chunks.Deps[i].OrderBy(x => x))
+                w.Append("import '").Append(RelativeImport(ChunkFile(i), ChunkFile(d))).Append("';\n");
+            // A bare Transpose.define outside the Transpose.assembly(...) wrapper has no ambient
+            // assembly, so each chunk names its own before defining anything.
+            w.Append("Transpose.$useAssembly(\"").Append(_assemblyName).Append("\");\n");
+            foreach (var t in chunks.Members[i])
+            {
+                w.Append(Dedent(bodies[t]));
+                w.Append('\n');
+            }
+            output.Add((ChunkFile(i), w.ToString()));
+        }
+
+        var lazyTypes = new List<INamedTypeSymbol>();
+        for (var i = 0; i < chunks.Members.Count; i++)
+            if (!eager.Contains(i)) lazyTypes.AddRange(chunks.Members[i]);
+
+        return new ModuleOutput
+        {
+            EntryJs = BuildEntryModule(types, chunks, eager, lazyTypes, ChunkFile),
+            EagerChunkCount = eager.Count,
+            LazyChunkCount = chunks.Members.Count - eager.Count,
+            LazyTypeCount = lazyTypes.Count,
+        }.With(output);
+    }
+
+    private sealed record ChunkGraph(
+        List<List<INamedTypeSymbol>> Members,
+        List<HashSet<int>> Deps,
+        Dictionary<INamedTypeSymbol, int> IndexOf);
+
+    /// <summary>
+    /// Groups the types into strongly-connected components of the reference graph and returns the
+    /// condensation, indexed so that a chunk's dependencies always have a lower index than itself
+    /// (a topological order) — which makes both the import lists and the file names deterministic.
+    /// </summary>
+    private static ChunkGraph Chunk(
+        List<INamedTypeSymbol> types,
+        ConcurrentDictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>> refs,
+        Dictionary<INamedTypeSymbol, int> order)
+    {
+        // Iterative Tarjan — the graph is a whole project's type graph, deep enough to blow a
+        // recursive walk's stack. Tarjan emits each component only after every component it points
+        // at, so the emission order is already a reverse-topological order of the condensation.
+        var index = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        var low = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        var onStack = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var stack = new Stack<INamedTypeSymbol>();
+        var components = new List<List<INamedTypeSymbol>>();
+        var next = 0;
+
+        // Deterministic successor order, so the component numbering never depends on hash order.
+        List<INamedTypeSymbol> Successors(INamedTypeSymbol t) =>
+            refs.TryGetValue(t, out var s)
+                ? s.Where(order.ContainsKey).OrderBy(x => order[x]).ToList()
+                : new List<INamedTypeSymbol>();
+
+        foreach (var root in types)
+        {
+            if (index.ContainsKey(root)) continue;
+            var work = new Stack<(INamedTypeSymbol node, List<INamedTypeSymbol> succ, int i)>();
+            index[root] = low[root] = next++;
+            stack.Push(root); onStack.Add(root);
+            work.Push((root, Successors(root), 0));
+
+            while (work.Count > 0)
+            {
+                var (node, succ, i) = work.Pop();
+                var advanced = false;
+                while (i < succ.Count)
+                {
+                    var w = succ[i++];
+                    if (!index.ContainsKey(w))
+                    {
+                        work.Push((node, succ, i));
+                        index[w] = low[w] = next++;
+                        stack.Push(w); onStack.Add(w);
+                        work.Push((w, Successors(w), 0));
+                        advanced = true;
+                        break;
+                    }
+                    if (onStack.Contains(w)) low[node] = Math.Min(low[node], index[w]);
+                }
+                if (advanced) continue;
+
+                if (low[node] == index[node])
+                {
+                    var comp = new List<INamedTypeSymbol>();
+                    INamedTypeSymbol popped;
+                    do
+                    {
+                        popped = stack.Pop();
+                        onStack.Remove(popped);
+                        comp.Add(popped);
+                    } while (!SymbolEqualityComparer.Default.Equals(popped, node));
+                    // Inside a chunk, keep the emitter's own dependency-depth ordering: it already
+                    // guarantees a type's bases are defined before it.
+                    comp.Sort((a, b) => order[a].CompareTo(order[b]));
+                    components.Add(comp);
+                }
+                if (work.Count > 0)
+                {
+                    var parent = work.Pop();
+                    low[parent.node] = Math.Min(low[parent.node], low[node]);
+                    work.Push(parent);
+                }
+            }
+        }
+
+        var indexOf = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        for (var i = 0; i < components.Count; i++)
+            foreach (var t in components[i]) indexOf[t] = i;
+
+        var deps = new List<HashSet<int>>(components.Count);
+        for (var i = 0; i < components.Count; i++) deps.Add(new HashSet<int>());
+        foreach (var t in types)
+        {
+            if (!refs.TryGetValue(t, out var s)) continue;
+            var from = indexOf[t];
+            foreach (var r in s)
+                if (indexOf.TryGetValue(r, out var to) && to != from) deps[from].Add(to);
+        }
+
+        return new ChunkGraph(components, deps, indexOf);
+    }
+
+    /// <summary>The entry module: it imports the eager chunks (so they are fully evaluated before
+    /// its own body runs), then declares what was deferred, attaches the reflection metadata for
+    /// <em>every</em> type, and starts the runtime.</summary>
+    private string BuildEntryModule(
+        List<INamedTypeSymbol> types, ChunkGraph chunks, HashSet<int> eager,
+        List<INamedTypeSymbol> lazyTypes, Func<int, string> chunkFile)
+    {
+        var sb = new StringBuilder();
+        sb.Append("/**\n * Transpose.Translator generated output (module entry).\n */\n");
+        foreach (var i in eager.OrderBy(x => x))
+            sb.Append("import './").Append(chunkFile(i)).Append("';\n");
+        sb.Append('\n');
+
+        if (!string.IsNullOrEmpty(AssemblyVersion))
+            sb.Append("Transpose.assemblyVersion(\"").Append(_assemblyName).Append("\", \"").Append(AssemblyVersion).Append("\");\n");
+        sb.Append("Transpose.$useAssembly(\"").Append(_assemblyName).Append("\");\n\n");
+
+        // Reflection metadata describes declarations only, so it is always eager and always covers
+        // every type. It is emitted BEFORE the manifest on purpose: Modules.register() ends with a
+        // Transpose.init(), and init runs the entry point — so anything emitted after the register
+        // call would not exist yet when Main runs. An entry whose type is still missing is deferred
+        // by setMetadata and flushed by that same init, at the top of it, before $main is scheduled.
+        if (ReflectionEnabled && BuildMetadataBlock(types) is { } meta)
+        {
+            foreach (var line in meta.Split('\n')) sb.Append(line).Append('\n');
+            sb.Append('\n');
+        }
+
+        // What was deferred. Registering stubs makes every one of these types visible to
+        // reflection — Assembly.GetTypes(), IsAssignableFrom, the attributes above — while its
+        // chunk stays unfetched.
+        if (lazyTypes.Count > 0)
+        {
+            sb.Append("Transpose.Modules.register({\n");
+            foreach (var t in lazyTypes)
+            {
+                var bases = ManifestBaseNames(t);
+                sb.Append("    \"").Append(MetaTypeDefName(t)).Append("\": { m: \"./")
+                  .Append(chunkFile(chunks.IndexOf[t])).Append("\", k: \"").Append(ManifestKind(t))
+                  .Append("\", a: \"").Append(_assemblyName).Append("\", i: [")
+                  .Append(string.Join(", ", bases.Select(b => "\"" + b + "\""))).Append("] },\n");
+            }
+            sb.Append("});\n\n");
+        }
+
+        var ready = CaptureAtCurrentIndent(() => EmitReadyRegistrations(types));
+        if (ready.Trim().Length > 0) sb.Append(ready.TrimEnd()).Append('\n');
+
+        sb.Append("Transpose.init();\n");
+        return sb.ToString();
+    }
+
+    private static string ManifestKind(INamedTypeSymbol type) => type.TypeKind switch
+    {
+        TypeKind.Interface => "interface",
+        TypeKind.Struct => "struct",
+        TypeKind.Enum => "enum",
+        _ => "class",
+    };
+
+    /// <summary>
+    /// The base class and interfaces a stub reports, as dotted names the runtime resolves with
+    /// <c>Transpose.unroll</c>. Names rather than expressions because a base may itself still be a
+    /// stub when the manifest is registered — only names can be resolved after every stub exists.
+    /// A constructed generic base contributes its definition name (<c>Foo$1</c>); that is all an
+    /// unrolled lookup can express, and it is enough for the common interface-scan case.
+    /// </summary>
+    private List<string> ManifestBaseNames(INamedTypeSymbol type)
+    {
+        var names = new List<string>();
+        void Add(INamedTypeSymbol t)
+        {
+            var n = TransposeNaming.IsTransposeCompiledSource(t)
+                ? (t.Arity > 0 ? _names.TypeFullName(t) + "$" + t.Arity : _names.TypeFullName(t))
+                : TransposeNaming.GetName(t);
+            if (!string.IsNullOrEmpty(n) && !names.Contains(n!)) names.Add(n!);
+        }
+        if (type.BaseType is { } bt && bt.SpecialType != SpecialType.System_Object) Add(bt);
+        foreach (var i in type.AllInterfaces.Where(TransposeNaming.IsInheritableInterface)) Add(i);
+        return names;
+    }
+
+    /// <summary>Removes the four-space indent a type body carries from being emitted inside a
+    /// <c>Transpose.assembly(...)</c> wrapper — a chunk has no wrapper.</summary>
+    private static string Dedent(string js)
+    {
+        var lines = js.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+            if (lines[i].StartsWith("    ", StringComparison.Ordinal)) lines[i] = lines[i].Substring(4);
+        return string.Join("\n", lines);
+    }
+
+    /// <summary>A relative specifier from one chunk file to another. Both live in the same folder in
+    /// every layout emitted today, so this is just <c>./name</c>, but it is computed rather than
+    /// assumed so a nested chunk directory keeps working.</summary>
+    private static string RelativeImport(string from, string to)
+    {
+        var fromDir = from.Contains('/') ? from.Substring(0, from.LastIndexOf('/')) : "";
+        var toDir = to.Contains('/') ? to.Substring(0, to.LastIndexOf('/')) : "";
+        return fromDir == toDir ? "./" + to.Substring(toDir.Length == 0 ? 0 : toDir.Length + 1) : "./" + to;
+    }
+}
+
+internal static class ModuleOutputExtensions
+{
+    public static Emitter.ModuleOutput With(this Emitter.ModuleOutput output, List<(string, string)> chunks)
+    {
+        foreach (var c in chunks) output.Chunks.Add(c);
+        return output;
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -311,11 +311,11 @@ public sealed partial class Emitter
             sb.Append("Transpose.Modules.register({\n");
             foreach (var t in lazyTypes)
             {
-                var bases = ManifestBaseNames(t);
+                var bases = ManifestBaseSpecs(t);
                 sb.Append("    \"").Append(MetaTypeDefName(t)).Append("\": { m: \"./")
                   .Append(chunkFile(chunks.IndexOf[t])).Append("\", k: \"").Append(ManifestKind(t))
                   .Append("\", a: \"").Append(_assemblyName).Append("\", i: [")
-                  .Append(string.Join(", ", bases.Select(b => "\"" + b + "\""))).Append("] },\n");
+                  .Append(string.Join(", ", bases)).Append("] },\n");
             }
             sb.Append("});\n\n");
         }
@@ -336,25 +336,73 @@ public sealed partial class Emitter
     };
 
     /// <summary>
-    /// The base class and interfaces a stub reports, as dotted names the runtime resolves with
-    /// <c>Transpose.unroll</c>. Names rather than expressions because a base may itself still be a
-    /// stub when the manifest is registered — only names can be resolved after every stub exists.
-    /// A constructed generic base contributes its definition name (<c>Foo$1</c>); that is all an
-    /// unrolled lookup can express, and it is enough for the common interface-scan case.
+    /// The base class and interfaces a stub reports, as JavaScript literals the runtime resolves
+    /// (see <c>Modules.$resolveType</c>). Specs rather than expressions because a base may itself
+    /// still be a stub when the manifest is registered — a spec can be resolved later, an
+    /// expression is evaluated on the spot.
+    ///
+    /// Two forms. A plain type is its dotted name, resolved with <c>Transpose.unroll</c>:
+    /// <c>"tss.IComponent"</c>. A CONSTRUCTED generic is an array of the definition name followed
+    /// by its arguments (each a spec in turn, so <c>IFoo&lt;IBar&lt;int&gt;&gt;</c> nests):
+    /// <c>["tss.CB$2", "tss.Avatar", "HTMLElement"]</c>. The runtime builds it by applying the
+    /// definition, which is what makes <c>IsAssignableFrom</c> against a constructed generic answer
+    /// from a stub — <c>varianceAssignable</c> matches on <c>$genericTypeDefinition</c> plus
+    /// <c>$typeArguments</c>, neither of which a bare definition object carries.
+    ///
+    /// A base whose arguments cannot be named — an open <c>class Deferred&lt;T&gt; : IFoo&lt;T&gt;</c>
+    /// (there is no T to write down until the definition is applied), an array argument, a type
+    /// nested in a generic — falls back to the definition name alone, which is what this emitted
+    /// before specs existed: the definition-level relationship is still reported, a question about
+    /// one specific instantiation still cannot be answered without loading the module.
     /// </summary>
-    private List<string> ManifestBaseNames(INamedTypeSymbol type)
+    private List<string> ManifestBaseSpecs(INamedTypeSymbol type)
     {
-        var names = new List<string>();
+        var specs = new List<string>();
         void Add(INamedTypeSymbol t)
         {
-            var n = TransposeNaming.IsTransposeCompiledSource(t)
-                ? (t.Arity > 0 ? _names.TypeFullName(t) + "$" + t.Arity : _names.TypeFullName(t))
-                : TransposeNaming.GetName(t);
-            if (!string.IsNullOrEmpty(n) && !names.Contains(n!)) names.Add(n!);
+            var name = ManifestTypeName(t);
+            if (string.IsNullOrEmpty(name)) return;
+            var spec = ManifestConstructedSpec(t) ?? "\"" + name + "\"";
+            if (!specs.Contains(spec)) specs.Add(spec);
         }
         if (type.BaseType is { } bt && bt.SpecialType != SpecialType.System_Object) Add(bt);
         foreach (var i in type.AllInterfaces.Where(TransposeNaming.IsInheritableInterface)) Add(i);
-        return names;
+        return specs;
+    }
+
+    /// <summary>The name a manifest spec resolves through <c>Transpose.unroll</c> — the same
+    /// arity-suffixed define name a reference uses, or the runtime binding of an external type.</summary>
+    private string? ManifestTypeName(INamedTypeSymbol t) =>
+        TransposeNaming.IsTransposeCompiledSource(t)
+            ? (t.Arity > 0 ? _names.TypeFullName(t) + "$" + t.Arity : _names.TypeFullName(t))
+            // The same two-step TypeRefCore uses for an external type: its [Name], else the name it
+            // takes from an enclosing [Scope]/[GlobalMethods] binding (HTMLElement and friends).
+            : TransposeNaming.GetName(t) ?? ScopedExternalName(t);
+
+    /// <summary>
+    /// The array-form spec for a constructed generic, or null when it is not one or cannot be
+    /// expressed (see <see cref="ManifestBaseSpecs"/>). Deliberately narrow: only a type whose own
+    /// arity accounts for every effective type argument, so a type nested in a generic — whose
+    /// define takes the enclosing arguments too — is left to the definition-name fallback rather
+    /// than guessed at.
+    /// </summary>
+    private string? ManifestConstructedSpec(INamedTypeSymbol t)
+    {
+        if (t.Arity == 0 || t.IsUnboundGenericType) return null;
+        if (t.TypeArguments.Length != t.Arity || EffectiveTypeArguments(t).Count != t.Arity) return null;
+        var def = ManifestTypeName(t);
+        if (string.IsNullOrEmpty(def)) return null;
+
+        var parts = new List<string> { "\"" + def + "\"" };
+        foreach (var arg in t.TypeArguments)
+        {
+            if (arg is not INamedTypeSymbol named) return null;      // a type PARAMETER or an array
+            if (ManifestConstructedSpec(named) is { } nested) { parts.Add(nested); continue; }
+            var argName = ManifestTypeName(named);
+            if (string.IsNullOrEmpty(argName) || named.Arity > 0) return null;
+            parts.Add("\"" + argName + "\"");
+        }
+        return "[" + string.Join(", ", parts) + "]";
     }
 
     /// <summary>Removes the four-space indent a type body carries from being emitted inside a

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -99,6 +99,36 @@ public sealed partial class Emitter
         }
     }
 
+    /// <summary>
+    /// Records, as hard dependencies, every part of <paramref name="type"/> that <see cref="TypeRefCore"/>
+    /// will emit as a CALL on a generic definition (<c>Foo$1(Bar)</c>). Used where the reference is
+    /// otherwise soft — <c>typeof(X)</c> — because a soft reference is only satisfiable by a stub
+    /// object, and a stub cannot be called: building a constructed generic needs the definition's
+    /// real code. An unbound <c>typeof(Foo&lt;&gt;)</c> emits the definition object rather than a
+    /// call and so stays soft, as does any non-generic type.
+    /// </summary>
+    private void RecordConstructedTypeRefs(ITypeSymbol type)
+    {
+        if (_recordedRefs is null && _recordedExternalRefs is null) return;   // not module mode
+        switch (type)
+        {
+            case IArrayTypeSymbol array:
+                // `typeof(Foo<Bar>[])` emits System.Array.type(Foo$1(Bar)) — the call is still there.
+                RecordConstructedTypeRefs(array.ElementType);
+                return;
+            case INamedTypeSymbol named:
+                if (!named.IsUnboundGenericType && EffectiveTypeArguments(named).Count > 0)
+                {
+                    // RecordRef records the definition and recurses through the arguments, which is
+                    // the same set the emitted call touches.
+                    RecordRef(named);
+                    return;
+                }
+                foreach (var arg in named.TypeArguments) RecordConstructedTypeRefs(arg);
+                return;
+        }
+    }
+
     /// <summary>The bare name a type's <c>Transpose.define</c> registers it under — no type
     /// arguments, arity suffixed. This is the key both the module manifest and the chunk map use.</summary>
     private string DefineName(INamedTypeSymbol named)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -69,7 +69,7 @@ public sealed partial class Emitter
         // chunker can group mutually-referencing types (see Emitter.Modules.cs). Recording here
         // rather than in a separate analysis pass keeps the two in step by construction: an edge
         // exists exactly when a reference was emitted.
-        if (_recordedRefs is not null && _softRefDepth == 0) RecordRef(type);
+        if ((_recordedRefs is not null || _recordedExternalRefs is not null) && _softRefDepth == 0) RecordRef(type);
         return type is ITypeParameterSymbol ? TypeRefCore(type) : UnshadowedTypeRef(TypeRefCore(type));
     }
 
@@ -85,11 +85,26 @@ public sealed partial class Emitter
                 RecordRef(array.ElementType);
                 return;
             case INamedTypeSymbol named:
-                if (named.Locations.Any(l => l.IsInSource) && !TransposeNaming.IsExternalType(named))
+                if (TransposeNaming.IsExternalType(named)) { /* native JS - nothing to load */ }
+                else if (named.Locations.Any(l => l.IsInSource))
                     _recordedRefs!.Add((INamedTypeSymbol)named.OriginalDefinition);
+                else if (_recordedExternalRefs is not null && TransposeNaming.IsTransposeCompiledSource(named))
+                    // A type from a *referenced* Transpose-compiled assembly. If that assembly was
+                    // itself built as modules, the chunk holding this type has to be imported, or the
+                    // reference would land on a stub. Recorded by emitted define name, which is the
+                    // key the referenced assembly's chunk map uses.
+                    _recordedExternalRefs.Add(DefineName(named));
                 foreach (var arg in named.TypeArguments) RecordRef(arg);
                 return;
         }
+    }
+
+    /// <summary>The bare name a type's <c>Transpose.define</c> registers it under — no type
+    /// arguments, arity suffixed. This is the key both the module manifest and the chunk map use.</summary>
+    private string DefineName(INamedTypeSymbol named)
+    {
+        var t = (INamedTypeSymbol)named.OriginalDefinition;
+        return t.Arity > 0 ? _names.TypeFullName(t) + "$" + t.Arity : _names.TypeFullName(t);
     }
 
     private string TypeRefCore(ITypeSymbol type)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -64,7 +64,33 @@ public sealed partial class Emitter
     /// PARAMETER never does, because it IS a local binding (the generic define's own parameter).
     /// </summary>
     private string TypeRef(ITypeSymbol type)
-        => type is ITypeParameterSymbol ? TypeRefCore(type) : UnshadowedTypeRef(TypeRefCore(type));
+    {
+        // Module mode records which source types this one's emitted body reaches into, so the
+        // chunker can group mutually-referencing types (see Emitter.Modules.cs). Recording here
+        // rather than in a separate analysis pass keeps the two in step by construction: an edge
+        // exists exactly when a reference was emitted.
+        if (_recordedRefs is not null && _softRefDepth == 0) RecordRef(type);
+        return type is ITypeParameterSymbol ? TypeRefCore(type) : UnshadowedTypeRef(TypeRefCore(type));
+    }
+
+    /// <summary>Adds every source named type inside <paramref name="type"/> (the type itself and,
+    /// recursively, its generic arguments and array element) to the current type's dependency set.
+    /// A generic argument counts: <c>Foo$1(X)</c> builds a generic instance whose base class can be
+    /// <c>X</c> itself, so X has to be defined before the application runs.</summary>
+    private void RecordRef(ITypeSymbol type)
+    {
+        switch (type)
+        {
+            case IArrayTypeSymbol array:
+                RecordRef(array.ElementType);
+                return;
+            case INamedTypeSymbol named:
+                if (named.Locations.Any(l => l.IsInSource) && !TransposeNaming.IsExternalType(named))
+                    _recordedRefs!.Add((INamedTypeSymbol)named.OriginalDefinition);
+                foreach (var arg in named.TypeArguments) RecordRef(arg);
+                return;
+        }
+    }
 
     private string TypeRefCore(ITypeSymbol type)
     {

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -72,6 +72,11 @@ public sealed partial class Emitter
     /// dependency set of the type currently being emitted, which module mode chunks on.</summary>
     private HashSet<INamedTypeSymbol>? _recordedRefs;
 
+    /// <summary>Alongside <see cref="_recordedRefs"/>: the define names of types from *referenced*
+    /// Transpose-compiled assemblies, so a chunk can import the referenced assembly's chunk that
+    /// holds them.</summary>
+    private HashSet<string>? _recordedExternalRefs;
+
     /// <summary>Nesting depth of a reference position that only needs a <em>Type object</em> rather
     /// than the type's code — a <c>typeof</c> operand. A stub satisfies those (see Modules.js), so
     /// they are not recorded as dependencies and do not fuse two chunks together.</summary>
@@ -226,9 +231,16 @@ public sealed partial class Emitter
 
     /// <param name="refs">When supplied, receives every source type the emitted body references.</param>
     public static JsWriter EmitOnlyType(Emitter emitter, INamedTypeSymbol type, HashSet<INamedTypeSymbol>? refs)
+        => EmitOnlyType(emitter, type, refs, null);
+
+    /// <param name="externalRefs">When supplied, receives the define names of referenced-assembly
+    /// types the emitted body reaches into.</param>
+    public static JsWriter EmitOnlyType(Emitter emitter, INamedTypeSymbol type,
+        HashSet<INamedTypeSymbol>? refs, HashSet<string>? externalRefs)
     {
         var clonedEmitter = emitter.Clone();
         clonedEmitter._recordedRefs = refs;
+        clonedEmitter._recordedExternalRefs = externalRefs;
         clonedEmitter.EmitType(type);
         return clonedEmitter._w;
     }

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -68,6 +68,15 @@ public sealed partial class Emitter
     /// top-level emitter consults it; the per-type clones never see it.</summary>
     private IncrementalPlan? _plan;
 
+    /// <summary>When non-null, every source type <see cref="TypeRef"/> emits is recorded here — the
+    /// dependency set of the type currently being emitted, which module mode chunks on.</summary>
+    private HashSet<INamedTypeSymbol>? _recordedRefs;
+
+    /// <summary>Nesting depth of a reference position that only needs a <em>Type object</em> rather
+    /// than the type's code — a <c>typeof</c> operand. A stub satisfies those (see Modules.js), so
+    /// they are not recorded as dependencies and do not fuse two chunks together.</summary>
+    private int _softRefDepth;
+
     /// <param name="models">A semantic-model cache to reuse. Passing the one the
     /// unsupported-feature scan already populated means every member that scan bound is bound
     /// once for the whole build instead of twice.</param>
@@ -213,8 +222,13 @@ public sealed partial class Emitter
     }
 
     public static JsWriter EmitOnlyType(Emitter emitter, INamedTypeSymbol type)
+        => EmitOnlyType(emitter, type, null);
+
+    /// <param name="refs">When supplied, receives every source type the emitted body references.</param>
+    public static JsWriter EmitOnlyType(Emitter emitter, INamedTypeSymbol type, HashSet<INamedTypeSymbol>? refs)
     {
         var clonedEmitter = emitter.Clone();
+        clonedEmitter._recordedRefs = refs;
         clonedEmitter.EmitType(type);
         return clonedEmitter._w;
     }

--- a/docs/experiments/js-modules/README.md
+++ b/docs/experiments/js-modules/README.md
@@ -1,0 +1,73 @@
+# js-modules experiment harness
+
+The evidence behind [`TODO.modules.md`](../../../TODO.modules.md): can `tps` emit ES modules per
+class / per cluster, loaded on demand?
+
+Nothing here is part of the compiler. Each script works on an **already-emitted site**, re-chunking
+its `tss.js` / `app.js` into modules and re-rendering the page, so every runtime question is answered
+without an emitter change. The parsing is textual and deliberately throwaway — a real implementation
+classifies references on Roslyn symbols, which is precisely the difference that made `split4.js`
+unsound (see §4 of the TODO).
+
+## Prerequisites
+
+A built Tesserae sample site, and Playwright's Chromium:
+
+```bash
+cd /path/to/transpose && dotnet build Transpose.slnx -c Release
+export PATH="$PWD/Transpose/Transpose.Compiler/bin/Release/net10.0:$PATH"
+cd /path/to/tesserae && dotnet build Tesserae.sln -c Debug
+SITE=/path/to/tesserae/Tesserae.Tests/bin/Debug/netstandard2.0/tps
+```
+
+The scripts hardcode `/opt/pw-browsers/chromium-1194/chrome-linux/chrome` and require
+`playwright` resolvable from `/opt/node22/lib/node_modules` — adjust for another machine.
+
+## The scripts
+
+| Script | What it does |
+| --- | --- |
+| `graph.js <site>` | Statistics only. Splits the bundles into per-`define` blocks, builds the reference graph, reports reachability from the entry point, SCC sizes, and which types are statically unreachable. |
+| `split.js <site> <out> eager\|lazy` | Experiment A/B — one module per type, imports from `inherits` edges only. `eager` imports everything (validates the split); `lazy` imports only the entry closure (shows reflection breaking). |
+| `split2.js <site> <out>` | Experiment C — adds metadata-backed type stubs and a synchronous fault-in loader. Restores the full sidebar; still fails on static calls into stubs. |
+| `split3.js <site> <out>` | **Experiment D — the working design.** Chunk = SCC of the full reference graph, so the chunk DAG is safe to wire with side-effect imports. Renders identically to the baseline with zero errors. |
+| `split4.js <site> <out>` | Experiment E — D plus a hard/soft reference classifier for finer chunks. Better on paper, **not sound**; kept as the statement of the open problem. |
+| `probe.js <site> <prefix> [port]` | The correctness oracle. Serves the site, loads it in Chromium, fingerprints the page, clicks all 140 samples and records each rendered pane, writes `<prefix>.json` + `<prefix>.png`. |
+| `marginal.js` | Static per-sample marginal load cost from the chunk DAG produced by `split3.js` into `site-scc`. |
+
+## The loop
+
+```bash
+node probe.js  "$SITE" baseline 5199          # oracle for the unmodified build
+node split3.js "$SITE" site-scc               # re-chunk
+node probe.js  "$PWD/site-scc" scc 5213       # oracle for the modular build
+```
+
+Then diff the two fingerprints — this is the gate, and it is what "0 errors, 140/140 identical" in
+the TODO means:
+
+```bash
+node -e "
+const a=require('./baseline.json'), b=require('./scc.json');
+const k=r=>r.samples.map(s=>\`\${s.label}|\${s.n}|\${s.t}\`);
+const ka=k(a), kb=k(b);
+console.log('differing rows:', ka.filter((x,i)=>x!==kb[i]).length,
+            '| errors:', a.errors.length, b.errors.length);
+"
+```
+
+## Caveats worth knowing before trusting a number
+
+- Reference extraction is **textual**, so anything that looks like a dotted type name counts. It was
+  checked against the one case that mattered (the samples' `typeof(OtherSample)` "See Also" lists are
+  real `System.Array.init([...])` references, not string literals), but it is not a substitute for
+  the symbol graph.
+- `Transpose.definei` blocks (interfaces with variance) are a *second* block-start form and a block
+  may contain more than one `inherits`. `split`/`split2`/`split3` survive this because their
+  all-references graph is conservative enough to cover it; `split4.js` had to handle both explicitly.
+- The fault-in path uses a **synchronous `XMLHttpRequest` + `eval`**. That is what lets an existing
+  synchronous `Activator.CreateInstance` work at all, and it is a dev-mode device only.
+- The page fingerprint reports 1648 elements against the baseline's 1649. The per-sample fingerprints
+  match exactly across all 140, and the difference reproduces in every modular variant including the
+  fully-eager one, so it is a property of the split boot sequence rather than of lazy loading. It was
+  not chased down.

--- a/docs/experiments/js-modules/graph.js
+++ b/docs/experiments/js-modules/graph.js
@@ -1,0 +1,147 @@
+// Reachability analysis over the emitted Transpose bundles.
+// Splits each bundle into per-`Transpose.define` blocks, extracts the dotted type
+// references inside each, and computes what the entry point can reach.
+const fs = require('fs');
+const dir = process.argv[2];
+
+const bundles = ['tss.js', 'app.js'];
+
+function splitDefines(text, file) {
+  const marker = '\n    Transpose.define(';
+  const out = [];
+  let i = text.indexOf(marker);
+  while (i >= 0) {
+    const next = text.indexOf(marker, i + 1);
+    const body = text.slice(i + 1, next < 0 ? text.length : next);
+    const m = body.match(/^ {4}Transpose\.define\("([^"]+)"/);
+    if (m) out.push({ name: m[1], body, file, size: body.length });
+    i = next;
+  }
+  return out;
+}
+
+const blocks = [];
+for (const b of bundles) {
+  const t = fs.readFileSync(`${dir}/${b}`, 'utf8');
+  blocks.push(...splitDefines(t, b));
+}
+
+// Define name -> block. Strip the $N arity suffix for matching too.
+const byName = new Map();
+for (const b of blocks) byName.set(b.name, b);
+
+// Sort names longest-first so `tss.UI.Theme` wins over `tss.UI`.
+const names = [...byName.keys()].sort((a, b) => b.length - a.length);
+const nameSet = new Set(names);
+
+// Extract every identifier-path occurrence in a body and keep the ones that are define names.
+const PATH = /\b[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+/g;
+
+function refsOf(block) {
+  const found = new Set();
+  for (const m of block.body.match(PATH) || []) {
+    // Longest matching prefix that is a known define.
+    let path = m;
+    while (path.length) {
+      if (nameSet.has(path)) { found.add(path); break; }
+      const dot = path.lastIndexOf('.');
+      if (dot < 0) break;
+      path = path.slice(0, dot);
+    }
+  }
+  found.delete(block.name);
+  return found;
+}
+
+// The `inherits: function () { return [...]; }` refs are needed at DEFINE time.
+function inheritsOf(block) {
+  const found = new Set();
+  const m = block.body.match(/inherits:\s*function\s*\(\)\s*\{\s*return\s*\[([^\]]*)\]/);
+  if (!m) return found;
+  for (const p of m[1].match(PATH) || []) {
+    let path = p;
+    while (path.length) {
+      if (nameSet.has(path)) { found.add(path); break; }
+      const dot = path.lastIndexOf('.');
+      if (dot < 0) break;
+      path = path.slice(0, dot);
+    }
+  }
+  found.delete(block.name);
+  return found;
+}
+
+const graph = new Map(), inh = new Map();
+for (const b of blocks) { graph.set(b.name, refsOf(b)); inh.set(b.name, inheritsOf(b)); }
+
+function reach(roots, g) {
+  const seen = new Set(roots);
+  const stack = [...roots];
+  while (stack.length) {
+    const n = stack.pop();
+    for (const r of g.get(n) || []) if (!seen.has(r)) { seen.add(r); stack.push(r); }
+  }
+  return seen;
+}
+
+const entry = 'Tesserae.Tests.App';
+const totalSize = blocks.reduce((a, b) => a + b.size, 0);
+const sizeOf = s => [...s].reduce((a, n) => a + (byName.get(n)?.size || 0), 0);
+
+const allRefReach = reach([entry], graph);
+const inhReach = reach([entry], inh);
+
+const fmt = n => (n / 1024).toFixed(0) + ' KB';
+console.log(`types (defines):            ${blocks.length}  (${fmt(totalSize)})`);
+console.log(`  tss.js                    ${blocks.filter(b => b.file === 'tss.js').length}`);
+console.log(`  app.js                    ${blocks.filter(b => b.file === 'app.js').length}`);
+console.log();
+console.log(`reachable from ${entry} following ALL emitted refs:`);
+console.log(`  ${allRefReach.size} types (${fmt(sizeOf(allRefReach))}) = ${(100 * allRefReach.size / blocks.length).toFixed(1)}% of types, ${(100 * sizeOf(allRefReach) / totalSize).toFixed(1)}% of bytes`);
+console.log();
+console.log(`reachable following ONLY inherits (define-time) edges:`);
+console.log(`  ${inhReach.size} types (${fmt(sizeOf(inhReach))})`);
+console.log();
+
+// Strongly-connected components over ALL refs (how clusterable is the graph?).
+function scc(g, nodes) {
+  let idx = 0; const index = new Map(), low = new Map(), on = new Set(), st = [], out = [];
+  function strong(v) {
+    const work = [[v, 0]];
+    index.set(v, idx); low.set(v, idx); idx++; st.push(v); on.add(v);
+    while (work.length) {
+      const frame = work[work.length - 1];
+      const [n, pi] = frame;
+      const succ = [...(g.get(n) || [])];
+      if (pi < succ.length) {
+        frame[1]++;
+        const w = succ[pi];
+        if (!index.has(w)) { index.set(w, idx); low.set(w, idx); idx++; st.push(w); on.add(w); work.push([w, 0]); }
+        else if (on.has(w)) low.set(n, Math.min(low.get(n), index.get(w)));
+      } else {
+        if (low.get(n) === index.get(n)) {
+          const comp = []; let w;
+          do { w = st.pop(); on.delete(w); comp.push(w); } while (w !== n);
+          out.push(comp);
+        }
+        work.pop();
+        if (work.length) { const p = work[work.length - 1][0]; low.set(p, Math.min(low.get(p), low.get(n))); }
+      }
+    }
+  }
+  for (const n of nodes) if (!index.has(n)) strong(n);
+  return out;
+}
+
+const comps = scc(graph, names).sort((a, b) => b.length - a.length);
+console.log(`strongly-connected components over ALL refs: ${comps.length}`);
+console.log(`  largest 5: ${comps.slice(0, 5).map(c => c.length).join(', ')}`);
+console.log(`  largest SCC = ${fmt(sizeOf(new Set(comps[0])))}`);
+const inhComps = scc(inh, names).sort((a, b) => b.length - a.length);
+console.log(`strongly-connected components over inherits only: ${inhComps.length}, largest ${inhComps[0].length}`);
+
+// What is NOT reachable statically -- the true lazy-load candidates.
+const unreach = names.filter(n => !allRefReach.has(n));
+console.log();
+console.log(`NOT statically reachable from the entry point: ${unreach.length} types (${fmt(sizeOf(new Set(unreach)))})`);
+console.log(`  sample: ${unreach.slice(0, 15).join(', ')}`);

--- a/docs/experiments/js-modules/marginal.js
+++ b/docs/experiments/js-modules/marginal.js
@@ -1,0 +1,34 @@
+// Static marginal cost of opening one sample, from the chunk DAG the SCC split produced.
+const fs=require('fs'), path=require('path');
+const site='/home/user/tesserae/Tesserae.Tests/bin/Debug/netstandard2.0/tps';
+const out='site-scc';
+const boot=fs.readFileSync(out+'/boot.mjs','utf8');
+const MAN=JSON.parse(boot.match(/const MAN = (\{.*?\});\n/s)[1]);
+// chunk -> deps, read from the emitted module headers
+const chunks={};
+for(const f of fs.readdirSync(out+'/c')){
+  const src=fs.readFileSync(out+'/c/'+f,'utf8');
+  const deps=[...src.matchAll(/^import '\.\/(c\d+\.mjs)';$/gm)].map(m=>m[1]);
+  chunks[f]={deps,size:fs.statSync(out+'/c/'+f).size};
+}
+const eager=new Set([...boot.matchAll(/^import '\.\/c\/(c\d+\.mjs)';$/gm)].map(m=>m[1]));
+// close the eager set
+{const st=[...eager]; while(st.length){const c=st.pop(); for(const d of chunks[c].deps) if(!eager.has(d)){eager.add(d);st.push(d);} }}
+const eagerBytes=[...eager].reduce((a,c)=>a+chunks[c].size,0);
+
+const samples=Object.keys(MAN).filter(n=>/Samples\.[A-Za-z]+Sample$/.test(n));
+const costs=samples.map(n=>{
+  const start=MAN[n].c.replace('./c/','');
+  const seen=new Set([start]), st=[start];
+  while(st.length){const c=st.pop(); for(const d of chunks[c].deps) if(!seen.has(d)&&!eager.has(d)){seen.add(d);st.push(d);} }
+  const bytes=[...seen].filter(c=>!eager.has(c)).reduce((a,c)=>a+chunks[c].size,0);
+  return {n:n.split('.').pop(),kb:bytes/1024,chunks:[...seen].filter(c=>!eager.has(c)).length};
+}).sort((a,b)=>a.kb-b.kb);
+const kb=x=>x.toFixed(0)+' KB';
+console.log('eager (initial) payload:', kb(eagerBytes/1024), 'over', eager.size, 'chunks');
+console.log('samples measured:', costs.length);
+console.log('  cheapest :', costs[0].n, kb(costs[0].kb));
+console.log('  median   :', kb(costs[Math.floor(costs.length/2)].kb));
+console.log('  p90      :', kb(costs[Math.floor(costs.length*0.9)].kb));
+console.log('  worst    :', costs[costs.length-1].n, kb(costs[costs.length-1].kb));
+console.log('  total if all opened:', kb(costs.reduce((a,c)=>a+c.kb,0)/1)); // overlapping, so > lazy total

--- a/docs/experiments/js-modules/probe.js
+++ b/docs/experiments/js-modules/probe.js
@@ -1,0 +1,102 @@
+// Renders the Tesserae sample app and captures a structural fingerprint of the page,
+// so a modular build can be diffed against the single-bundle baseline.
+//
+//   node probe.js <siteDir> <outPrefix> [port]
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const siteDir = process.argv[2];
+const outPrefix = process.argv[3];
+const port = parseInt(process.argv[4] || '5199', 10);
+
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.woff2': 'font/woff2',
+  '.woff': 'font/woff', '.ttf': 'font/ttf', '.gif': 'image/gif', '.ico': 'image/x-icon',
+};
+
+function serve() {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      let p = decodeURIComponent(req.url.split('?')[0]);
+      if (p === '/') p = '/index.html';
+      const file = path.join(siteDir, p);
+      if (!file.startsWith(siteDir) || !fs.existsSync(file) || fs.statSync(file).isDirectory()) {
+        res.writeHead(404); res.end('nope'); return;
+      }
+      res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    });
+    server.listen(port, () => resolve(server));
+  });
+}
+
+(async () => {
+  const server = await serve();
+  const browser = await chromium.launch({ executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome' });
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 1000 } });
+  const page = await ctx.newPage();
+
+  const console_ = [], errors = [], requests = [];
+  page.on('console', m => console_.push(`${m.type()}: ${m.text()}`));
+  page.on('pageerror', e => errors.push(String(e)));
+  page.on('request', r => requests.push(r.url().replace(`http://localhost:${port}`, '')));
+
+  const t0 = Date.now();
+  await page.goto(`http://localhost:${port}/index.html`, { waitUntil: 'networkidle', timeout: 60000 });
+  await page.waitForTimeout(2500);
+  const loadMs = Date.now() - t0;
+
+  // The sample gallery: the sidebar is built from the reflection-discovered ISample types.
+  const fingerprint = await page.evaluate(() => {
+    const norm = s => (s || '').replace(/\s+/g, ' ').trim();
+    const sidebar = [...document.querySelectorAll('.tss-sidebar-item, [class*=sidebar] [class*=item]')]
+      .map(e => norm(e.textContent)).filter(Boolean);
+    return {
+      title: document.title,
+      bodyTextLen: norm(document.body.innerText).length,
+      elementCount: document.querySelectorAll('*').length,
+      sidebarCount: sidebar.length,
+      sidebar: sidebar.slice(0, 400),
+      // How many types the runtime believes the tss + app assemblies contain.
+      tssTypes: (() => { try { return Object.keys(System.Reflection.Assembly.assemblies['tss'].$types).length; } catch { return -1; } })(),
+      appTypes: (() => { try { return Object.keys(System.Reflection.Assembly.assemblies['Tesserae.Tests'].$types).length; } catch { return -1; } })(),
+    };
+  });
+
+  // Click through every sidebar entry and fingerprint the rendered sample.
+  const samples = [];
+  const items = await page.$$('[class*=sidebar] [class*=item]');
+  for (let i = 0; i < items.length; i++) {
+    const els = await page.$$('[class*=sidebar] [class*=item]');
+    if (i >= els.length) break;
+    let label = '';
+    try { label = ((await els[i].innerText()) || '').replace(/\s+/g, ' ').trim(); } catch { }
+    if (!label) continue;
+    try {
+      await els[i].click({ timeout: 3000 });
+      await page.waitForTimeout(220);
+      const s = await page.evaluate(() => {
+        const main = document.querySelector('[class*=content], main') || document.body;
+        return { n: main.querySelectorAll('*').length, t: (main.innerText || '').replace(/\s+/g, ' ').trim().length };
+      });
+      samples.push({ label, ...s });
+    } catch (e) {
+      samples.push({ label, error: String(e).slice(0, 120) });
+    }
+  }
+
+  await page.screenshot({ path: `${outPrefix}.png`, fullPage: false });
+  const report = { loadMs, fingerprint, samples, errors, console: console_.filter(c => !c.startsWith('log:')).slice(0, 60), requestCount: requests.length };
+  fs.writeFileSync(`${outPrefix}.json`, JSON.stringify(report, null, 2));
+
+  console.log(`load ${loadMs}ms  elements=${fingerprint.elementCount}  sidebar=${fingerprint.sidebarCount}  tssTypes=${fingerprint.tssTypes} appTypes=${fingerprint.appTypes}`);
+  console.log(`samples clicked: ${samples.length}, errors: ${errors.length}, requests: ${requests.length}`);
+  if (errors.length) console.log('ERRORS:\n' + errors.slice(0, 10).join('\n'));
+
+  await browser.close();
+  server.close();
+})();

--- a/docs/experiments/js-modules/split.js
+++ b/docs/experiments/js-modules/split.js
@@ -1,0 +1,173 @@
+// Experiment: mechanically split the emitted tss.js / app.js bundles into one ES module
+// per type, wire define-time (inherits) dependencies as side-effect imports, and boot.
+//
+//   node split.js <siteDir> <outDir> <mode>
+//     mode = eager   : boot imports every module (validates the split itself)
+//     mode = lazy    : boot imports only the statically reachable closure; the rest are
+//                      fetched on demand through a reflection-aware loader
+const fs = require('fs');
+const path = require('path');
+
+const siteDir = process.argv[2];
+const outDir = process.argv[3];
+const mode = process.argv[4] || 'eager';
+
+const BUNDLES = [
+  { file: 'tss.js', asm: 'tss' },
+  { file: 'app.js', asm: 'Tesserae.Tests' },
+];
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+// Copy the site verbatim, then replace the two bundles with modules.
+for (const e of fs.readdirSync(siteDir)) {
+  fs.cpSync(path.join(siteDir, e), path.join(outDir, e), { recursive: true });
+}
+fs.rmSync(path.join(outDir, 'tss.js'));
+fs.rmSync(path.join(outDir, 'app.js'));
+
+const MODDIR = path.join(outDir, 'm');
+fs.mkdirSync(MODDIR, { recursive: true });
+
+// ---- parse the bundles into per-define blocks + trailing metadata --------------------
+const blocks = [];
+const tails = [];
+for (const { file, asm } of BUNDLES) {
+  const text = fs.readFileSync(path.join(siteDir, file), 'utf8');
+  const marker = '\n    Transpose.define(';
+  const idxs = [];
+  for (let i = text.indexOf(marker); i >= 0; i = text.indexOf(marker, i + 1)) idxs.push(i);
+  for (let k = 0; k < idxs.length; k++) {
+    const start = idxs[k] + 1;
+    const end = k + 1 < idxs.length ? idxs[k + 1] : text.lastIndexOf('\n});');
+    const body = text.slice(start, end);
+    const m = body.match(/^ {4}Transpose\.define\("([^"]+)"/);
+    if (m) blocks.push({ name: m[1], body, asm });
+  }
+  // Anything after the last define and before the closing `});` — the inline $m metadata.
+  const lastEnd = text.lastIndexOf('\n});');
+  const afterLast = idxs.length ? text.slice(idxs[idxs.length - 1] + 1) : '';
+  const metaStart = afterLast.indexOf('\n    var $m = Transpose.setMetadata');
+  if (metaStart >= 0) {
+    tails.push({ asm, js: afterLast.slice(metaStart, afterLast.lastIndexOf('\n});')) });
+    const b = blocks[blocks.length - 1];
+    b.body = b.body.slice(0, b.body.length - (afterLast.length - metaStart) + (afterLast.length - afterLast.length));
+    b.body = afterLast.slice(0, metaStart);
+    b.body = b.body; // trimmed above
+  }
+}
+
+const byName = new Map(blocks.map(b => [b.name, b]));
+const names = [...byName.keys()];
+const nameSet = new Set(names);
+const idOf = new Map(names.map((n, i) => [n, i]));
+
+const PATH = /\b[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+/g;
+function knownRefs(text) {
+  const found = new Set();
+  for (const m of text.match(PATH) || []) {
+    let p = m;
+    while (p.length) {
+      if (nameSet.has(p)) { found.add(p); break; }
+      const d = p.lastIndexOf('.');
+      if (d < 0) break;
+      p = p.slice(0, d);
+    }
+  }
+  return found;
+}
+
+// Define-time dependencies: whatever the `inherits` thunk returns must already be defined.
+function defineTimeDeps(b) {
+  const m = b.body.match(/inherits:\s*function\s*\(\)\s*\{\s*return\s*\[([^\]]*)\]/);
+  const s = m ? knownRefs(m[1]) : new Set();
+  s.delete(b.name);
+  return s;
+}
+// Everything the body mentions — used only for the reachability closure, not for imports.
+function allDeps(b) { const s = knownRefs(b.body); s.delete(b.name); return s; }
+
+const dtDeps = new Map(blocks.map(b => [b.name, defineTimeDeps(b)]));
+const anyDeps = new Map(blocks.map(b => [b.name, allDeps(b)]));
+
+// ---- write one module per type ------------------------------------------------------
+const fileOf = n => `t${idOf.get(n)}.mjs`;
+for (const b of blocks) {
+  const deps = [...dtDeps.get(b.name)].filter(d => byName.has(d));
+  const imports = ["import '../_rt.mjs';", ...deps.map(d => `import './${fileOf(d)}';`)].join('\n');
+  const js = `${imports}\nTranspose.$useAssembly(${JSON.stringify(b.asm)});\n${b.body.replace(/^ {4}/gm, '')}\n`;
+  fs.writeFileSync(path.join(MODDIR, fileOf(b.name)), js);
+}
+
+// ---- runtime shim -------------------------------------------------------------------
+fs.writeFileSync(path.join(outDir, '_rt.mjs'), `
+// Sets the ambient assembly a bare Transpose.define registers into. The single-bundle build
+// gets this from the Transpose.assembly(...) wrapper; a per-type module has no wrapper, so
+// it names its assembly explicitly right before its define.
+Transpose.$useAssembly = function (name) {
+  var asm = System.Reflection.Assembly.assemblies[name];
+  if (!asm) asm = new System.Reflection.Assembly(name, {});
+  Transpose.$currentAssembly = asm;
+};
+`);
+
+// ---- reachability from the entry point ----------------------------------------------
+function reach(roots, g) {
+  const seen = new Set(roots), st = [...roots];
+  while (st.length) { const n = st.pop(); for (const r of g.get(n) || []) if (!seen.has(r)) { seen.add(r); st.push(r); } }
+  return seen;
+}
+const ENTRY = 'Tesserae.Tests.App';
+const eagerSet = mode === 'eager' ? new Set(names) : reach([ENTRY], anyDeps);
+const lazySet = names.filter(n => !eagerSet.has(n));
+
+// ---- boot module --------------------------------------------------------------------
+const manifest = {};
+for (const n of names) manifest[n] = `m/${fileOf(n)}`;
+fs.writeFileSync(path.join(outDir, 'modules.json'), JSON.stringify(manifest));
+
+const eagerImports = [...eagerSet].map(n => `import './m/${fileOf(n)}';`).join('\n');
+const tailJs = tails.map(t => `Transpose.$useAssembly(${JSON.stringify(t.asm)});\n(function ($asm, globals) {\n${t.js}\n})(Transpose.$currentAssembly, Transpose.global);`).join('\n');
+
+fs.writeFileSync(path.join(outDir, 'boot.mjs'), `
+import './_rt.mjs';
+${eagerImports}
+
+Transpose.assemblyVersion("tss", "1.0.0.0");
+Transpose.assemblyVersion("Tesserae.Tests", "1.0.0.0");
+
+// Reflection metadata for BOTH assemblies, always eager: it describes declarations only and
+// Transpose.setMetadata already defers an entry whose type is not yet defined (Reflection.js),
+// re-deferring on each Transpose.init() until the owning module arrives.
+${tailJs}
+
+// The lazily-split types, and the loader that can pull one in on demand.
+const LAZY = ${JSON.stringify(Object.fromEntries(lazySet.map(n => [n, `./m/${fileOf(n)}`])))};
+Transpose.$lazyTypes = LAZY;
+Transpose.$loadType = async function (name) {
+  const p = LAZY[name];
+  if (!p) return Transpose.Reflection.getType(name);
+  await import(p);
+  Transpose.init();
+  return Transpose.Reflection.getType(name);
+};
+Transpose.$loadAll = async function () {
+  await Promise.all(Object.values(LAZY).map(p => import(p)));
+  Transpose.init();
+};
+
+Transpose.init();
+`);
+
+// ---- rewrite index.html -------------------------------------------------------------
+const idx = path.join(outDir, 'index.html');
+let html = fs.readFileSync(idx, 'utf8');
+html = html.replace(/\s*<script src="tss\.js" defer><\/script>/, '');
+html = html.replace(/(\s*)<script src="app\.js" defer><\/script>/, '$1<script type="module" src="boot.mjs"></script>');
+fs.writeFileSync(idx, html);
+
+const bytes = n => fs.statSync(path.join(MODDIR, fileOf(n))).size;
+const sum = s => [...s].reduce((a, n) => a + bytes(n), 0);
+console.log(`mode=${mode}  types=${names.length}  modules written=${names.length}`);
+console.log(`  eager: ${eagerSet.size} modules, ${(sum(eagerSet) / 1024).toFixed(0)} KB`);
+console.log(`  lazy:  ${lazySet.length} modules, ${(sum(new Set(lazySet)) / 1024).toFixed(0)} KB`);

--- a/docs/experiments/js-modules/split2.js
+++ b/docs/experiments/js-modules/split2.js
@@ -1,0 +1,254 @@
+// Experiment 2: lazy per-type modules + metadata-backed TYPE STUBS, so reflection
+// (Assembly.GetTypes / IsAssignableFrom / GetCustomAttributes / Name) still sees every type
+// while its code stays unloaded. Activator.CreateInstance on a stub triggers the load.
+//
+//   node split2.js <siteDir> <outDir> [preloadOnStub]
+const fs = require('fs');
+const path = require('path');
+
+const siteDir = process.argv[2];
+const outDir = process.argv[3];
+
+const BUNDLES = [{ file: 'tss.js', asm: 'tss' }, { file: 'app.js', asm: 'Tesserae.Tests' }];
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+for (const e of fs.readdirSync(siteDir)) fs.cpSync(path.join(siteDir, e), path.join(outDir, e), { recursive: true });
+fs.rmSync(path.join(outDir, 'tss.js'));
+fs.rmSync(path.join(outDir, 'app.js'));
+const MODDIR = path.join(outDir, 'm');
+fs.mkdirSync(MODDIR, { recursive: true });
+
+const blocks = [], tails = [];
+for (const { file, asm } of BUNDLES) {
+  const text = fs.readFileSync(path.join(siteDir, file), 'utf8');
+  const marker = '\n    Transpose.define(';
+  const idxs = [];
+  for (let i = text.indexOf(marker); i >= 0; i = text.indexOf(marker, i + 1)) idxs.push(i);
+  for (let k = 0; k < idxs.length; k++) {
+    const start = idxs[k] + 1;
+    const end = k + 1 < idxs.length ? idxs[k + 1] : text.lastIndexOf('\n});');
+    let body = text.slice(start, end);
+    if (k === idxs.length - 1) {
+      const ms = body.indexOf('\n    var $m = Transpose.setMetadata');
+      if (ms >= 0) { tails.push({ asm, js: body.slice(ms) }); body = body.slice(0, ms); }
+    }
+    const m = body.match(/^ {4}Transpose\.define\("([^"]+)"/);
+    if (m) blocks.push({ name: m[1], body, asm });
+  }
+}
+
+const byName = new Map(blocks.map(b => [b.name, b]));
+const names = [...byName.keys()];
+const nameSet = new Set(names);
+const idOf = new Map(names.map((n, i) => [n, i]));
+const PATH = /\b[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+/g;
+function knownRefs(text) {
+  const f = new Set();
+  for (const m of text.match(PATH) || []) {
+    let p = m;
+    while (p.length) { if (nameSet.has(p)) { f.add(p); break; } const d = p.lastIndexOf('.'); if (d < 0) break; p = p.slice(0, d); }
+  }
+  return f;
+}
+const dt = new Map(), any = new Map(), kind = new Map(), inheritNames = new Map();
+for (const b of blocks) {
+  const im = b.body.match(/inherits:\s*function\s*\(\)\s*\{\s*return\s*\[([^\]]*)\]/);
+  const s = im ? knownRefs(im[1]) : new Set(); s.delete(b.name);
+  dt.set(b.name, s);
+  const a = knownRefs(b.body); a.delete(b.name); any.set(b.name, a);
+  kind.set(b.name, /\$kind:\s*"interface"/.test(b.body) ? 'interface' : /\$kind:\s*"(struct|enum)"/.exec(b.body)?.[1] || 'class');
+  // Full inherits list as *emitted text* (may include runtime types outside this graph).
+  inheritNames.set(b.name, im ? im[1].split(',').map(s => s.trim()).filter(Boolean) : []);
+}
+
+const fileOf = n => `t${idOf.get(n)}.mjs`;
+for (const b of blocks) {
+  const deps = [...dt.get(b.name)].filter(d => byName.has(d));
+  const imports = ["import '../_rt.mjs';", ...deps.map(d => `import './${fileOf(d)}';`)].join('\n');
+  fs.writeFileSync(path.join(MODDIR, fileOf(b.name)),
+    `${imports}\nTranspose.$useAssembly(${JSON.stringify(b.asm)});\n${b.body.replace(/^ {4}/gm, '')}\n`);
+}
+
+function reach(roots, g) { const s = new Set(roots), st = [...roots]; while (st.length) { const n = st.pop(); for (const r of g.get(n) || []) if (!s.has(r)) { s.add(r); st.push(r); } } return s; }
+const ENTRY = 'Tesserae.Tests.App';
+const eagerSet = reach([ENTRY], any);
+const lazy = names.filter(n => !eagerSet.has(n));
+
+// Manifest for the lazy types: module path, kind, assembly, and the *emitted* inherits list.
+const man = {};
+for (const n of lazy) man[n] = { m: `./m/${fileOf(n)}`, k: kind.get(n), a: byName.get(n).asm, i: inheritNames.get(n) };
+
+fs.writeFileSync(path.join(outDir, '_rt.mjs'), `
+Transpose.$useAssembly = function (name) {
+  var asm = System.Reflection.Assembly.assemblies[name];
+  if (!asm) asm = new System.Reflection.Assembly(name, {});
+  Transpose.$currentAssembly = asm;
+};
+`);
+
+const tailJs = tails.map(t => `Transpose.$useAssembly(${JSON.stringify(t.asm)});\n(function ($asm, globals) {\n${t.js}\n})(Transpose.$currentAssembly, Transpose.global);`).join('\n');
+
+fs.writeFileSync(path.join(outDir, 'boot.mjs'), `
+import './_rt.mjs';
+${[...eagerSet].map(n => `import './m/${fileOf(n)}';`).join('\n')}
+
+Transpose.assemblyVersion("tss", "1.0.0.0");
+Transpose.assemblyVersion("Tesserae.Tests", "1.0.0.0");
+
+const MAN = ${JSON.stringify(man)};
+
+// ---- stub types -------------------------------------------------------------------
+// A stub stands in for a type whose module is not loaded. It is registered exactly where the
+// real Transpose.define would put it (the global path + the assembly's $types map), so
+// Assembly.GetTypes(), Type.Name, IsInterface, IsAssignableFrom and the reflection metadata
+// all behave as if the type were present. Only *using* the type (construction, calls) needs
+// the real thing, and that is what forces the module load.
+const STUBS = Object.create(null);
+const STUB_CARRY = Object.create(null);
+function place(name, value) {
+  const parts = name.split('.');
+  let scope = Transpose.global;
+  for (let i = 0; i < parts.length - 1; i++) scope = scope[parts[i]] || (scope[parts[i]] = {});
+  const leaf = parts[parts.length - 1];
+  if (scope[leaf] !== undefined && typeof scope[leaf] === 'function') return; // a real type already lives here
+  // Carry over anything already hung off this path (nested types placed earlier).
+  const existing = scope[leaf];
+  if (existing) for (const k of Object.keys(existing)) value[k] = existing[k];
+  scope[leaf] = value;
+}
+// Dev-mode fault-in: resolve a stub's module synchronously so an existing synchronous call
+// (Activator.CreateInstance, a static-member touch) keeps working. Production wants the async
+// boundary instead; this exists to prove the semantics are reachable at all.
+// Seeded with every module the boot graph already pulled in, so a fault-in never re-evaluates
+// a define that has already run (Transpose.define rejects a redefinition).
+const SYNC_LOADED = new Set(${JSON.stringify(['_rt.mjs', ...[...eagerSet].map(n => `./m/${fileOf(n)}`)])});
+const MOD_OF = ${JSON.stringify(Object.fromEntries(lazy.map(n => [`./m/${fileOf(n)}`, n])))};
+function loadSync(url) {
+  if (SYNC_LOADED.has(url)) return;
+  SYNC_LOADED.add(url);
+  // The stub occupies the global path and the assembly's $types slot; clear both so the real
+  // Transpose.define does not report "Class X is already defined".
+  const owner = MOD_OF[url];
+  if (owner) {
+    const parts = owner.split('.');
+    let scope = Transpose.global;
+    for (let i = 0; i < parts.length - 1 && scope; i++) scope = scope[parts[i]];
+    const stub = scope && scope[parts[parts.length - 1]];
+    if (stub && stub.$stub) {
+      const carry = {};
+      for (const k of Object.keys(stub)) if (k.charAt(0) !== '$') carry[k] = stub[k];
+      delete scope[parts[parts.length - 1]];
+      STUB_CARRY[owner] = carry;
+      const asm = System.Reflection.Assembly.assemblies[MAN[owner].a];
+      if (asm) delete asm.$types[owner];
+    }
+  }
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', new URL(url, import.meta.url).href, false);
+  xhr.send(null);
+  let src = xhr.responseText;
+  // Follow the module's own side-effect imports first, then evaluate it with them stripped.
+  const base = url.slice(0, url.lastIndexOf('/') + 1);
+  for (const m of src.matchAll(/^import\\s+'([^']+)';$/gm)) {
+    const rel = m[1];
+    loadSync(rel.startsWith('../') ? rel.slice(3) : base + rel.replace('./', ''));
+  }
+  src = src.replace(/^import\\s+'[^']+';$/gm, '');
+  (0, eval)(src);
+  if (owner && STUB_CARRY[owner]) {
+    const real = Transpose.Reflection.getType(owner);
+    if (real) for (const k of Object.keys(STUB_CARRY[owner])) if (real[k] === undefined) real[k] = STUB_CARRY[owner][k];
+    delete STUB_CARRY[owner];
+  }
+}
+
+function makeStub(name, info) {
+  const fn = function () {
+    loadSync(info.m);
+    Transpose.init();
+    const real = Transpose.Reflection.getType(name);
+    if (!real || real.$stub) throw new Error('Transpose: could not fault in module for ' + name);
+    if (!real.$metadata && fn.$metadata) { real.$metadata = fn.$metadata; real.$getMetadata = Transpose.Reflection.getMetadata; }
+    // Re-dispatch the construction onto the real class.
+    return new real();
+  };
+  fn.$$name = name;
+  fn.$stub = true;
+  fn.$module = info.m;
+  fn.$kind = info.k;
+  if (info.k === 'interface') fn.$isInterface = true;
+  fn.prototype = { constructor: fn };
+  fn.$assembly = System.Reflection.Assembly.assemblies[info.a];
+  return fn;
+}
+// Outermost first: a nested type is placed *onto* its container, so the container's stub has
+// to exist before it, or placing the nested one would create a plain {} that the container's
+// own stub then overwrites (losing the nested type).
+for (const name of Object.keys(MAN).sort((a, b) => a.split('.').length - b.split('.').length)) {
+  const info = MAN[name];
+  if (name.indexOf('$') >= 0) continue;                 // skip generic definitions in this experiment
+  const asm = System.Reflection.Assembly.assemblies[info.a] || new System.Reflection.Assembly(info.a, {});
+  const stub = makeStub(name, info);
+  STUBS[name] = stub;
+  place(name, stub);
+  asm.\$types[name] = stub;
+}
+// Resolve the inherits chain once every stub exists (a stub may extend another stub).
+for (const name in STUBS) {
+  const list = MAN[name].i.map(expr => { try { return eval(expr); } catch { return null; } }).filter(Boolean);
+  STUBS[name].$$inherits = list;
+  const iface = [];
+  for (const b of list) {
+    if (b.$isInterface) iface.push(b);
+    if (b.$interfaces) iface.push.apply(iface, b.$interfaces);
+    if (b.$$inherits) for (const g of b.$$inherits) if (g.$isInterface) iface.push(g);
+  }
+  STUBS[name].$interfaces = iface;
+}
+
+// Reflection metadata (both assemblies) — eager, and it attaches to the stubs.
+${tailJs}
+
+// ---- the loader -------------------------------------------------------------------
+Transpose.$loadType = async function (name) {
+  const info = MAN[name];
+  if (!info) return Transpose.Reflection.getType(name);
+  const meta = STUBS[name] && STUBS[name].$metadata;
+  await import(info.m);
+  Transpose.init();
+  const real = Transpose.Reflection.getType(name);
+  if (real && meta && !real.$metadata) { real.$metadata = meta; real.$getMetadata = Transpose.Reflection.getMetadata; }
+  return real;
+};
+Transpose.$isStub = t => !!(t && t.$stub);
+
+// The runtime hook: any reflective *use* of a type faults its module in first.
+// (Activator.CreateInstance is the one Tesserae's sample gallery goes through.)
+function faultIn(type) {
+  if (!type || !type.$stub) return type;
+  const name = type.$$name;
+  loadSync(MAN[name].m);
+  Transpose.init();
+  const real = Transpose.Reflection.getType(name);
+  if (real && !real.$stub) {
+    if (!real.$metadata && type.$metadata) { real.$metadata = type.$metadata; real.$getMetadata = Transpose.Reflection.getMetadata; }
+    return real;
+  }
+  return type;
+}
+const _createInstance = Transpose.createInstance;
+Transpose.createInstance = function (type, nonPublic, args) { return _createInstance.call(this, faultIn(type), nonPublic, args); };
+Transpose.$faultIn = faultIn;
+
+Transpose.init();
+`);
+
+let html = fs.readFileSync(path.join(outDir, 'index.html'), 'utf8');
+html = html.replace(/\s*<script src="tss\.js" defer><\/script>/, '');
+html = html.replace(/(\s*)<script src="app\.js" defer><\/script>/, '$1<script type="module" src="boot.mjs"></script>');
+fs.writeFileSync(path.join(outDir, 'index.html'), html);
+
+const bytes = n => fs.statSync(path.join(MODDIR, fileOf(n))).size;
+const sum = s => [...s].reduce((a, n) => a + bytes(n), 0);
+console.log(`types=${names.length}  eager=${eagerSet.size} (${(sum(eagerSet) / 1024).toFixed(0)} KB)  lazy=${lazy.length} (${(sum(new Set(lazy)) / 1024).toFixed(0)} KB)`);

--- a/docs/experiments/js-modules/split3.js
+++ b/docs/experiments/js-modules/split3.js
@@ -1,0 +1,217 @@
+// Experiment 3: chunk = strongly-connected component of the FULL reference graph.
+// The condensation of that graph is a DAG, so a chunk can import every chunk it references
+// as a side-effect ESM import and the evaluation order is always safe — including for
+// define-time (inherits) references, which is what a per-class split cannot guarantee.
+//
+//   node split3.js <siteDir> <outDir>
+const fs = require('fs');
+const path = require('path');
+
+const siteDir = process.argv[2], outDir = process.argv[3];
+const BUNDLES = [{ file: 'tss.js', asm: 'tss' }, { file: 'app.js', asm: 'Tesserae.Tests' }];
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+for (const e of fs.readdirSync(siteDir)) fs.cpSync(path.join(siteDir, e), path.join(outDir, e), { recursive: true });
+fs.rmSync(path.join(outDir, 'tss.js')); fs.rmSync(path.join(outDir, 'app.js'));
+const MODDIR = path.join(outDir, 'c'); fs.mkdirSync(MODDIR, { recursive: true });
+
+// ---- parse ---------------------------------------------------------------------------
+const blocks = [], tails = [];
+for (const { file, asm } of BUNDLES) {
+  const text = fs.readFileSync(path.join(siteDir, file), 'utf8');
+  const marker = '\n    Transpose.define(';
+  const idxs = []; for (let i = text.indexOf(marker); i >= 0; i = text.indexOf(marker, i + 1)) idxs.push(i);
+  for (let k = 0; k < idxs.length; k++) {
+    let body = text.slice(idxs[k] + 1, k + 1 < idxs.length ? idxs[k + 1] : text.lastIndexOf('\n});'));
+    if (k === idxs.length - 1) {
+      const ms = body.indexOf('\n    var $m = Transpose.setMetadata');
+      if (ms >= 0) { tails.push({ asm, js: body.slice(ms) }); body = body.slice(0, ms); }
+    }
+    const m = body.match(/^ {4}Transpose\.define\("([^"]+)"/);
+    if (m) blocks.push({ name: m[1], body, asm, order: blocks.length });
+  }
+}
+const byName = new Map(blocks.map(b => [b.name, b]));
+const names = [...byName.keys()], nameSet = new Set(names);
+const PATH = /\b[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+/g;
+const refs = t => { const f = new Set(); for (const m of t.match(PATH) || []) { let p = m; while (p.length) { if (nameSet.has(p)) { f.add(p); break; } const d = p.lastIndexOf('.'); if (d < 0) break; p = p.slice(0, d); } } return f; };
+const g = new Map();
+for (const b of blocks) { const s = refs(b.body); s.delete(b.name); g.set(b.name, s); }
+
+// ---- SCC (iterative Tarjan) ------------------------------------------------------------
+function scc(g, nodes) {
+  let idx = 0; const index = new Map(), low = new Map(), on = new Set(), st = [], out = [];
+  for (const root of nodes) {
+    if (index.has(root)) continue;
+    const work = [[root, 0]];
+    index.set(root, idx); low.set(root, idx); idx++; st.push(root); on.add(root);
+    while (work.length) {
+      const fr = work[work.length - 1], n = fr[0], succ = [...(g.get(n) || [])];
+      if (fr[1] < succ.length) {
+        const w = succ[fr[1]++];
+        if (!index.has(w)) { index.set(w, idx); low.set(w, idx); idx++; st.push(w); on.add(w); work.push([w, 0]); }
+        else if (on.has(w)) low.set(n, Math.min(low.get(n), index.get(w)));
+      } else {
+        if (low.get(n) === index.get(n)) { const c = []; let w; do { w = st.pop(); on.delete(w); c.push(w); } while (w !== n); out.push(c); }
+        work.pop();
+        if (work.length) { const p = work[work.length - 1][0]; low.set(p, Math.min(low.get(p), low.get(n))); }
+      }
+    }
+  }
+  return out;
+}
+const comps = scc(g, names);
+const chunkOf = new Map();
+comps.forEach((c, i) => c.forEach(n => chunkOf.set(n, i)));
+
+// Chunk-level DAG.
+const chunkDeps = comps.map(() => new Set());
+for (const n of names) for (const r of g.get(n)) { const a = chunkOf.get(n), b = chunkOf.get(r); if (a !== b) chunkDeps[a].add(b); }
+
+// ---- write one module per chunk -------------------------------------------------------
+// Inside a chunk, types are emitted in the bundle's original order — which the compiler already
+// sorted by dependency depth, so inherits is satisfied within the chunk exactly as it is today.
+for (let i = 0; i < comps.length; i++) {
+  const members = comps[i].map(n => byName.get(n)).sort((a, b) => a.order - b.order);
+  const imports = ["import '../_rt.mjs';", ...[...chunkDeps[i]].map(d => `import './c${d}.mjs';`)].join('\n');
+  const body = members.map(b => `Transpose.$useAssembly(${JSON.stringify(b.asm)});\n${b.body.replace(/^ {4}/gm, '')}`).join('\n');
+  fs.writeFileSync(path.join(MODDIR, `c${i}.mjs`), `${imports}\n${body}\n`);
+}
+
+fs.writeFileSync(path.join(outDir, '_rt.mjs'), `
+Transpose.$useAssembly = function (name) {
+  var asm = System.Reflection.Assembly.assemblies[name];
+  if (!asm) asm = new System.Reflection.Assembly(name, {});
+  Transpose.$currentAssembly = asm;
+};
+`);
+
+// ---- eager set = chunks reachable from the entry point ---------------------------------
+const ENTRY = 'Tesserae.Tests.App';
+const entryChunk = chunkOf.get(ENTRY);
+const eagerChunks = new Set([entryChunk]); {
+  const st = [entryChunk];
+  while (st.length) { const c = st.pop(); for (const d of chunkDeps[c]) if (!eagerChunks.has(d)) { eagerChunks.add(d); st.push(d); } }
+}
+const lazyChunks = comps.map((_, i) => i).filter(i => !eagerChunks.has(i));
+const lazyTypes = lazyChunks.flatMap(i => comps[i]);
+
+const kindOf = n => /\$kind:\s*"interface"/.test(byName.get(n).body) ? 'interface' : 'class';
+const inheritsOf = n => { const m = byName.get(n).body.match(/inherits:\s*function\s*\(\)\s*\{\s*return\s*\[([^\]]*)\]/); return m ? m[1].split(',').map(s => s.trim()).filter(Boolean) : []; };
+const man = {};
+for (const n of lazyTypes) man[n] = { c: `./c/c${chunkOf.get(n)}.mjs`, k: kindOf(n), a: byName.get(n).asm, i: inheritsOf(n) };
+
+const tailJs = tails.map(t => `Transpose.$useAssembly(${JSON.stringify(t.asm)});\n(function ($asm, globals) {\n${t.js}\n})(Transpose.$currentAssembly, Transpose.global);`).join('\n');
+
+fs.writeFileSync(path.join(outDir, 'boot.mjs'), `
+import './_rt.mjs';
+${[...eagerChunks].map(i => `import './c/c${i}.mjs';`).join('\n')}
+
+Transpose.assemblyVersion("tss", "1.0.0.0");
+Transpose.assemblyVersion("Tesserae.Tests", "1.0.0.0");
+
+const MAN = ${JSON.stringify(man)};
+const STUBS = Object.create(null), STUB_CARRY = Object.create(null);
+const CHUNK_MEMBERS = ${JSON.stringify(Object.fromEntries(lazyChunks.map(i => [`./c/c${i}.mjs`, comps[i]])))};
+
+function place(name, value) {
+  const parts = name.split('.');
+  let scope = Transpose.global;
+  for (let i = 0; i < parts.length - 1; i++) scope = scope[parts[i]] || (scope[parts[i]] = {});
+  const leaf = parts[parts.length - 1];
+  if (typeof scope[leaf] === 'function') return;
+  const existing = scope[leaf];
+  if (existing) for (const k of Object.keys(existing)) value[k] = existing[k];
+  scope[leaf] = value;
+}
+function makeStub(name, info) {
+  const fn = function () { throw new Error('Transpose: ' + name + ' is in an unloaded chunk'); };
+  fn.$$name = name; fn.$stub = true; fn.$chunk = info.c; fn.$kind = info.k;
+  if (info.k === 'interface') fn.$isInterface = true;
+  fn.prototype = { constructor: fn };
+  fn.$assembly = System.Reflection.Assembly.assemblies[info.a];
+  return fn;
+}
+for (const name of Object.keys(MAN).sort((a, b) => a.split('.').length - b.split('.').length)) {
+  if (name.indexOf('$') >= 0) continue;
+  const info = MAN[name];
+  const asm = System.Reflection.Assembly.assemblies[info.a] || new System.Reflection.Assembly(info.a, {});
+  const stub = makeStub(name, info);
+  STUBS[name] = stub; place(name, stub); asm.$types[name] = stub;
+}
+for (const name in STUBS) {
+  const list = MAN[name].i.map(e => { try { return eval(e); } catch { return null; } }).filter(Boolean);
+  STUBS[name].$$inherits = list;
+  const ifc = [];
+  for (const b of list) { if (b.$isInterface) ifc.push(b); if (b.$interfaces) ifc.push.apply(ifc, b.$interfaces); if (b.$$inherits) for (const gg of b.$$inherits) if (gg.$isInterface) ifc.push(gg); }
+  STUBS[name].$interfaces = ifc;
+}
+
+${tailJs}
+
+// ---- synchronous chunk fault-in --------------------------------------------------------
+const LOADED = new Set(${JSON.stringify(['_rt.mjs', ...[...eagerChunks].map(i => `./c/c${i}.mjs`)])});
+function loadChunk(url) {
+  if (LOADED.has(url)) return;
+  LOADED.add(url);
+  for (const name of (CHUNK_MEMBERS[url] || [])) {
+    const parts = name.split('.');
+    let scope = Transpose.global;
+    for (let i = 0; i < parts.length - 1 && scope; i++) scope = scope[parts[i]];
+    const stub = scope && scope[parts[parts.length - 1]];
+    if (stub && stub.$stub) {
+      const carry = {};
+      for (const k of Object.keys(stub)) if (k.charAt(0) !== '$') carry[k] = stub[k];
+      STUB_CARRY[name] = { carry: carry, meta: stub.$metadata };
+      delete scope[parts[parts.length - 1]];
+      const asm = System.Reflection.Assembly.assemblies[MAN[name].a];
+      if (asm) delete asm.$types[name];
+    }
+  }
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', new URL(url, import.meta.url).href, false);
+  xhr.send(null);
+  let src = xhr.responseText;
+  const base = url.slice(0, url.lastIndexOf('/') + 1);
+  for (const m of src.matchAll(/^import\\s+'([^']+)';$/gm)) {
+    const rel = m[1];
+    loadChunk(rel.indexOf('../') === 0 ? rel.slice(3) : base + rel.replace('./', ''));
+  }
+  (0, eval)(src.replace(/^import\\s+'[^']+';$/gm, ''));
+  Transpose.init();
+  for (const name of (CHUNK_MEMBERS[url] || [])) {
+    const saved = STUB_CARRY[name]; if (!saved) continue;
+    const real = Transpose.Reflection.getType(name);
+    if (real && !real.$stub) {
+      for (const k of Object.keys(saved.carry)) if (real[k] === undefined) real[k] = saved.carry[k];
+      if (!real.$metadata && saved.meta) { real.$metadata = saved.meta; real.$getMetadata = Transpose.Reflection.getMetadata; }
+    }
+    delete STUB_CARRY[name];
+  }
+}
+function faultIn(type) {
+  if (!type || !type.$stub) return type;
+  loadChunk(type.$chunk);
+  const real = Transpose.Reflection.getType(type.$$name);
+  return real && !real.$stub ? real : type;
+}
+const _ci = Transpose.createInstance;
+Transpose.createInstance = function (t, nonPublic, args) { return _ci.call(this, faultIn(t), nonPublic, args); };
+Transpose.$faultIn = faultIn;
+Transpose.$loadChunk = loadChunk;
+
+Transpose.init();
+`);
+
+let html = fs.readFileSync(path.join(outDir, 'index.html'), 'utf8');
+html = html.replace(/\s*<script src="tss\.js" defer><\/script>/, '');
+html = html.replace(/(\s*)<script src="app\.js" defer><\/script>/, '$1<script type="module" src="boot.mjs"></script>');
+fs.writeFileSync(path.join(outDir, 'index.html'), html);
+
+const sz = i => fs.statSync(path.join(MODDIR, `c${i}.mjs`)).size;
+const tot = a => a.reduce((x, i) => x + sz(i), 0);
+console.log(`types=${names.length}  chunks=${comps.length}`);
+console.log(`  eager chunks ${eagerChunks.size}: ${(tot([...eagerChunks]) / 1024).toFixed(0)} KB  (${comps.filter((_, i) => eagerChunks.has(i)).flat().length} types)`);
+console.log(`  lazy  chunks ${lazyChunks.length}: ${(tot(lazyChunks) / 1024).toFixed(0)} KB  (${lazyTypes.length} types)`);
+console.log(`  biggest chunk: ${(Math.max(...comps.map((_, i) => sz(i))) / 1024).toFixed(0)} KB`);

--- a/docs/experiments/js-modules/split4.js
+++ b/docs/experiments/js-modules/split4.js
@@ -1,0 +1,260 @@
+// Experiment 3: chunk = strongly-connected component of the FULL reference graph.
+// The condensation of that graph is a DAG, so a chunk can import every chunk it references
+// as a side-effect ESM import and the evaluation order is always safe — including for
+// define-time (inherits) references, which is what a per-class split cannot guarantee.
+//
+//   node split3.js <siteDir> <outDir>
+const fs = require('fs');
+const path = require('path');
+
+const siteDir = process.argv[2], outDir = process.argv[3];
+const BUNDLES = [{ file: 'tss.js', asm: 'tss' }, { file: 'app.js', asm: 'Tesserae.Tests' }];
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+for (const e of fs.readdirSync(siteDir)) fs.cpSync(path.join(siteDir, e), path.join(outDir, e), { recursive: true });
+fs.rmSync(path.join(outDir, 'tss.js')); fs.rmSync(path.join(outDir, 'app.js'));
+const MODDIR = path.join(outDir, 'c'); fs.mkdirSync(MODDIR, { recursive: true });
+
+// ---- parse ---------------------------------------------------------------------------
+const blocks = [], tails = [];
+for (const { file, asm } of BUNDLES) {
+  const text = fs.readFileSync(path.join(siteDir, file), 'utf8');
+  const idxs = [];
+  for (const m of text.matchAll(/\n {4}Transpose\.definei?\(/g)) idxs.push(m.index);
+  for (let k = 0; k < idxs.length; k++) {
+    let body = text.slice(idxs[k] + 1, k + 1 < idxs.length ? idxs[k + 1] : text.lastIndexOf('\n});'));
+    if (k === idxs.length - 1) {
+      const ms = body.indexOf('\n    var $m = Transpose.setMetadata');
+      if (ms >= 0) { tails.push({ asm, js: body.slice(ms) }); body = body.slice(0, ms); }
+    }
+    const m = body.match(/^ {4}Transpose\.definei?\("([^"]+)"/);
+    if (m) blocks.push({ name: m[1], body, asm, order: blocks.length });
+  }
+}
+const byName = new Map(blocks.map(b => [b.name, b]));
+const names = [...byName.keys()], nameSet = new Set(names);
+const PATH = /\b[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+/g;
+// HARD reference: the emitted code *uses* the type — constructs it (`new X(`), reads a static
+// member (`X.`), or extends it (inherits). Those need the real class, so they are import edges.
+// SOFT reference: a bare mention — `typeof(X)`, a generic type argument, an `is`/cast operand.
+// Those only need a Type object, which a stub already provides, so they are NOT import edges.
+// Is the reference at `at` inside the argument list of a `Name$N(...)` generic application?
+function isGenericArgument(text, at) {
+  let depth = 0;
+  for (let i = at - 1; i >= 0 && at - i < 4000; i--) {
+    const ch = text.charAt(i);
+    if (ch === ')') depth++;
+    else if (ch === '(') {
+      if (depth === 0) return /\$\d+$/.test(text.slice(Math.max(0, i - 40), i));
+      depth--;
+    }
+  }
+  return false;
+}
+function hardRefs(text) {
+  const f = new Set();
+  for (const m of text.matchAll(PATH)) {
+    const after = text.charAt(m.index + m[0].length);
+    let p = m[0];
+    while (p.length) {
+      if (nameSet.has(p)) {
+        // `p` is the type; anything after it in the matched path means a member access.
+        // Hard when the code reaches *into* the type (a member access or a construction), and
+        // also when the type is a generic type ARGUMENT: `Foo$1(X)` builds a generic instance
+        // whose base class can be X itself, so X must be defined before the application runs.
+        const isMemberAccess = p.length < m[0].length || after === '.' || after === '(';
+        if (isMemberAccess || isGenericArgument(text, m.index)) f.add(p);
+        break;
+      }
+      const d = p.lastIndexOf('.'); if (d < 0) break; p = p.slice(0, d);
+    }
+  }
+  return f;
+}
+const g = new Map();
+for (const b of blocks) {
+  const s = hardRefs(b.body);
+  // inherits is always hard, even though it reads as a bare mention.
+  for (const im of b.body.matchAll(/inherits:\s*function\s*\(\)\s*\{\s*return\s*\[([^\]]*)\]/g))
+    for (const m of im[1].matchAll(PATH)) { let p = m[0]; while (p.length) { if (nameSet.has(p)) { s.add(p); break; } const d = p.lastIndexOf('.'); if (d < 0) break; p = p.slice(0, d); } }
+  s.delete(b.name);
+  g.set(b.name, s);
+}
+
+// ---- SCC (iterative Tarjan) ------------------------------------------------------------
+function scc(g, nodes) {
+  let idx = 0; const index = new Map(), low = new Map(), on = new Set(), st = [], out = [];
+  for (const root of nodes) {
+    if (index.has(root)) continue;
+    const work = [[root, 0]];
+    index.set(root, idx); low.set(root, idx); idx++; st.push(root); on.add(root);
+    while (work.length) {
+      const fr = work[work.length - 1], n = fr[0], succ = [...(g.get(n) || [])];
+      if (fr[1] < succ.length) {
+        const w = succ[fr[1]++];
+        if (!index.has(w)) { index.set(w, idx); low.set(w, idx); idx++; st.push(w); on.add(w); work.push([w, 0]); }
+        else if (on.has(w)) low.set(n, Math.min(low.get(n), index.get(w)));
+      } else {
+        if (low.get(n) === index.get(n)) { const c = []; let w; do { w = st.pop(); on.delete(w); c.push(w); } while (w !== n); out.push(c); }
+        work.pop();
+        if (work.length) { const p = work[work.length - 1][0]; low.set(p, Math.min(low.get(p), low.get(n))); }
+      }
+    }
+  }
+  return out;
+}
+const comps = scc(g, names);
+const chunkOf = new Map();
+comps.forEach((c, i) => c.forEach(n => chunkOf.set(n, i)));
+
+// Chunk-level DAG.
+const chunkDeps = comps.map(() => new Set());
+for (const n of names) for (const r of g.get(n)) { const a = chunkOf.get(n), b = chunkOf.get(r); if (a !== b) chunkDeps[a].add(b); }
+
+// ---- write one module per chunk -------------------------------------------------------
+// Inside a chunk, types are emitted in the bundle's original order — which the compiler already
+// sorted by dependency depth, so inherits is satisfied within the chunk exactly as it is today.
+for (let i = 0; i < comps.length; i++) {
+  const members = comps[i].map(n => byName.get(n)).sort((a, b) => a.order - b.order);
+  const imports = ["import '../_rt.mjs';", ...[...chunkDeps[i]].map(d => `import './c${d}.mjs';`)].join('\n');
+  const body = members.map(b => `Transpose.$useAssembly(${JSON.stringify(b.asm)});\n${b.body.replace(/^ {4}/gm, '')}`).join('\n');
+  fs.writeFileSync(path.join(MODDIR, `c${i}.mjs`), `${imports}\n${body}\n`);
+}
+
+fs.writeFileSync(path.join(outDir, '_rt.mjs'), `
+Transpose.$useAssembly = function (name) {
+  var asm = System.Reflection.Assembly.assemblies[name];
+  if (!asm) asm = new System.Reflection.Assembly(name, {});
+  Transpose.$currentAssembly = asm;
+};
+`);
+
+// ---- eager set = chunks reachable from the entry point ---------------------------------
+const ENTRY = 'Tesserae.Tests.App';
+const entryChunk = chunkOf.get(ENTRY);
+const eagerChunks = new Set([entryChunk]); {
+  const st = [entryChunk];
+  while (st.length) { const c = st.pop(); for (const d of chunkDeps[c]) if (!eagerChunks.has(d)) { eagerChunks.add(d); st.push(d); } }
+}
+const lazyChunks = comps.map((_, i) => i).filter(i => !eagerChunks.has(i));
+const lazyTypes = lazyChunks.flatMap(i => comps[i]);
+
+const kindOf = n => /\$kind:\s*"interface"/.test(byName.get(n).body) ? 'interface' : 'class';
+const inheritsOf = n => { const m = byName.get(n).body.match(/^ {4}Transpose\.definei?\("[^"]+",[\s\S]*?inherits:\s*function\s*\(\)\s*\{\s*return\s*\[([^\]]*)\]/); return m ? m[1].split(',').map(s => s.trim()).filter(Boolean) : []; };
+const man = {};
+for (const n of lazyTypes) man[n] = { c: `./c/c${chunkOf.get(n)}.mjs`, k: kindOf(n), a: byName.get(n).asm, i: inheritsOf(n) };
+
+const tailJs = tails.map(t => `Transpose.$useAssembly(${JSON.stringify(t.asm)});\n(function ($asm, globals) {\n${t.js}\n})(Transpose.$currentAssembly, Transpose.global);`).join('\n');
+
+fs.writeFileSync(path.join(outDir, 'boot.mjs'), `
+import './_rt.mjs';
+${[...eagerChunks].map(i => `import './c/c${i}.mjs';`).join('\n')}
+
+Transpose.assemblyVersion("tss", "1.0.0.0");
+Transpose.assemblyVersion("Tesserae.Tests", "1.0.0.0");
+
+const MAN = ${JSON.stringify(man)};
+const STUBS = Object.create(null), STUB_CARRY = Object.create(null);
+const CHUNK_MEMBERS = ${JSON.stringify(Object.fromEntries(lazyChunks.map(i => [`./c/c${i}.mjs`, comps[i]])))};
+
+function place(name, value) {
+  const parts = name.split('.');
+  let scope = Transpose.global;
+  for (let i = 0; i < parts.length - 1; i++) scope = scope[parts[i]] || (scope[parts[i]] = {});
+  const leaf = parts[parts.length - 1];
+  if (typeof scope[leaf] === 'function') return;
+  const existing = scope[leaf];
+  if (existing) for (const k of Object.keys(existing)) value[k] = existing[k];
+  scope[leaf] = value;
+}
+function makeStub(name, info) {
+  const fn = function () { throw new Error('Transpose: ' + name + ' is in an unloaded chunk'); };
+  fn.$$name = name; fn.$stub = true; fn.$chunk = info.c; fn.$kind = info.k;
+  if (info.k === 'interface') fn.$isInterface = true;
+  fn.prototype = { constructor: fn };
+  fn.$assembly = System.Reflection.Assembly.assemblies[info.a];
+  return fn;
+}
+for (const name of Object.keys(MAN).sort((a, b) => a.split('.').length - b.split('.').length)) {
+  if (name.indexOf('$') >= 0) continue;
+  const info = MAN[name];
+  const asm = System.Reflection.Assembly.assemblies[info.a] || new System.Reflection.Assembly(info.a, {});
+  const stub = makeStub(name, info);
+  STUBS[name] = stub; place(name, stub); asm.$types[name] = stub;
+}
+for (const name in STUBS) {
+  const list = MAN[name].i.map(e => { try { return eval(e); } catch { return null; } }).filter(Boolean);
+  STUBS[name].$$inherits = list;
+  const ifc = [];
+  for (const b of list) { if (b.$isInterface) ifc.push(b); if (b.$interfaces) ifc.push.apply(ifc, b.$interfaces); if (b.$$inherits) for (const gg of b.$$inherits) if (gg.$isInterface) ifc.push(gg); }
+  STUBS[name].$interfaces = ifc;
+}
+
+${tailJs}
+
+// ---- synchronous chunk fault-in --------------------------------------------------------
+const LOADED = new Set(${JSON.stringify(['_rt.mjs', ...[...eagerChunks].map(i => `./c/c${i}.mjs`)])});
+function loadChunk(url) {
+  if (LOADED.has(url)) return;
+  LOADED.add(url);
+  for (const name of (CHUNK_MEMBERS[url] || [])) {
+    const parts = name.split('.');
+    let scope = Transpose.global;
+    for (let i = 0; i < parts.length - 1 && scope; i++) scope = scope[parts[i]];
+    const stub = scope && scope[parts[parts.length - 1]];
+    if (stub && stub.$stub) {
+      const carry = {};
+      for (const k of Object.keys(stub)) if (k.charAt(0) !== '$') carry[k] = stub[k];
+      STUB_CARRY[name] = { carry: carry, meta: stub.$metadata };
+      delete scope[parts[parts.length - 1]];
+      const asm = System.Reflection.Assembly.assemblies[MAN[name].a];
+      if (asm) delete asm.$types[name];
+    }
+  }
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', new URL(url, import.meta.url).href, false);
+  xhr.send(null);
+  let src = xhr.responseText;
+  const base = url.slice(0, url.lastIndexOf('/') + 1);
+  for (const m of src.matchAll(/^import\\s+'([^']+)';$/gm)) {
+    const rel = m[1];
+    loadChunk(rel.indexOf('../') === 0 ? rel.slice(3) : base + rel.replace('./', ''));
+  }
+  (0, eval)(src.replace(/^import\\s+'[^']+';$/gm, ''));
+  Transpose.init();
+  for (const name of (CHUNK_MEMBERS[url] || [])) {
+    const saved = STUB_CARRY[name]; if (!saved) continue;
+    const real = Transpose.Reflection.getType(name);
+    if (real && !real.$stub) {
+      for (const k of Object.keys(saved.carry)) if (real[k] === undefined) real[k] = saved.carry[k];
+      if (!real.$metadata && saved.meta) { real.$metadata = saved.meta; real.$getMetadata = Transpose.Reflection.getMetadata; }
+    }
+    delete STUB_CARRY[name];
+  }
+}
+function faultIn(type) {
+  if (!type || !type.$stub) return type;
+  loadChunk(type.$chunk);
+  const real = Transpose.Reflection.getType(type.$$name);
+  return real && !real.$stub ? real : type;
+}
+const _ci = Transpose.createInstance;
+Transpose.createInstance = function (t, nonPublic, args) { return _ci.call(this, faultIn(t), nonPublic, args); };
+Transpose.$faultIn = faultIn;
+Transpose.$loadChunk = loadChunk;
+
+Transpose.init();
+`);
+
+let html = fs.readFileSync(path.join(outDir, 'index.html'), 'utf8');
+html = html.replace(/\s*<script src="tss\.js" defer><\/script>/, '');
+html = html.replace(/(\s*)<script src="app\.js" defer><\/script>/, '$1<script type="module" src="boot.mjs"></script>');
+fs.writeFileSync(path.join(outDir, 'index.html'), html);
+
+const sz = i => fs.statSync(path.join(MODDIR, `c${i}.mjs`)).size;
+const tot = a => a.reduce((x, i) => x + sz(i), 0);
+console.log(`types=${names.length}  chunks=${comps.length}`);
+console.log(`  eager chunks ${eagerChunks.size}: ${(tot([...eagerChunks]) / 1024).toFixed(0)} KB  (${comps.filter((_, i) => eagerChunks.has(i)).flat().length} types)`);
+console.log(`  lazy  chunks ${lazyChunks.length}: ${(tot(lazyChunks) / 1024).toFixed(0)} KB  (${lazyTypes.length} types)`);
+console.log(`  biggest chunk: ${(Math.max(...comps.map((_, i) => sz(i))) / 1024).toFixed(0)} KB`);


### PR DESCRIPTION
Adds an opt-in module output mode. `"outputBy": "Module"` in a project's `tps.json` makes `tps` emit one ES module per chunk (`chunks/<assembly>/cN.mjs`) plus an entry module, instead of one bundle, and index.html carries a `<script type="module">` for it. Only the code the entry point actually reaches ships up front; everything else is fetched when something needs it.

## What a chunk is

A chunk is a **strongly-connected component of the reference graph** the emitter records as it walks each type. That is the smallest sound unit: `Transpose.define` resolves `inherits` eagerly, so a per-class split cannot order a reference cycle — one of the two files would always be evaluated with its base still undefined. Tarjan yields components in reverse-topological order, so numbering them gives a DAG in which every import points at a lower index, which also makes the file names deterministic.

A `typeof(X)` operand is a *soft* reference — it wants a `Type` object, which a stub answers for — so it does not fuse chunks. The exception is a **constructed** generic: it has no object to point at, it is built by *applying* its definition (`Foo$1(Bar)`), and applying a stub throws, so its definition and arguments stay hard references even inside a `typeof`.

## Reflection while the code is absent

`Resources/Modules.js` adds `Transpose.Modules`: a registry that stubs every deferred type at the same global path and in the same assembly `$types` map a real `Transpose.define` would use. `Assembly.GetTypes()`, `Type.Name`, `IsInterface`, `IsAssignableFrom`, `GetInterfaces` and the eagerly-emitted metadata all keep working unloaded. `Modules.LoadAsync(type)` fetches the module (default loader is a dynamic `import()` built through `new Function`, so `tps.js` stays parseable in engines that cannot compile one; `Modules.SetLoader` substitutes another).

*Using* a deferred type synchronously cannot work — fetching is asynchronous, C# construction is not — so `Activator.CreateInstanceAsync` is the way in, and `Transpose.createInstance` carries a stub guard that throws naming the module rather than failing obscurely inside a constructor.

**Generic bases are carried properly.** A base or interface reaches the manifest as either a name or `[definition, ...arguments]` (`["tss.CB$2", "tss.Avatar", "HTMLElement"]`), and the runtime applies the definition on the first read of the stub's `$$inherits`/`$interfaces`/`$allInterfaces` — never at `register` time, because a base may itself be a stub, and never caching a partial resolution. Flattening to `Foo$1` (all a `Transpose.unroll` path walk can express, since a constructed generic deliberately gets no global slot) made `IsAssignableFrom(IFoo<Bar>, stub)` answer false, silently. An **open** base (`class Relay<T> : IHandler<T>`) has no argument to write down, so the spec is the bare definition and the runtime applies it to placeholder type parameters — which is exactly the shape a loaded definition records, since `$staticInit` does the same.

## Packages split too

`--emit-package` chunks as well. A library has no entry point to be lazy relative to, so it defers everything (its eager set is just the chunks holding `[Ready]` handlers) and publishes a chunk map — emitted type name → chunk file — embedded as `Transpose.Modules.json`. Like the `BuildStamp`, it is embedded but deliberately *not* listed in `Transpose.Resources.json`, so nothing extracts it into a site. A consuming build merges its references' maps (`ModuleMap.Read`, via Mono.Cecil — never `Assembly.LoadFrom`) and emits `import '../<lib>/cN.mjs'` from whichever of its own chunks reaches into a library type.

## Five things that are load-bearing

Each was found by running it, not by reasoning about it, and each has a comment saying so:

1. The entry module emits its **reflection metadata before the manifest** — `Modules.register` ends with `Transpose.init()`, and `init` runs `Main`, so anything after it would not exist yet.
2. The stub swap lives in **`Transpose.define` itself** (`Class.set`), not in the loader: a chunk can also be evaluated as a plain static import from another chunk, which never passes through the loader.
3. The metadata hand-off is keyed by type **name** (`Modules.$metaFor`) rather than held on the stub object, for the same reason.
4. A stub is **retired in place, never deleted**. `Class.set` already copies the members of whatever occupied the slot onto the new class — that is how a nested type registered onto the stub survives — and it has to survive *before* the define resolves `inherits`, because a type's own base can mention its nested type (`Nav : …<Nav.NavLink>`).
5. A generic base **resolves lazily**, on first read, never at `register` time — the base's own definition may still be a stub, and a partial answer must not be cached or a base whose module arrives later is never picked up.

## Measured

Tesserae's sample gallery, both the library and the app built as modules, driven through headless Chromium. `tss` + app JavaScript, excluding the `tps` runtime and the third-party bundle, which are identical either way:

| | single bundle | as modules |
| --- | --- | --- |
| with the library's reflection on | 5,968 KB raw / 762 KB gz | 4,235 KB / 527 KB |
| with it off (Tesserae's current setting) | 3,473 KB / 534 KB | **1,750 KB / 323 KB** |

628 chunks (468 library, 160 app), 212 eager, 416 on demand. The split's own contribution grows from 29%/31% to 50%/40% once the eager reflection metadata — which it can never touch, since metadata has to load for reflection to see a deferred type at all — is out of the way.

All 140 samples fingerprint identically (element and text counts) except four established as run-to-run unstable in the *single-bundle* build itself: `Searchable List`, `Searchable Grouped List` (virtualized windows), `Avatar` (randomised) and `Node View` (graph layout). Zero console errors, and reflection still enumerates all 528 + 162 types.

Stub-vs-loaded was checked question by question against the real runtime, for a constructed base, an open base and a partially-open one — every answer matches what the loaded definition gives, including the idiomatic `GetInterfaces().Any(i => i.GetGenericTypeDefinition() == typeof(IFoo<>))` scan.

## Tests

- `ModuleEmitTests` (18) — chunking, ordering, the manifest and its constructed-generic specs, the entry module, `typeof` soft vs hard.
- `ModulePackageTests` (5) — the package embed/extract protocol and cross-assembly imports end to end.
- `LazyModuleActivatorTests` (10) — the runtime registry, stub reflection, constructed and open generic bases, `CreateInstanceAsync`, and the synchronous-construction guard.

Full translator suite green (901 passed).

## Not done

Deliberately out of scope here, and listed in `TODO.modules.md`:

- **`--incremental`** — chunk assignment is a whole-program property, so the two should not be combined yet.
- **Minification** — a module entry and its chunks carry `import` syntax, and while NUglify does handle it (measured: 25% off raw, 9% off gzipped on the eager set), the `.js`/`.min.js` variant switch is a per-file rename while a chunk names its dependencies inside its own text — so it needs an import-specifier rewrite across the graph and its own `JsMinifierTests` coverage.
- **Watch mode** with module output.

The design, the rejected alternatives and the full measurement log are in [`TODO.modules.md`](https://github.com/curiosity-ai/transpose/blob/claude/transpose-js-modules-per-class-6zedf1/TODO.modules.md); the exploratory scripts that produced the early numbers are under `docs/experiments/js-modules/`.

The consumer side is curiosity-ai/tesserae on the same branch name.
