### PR TITLE
Fix module output ordering issues with nested types and attributes

### DIFF
--- a/BCL/Transpose.BCL/Resources/Class.js
+++ b/BCL/Transpose.BCL/Resources/Class.js
@@ -896,11 +896,23 @@
             }
 
             if (exists) {
+                // A plain object in a type's slot is the namespace placeholder Class.set creates while
+                // walking the path of a type nested deeper inside it — so a type defined BEFORE the one
+                // that contains it already registered itself under this path. That ordering is normal
+                // with module output, where the chunk holding the nested type can evaluate first, and
+                // the members it left behind have to travel onto the class now taking the slot. A member
+                // that is a type is carried over by the loop below; one that is itself a placeholder
+                // (a still-undefined type holding nested types of its own) is a plain object and is
+                // carried over as-is. A previous occupant that is a *function* is a retired stub, whose
+                // own properties (interfaces, markers) belong to the stub and must not be copied.
+                var existsIsNamespacePlaceholder = typeof exists === "object";
 
                 for (key in exists) {
                     var o = exists[key];
 
-                    if (typeof o === "function" && o.$$name) {
+                    if (existsIsNamespacePlaceholder && o && typeof o === "object" && !cls.hasOwnProperty(key)) {
+                        cls[key] = o;
+                    } else if (typeof o === "function" && o.$$name) {
                         (function (cls, key, o) {
                             Object.defineProperty(cls, key, {
                                 get: function () {

--- a/BCL/Transpose.BCL/Resources/Core.js
+++ b/BCL/Transpose.BCL/Resources/Core.js
@@ -1431,7 +1431,14 @@
                     var v = value[i];
 
                     if (Transpose.isString(v)) {
-                        value[i] = Transpose.unroll(v, scope);
+                        var resolved = Transpose.unroll(v, scope);
+
+                        // Leave a name that does not resolve yet in place, so a later pass can. With
+                        // module output a namespace holding only deferred types is empty until the
+                        // stubs are registered, and the metadata array naming it is shared by every
+                        // type in the assembly - overwriting the entry with null on the first pass
+                        // made the retry a no-op and the metadata then read a member off undefined.
+                        if (resolved != null) value[i] = resolved;
                     }
                 }
 

--- a/BCL/Transpose.BCL/Resources/Reflection.js
+++ b/BCL/Transpose.BCL/Resources/Reflection.js
@@ -12,9 +12,13 @@
                 }
             }
 
-            ns = Transpose.unroll(ns);
+            Transpose.unroll(ns);
             type.$getMetadata = Transpose.Reflection.getMetadata;
             type.$metadata = metadata;
+            // The metadata function closes over this array, and a namespace in it can still be
+            // unresolvable now and resolvable later (module output registers its stubs after the
+            // metadata). getMetadata gives it another pass before materializing.
+            if (ns) type.$metadataNs = ns;
 
             // A module-mode stub holds the metadata for a type whose code has not arrived. Remember
             // it against the type NAME as well, so whichever route eventually replaces the stub —
@@ -61,6 +65,8 @@
         },
 
         getMetadata: function () {
+            if (this.$metadataNs) Transpose.unroll(this.$metadataNs);
+
             if (!this.$metadata && this.$genericTypeDefinition) {
                 this.$metadata = this.$genericTypeDefinition.$factoryMetadata || this.$genericTypeDefinition.$metadata;
             }

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -433,6 +433,41 @@ itself generic, a diagnostic when the attribute is put on a type that is instant
 from (where the edges really are needed at definition time), and whether the published map should be
 folded into `Transpose.Modules.json` rather than shipping a second sidecar.
 
+### 7f. Three things a real app found
+
+Running a second application through module output — Curiosity's front-end, which unlike the Tesserae
+gallery keeps reflection **on** — turned up three failures that Tesserae could not have shown. All
+three are ordering problems around code the chunker deliberately does not walk.
+
+- **A nested type whose chunk evaluates first was dropped.** `Transpose.define("App.Sidebar.Mode")`
+  walks the path and leaves a plain object where `App.Sidebar` will go; when `App`'s own chunk later
+  defines `App`, `Class.set` copied the previous occupant's members onto the new class — but only the
+  ones that are *types* (a function with `$$name`). The intermediate placeholder is a plain object, so
+  the whole sub-tree under it went missing, and `App.Sidebar.Mode` read `undefined` at static-init
+  time. `Class.set` now carries a plain-object previous occupant over as-is. A previous occupant that
+  is a *function* is a retired stub, whose own properties must not be copied — that distinction is
+  what keeps the fix from corrupting the stub hand-off.
+- **An attribute class the metadata constructs must be eager.** Metadata is emitted outside the
+  per-type walk, so nothing imports what it names — fine for a type reference, which a stub answers,
+  and wrong for an attribute, which the metadata *constructs* (`new SomeAttribute(...)`) the first
+  time a type's metadata is materialized. `MetadataAttributeClasses` adds them to the eager roots, and
+  an attribute class from a referenced module-mode assembly is imported by the entry module.
+- **A namespace that is empty when the metadata registers must stay resolvable.** The whole
+  assembly's metadata shares one namespace array and `Transpose.unroll` resolves it in place on the
+  first `setMetadata` call. A namespace holding only deferred types is empty at that point — the
+  stubs are registered *after* the metadata, deliberately — and overwriting the entry with `null`
+  made the later pass (the deferred-metadata flush at the end of `Modules.register`) a no-op, so the
+  metadata read a member off `undefined`. `unroll` now leaves a name it cannot resolve in place, and
+  `getMetadata` gives the array one more pass before materializing.
+
+What that application still cannot do is defer the types a **reflection-driven deserializer**
+constructs. Newtonsoft builds an object graph from the metadata — member type by member type — and
+that construction is synchronous, so any DTO in an unfetched chunk throws. Nothing in the reference
+graph records that edge (the deserializer only ever sees a `Type`), so the current answer is to keep
+such an assembly's chunks eager: build it as a site rather than as a package. Making it lazy needs
+either an opt-out attribute for "never defer this type" or a preload pass that walks the metadata
+graph of `T` before deserializing into it.
+
 ### Not done
 
 - **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today

--- a/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
+++ b/Transpose/Transpose.Translator.Tests/LazyModuleActivatorTests.cs
@@ -454,5 +454,103 @@ public class Program
             StringAssert.Contains(output, "stillStub: True");
             StringAssert.Contains(output, "<<DONE>>");
         }
+
+        /// <summary>
+        /// The reflection metadata of a whole assembly shares ONE namespace array, and
+        /// <c>Transpose.unroll</c> resolves it in place the first time any type's metadata is
+        /// registered. With module output a namespace can be empty at that moment — every type in it
+        /// was deferred, and the stubs are registered after the metadata — so the entry has to stay
+        /// resolvable later. Overwriting it with null on the first pass made every later pass a no-op,
+        /// and the metadata then read a member off undefined.
+        /// </summary>
+        [TestMethod]
+        public async Task AnUnresolvableNamespaceIsLeftForALaterPassAsync()
+        {
+            var output = await RunTest(@"
+using System;
+using Transpose;
+
+public static class Ns
+{
+    public static bool FirstPassKeepsTheName() => Script.Write<bool>(
+        @""(function () { Transpose.global.$nsProbe = ['LateArrival']; Transpose.unroll(Transpose.global.$nsProbe); return typeof Transpose.global.$nsProbe[0] === 'string'; })()"");
+
+    public static bool SecondPassResolvesIt() => Script.Write<bool>(
+        @""(function () { Transpose.global.LateArrival = { Widget: 42 }; Transpose.unroll(Transpose.global.$nsProbe); return !!(Transpose.global.$nsProbe[0] && Transpose.global.$nsProbe[0].Widget === 42); })()"");
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""kept: "" + Ns.FirstPassKeepsTheName());
+        Console.WriteLine(""resolved: "" + Ns.SecondPassResolvesIt());
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "kept: True");
+            StringAssert.Contains(output, "resolved: True");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A chunk holding a nested type can evaluate before the chunk holding the type that contains
+        /// it — chunk order is the reference graph's, not the source's — so <c>Transpose.define</c>
+        /// meets a namespace placeholder where the containing type is about to go. What that
+        /// placeholder holds has to survive the containing type taking the slot, at every depth: a
+        /// two-level path (<c>Outer.Inner</c>) was already carried over, a three-level one
+        /// (<c>Outer.Inner.Leaf</c>) was dropped, because the member being carried is then a plain
+        /// object rather than a type. Dropping it left the deeper type reachable by name and absent
+        /// from its own containing type, so reading it threw "cannot read properties of undefined".
+        /// </summary>
+        [TestMethod]
+        public async Task ANestedTypeDefinedBeforeItsContainingTypesSurvivesAsync()
+        {
+            var output = await RunTest(@"
+using System;
+using Transpose;
+
+public static class Chunks
+{
+    // What a chunk that evaluates first would run: the innermost type, whose containing types are
+    // defined only by the chunk that comes after it.
+    public static void DefineLeafFirst()
+    {
+        Script.Write(@""Transpose.define('Outer.Inner.Leaf', { $kind: 'nested enum', statics: { fields: { First: 0, Second: 1 } } });"");
+    }
+
+    public static void DefineContainers()
+    {
+        Script.Write(@""Transpose.define('Outer', { statics: { methods: { Name: function () { return 'outer'; } } } });"");
+        Script.Write(@""Transpose.define('Outer.Inner', { $kind: 'nested class', statics: { methods: { Name: function () { return 'inner'; } } } });"");
+    }
+
+    public static string LeafFirstValue() => Script.Write<string>(""'' + Outer.Inner.Leaf.Second"");
+    public static bool   LeafIsPresent()  => Script.Write<bool>(""typeof Outer.Inner.Leaf !== 'undefined'"");
+    public static string InnerName()      => Script.Write<string>(""Outer.Inner.Name()"");
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Chunks.DefineLeafFirst();
+        Chunks.DefineContainers();
+
+        Console.WriteLine(""leaf present: "" + Chunks.LeafIsPresent());
+        Console.WriteLine(""leaf value: "" + Chunks.LeafFirstValue());
+        Console.WriteLine(""inner: "" + Chunks.InnerName());
+        Console.WriteLine(""<<DONE>>"");
+    }
+}
+", skipRoslyn: true);
+
+            StringAssert.Contains(output, "leaf present: True");
+            StringAssert.Contains(output, "leaf value: 1");
+            StringAssert.Contains(output, "inner: inner");
+            StringAssert.Contains(output, "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -300,6 +300,27 @@ public class Program { public static void Main() { Console.WriteLine(new Used().
         }
 
         [TestMethod]
+        public void AnAttributeClassTheMetadataConstructsIsEager()
+        {
+            var m = Emit(@"
+using System;
+public class MarkerAttribute : Attribute { public MarkerAttribute(string note) { Note = note; } public string Note; }
+
+[Marker(""x"")]
+public class Marked { public int N; }
+
+public class Program { public static void Main() { Console.WriteLine(1); } }
+");
+            // The metadata records the attribute as `new MarkerAttribute(...)`, built the first time
+            // Marked's metadata is materialized (GetCustomAttributes, getMembers, a reflection-driven
+            // deserializer). A stub answers every other reflection question but cannot be constructed,
+            // and nothing imports the class — metadata takes no part in chunking — so the entry must.
+            var marker = System.IO.Path.GetFileName(ChunkOf(m, "MarkerAttribute"));
+            Assert.IsTrue(m.EntryJs.Contains($"import './chunks/{marker}'"),
+                "the entry module must import the chunk of an attribute class its metadata constructs");
+        }
+
+        [TestMethod]
         public void MetadataIsEmittedBeforeTheManifest()
         {
             var m = Emit(@"

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -118,6 +118,7 @@ public sealed partial class Emitter
         //    all eager would defeat the split entirely;
         //  - neither (a site build with no Main): everything, since nothing can be deferred safely.
         var roots = new List<INamedTypeSymbol>();
+        var canDefer = packageMode;
         if (packageMode)
         {
             roots.AddRange(types.Where(t => t.GetMembers().OfType<IMethodSymbol>()
@@ -126,10 +127,19 @@ public sealed partial class Emitter
         else if (_compilation.GetEntryPoint(default)?.ContainingType?.OriginalDefinition is INamedTypeSymbol main)
         {
             roots.Add(main);
+            canDefer = true;
         }
 
+        // The reflection metadata covers every type and *constructs* the attributes it records —
+        // `new SomeAttribute(...)`, the first time a type's metadata is materialized (getMembers,
+        // GetCustomAttributes, a reflection-driven deserializer). That construction is synchronous,
+        // so an attribute class whose chunk has not been fetched throws where a stub answers every
+        // other reflection question. The classes are few and small, and nothing imports them (the
+        // metadata is emitted outside the per-type walk), so they join the roots of the eager set.
+        if (canDefer && ReflectionEnabled) roots.AddRange(MetadataAttributeClasses(types));
+
         var eager = new HashSet<int>();
-        if (roots.Count > 0 || packageMode)
+        if (canDefer)
         {
             var stack = new Stack<int>();
             foreach (var r in roots)
@@ -184,7 +194,7 @@ public sealed partial class Emitter
 
         var result = new ModuleOutput
         {
-            EntryJs = BuildEntryModule(types, chunks, eager, lazyTypes, ChunkFile),
+            EntryJs = BuildEntryModule(types, chunks, eager, lazyTypes, ChunkFile, externalChunks),
             EagerChunkCount = eager.Count,
             LazyChunkCount = chunks.Members.Count - eager.Count,
             LazyTypeCount = lazyTypes.Count,
@@ -294,17 +304,73 @@ public sealed partial class Emitter
         return new ChunkGraph(components, deps, indexOf);
     }
 
+    /// <summary>The chunk files of the attribute classes the metadata records that come from a
+    /// referenced module-mode assembly, sorted so the entry module is byte-identical run to run.
+    /// Empty when reflection is off or no reference was built as modules.</summary>
+    private IEnumerable<string> ExternalMetadataAttributeChunks(
+        List<INamedTypeSymbol> types, IReadOnlyDictionary<string, string>? externalChunks)
+    {
+        if (!ReflectionEnabled || externalChunks is null) return Array.Empty<string>();
+
+        var mine = new HashSet<INamedTypeSymbol>(types, SymbolEqualityComparer.Default);
+        var files = new SortedSet<string>(StringComparer.Ordinal);
+
+        void Collect(IEnumerable<AttributeData> attrs)
+        {
+            foreach (var a in ReflectableAttributes(attrs))
+                if (a.AttributeClass?.OriginalDefinition is INamedTypeSymbol ac && !mine.Contains(ac)
+                    && externalChunks.TryGetValue(DefineName(ac), out var file))
+                    files.Add(file);
+        }
+
+        foreach (var t in types)
+        {
+            Collect(t.GetAttributes());
+            foreach (var m in t.GetMembers()) Collect(m.GetAttributes());
+        }
+        return files;
+    }
+
+    /// <summary>Every attribute class this compilation emits that the reflection metadata records —
+    /// on a type, or on one of its members — deduplicated. Cross-assembly attribute classes are not
+    /// here: they are imported by the entry module instead (BuildEntryModule).</summary>
+    private List<INamedTypeSymbol> MetadataAttributeClasses(List<INamedTypeSymbol> types)
+    {
+        var found = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var byName = new HashSet<INamedTypeSymbol>(types, SymbolEqualityComparer.Default);
+
+        void Collect(IEnumerable<AttributeData> attrs)
+        {
+            foreach (var a in ReflectableAttributes(attrs))
+                if (a.AttributeClass?.OriginalDefinition is INamedTypeSymbol ac && byName.Contains(ac))
+                    found.Add(ac);
+        }
+
+        foreach (var t in types)
+        {
+            Collect(t.GetAttributes());
+            foreach (var m in t.GetMembers()) Collect(m.GetAttributes());
+        }
+        return found.ToList();
+    }
+
     /// <summary>The entry module: it imports the eager chunks (so they are fully evaluated before
     /// its own body runs), then declares what was deferred, attaches the reflection metadata for
     /// <em>every</em> type, and starts the runtime.</summary>
     private string BuildEntryModule(
         List<INamedTypeSymbol> types, ChunkGraph chunks, HashSet<int> eager,
-        List<INamedTypeSymbol> lazyTypes, Func<int, string> chunkFile)
+        List<INamedTypeSymbol> lazyTypes, Func<int, string> chunkFile,
+        IReadOnlyDictionary<string, string>? externalChunks)
     {
         var sb = new StringBuilder();
         sb.Append("/**\n * Transpose.Translator generated output (module entry).\n */\n");
         foreach (var i in eager.OrderBy(x => x))
             sb.Append("import './").Append(chunkFile(i)).Append("';\n");
+        // An attribute class the metadata constructs can live in a referenced module-mode assembly,
+        // where it is no more constructible from a stub than a local one is - and no chunk of this
+        // assembly imports it, since the metadata takes no part in chunking.
+        foreach (var file in ExternalMetadataAttributeChunks(types, externalChunks))
+            sb.Append("import './").Append(file).Append("';\n");
         sb.Append('\n');
 
         if (!string.IsNullOrEmpty(AssemblyVersion))


### PR DESCRIPTION
## Summary

Fixes three ordering-related failures in module output that only surface when reflection is enabled and chunks evaluate out of source order. These issues were discovered running a real application (Curiosity's front-end) through module output.

## Key Changes

- **Nested types defined before their containers now survive.** When a chunk holding a nested type evaluates before the chunk holding its containing type, `Class.set` was dropping the intermediate namespace placeholder. Now it carries over plain-object placeholders (which represent unresolved nested types) while still correctly handling retired stubs. This preserves the full path for deeply nested types (e.g., `Outer.Inner.Leaf`).

- **Attribute classes the metadata constructs are now eager.** The reflection metadata is emitted outside the per-type walk, so nothing imports attribute classes it names. However, metadata *constructs* attributes (`new SomeAttribute(...)`) when a type's metadata is first materialized. `MetadataAttributeClasses` adds these to the eager roots, and the entry module imports attribute classes from referenced module-mode assemblies.

- **Unresolvable namespaces stay resolvable for later passes.** The assembly's metadata shares one namespace array, and `Transpose.unroll` resolves it in place on the first `setMetadata` call. A namespace holding only deferred types is empty at that point (stubs register *after* metadata), so overwriting with `null` made later passes no-ops. Now `unroll` leaves unresolved names in place, and `getMetadata` gives the array another pass before materializing.

## Implementation Details

- **Class.js**: `Class.set` now distinguishes between plain-object namespace placeholders (carried over as-is) and function stubs (whose properties are not copied).

- **Core.js**: `Transpose.unroll` leaves unresolved namespace entries in place instead of overwriting with `null`.

- **Reflection.js**: `getMetadata` calls `unroll` again before materializing metadata, and stores the namespace array for this retry.

- **Emitter.Modules.cs**: 
  - `MetadataAttributeClasses` collects attribute classes this compilation emits that the metadata records.
  - `ExternalMetadataAttributeChunks` collects attribute classes from referenced module-mode assemblies.
  - `BuildEntryModule` imports both local and external attribute class chunks.

- **Tests**: Two new integration tests verify nested types survive early evaluation and that unresolvable namespaces resolve on later passes. One new unit test verifies attribute classes are imported by the entry module.

## Notes

Reflection-driven deserializers (e.g., Newtonsoft) still cannot defer types they construct, as that construction is synchronous and the deserializer sees no edge in the reference graph. The workaround is to build such assemblies as sites rather than packages.

https://claude.ai/code/session_01R9FwQFfY5ZouvhMx54A57A