### PR TITLE
Coalesce module chunks into a size band, and record the dependency an activator hides

### DIFF
--- a/BCL/Transpose.BCL/Attributes/ConstructsTypeArgumentsAttribute.cs
+++ b/BCL/Transpose.BCL/Attributes/ConstructsTypeArgumentsAttribute.cs
@@ -1,0 +1,65 @@
+namespace Transpose
+{
+    /// <summary>
+    /// Says that calling this method <b>constructs</b> its type arguments at run time, through
+    /// reflection, rather than merely naming them — so their JavaScript has to be present wherever
+    /// the call is.
+    ///
+    /// This exists for the module chunker (<c>outputBy: Module</c>). A chunk is a component of the
+    /// reference graph the emitter records while emitting, so a type is only kept loadable if some
+    /// emitted code <em>refers</em> to it. A reflection-driven deserializer breaks that:
+    /// <c>JsonConvert.DeserializeObject&lt;Order&gt;(json)</c> emits nothing that mentions
+    /// <c>Order</c> beyond its <c>Type</c> object — which a deferred type's stub answers perfectly
+    /// well — and then walks <c>Order</c>'s metadata and <c>new</c>s up <c>Order</c> and every member
+    /// type it finds. Constructing a stub throws, and fetching its module is asynchronous, so there
+    /// is nothing the runtime can do about it at that point.
+    ///
+    /// Marking the method closes the gap at the only place the compiler can see the edge: the call
+    /// site. Each call records its type arguments — and, transitively, every type reachable from them
+    /// through the fields and properties reflection describes — as real dependencies of the type
+    /// being emitted, so the chunk that makes the call imports the chunks that define the DTOs. The
+    /// types stay deferrable for code that does not deserialize them; they are pulled in exactly
+    /// where they are needed, not made globally eager.
+    ///
+    /// Apply it to the deserializing entry points of a binding library (Json.NET's
+    /// <c>DeserializeObject&lt;T&gt;</c>, System.Text.Json's <c>Deserialize&lt;TValue&gt;</c>), or to
+    /// your own generic method that activates its type argument. It is not needed for a method that
+    /// only reads a value it was handed (serialization), and it does nothing outside module output.
+    ///
+    /// Where the type argument is not statically known — <c>DeserializeObject(json, someType)</c>, a
+    /// type argument that is itself a type parameter — there is nothing at the call site to record.
+    /// Use <see cref="NeverDeferAttribute"/> on those types instead.
+    ///
+    /// <b>Marking somebody else's activator.</b> The assembly-level form names the type from outside
+    /// it, so an application can opt in without waiting for the library to be re-released — and can
+    /// do it for a third-party library it cannot edit at all:
+    ///
+    /// <code>
+    /// [assembly: Transpose.ConstructsTypeArguments(typeof(Newtonsoft.Json.JsonConvert))]
+    /// [assembly: Transpose.ConstructsTypeArguments(typeof(System.Text.Json.JsonSerializer))]
+    /// </code>
+    ///
+    /// It applies to every generic method of that type, and only within the assembly that declares
+    /// it — it is a statement about how <em>this</em> code calls the activator, so it neither
+    /// travels to a consumer nor needs to.
+    /// </summary>
+    [NonScriptable]
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Class
+                           | System.AttributeTargets.Struct | System.AttributeTargets.Assembly,
+                           AllowMultiple = true, Inherited = false)]
+    public sealed class ConstructsTypeArgumentsAttribute : System.Attribute
+    {
+        /// <summary>On a method or a type: that method, or every generic method of that type,
+        /// constructs its type arguments.</summary>
+        public ConstructsTypeArgumentsAttribute()
+        {
+        }
+
+        /// <summary>On the assembly: every generic method of <paramref name="activator"/> constructs
+        /// its type arguments, for calls made from this assembly. The form for an activator you do
+        /// not own.</summary>
+        public ConstructsTypeArgumentsAttribute(System.Type activator)
+        {
+        }
+    }
+}

--- a/BCL/Transpose.BCL/Attributes/NeverDeferAttribute.cs
+++ b/BCL/Transpose.BCL/Attributes/NeverDeferAttribute.cs
@@ -1,0 +1,31 @@
+namespace Transpose
+{
+    /// <summary>
+    /// Keeps a type's JavaScript in the initial payload: it is never left as a
+    /// <c>Transpose.Modules</c> stub, whatever the reference graph says.
+    ///
+    /// With <c>outputBy: Module</c> a type nothing statically references is deferred — its chunk is
+    /// fetched on demand, and until then a stub answers every reflection question but throws when
+    /// constructed, because fetching a module is asynchronous and construction is not. That is the
+    /// right default, and it is wrong for a type that something reaches purely through reflection:
+    /// a DTO a deserializer activates from its metadata, a settings class resolved by name, a type
+    /// looked up from a string.
+    ///
+    /// This is the blunt instrument, and deliberately so — the type joins the eager roots, exactly
+    /// like the attribute classes the reflection metadata constructs, so it and everything it needs
+    /// are in the entry module's imports. Prefer <see cref="ConstructsTypeArgumentsAttribute"/> on
+    /// the generic method that does the activating: it records the same dependency at the call site,
+    /// so the type is fetched with the code that deserializes it rather than at start-up. Reach for
+    /// this one where that cannot work — the type argument is a <c>Type</c> value rather than a
+    /// static type argument, or the reflective lookup is in a library you cannot annotate.
+    ///
+    /// It does nothing outside module output.
+    /// </summary>
+    [NonScriptable]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct
+                           | System.AttributeTargets.Interface | System.AttributeTargets.Enum,
+                           Inherited = false)]
+    public sealed class NeverDeferAttribute : System.Attribute
+    {
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,9 @@ metadata, not a web resource, so `OutputBuilder` never extracts it into a site.
 - `[Script]` — raw JS body.
 - `[GlobalMethods]` / `[Scope]` — project static members / a type onto ambient JS globals.
 - `[ObjectLiteral]` — treat a class/struct as a plain JS object.
+- `[SkipTypeClustering]` / `[ConstructsTypeArguments]` / `[NeverDefer]` — module-output chunking:
+  keep a facade out of the reference graph, mark a generic method that *constructs* its type
+  arguments reflectively, and pin a type into the initial payload. See the module-output section.
 
 ## Building and bootstrapping
 
@@ -597,6 +600,25 @@ The short version:
   that set the same pass gives 53 chunks *and* 1,055 KB raw / 160 KB gz, so the ceiling is the
   missing information: the fix is to coalesce across assemblies in the site build, where the whole
   program is visible. See `TODO.modules.md` §7g.
+
+  **`[ConstructsTypeArguments]` and `[NeverDefer]` cover the edge an activator hides.** The chunker
+  records an edge exactly when a reference is *emitted*, so a reflection-driven deserializer defeats
+  it: `JsonConvert.DeserializeObject<Order>(json)` emits nothing about `Order` a stub cannot answer,
+  then walks its metadata and constructs it and every member type below it — and constructing a stub
+  throws. `[ConstructsTypeArguments]` on the activating generic method puts the edge back at the
+  **call site**, where the type argument is written down: the call records its type arguments and,
+  transitively, everything reachable through the fields and properties reflection describes (through
+  arrays and generic arguments, so a `List<Line>` member reaches `Line`) as dependencies of the type
+  being emitted. The DTO is fetched with the code that deserializes it and stays deferred for
+  everything else — the same move `[SkipTypeClustering]` makes, in the other direction. It is read on
+  the method, on its containing type, or from the calling assembly
+  (`[assembly: ConstructsTypeArguments(typeof(JsonConvert))]`), which is how an application marks an
+  activator it does not own or that has not been re-released with the annotation.
+  **`[NeverDefer]`** is the blunt fallback for what a call site cannot show — a `Type` *value*, a
+  class resolved from a string: the type joins the eager roots, like the attribute classes the
+  metadata constructs. See `Emitter.ReflectionDeps.cs`, `ModuleReflectionDepsTests` and
+  `TODO.modules.md` §7h; the shipped JSON bindings still have to be annotated, which waits on a BCL
+  release carrying the attribute.
 
   Still single-bundle: `--incremental` (chunk assignment is a whole-program property — do not combine
   them yet), minification (a module entry and its chunks are emitted formatted only, since they carry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,6 +574,30 @@ The short version:
   2,304 KB to 1,055 KB raw — better than deleting the facade (1,788 KB), which is the invasive change
   it makes unnecessary. See `TODO.modules.md` §7e for what is not yet settled.
 
+  **A second pass merges the components into chunks worth fetching.** An SCC is the smallest *sound*
+  unit and a far too small *useful* one: Tesserae's gallery emitted 682 chunks with a **2.2 KB
+  median**, half under 1 KB, so a screen needing twenty types paid twenty requests.
+  `Emitter.ModuleChunks.cs` groups them by **load signature** — the set of roots (chunks nothing
+  imports, i.e. what an application can ask for) that reach a chunk, which *is* its load condition —
+  orders the classes reverse-topologically with a Jaccard-similarity tie-break so nearly-co-loaded
+  classes end up adjacent, and cuts that sequence into contiguous buckets in a size band
+  (`modules.minChunkSize`/`maxChunkSize` in tps.json, default **50–100 KB**; 0 restores one chunk per
+  component). A bucket only spans a class boundary while it is under the minimum — that is the one
+  place over-fetch is traded for size. **Sizes are exact**: bodies are emitted before chunking (which
+  needs the graph the emit records), so nothing is estimated and nothing is emitted twice. The result
+  is still a DAG by construction — `i → d` implies `sig(d) ⊇ sig(i)`, so the class graph is acyclic,
+  and within a class members keep the first pass's already-topological index order — and the
+  lower-index invariant is re-checked, falling back to the unmerged graph if it ever fails. The eager
+  group is bucketed separately, so deferred code is never pulled into the initial payload.
+
+  Measured: 682 → **56 chunks, 52 KB median**, all 132 samples rendering identically. The cost is
+  entirely on the *package* side: the app's 161 → 18 chunks leaves its eager payload untouched,
+  while the library's 521 → 38 raises it from 1,055 KB to 1,816 KB raw, because a package has no
+  entry point and cannot see which of its chunks a consumer needs at start-up. With an oracle for
+  that set the same pass gives 53 chunks *and* 1,055 KB raw / 160 KB gz, so the ceiling is the
+  missing information: the fix is to coalesce across assemblies in the site build, where the whole
+  program is visible. See `TODO.modules.md` §7f.
+
   Still single-bundle: `--incremental` (chunk assignment is a whole-program property — do not combine
   them yet), minification (a module entry and its chunks are emitted formatted only, since they carry
   `import` syntax `JsMinifier` does not handle), and watch mode.

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -461,12 +461,7 @@ three are ordering problems around code the chunker deliberately does not walk.
   `getMetadata` gives the array one more pass before materializing.
 
 What that application still cannot do is defer the types a **reflection-driven deserializer**
-constructs. Newtonsoft builds an object graph from the metadata — member type by member type — and
-that construction is synchronous, so any DTO in an unfetched chunk throws. Nothing in the reference
-graph records that edge (the deserializer only ever sees a `Type`), so the current answer is to keep
-such an assembly's chunks eager: build it as a site rather than as a package. Making it lazy needs
-either an opt-out attribute for "never defer this type" or a preload pass that walks the metadata
-graph of `T` before deserializing into it.
+constructs — see §7h, which is the answer to it.
 
 ### 7g. The second pass — coalescing components into chunks worth fetching
 
@@ -553,10 +548,73 @@ missing information, and closing it needs the packing to happen where the whole 
   set its own `modules.minChunkSize`; the measured curve on this pair, with the app left at 50 KB, is
   521→329 chunks at +60 KB eager (5 KB band), 521→201 at +133 KB (10 KB), 521→115 at +421 KB (20 KB).
 
+### 7h. `[ConstructsTypeArguments]` and `[NeverDefer]` — the edge an activator hides
+
+The chunker records an edge exactly when a type reference is **emitted**, which is what makes it
+sound: a type stays loadable because some code names it. A reflection-driven deserializer defeats
+that, and §7f above hit it head-on. `JsonConvert.DeserializeObject<Order>(json)` emits nothing about
+`Order` beyond its `Type` object — which a deferred type's stub answers perfectly well — and then
+walks that metadata and `new`s up `Order` and every member type below it. Constructing a stub throws,
+and its module can only be fetched asynchronously, so by then it is too late. Nothing in the
+reference graph records the edge, because the deserializer only ever holds a `Type`.
+
+Two attributes close it, and they are deliberately different instruments.
+
+**`[ConstructsTypeArguments]`** goes on the generic method that does the activating, and puts the edge
+back at the one place the compiler can see it: the **call site**, where the type argument is written
+down. Each call records its type arguments — and, transitively, every type reachable from them
+through the fields and properties reflection describes, looking through arrays and generic arguments
+so a `List<Line>` member reaches `Line` — as real dependencies of the type being emitted. So the
+chunk that deserializes an `Order` imports the chunk that defines it, and the DTO stays deferred for
+every screen that does not deserialize one. It is the same move `[SkipTypeClustering]` makes, in the
+other direction: that one takes edges *away* from a facade, this one adds edges an activator hides.
+
+The walk is an over-approximation on purpose, exactly like `BuildSkipClusterDeps`: it only has to be
+a superset of what the deserializer touches, and over-approximating costs an import that was not
+needed rather than a missing one that throws.
+
+It is read in three places, so whoever knows about the activator can mark it:
+
+```csharp
+// the binding library, on the method or on the activator class
+[ConstructsTypeArguments] public static extern T DeserializeObject<T>(string value);
+
+// or the application, for a library it cannot edit — or has not been re-released yet
+[assembly: Transpose.ConstructsTypeArguments(typeof(Newtonsoft.Json.JsonConvert))]
+[assembly: Transpose.ConstructsTypeArguments(typeof(System.Text.Json.JsonSerializer))]
+```
+
+The assembly-level form applies to every generic method of the named type and only within the
+assembly that declares it — it is a statement about how *this* code calls the activator, so it
+neither travels to a consumer nor needs to.
+
+**`[NeverDefer]`** is the blunt instrument, for what a call site cannot show: `DeserializeObject(json,
+someType)` with a `Type` **value**, a class resolved from a string, a type argument that is itself a
+type parameter. The type joins the eager roots — the same machinery as the attribute classes the
+metadata constructs (§7f) — so it and its own dependencies are in the entry module's imports. Prefer
+`[ConstructsTypeArguments]`: it fetches the DTO with the code that deserializes it instead of making
+it eager for everyone.
+
+Covered by `ModuleReflectionDepsTests`, which starts from the failing case (without the attribute,
+nothing reaches the DTO's members) and includes the cross-assembly shape — the activator compiled
+into a package and the attribute read back out of its metadata.
+
+**Still to do: annotate the shipped bindings.** `Transpose.Newtonsoft.Json`'s four
+`DeserializeObject<T>`/`DeserializeAnonymousType<T>` overloads and `Transpose.System.Text.Json`'s two
+`Deserialize<TValue>` overloads should carry `[ConstructsTypeArguments]` directly, so an application
+gets the behaviour without the assembly-level declaration. That cannot land in the same commit as
+the attribute itself: every `Packages/*` project pins a published `Transpose.BCL` (26.7.3303 today),
+so the annotation only compiles once a BCL carrying the attribute is released and those pins are
+bumped. Until then the assembly-level form is the supported route, and it is the only route for a
+third-party activator anyway.
+
 ### Not done
 
 - **Coalescing across assemblies at the site build** — see §7g. The pass runs per assembly, so a
   package's chunks are packed without knowing which of them its consumer needs at start-up.
+- **`[ConstructsTypeArguments]` on the shipped JSON bindings** — see §7h. The attribute and the
+  emitter support are in; annotating `Transpose.Newtonsoft.Json` and `Transpose.System.Text.Json`
+  waits on a released `Transpose.BCL` that carries it and a bump of those projects' pins.
 - **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today
   reuses cached per-type JavaScript could still reshuffle chunks. Module mode has not been checked
   against the cache and the two should not be combined yet.

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -433,8 +433,95 @@ itself generic, a diagnostic when the attribute is put on a type that is instant
 from (where the edges really are needed at definition time), and whether the published map should be
 folded into `Transpose.Modules.json` rather than shipping a second sidecar.
 
+### 7f. The second pass — coalescing components into chunks worth fetching
+
+An SCC is the smallest **sound** unit, and it turned out to be far too small a **useful** one. With
+`[SkipTypeClustering]` in place, Tesserae's gallery emitted **682 chunks with a median of 2.2 KB**,
+half of them under 1 KB — so a sample that needs twenty types paid twenty requests to fetch 30 KB.
+That is what the second pass (`Emitter.ModuleChunks.cs`) merges back up, to a size band that
+defaults to **50–100 KB** (`modules.minChunkSize` / `modules.maxChunkSize` in tps.json; 0 turns the
+pass off and restores one chunk per component).
+
+**Sizes are exact, not estimated.** The type bodies are already emitted when chunking runs — chunking
+needs the reference graph the emit records — so the byte count of every component is known. There is
+no complexity heuristic and no emit-measure-regroup round trip.
+
+What it merges by is *what loads together*:
+
+- **Load signature.** A chunk nothing imports is a **root**: it is only ever fetched because the
+  application asked for it. Every other chunk is fetched exactly when one of the roots that reaches
+  it is — so the set of roots reaching a chunk *is* its load condition, and two chunks with the same
+  set are always fetched together. Merging those costs nothing.
+- **Ordering.** Signature classes come out in a reverse-topological order of the class graph, and
+  among the classes ready at each step the one whose root set is most similar (Jaccard) to the one
+  just emitted goes next — so classes that *nearly* always load together end up adjacent.
+- **Bucketing.** The sequence is cut into contiguous buckets inside the band. A bucket only spans a
+  class boundary while it is still under the minimum: below that a chunk is not worth a request of
+  its own, and its neighbour in the load order is the least-bad thing to pay for. That is the one
+  place the pass trades over-fetch for size.
+
+**The merged graph is still a DAG, by construction rather than by checking.** If chunk `i` depends on
+chunk `d` then every root reaching `i` reaches `d`, i.e. `sig(d) ⊇ sig(i)`; a cycle among signature
+classes would force all of them equal, so the class graph is acyclic and reverse-topological order
+places every dependency first. Within a class (and within the eager group) members keep the first
+pass's index order, which is already topological, and a contiguous run of a topological order cannot
+contain a forward edge. The invariant "every import points at a lower-numbered chunk" is re-checked
+before the merged graph is returned; a violation falls back to the unmerged graph rather than
+emitting a site that cannot evaluate.
+
+**The eager group is never mixed with the lazy one.** The eager set is closed under dependencies, so
+merging an eager chunk with a lazy one would move deferred code into the initial payload. Eager
+chunks are bucketed first and on their own, purely by size — they all load anyway, so there is no
+over-fetch to trade against.
+
+#### Measured on the Tesserae sample gallery
+
+| | chunks | median chunk | eager payload |
+| --- | --- | --- | --- |
+| one chunk per SCC | 682 | 2.2 KB | 1,055 KB raw / 187 KB gz |
+| coalesced 50–100 KB | **56** | **52.4 KB** | 1,816 KB raw / 296 KB gz |
+
+All 132 samples render identically (`textdiff-samples.js`, 127 identical and the other five —
+`Charts`, `Masonry`, `Pivot`, `Date Time Picker`, `Time Histogram Picker` — differing exactly the
+same way when the *same* build is compared against itself, i.e. the wall-clock/randomised noise
+floor), zero console errors from `all-samples.js`.
+
+#### Where the eager growth comes from, and what would remove it
+
+The two halves of that build behave completely differently, and the difference is **information, not
+algorithm**:
+
+- The **application** goes 161 → 18 chunks and its eager payload does not move at all. It knows its
+  entry point, so it knows which of its chunks are eager, and the pass never merges across that line.
+- The **library** goes 521 → 38 chunks, and that is where the whole +761 KB comes from. A package has
+  no entry point to be lazy relative to and cannot see its consumer, so it does not know which of its
+  chunks that consumer needs at start-up. Measured on this pair: 116 library chunks (822 KB) are in
+  the app's eager set; 92 of them are the library's widely-reached core (reached by more than 16
+  roots — that tier is 100% eager and merges cleanly), but 24 of them (138 KB) are near-leaves the
+  app's shell happens to use directly, and there is nothing in the library's own graph that
+  distinguishes those from the 331 leaves nobody loads at start-up. Merging each of the 24 into a
+  ~55 KB bucket is the ~1 MB.
+
+Simulating the same pass with an oracle for the app's eager set gives **53 chunks, median 54.5 KB,
+and 1,055 KB raw / 160 KB gz** — the same chunk count *and* a smaller payload than the unmerged
+build, because bigger files compress better. So the ceiling here is not the packing, it is the
+missing information, and closing it needs the packing to happen where the whole program is visible:
+
+- **The follow-up: coalesce across assemblies in the site build.** Chunk assignment is a whole-program
+  property (the same reason `--incremental` is not combined with module mode), and a library alone is
+  not the whole program. The site build has every chunk file on disk — its own and every reference's,
+  extracted from the package — plus the merged chunk map, so it can build the cross-assembly chunk
+  graph, run this same pass over it, and write the merged files. It would have to rewrite the
+  `import '…';` prologues and the `m: "./chunks/…"` entries of each entry module's
+  `Transpose.Modules.register` manifest, both of which are emitted in a fixed one-per-line form.
+- **Until then the band is per project.** A library that knows it is consumed by one application can
+  set its own `modules.minChunkSize`; the measured curve on this pair, with the app left at 50 KB, is
+  521→329 chunks at +60 KB eager (5 KB band), 521→201 at +133 KB (10 KB), 521→115 at +421 KB (20 KB).
+
 ### Not done
 
+- **Coalescing across assemblies at the site build** — see §7f. The pass runs per assembly, so a
+  package's chunks are packed without knowing which of them its consumer needs at start-up.
 - **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today
   reuses cached per-type JavaScript could still reshuffle chunks. Module mode has not been checked
   against the cache and the two should not be combined yet.

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -361,7 +361,9 @@ internal static class ProjectBuild
                 externalSkipClusterDeps: externalSkipDeps,
                 // A library has no entry point to be lazy relative to: nothing is eager beyond its
                 // [Ready] handlers, and its consumers pull in what they actually use.
-                packageModules: options.EmitPackage);
+                packageModules: options.EmitPackage,
+                minChunkBytes: tpscfg?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
+                maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes);
         }
         catch (Exception ex)
         {
@@ -396,7 +398,7 @@ internal static class ProjectBuild
             log.Info($"  dll:      {dllPath}");
             if (result.Modules is { } pkgMods)
                 log.Info($"  modules:    {pkgMods.Chunks.Count} chunk(s) — {pkgMods.EagerChunkCount} loaded up front, " +
-                         $"{pkgMods.LazyChunkCount} on demand ({pkgMods.LazyTypeCount} type(s) deferred)");
+                         $"{pkgMods.LazyChunkCount} on demand ({pkgMods.LazyTypeCount} type(s) deferred){ChunkSizes(pkgMods)}");
             log.Info($"  embedded: {string.Join(", ", items.Take(6).Select(i => i.Name))}{(items.Count > 6 ? ", …" : "")}");
             return BuildOutcome.NoSite(0, result.Diagnostics);
         }
@@ -425,7 +427,7 @@ internal static class ProjectBuild
             log.Info($"\nOK — built site in {outDir} ({js.Length:N0} bytes of {config.FileName}) in {sw.ElapsedMilliseconds} ms.");
             if (result.Modules is { } mods)
                 log.Info($"  modules:    {mods.Chunks.Count} chunk(s) — {mods.EagerChunkCount} loaded up front, " +
-                         $"{mods.LazyChunkCount} on demand ({mods.LazyTypeCount} type(s) deferred)");
+                         $"{mods.LazyChunkCount} on demand ({mods.LazyTypeCount} type(s) deferred){ChunkSizes(mods)}");
             log.Info($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
             if (dllPath is not null) log.Info($"  dll:        {dllPath}");
             if (siteResult.RemovedStaleFiles.Count > 0)
@@ -551,6 +553,15 @@ internal static class ProjectBuild
         if (tpscfg is not null)
             foreach (var file in tpscfg.Resources.SelectMany(g => g.Files).OrderBy(n => n, StringComparer.Ordinal))
                 yield return "res=" + file + "=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, file));
+    }
+
+    /// <summary>The chunk size distribution, so a `modules.minChunkSize` setting can be judged from
+    /// the build's own output rather than by measuring the site afterwards.</summary>
+    private static string ChunkSizes(Translator.Emitter.ModuleOutput modules)
+    {
+        if (modules.Chunks.Count == 0) return "";
+        var sizes = modules.Chunks.Select(c => c.js.Length).OrderBy(n => n).ToList();
+        return $", median {sizes[sizes.Count / 2] / 1024.0:N1} KB, largest {sizes[^1] / 1024.0:N1} KB";
     }
 
     /// <summary>What shape of output this build produces — the distributable package DLL, a runnable
@@ -809,7 +820,9 @@ internal static class ProjectBuild
                 chunkDirectory: "chunks/" + project.AssemblyName,
                 externalChunks: tpscfg is { OutputByModule: true } ? ModuleMap.Read(project.ReferencePaths) : null,
                 externalSkipClusterDeps: tpscfg is { OutputByModule: true } ? ModuleMap.ReadSkipClusterDeps(project.ReferencePaths) : null,
-                packageModules: true);
+                packageModules: true,
+                minChunkBytes: tpscfg?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
+                maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes);
         }
         catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex, log); return false; }
 

--- a/Transpose/Transpose.Compiler.Core/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler.Core/TransposeJson.cs
@@ -61,6 +61,19 @@ internal sealed class TransposeJson
     public bool OutputByModule => string.Equals(OutputBy, "Module", System.StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// <c>modules.minChunkSize</c> / <c>modules.maxChunkSize</c> — the size band the second chunking
+    /// pass merges towards, in bytes of emitted JavaScript. The first pass emits one chunk per
+    /// strongly-connected component, which is the smallest <em>sound</em> unit and far too fine to
+    /// fetch (a real library lands around a 2 KB median); the second groups components that load
+    /// together until each chunk is worth its own request. Set <c>minChunkSize</c> to 0 to turn the
+    /// second pass off and get one chunk per component. Only read in <c>outputBy: Module</c>.
+    /// </summary>
+    public int ModuleMinChunkBytes { get; init; } = Emitter.DefaultMinChunkBytes;
+
+    /// <inheritdoc cref="ModuleMinChunkBytes"/>
+    public int ModuleMaxChunkBytes { get; init; } = Emitter.DefaultMaxChunkBytes;
+
+    /// <summary>
     /// <c>cleanOutputFolder</c> — prune stale files from the site output folder after a build:
     /// any file left over from a previous build that <em>this</em> build did not (re)write is
     /// deleted, and directories it empties are removed. This is the improved take on the legacy h5
@@ -145,6 +158,8 @@ internal sealed class TransposeJson
             CleanOutputFolderExclude = merged.CleanOutputFolderExclude,
             ReflectionDisabled = merged.ReflectionDisabled ?? false,
             ReflectionTarget = merged.ReflectionTarget ?? "file",
+            ModuleMinChunkBytes = merged.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
+            ModuleMaxChunkBytes = merged.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes,
         };
     }
 
@@ -166,6 +181,8 @@ internal sealed class TransposeJson
         public List<string> CleanOutputFolderExclude = new();
         public bool? ReflectionDisabled;
         public string? ReflectionTarget;
+        public int? ModuleMinChunkBytes;
+        public int? ModuleMaxChunkBytes;
 
         public static Draft Merge(Draft b, Draft? o)
         {
@@ -185,6 +202,8 @@ internal sealed class TransposeJson
                 CleanOutputFolderExclude = b.CleanOutputFolderExclude.Concat(o.CleanOutputFolderExclude).ToList(),
                 ReflectionDisabled = o.ReflectionDisabled ?? b.ReflectionDisabled,
                 ReflectionTarget = o.ReflectionTarget  ?? b.ReflectionTarget,
+                ModuleMinChunkBytes = o.ModuleMinChunkBytes ?? b.ModuleMinChunkBytes,
+                ModuleMaxChunkBytes = o.ModuleMaxChunkBytes ?? b.ModuleMaxChunkBytes,
             };
         }
     }
@@ -205,6 +224,11 @@ internal sealed class TransposeJson
 
         var html = root.TryGetProperty("html", out var h) && h.ValueKind == JsonValueKind.Object ? h : default;
         var reflection = root.TryGetProperty("reflection", out var rfl) && rfl.ValueKind == JsonValueKind.Object ? rfl : default;
+        var modules = root.TryGetProperty("modules", out var mdl) && mdl.ValueKind == JsonValueKind.Object ? mdl : default;
+
+        int? Int(JsonElement e, string name)
+            => e.ValueKind == JsonValueKind.Object && e.TryGetProperty(name, out var v)
+               && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var i) ? i : (int?)null;
 
         var cleanExclude = new List<string>();
         if (root.TryGetProperty("cleanOutputFolderExclude", out var ce) && ce.ValueKind == JsonValueKind.Array)
@@ -249,6 +273,8 @@ internal sealed class TransposeJson
                 ? rd.ValueKind == JsonValueKind.True
                 : (bool?)null,
             ReflectionTarget = reflection.ValueKind == JsonValueKind.Object ? Str(reflection, "target") : null,
+            ModuleMinChunkBytes = Int(modules, "minChunkSize"),
+            ModuleMaxChunkBytes = Int(modules, "maxChunkSize"),
         };
     }
 

--- a/Transpose/Transpose.Translator.Tests/ModuleChunkCoalescingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleChunkCoalescingTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The second chunking pass (<c>Emitter.ModuleChunks.cs</c>): merging the strongly-connected
+    /// components back up into chunks worth fetching.
+    ///
+    /// The first pass emits one chunk per SCC, which is the smallest <em>sound</em> unit and far too
+    /// fine to fetch — a real library lands around a 2 KB median, so a screen that needs twenty types
+    /// pays twenty requests. This pass merges components that load together until each chunk is in a
+    /// target size band.
+    ///
+    /// The band is set per test rather than left at the shipped 50–100 KB: these snippets are a few
+    /// hundred bytes each, so the real band would collapse every one of them into a single chunk and
+    /// there would be nothing to observe.
+    /// </summary>
+    [TestClass]
+    public class ModuleChunkCoalescingTests
+    {
+        private static Emitter.ModuleOutput Emit(string source, int min, int max) =>
+            ModuleEmitTests.Emit(source, minChunkBytes: min, maxChunkBytes: max);
+
+        private static IEnumerable<string> ImportsOf(string js) =>
+            Regex.Matches(js, @"^import '\./(c\d+\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
+
+        private static int IndexOfChunk(string relPath) => int.Parse(Regex.Match(relPath, @"c(\d+)\.mjs").Groups[1].Value);
+
+        /// <summary>Ten independent types, each with a body big enough to be worth measuring.</summary>
+        private static string Widgets(int count, int bodyLines, string prefix = "W")
+        {
+            var sb = new StringBuilder();
+            for (var i = 0; i < count; i++)
+            {
+                sb.Append("public class ").Append(prefix).Append(i).Append(" { public int Run(int n) { var t = 0;\n");
+                for (var line = 0; line < bodyLines; line++)
+                    sb.Append("    t += n * ").Append(line).Append(" + (n / ").Append(line + 1).Append(");\n");
+                sb.Append("    return t; } }\n");
+            }
+            return sb.ToString();
+        }
+
+        [TestMethod]
+        public void ComponentsThatAlwaysLoadTogetherAreMergedIntoOneChunk()
+        {
+            // Root reaches every widget and nothing else does, so all of them are fetched exactly
+            // when Root is: their load condition is identical and merging them costs nothing.
+            var uses = string.Join(" + ", Enumerable.Range(0, 6).Select(i => $"new W{i}().Run(n)"));
+            var m = Emit(Widgets(6, 12) + $@"
+public class Root {{ public int All(int n) {{ return {uses}; }} }}
+public class Program {{ public static void Main() {{ System.Console.WriteLine(new Root().All(1)); }} }}
+", min: 8 * 1024, max: 16 * 1024);
+
+            var chunks = Enumerable.Range(0, 6).Select(i => ModuleEmitTests.ChunkOf(m, "W" + i)).Distinct().ToList();
+            Assert.AreEqual(1, chunks.Count,
+                "six components with the same load condition should be one chunk, not six");
+        }
+
+        [TestMethod]
+        public void ZeroTurnsThePassOffAndKeepsOneChunkPerComponent()
+        {
+            var source = Widgets(6, 12) + @"
+public class Root { public int All(int n) { return new W0().Run(n); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Root().All(1)); } }
+";
+            var off = Emit(source, min: 0, max: 0);
+            var on = Emit(source, min: 8 * 1024, max: 16 * 1024);
+            Assert.IsTrue(off.Chunks.Count > on.Chunks.Count,
+                $"min=0 must leave the components split ({off.Chunks.Count} chunks) — coalesced gave {on.Chunks.Count}");
+            Assert.AreEqual(6, Enumerable.Range(0, 6).Select(i => ModuleEmitTests.ChunkOf(off, "W" + i)).Distinct().Count());
+        }
+
+        [TestMethod]
+        public void AnEagerChunkIsNeverMergedWithADeferredOne()
+        {
+            // Program (eager) and Deferred (nothing reaches it, so it stays a stub) are both tiny and
+            // adjacent, which is exactly the pair a size-only bucketer would fuse — and fusing them
+            // would drag the deferred code into the initial payload, the opposite of the point.
+            var m = Emit(Widgets(4, 12, "E") + Widgets(4, 12, "L") + @"
+public class Shell { public int Boot(int n) { return new E0().Run(n) + new E1().Run(n) + new E2().Run(n) + new E3().Run(n); } }
+public class Deferred { public int Later(int n) { return new L0().Run(n) + new L1().Run(n) + new L2().Run(n) + new L3().Run(n); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Shell().Boot(1)); } }
+", min: 32 * 1024, max: 64 * 1024);
+
+            var eagerChunk = ModuleEmitTests.ChunkOf(m, "Program");
+            Assert.AreNotEqual(eagerChunk, ModuleEmitTests.ChunkOf(m, "Deferred"),
+                "a deferred type must not end up in an eagerly imported chunk");
+            foreach (var name in new[] { "L0", "L1", "L2", "L3" })
+                Assert.AreNotEqual(eagerChunk, ModuleEmitTests.ChunkOf(m, name),
+                    name + " is only reachable from the deferred type and must stay out of the eager chunk");
+            Assert.IsTrue(m.LazyChunkCount > 0, "something has to still be deferred");
+        }
+
+        [TestMethod]
+        public void EveryImportStillPointsAtALowerNumberedChunk()
+        {
+            // The merged graph has to stay a DAG, and the emitter's invariant is stronger than that:
+            // a chunk only ever imports lower-numbered chunks. That is what makes the file names
+            // deterministic, and — because Transpose.define resolves `inherits` eagerly — what makes
+            // the evaluation order sound. A merge is the one operation that could break it.
+            var body = new StringBuilder(Widgets(24, 10));
+            for (var i = 0; i < 8; i++)
+                body.Append($"public class Mid{i} {{ public int Go(int n) {{ return new W{i}().Run(n) + new W{i + 8}().Run(n) + new W{i + 16}().Run(n); }} }}\n");
+            body.Append("public class Program { public static void Main() { System.Console.WriteLine(new Mid0().Go(1) + new Mid1().Go(2)); } }\n");
+
+            var m = Emit(body.ToString(), min: 6 * 1024, max: 12 * 1024);
+
+            foreach (var (relPath, js) in m.Chunks)
+            {
+                var self = IndexOfChunk(relPath);
+                foreach (var imported in ImportsOf(js))
+                    Assert.IsTrue(IndexOfChunk(imported) < self,
+                        $"{relPath} imports {imported}, which is not a lower-numbered chunk");
+            }
+        }
+
+        [TestMethod]
+        public void EveryEmittedTypeIsStillDefinedExactlyOnce()
+        {
+            var m = Emit(Widgets(20, 10) + @"
+public class Program { public static void Main() { System.Console.WriteLine(new W0().Run(1)); } }
+", min: 6 * 1024, max: 12 * 1024);
+
+            var defined = m.Chunks
+                .SelectMany(c => Regex.Matches(c.js, @"Transpose\.definei?\(""([^""]+)""").Select(x => x.Groups[1].Value))
+                .ToList();
+            CollectionAssert.AllItemsAreUnique(defined, "merging must not duplicate or drop a define");
+            foreach (var i in Enumerable.Range(0, 20))
+                CollectionAssert.Contains(defined, "W" + i);
+        }
+
+        [TestMethod]
+        public void TheChunkMapAndTheManifestFollowTheMergedChunks()
+        {
+            var m = Emit(Widgets(12, 10) + @"
+public class Program { public static void Main() { System.Console.WriteLine(new W0().Run(1)); } }
+", min: 6 * 1024, max: 12 * 1024);
+
+            foreach (var i in Enumerable.Range(0, 12))
+            {
+                var expected = ModuleEmitTests.ChunkOf(m, "W" + i);
+                Assert.AreEqual(expected, m.TypeToChunk["W" + i],
+                    "the published chunk map must name the chunk a type actually landed in");
+                // Deferred types are registered with the same file the map names, so a stub resolves
+                // to the module that really defines it.
+                if (m.EntryJs.Contains($"\"W{i}\": {{ m: "))
+                    StringAssert.Contains(m.EntryJs, $"\"W{i}\": {{ m: \"./{expected}\"");
+            }
+        }
+
+        [TestMethod]
+        public void AChunkStaysUnderTheCeilingUnlessOneComponentIsAlreadyOverIt()
+        {
+            const int max = 12 * 1024;
+            var m = Emit(Widgets(30, 8) + @"
+public class Program { public static void Main() { System.Console.WriteLine(new W0().Run(1)); } }
+", min: 6 * 1024, max: max);
+
+            foreach (var (relPath, js) in m.Chunks)
+            {
+                // The import prologue is not part of what the bucketer measures, so allow for it.
+                var body = js.Length - js.Split('\n').Where(l => l.StartsWith("import ")).Sum(l => l.Length + 1);
+                Assert.IsTrue(body <= max + 2048, $"{relPath} is {body} bytes, past the {max}-byte ceiling");
+            }
+            Assert.IsTrue(m.Chunks.Count > 1, "30 widgets at 8 lines each should not fit in one 12 KB chunk");
+        }
+
+        [TestMethod]
+        public void TwoBuildsOfTheSameSourcesProduceTheSameChunks()
+        {
+            var source = Widgets(16, 10) + @"
+public class Left { public int Go(int n) { return new W0().Run(n) + new W1().Run(n) + new W2().Run(n); } }
+public class Right { public int Go(int n) { return new W3().Run(n) + new W4().Run(n) + new W2().Run(n); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Left().Go(1)); } }
+";
+            var a = Emit(source, min: 6 * 1024, max: 12 * 1024);
+            var b = Emit(source, min: 6 * 1024, max: 12 * 1024);
+
+            CollectionAssert.AreEqual(a.Chunks.Select(c => c.relPath).ToList(), b.Chunks.Select(c => c.relPath).ToList());
+            for (var i = 0; i < a.Chunks.Count; i++)
+                Assert.AreEqual(a.Chunks[i].js, b.Chunks[i].js, "chunk " + a.Chunks[i].relPath + " differs between builds");
+            Assert.AreEqual(a.EntryJs, b.EntryJs);
+        }
+
+        [TestMethod]
+        public void CodeExclusiveToOneDeferredRootDoesNotFollowAnother()
+        {
+            // Two independent deferred features, each with enough exclusive code to fill a chunk of
+            // its own. Their load conditions are disjoint, so once a bucket is worth its request the
+            // pass must stop rather than fuse the two features together.
+            var m = Emit(Widgets(8, 14, "A") + Widgets(8, 14, "B") + @"
+public class FeatureA { public int Go(int n) { return new A0().Run(n) + new A1().Run(n) + new A2().Run(n) + new A3().Run(n)
+                                                    + new A4().Run(n) + new A5().Run(n) + new A6().Run(n) + new A7().Run(n); } }
+public class FeatureB { public int Go(int n) { return new B0().Run(n) + new B1().Run(n) + new B2().Run(n) + new B3().Run(n)
+                                                    + new B4().Run(n) + new B5().Run(n) + new B6().Run(n) + new B7().Run(n); } }
+public class Program { public static void Main() { System.Console.WriteLine(42); } }
+", min: 2 * 1024, max: 1024 * 1024);
+
+            // Each feature's exclusive code is over the minimum on its own, so the bucket earns its
+            // request before the load condition changes and the pass stops there rather than fusing
+            // the two features. (Crossing that boundary is only allowed while the bucket is still
+            // under the minimum — that is the one place the pass trades over-fetch for size.)
+            var aChunks = Enumerable.Range(0, 8).Select(i => ModuleEmitTests.ChunkOf(m, "A" + i))
+                .Append(ModuleEmitTests.ChunkOf(m, "FeatureA")).ToHashSet();
+            var bChunks = Enumerable.Range(0, 8).Select(i => ModuleEmitTests.ChunkOf(m, "B" + i))
+                .Append(ModuleEmitTests.ChunkOf(m, "FeatureB")).ToHashSet();
+            CollectionAssert.AreEquivalent(Array.Empty<string>(), aChunks.Intersect(bChunks).ToList(),
+                "two features that are never loaded together must not share a chunk");
+            Assert.AreEqual(1, aChunks.Count, "the eight components exclusive to FeatureA should be one chunk");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -19,24 +19,31 @@ namespace Transpose.Translator.Tests
     [TestClass]
     public class ModuleEmitTests : TranslatorTestBase
     {
-        private static Emitter.ModuleOutput Emit(
+        /// <param name="minChunkBytes">Off by default: these snippets are a few hundred bytes each, so
+        /// the real 50 KB coalescing band would merge every one of them into a single chunk and there
+        /// would be nothing left to assert about the component split. The second pass has its own
+        /// suite (<see cref="ModuleChunkCoalescingTests"/>), which sets a band the snippets can reach.</param>
+        internal static Emitter.ModuleOutput Emit(
             string source,
             bool packageModules = false,
             IReadOnlyDictionary<string, string>? externalChunks = null,
-            string chunkDirectory = "chunks")
+            string chunkDirectory = "chunks",
+            int minChunkBytes = 0,
+            int maxChunkBytes = 0)
         {
             var result = new RoslynTranslator().BuildAssembly(
                 new[] { ("App.cs", source) }, CompilationBuilder.DefaultAssemblyName,
                 extraReferencePaths: null, preprocessorSymbols: new[] { "DEBUG", "TRACE" },
                 emitAssembly: false, emitModules: true,
-                chunkDirectory: chunkDirectory, externalChunks: externalChunks, packageModules: packageModules);
+                chunkDirectory: chunkDirectory, externalChunks: externalChunks, packageModules: packageModules,
+                minChunkBytes: minChunkBytes, maxChunkBytes: maxChunkBytes);
             if (!result.Success)
                 Assert.Fail("translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));
             return result.Modules!;
         }
 
         /// <summary>The chunk a type's <c>Transpose.define</c> was emitted into.</summary>
-        private static string ChunkOf(Emitter.ModuleOutput m, string typeName) =>
+        internal static string ChunkOf(Emitter.ModuleOutput m, string typeName) =>
             m.Chunks.First(c => Regex.IsMatch(c.js, @"Transpose\.definei?\(""" + Regex.Escape(typeName) + @"""")).relPath;
 
         private static IEnumerable<string> ImportsOf(string js) =>

--- a/Transpose/Transpose.Translator.Tests/ModuleReflectionDepsTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleReflectionDepsTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The dependency a reflection-driven activator creates, which nothing in the emitted code shows
+    /// — <c>[ConstructsTypeArguments]</c> and <c>[NeverDefer]</c> (Emitter.ReflectionDeps.cs).
+    ///
+    /// The chunker records an edge exactly when a reference is emitted, so a type stays loadable
+    /// because some code names it. <c>JsonConvert.DeserializeObject&lt;Order&gt;(json)</c> emits
+    /// nothing about <c>Order</c> that a stub cannot answer, then constructs it and every member type
+    /// below it from the metadata — and constructing a stub throws.
+    ///
+    /// These snippets apply attributes the BCL only carries once it is rebuilt from this tree, so
+    /// they need a <c>TRANSPOSE_DLL_PATH</c> pointing at a locally built <c>Transpose.dll</c> — the
+    /// same thing the runtime-behaviour tests need, and what CI sets.
+    /// </summary>
+    [TestClass]
+    public class ModuleReflectionDepsTests
+    {
+        private const string Dtos = @"
+public class Country { public string Name; }
+public class Address { public string City; public Country Where; }
+public class Line    { public string Sku; }
+public class Order   { public Address Ship; public System.Collections.Generic.List<Line> Lines; }
+public class Nobody  { public int N; }
+";
+
+        /// <summary>A stand-in for a binding library's deserializer: it hands back a T it built from
+        /// T's metadata, so nothing it emits mentions T's members.</summary>
+        private const string Activator = @"
+public static class Wire
+{
+    public static T Read<T>(string json) { return default(T); }
+    public static string Write<T>(T value) { return """"; }
+}
+";
+
+        private static IEnumerable<string> ImportsOf(string js) =>
+            Regex.Matches(js, @"^import '\./(c\d+\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
+
+        /// <summary>Everything the chunk holding <paramref name="typeName"/> pulls in, transitively.</summary>
+        private static HashSet<string> ChunkClosure(Emitter.ModuleOutput m, string typeName)
+        {
+            var start = System.IO.Path.GetFileName(ModuleEmitTests.ChunkOf(m, typeName));
+            var seen = new HashSet<string> { start };
+            var stack = new Stack<string>(new[] { start });
+            while (stack.Count > 0)
+            {
+                var file = stack.Pop();
+                var js = m.Chunks.First(c => c.relPath.EndsWith(file)).js;
+                foreach (var i in ImportsOf(js)) if (seen.Add(i)) stack.Push(i);
+            }
+            return seen;
+        }
+
+        private static bool Reaches(Emitter.ModuleOutput m, string from, string to) =>
+            ChunkClosure(m, from).Contains(System.IO.Path.GetFileName(ModuleEmitTests.ChunkOf(m, to)));
+
+        private static string Program(string marker) => Dtos + Activator.Replace("public static T Read<T>", marker + " public static T Read<T>") + @"
+public class Screen  { public Order Load(string j) { return Wire.Read<Order>(j); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Load(""{}"")); } }
+";
+
+        [TestMethod]
+        public void WithoutTheAttributeAnActivatedTypesMembersAreNotReached()
+        {
+            // The baseline the attribute exists to fix. `Read<Order>` names Order — a Type object,
+            // which a stub answers — and nothing names Address, Country or Line at all, so the
+            // deserializer's `new Address()` would hit a stub.
+            var m = ModuleEmitTests.Emit(Program(""));
+            Assert.IsFalse(Reaches(m, "Screen", "Address"),
+                "nothing emitted mentions Address, so its chunk should not be reachable from the caller");
+            Assert.IsFalse(Reaches(m, "Screen", "Line"));
+        }
+
+        [TestMethod]
+        public void ConstructsTypeArgumentsPullsTheWholeMemberGraphIntoTheCallersChunk()
+        {
+            var m = ModuleEmitTests.Emit(Program("[Transpose.ConstructsTypeArguments]"));
+
+            // The type argument itself...
+            Assert.IsTrue(Reaches(m, "Screen", "Order"), "the type argument's chunk must be imported");
+            // ...its member types, recursively...
+            Assert.IsTrue(Reaches(m, "Screen", "Address"), "a member type is constructed too");
+            Assert.IsTrue(Reaches(m, "Screen", "Country"), "the walk is transitive");
+            // ...and through a collection: the member is declared List<Line>, and Line is what gets built.
+            Assert.IsTrue(Reaches(m, "Screen", "Line"), "a generic argument of a member type counts");
+        }
+
+        [TestMethod]
+        public void AnUnrelatedTypeIsNotDraggedIn()
+        {
+            var m = ModuleEmitTests.Emit(Program("[Transpose.ConstructsTypeArguments]"));
+            Assert.IsFalse(Reaches(m, "Screen", "Nobody"),
+                "the walk follows the activated type's members, not the whole assembly");
+        }
+
+        [TestMethod]
+        public void TheAttributeOnTheContainingTypeCoversEveryGenericMember()
+        {
+            var source = Dtos + "[Transpose.ConstructsTypeArguments]" + Activator + @"
+public class Screen  { public Order Load(string j) { return Wire.Read<Order>(j); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Load(""{}"")); } }
+";
+            var m = ModuleEmitTests.Emit(source);
+            Assert.IsTrue(Reaches(m, "Screen", "Address"),
+                "a binding library should be able to mark the activator class rather than each overload");
+        }
+
+        [TestMethod]
+        public void ANonGenericCallIsUnaffected()
+        {
+            // Nothing to record: the type is a runtime value, not a type argument. This is the case
+            // [NeverDefer] exists for.
+            var m = ModuleEmitTests.Emit(Dtos + @"
+public static class Wire { [Transpose.ConstructsTypeArguments] public static object Read(string json, System.Type t) { return null; } }
+public class Screen  { public object Load(string j) { return Wire.Read(j, typeof(Order)); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Load(""{}"")); } }
+");
+            Assert.IsFalse(Reaches(m, "Screen", "Address"),
+                "a Type-valued argument writes nothing down for the compiler to follow");
+        }
+
+        [TestMethod]
+        public void AnActivatorInAReferencedAssemblyIsHonoured()
+        {
+            // The shape that matters in practice: the activator is JsonConvert, compiled into a
+            // package, and the attribute is read back out of its metadata rather than its source.
+            var library = Path.Combine(Path.GetTempPath(), "tps-activator-" + Guid.NewGuid().ToString("N") + ".dll");
+            try
+            {
+                var built = new RoslynTranslator().BuildAssembly(
+                    new[] { ("Lib.cs", @"
+namespace Wiring
+{
+    public static class Wire
+    {
+        [Transpose.ConstructsTypeArguments]
+        public static T Read<T>(string json) { return default(T); }
+    }
+}") },
+                    "Wiring", extraReferencePaths: null, preprocessorSymbols: new[] { "DEBUG", "TRACE" },
+                    emitAssembly: true);
+                Assert.IsTrue(built.Success, string.Join("\n", built.Errors.Select(d => d.GetMessage())));
+                File.WriteAllBytes(library, built.AssemblyBytes!);
+
+                var app = new RoslynTranslator().BuildAssembly(
+                    new[] { ("App.cs", Dtos + @"
+public class Screen  { public Order Load(string j) { return Wiring.Wire.Read<Order>(j); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Load(""{}"")); } }
+") },
+                    CompilationBuilder.DefaultAssemblyName, extraReferencePaths: new[] { library },
+                    preprocessorSymbols: new[] { "DEBUG", "TRACE" },
+                    emitAssembly: false, emitModules: true, minChunkBytes: 0, maxChunkBytes: 0);
+                Assert.IsTrue(app.Success, string.Join("\n", app.Errors.Select(d => d.GetMessage())));
+
+                var m = app.Modules!;
+                Assert.IsTrue(Reaches(m, "Screen", "Order"), "the type argument's chunk must be imported");
+                Assert.IsTrue(Reaches(m, "Screen", "Country"), "and the graph below it");
+                Assert.IsFalse(Reaches(m, "Screen", "Nobody"));
+            }
+            finally
+            {
+                try { if (File.Exists(library)) File.Delete(library); } catch { }
+            }
+        }
+
+        [TestMethod]
+        public void AnAssemblyCanDeclareAnActivatorItDoesNotOwn()
+        {
+            // The escape hatch for a library that cannot be edited, or has not been re-released with
+            // the annotation: name the activator type from the calling assembly. It applies to every
+            // generic method of that type, and only to calls made from here.
+            var source = "[assembly: Transpose.ConstructsTypeArguments(typeof(Wire))]" + Dtos + Activator + @"
+public class Screen  { public Order Load(string j) { return Wire.Read<Order>(j); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Load(""{}"")); } }
+";
+            var m = ModuleEmitTests.Emit(source);
+            Assert.IsTrue(Reaches(m, "Screen", "Order"));
+            Assert.IsTrue(Reaches(m, "Screen", "Country"), "the walk is the same as for the marked method");
+            Assert.IsFalse(Reaches(m, "Screen", "Nobody"));
+        }
+
+        [TestMethod]
+        public void DeclaringOneActivatorDoesNotMarkAnother()
+        {
+            var source = "[assembly: Transpose.ConstructsTypeArguments(typeof(Elsewhere))]" + Dtos + Activator + @"
+public static class Elsewhere { public static T Read<T>(string json) { return default(T); } }
+public class Screen  { public Order Load(string j) { return Wire.Read<Order>(j); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Load(""{}"")); } }
+";
+            var m = ModuleEmitTests.Emit(source);
+            Assert.IsFalse(Reaches(m, "Screen", "Address"),
+                "the declaration names one activator type, not every generic method in the project");
+        }
+
+        [TestMethod]
+        public void SerializingTheSameTypeIsNotAffected()
+        {
+            // Serialization reads an instance it was handed; it never constructs the type, so there
+            // is no hidden edge and marking it would only inflate what a screen fetches.
+            var m = ModuleEmitTests.Emit(Dtos + Activator.Replace("public static T Read<T>",
+                "[Transpose.ConstructsTypeArguments] public static T Read<T>") + @"
+public class Screen  { public string Save(Order o) { return Wire.Write<Order>(o); } }
+public class Program { public static void Main() { System.Console.WriteLine(new Screen().Save(null)); } }
+");
+            Assert.IsFalse(Reaches(m, "Screen", "Country"),
+                "Write<T> is not marked, so it pulls in nothing beyond what the emitted code names");
+        }
+
+        [TestMethod]
+        public void NeverDeferKeepsATypeOutOfTheDeferredManifest()
+        {
+            const string source = @"
+public class Settings { public string Theme; }
+public class Program { public static void Main() { System.Console.WriteLine(1); } }
+";
+            var deferred = ModuleEmitTests.Emit(source);
+            StringAssert.Contains(deferred.EntryJs, "\"Settings\": { m: ",
+                "nothing references Settings, so it is deferred — that is the default this attribute overrides");
+
+            var eager = ModuleEmitTests.Emit(source.Replace("public class Settings",
+                "[Transpose.NeverDefer] public class Settings"));
+            Assert.IsFalse(eager.EntryJs.Contains("\"Settings\": { m: "),
+                "[NeverDefer] must keep the type out of the stub manifest");
+            Assert.AreEqual(0, eager.LazyChunkCount, "its chunk has to be one the entry module imports");
+        }
+
+        [TestMethod]
+        public void NeverDeferAlsoPullsInWhatTheTypeItselfNeeds()
+        {
+            var m = ModuleEmitTests.Emit(@"
+public class Palette { public string Accent; }
+public class Settings { public Palette Colors = new Palette(); }
+public class Program { public static void Main() { System.Console.WriteLine(1); } }
+".Replace("public class Settings", "[Transpose.NeverDefer] public class Settings"));
+
+            // The eager set is closed over chunk dependencies, so a [NeverDefer] root brings its own
+            // references with it — the same closure the entry point gets.
+            Assert.IsFalse(m.EntryJs.Contains("\"Palette\": { m: "),
+                "a [NeverDefer] type's own dependencies have to be loaded with it");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -89,7 +89,9 @@ public sealed class RoslynTranslator
         string chunkDirectory = "chunks",
         IReadOnlyDictionary<string, string>? externalChunks = null,
         bool packageModules = false,
-        IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null)
+        IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
+        int minChunkBytes = Emitter.DefaultMinChunkBytes,
+        int maxChunkBytes = Emitter.DefaultMaxChunkBytes)
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -227,7 +229,8 @@ public sealed class RoslynTranslator
                 // metadata script and the "javascript" of this build is the entry module.
                 CompileProgress.Report("emitting JavaScript modules");
                 moduleOutput = PhaseTimings.Measure("emit JavaScript (modules)",
-                    () => emitter.EmitModules(chunkDirectory, externalChunks, packageModules, externalSkipClusterDeps));
+                    () => emitter.EmitModules(chunkDirectory, externalChunks, packageModules, externalSkipClusterDeps,
+                                              minChunkBytes, maxChunkBytes));
                 js = moduleOutput.EntryJs;
             }
             else

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -1041,7 +1041,12 @@ public sealed partial class Emitter
     private void EmitMemberAccess(MemberAccessExpressionSyntax member)
     {
         // A property/field read on a [SkipTypeClustering] facade, same reasoning as a call.
-        RecordSkipClusterCall(_model.GetSymbolInfo(member).Symbol);
+        var accessed = _model.GetSymbolInfo(member).Symbol;
+        RecordSkipClusterCall(accessed);
+        // A method GROUP of a [ConstructsTypeArguments] method — `Parse` in
+        // `list.Select(JsonConvert.DeserializeObject<Order>)` — is a call the emitter never walks as
+        // an invocation, and its type argument is written down right here (Emitter.ReflectionDeps.cs).
+        RecordActivatedTypeArguments(accessed);
 
         // `Transpose.Script.ToDynamic().Transpose.global.console` — ToDynamic() is the JS global
         // root ([GlobalTarget]); a member access on it is a plain global reference, so drop the

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -28,6 +28,12 @@ public sealed partial class Emitter
         // because that is the only place the compiler knows the call happens (Emitter.SkipClustering.cs).
         RecordSkipClusterCall(symbol);
 
+        // A call to a [ConstructsTypeArguments] method — a reflection-driven activator such as
+        // JsonConvert.DeserializeObject<T>. Its type arguments are built from their metadata rather
+        // than named by emitted code, so the call site is the only place that edge exists
+        // (Emitter.ReflectionDeps.cs).
+        RecordActivatedTypeArguments(symbol);
+
         if (symbol is null)
         {
             // A `Script.Write(...)` call with a `dynamic` argument binds as late-bound, so Symbol is

--- a/Transpose/Transpose.Translator/Emit/Emitter.ModuleChunks.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.ModuleChunks.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// The second chunking pass: coalescing the strongly-connected components into chunks that are
+/// worth fetching.
+///
+/// The first pass (<c>Emitter.Modules.cs</c>) produces the <em>smallest sound</em> unit — one chunk
+/// per SCC of the reference graph. On a real library that is far too fine: Tesserae came out at 682
+/// chunks with a median of 2.2 KB, and half of them under 1 KB. Every one of those is a separate
+/// HTTP request, a separate module record, and a separate compression context, so a sample that
+/// needs twenty small types pays twenty round trips to fetch 30 KB.
+///
+/// This pass merges them back up to a target size band (50–100 KB by default) <b>without</b> making
+/// anything load that would not have loaded anyway, where it can. The rule it merges by is the one
+/// the request asks for — <em>what is used together</em>:
+///
+/// <list type="number">
+/// <item><b>Load signature.</b> A chunk with no importer is a <em>root</em>: nothing pulls it in, so
+/// it is only ever fetched because the application asked for it (<c>Modules.LoadAsync</c>). Every
+/// other chunk is fetched exactly when one of the roots that reaches it is. So the set of roots that
+/// reach a chunk <em>is</em> its load condition, and two chunks with the same set are always
+/// fetched together — merging them costs nothing at all.</item>
+/// <item><b>Ordering.</b> Classes of equal signature are emitted in a reverse-topological order of
+/// the class graph, choosing at each step the ready class most similar (Jaccard over the root sets)
+/// to the one just emitted, so classes that <em>nearly</em> always load together end up adjacent.</item>
+/// <item><b>Bucketing.</b> The resulting sequence is cut into contiguous buckets of
+/// <c>min…max</c> bytes. A bucket only spans a class boundary while it is still under the minimum,
+/// which is where the over-fetch is: below the minimum a chunk is not worth a request of its own,
+/// and its neighbour in the order above is the least-bad thing to pay for.</item>
+/// </list>
+///
+/// <b>Sizes are exact, not estimated.</b> The type bodies are emitted before chunking (chunking
+/// needs the reference graph the emit records), so the byte count of every chunk is already known —
+/// no complexity heuristic and no emit-measure-regroup round trip.
+///
+/// <b>Why the result is still a DAG.</b> Chunk evaluation order has to be sound —
+/// <c>Transpose.define</c> resolves <c>inherits</c> eagerly, so a cycle between two chunks is
+/// exactly the failure the SCC pass exists to prevent, and merging is the one operation that could
+/// reintroduce one (merging A and C when A → B → C makes the merged node and B import each other).
+/// Two properties rule that out by construction, so no cycle check is needed:
+/// <list type="bullet">
+/// <item>If chunk <c>i</c> depends on chunk <c>d</c>, then every root that reaches <c>i</c> reaches
+/// <c>d</c>: <c>sig(d) ⊇ sig(i)</c>. So a cycle among signature classes would force all of them
+/// equal — i.e. one class — and the class graph is acyclic. Emitting classes in reverse-topological
+/// order therefore places every dependency before its dependent.</item>
+/// <item>Within a class, and within the eager group, members are emitted in the first pass's own
+/// index order, which is already topological (a dependency always has a lower index). A contiguous
+/// run of a topological order can never contain an edge pointing forward.</item>
+/// </list>
+/// Both together mean every edge of the merged graph points at a bucket with a lower-or-equal index,
+/// which is the invariant the emitter already relies on for deterministic file names. It is
+/// re-checked before the merged graph is returned, and a violation falls back to the unmerged one
+/// rather than emitting a site that cannot evaluate.
+///
+/// <b>The eager group is never mixed with the lazy one.</b> The eager set is closed under
+/// dependencies, so merging an eager chunk with a lazy one would move the lazy code into the initial
+/// payload — the opposite of the point. Eager chunks are bucketed first, on their own, purely by
+/// size: they all load anyway, so there is no over-fetch to trade against and packing them as tightly
+/// as the maximum allows is strictly better.
+/// </summary>
+public sealed partial class Emitter
+{
+    /// <summary>Below this, a chunk is not worth a request of its own and is merged with its
+    /// neighbour in the load order. 0 disables the pass entirely (one chunk per SCC).</summary>
+    public const int DefaultMinChunkBytes = 50 * 1024;
+
+    /// <summary>A bucket stops accepting chunks once adding one would take it past this. A single
+    /// SCC larger than this is not split — an SCC is atomic.</summary>
+    public const int DefaultMaxChunkBytes = 100 * 1024;
+
+    /// <summary>
+    /// Merges the SCC chunks into buckets of <paramref name="minBytes"/>–<paramref name="maxBytes"/>,
+    /// grouping by what is loaded together. See the type remarks for the algorithm and why the
+    /// result is still a DAG. Returns the input unchanged when the pass is disabled, when there is
+    /// nothing to merge, or when the safety re-check fails.
+    /// </summary>
+    /// <param name="sizes">Exact emitted bytes per chunk.</param>
+    /// <param name="eager">Chunks the entry module imports. Never merged with the rest.</param>
+    /// <param name="order">The emitter's dependency-depth ordering, which decides the order of types
+    /// inside a merged chunk — it already guarantees a type's bases are defined before it.</param>
+    private static ChunkGraph Coalesce(
+        ChunkGraph chunks,
+        IReadOnlyList<int> sizes,
+        HashSet<int> eager,
+        Dictionary<INamedTypeSymbol, int> order,
+        int minBytes,
+        int maxBytes,
+        out HashSet<int> coalescedEager)
+    {
+        coalescedEager = eager;
+        var n = chunks.Members.Count;
+        if (minBytes <= 0 || n <= 1) return chunks;
+        if (maxBytes < minBytes) maxBytes = minBytes;
+
+        // Everything below reads the first pass's index order as a topological order. It is one by
+        // construction (Tarjan emits a component only after every component it points at), but the
+        // whole pass is unsound if it ever stops being one, so it is checked rather than assumed.
+        for (var i = 0; i < n; i++)
+            foreach (var d in chunks.Deps[i])
+                if (d >= i) return chunks;
+
+        // --- 1. roots and load signatures ------------------------------------------------------
+        // A root is a lazy chunk nothing imports: it is fetched only when the application asks for
+        // it. (A lazy chunk can only be imported by another lazy chunk — if an eager one imported
+        // it, the eager closure would have made it eager too.)
+        var indegree = new int[n];
+        for (var i = 0; i < n; i++)
+            foreach (var d in chunks.Deps[i]) indegree[d]++;
+
+        var rootId = new int[n];
+        Array.Fill(rootId, -1);
+        var rootCount = 0;
+        for (var i = 0; i < n; i++)
+            if (!eager.Contains(i) && indegree[i] == 0) rootId[i] = rootCount++;
+
+        // sig[i] = the roots that reach chunk i. Dependencies have lower indices, so one descending
+        // sweep is a complete propagation: when i is read, every chunk that could contribute to it
+        // has already been read.
+        var words = Math.Max(1, (rootCount + 63) / 64);
+        var sig = new ulong[n][];
+        for (var i = 0; i < n; i++)
+        {
+            sig[i] = new ulong[words];
+            if (rootId[i] >= 0) sig[i][rootId[i] >> 6] |= 1UL << (rootId[i] & 63);
+        }
+        for (var i = n - 1; i >= 0; i--)
+            foreach (var d in chunks.Deps[i])
+                for (var w = 0; w < words; w++) sig[d][w] |= sig[i][w];
+
+        // --- 2. one class per distinct signature (lazy chunks only) ----------------------------
+        var classOf = new int[n];
+        Array.Fill(classOf, -1);
+        var classSig = new List<ulong[]>();
+        var classMembers = new List<List<int>>();
+        var byKey = new Dictionary<ulong[], int>(BitsComparer.Instance);
+        for (var i = 0; i < n; i++)
+        {
+            if (eager.Contains(i)) continue;
+            if (!byKey.TryGetValue(sig[i], out var c))
+            {
+                c = classSig.Count;
+                byKey[sig[i]] = c;
+                classSig.Add(sig[i]);
+                classMembers.Add(new List<int>());
+            }
+            classOf[i] = c;
+            classMembers[c].Add(i);      // ascending, because i ascends
+        }
+
+        // --- 3. order the classes ---------------------------------------------------------------
+        var classOrder = OrderClasses(chunks, classOf, classSig, classMembers);
+        if (classOrder is null) return chunks;
+
+        // --- 4. cut the sequence into buckets ---------------------------------------------------
+        var buckets = new List<List<int>>();
+        var current = new List<int>();
+        var currentBytes = 0;
+        var currentClass = int.MinValue;
+
+        void Flush()
+        {
+            if (current.Count == 0) return;
+            buckets.Add(current);
+            current = new List<int>();
+            currentBytes = 0;
+        }
+
+        void Take(int chunk, int cls)
+        {
+            // Start a new bucket when this one is full, or when the load condition changes and the
+            // bucket already earns its request. Crossing a class boundary under the minimum is the
+            // deliberate over-fetch: it is what buys the size band.
+            if (current.Count > 0 && (currentBytes + sizes[chunk] > maxBytes
+                                      || (cls != currentClass && currentBytes >= minBytes)))
+                Flush();
+            current.Add(chunk);
+            currentBytes += sizes[chunk];
+            currentClass = cls;
+        }
+
+        for (var i = 0; i < n; i++)
+            if (eager.Contains(i)) Take(i, -1);
+        Flush();
+        var eagerBuckets = buckets.Count;
+
+        foreach (var c in classOrder)
+            foreach (var i in classMembers[c]) Take(i, c);
+        Flush();
+
+        // --- 5. rebuild the graph ----------------------------------------------------------------
+        var bucketOf = new int[n];
+        Array.Fill(bucketOf, -1);
+        var members = new List<List<INamedTypeSymbol>>(buckets.Count);
+        var indexOf = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        for (var b = 0; b < buckets.Count; b++)
+        {
+            var list = new List<INamedTypeSymbol>();
+            foreach (var i in buckets[b])
+            {
+                bucketOf[i] = b;
+                list.AddRange(chunks.Members[i]);
+            }
+            // The emitter's dependency-depth ordering is global, so re-sorting the union of several
+            // components by it keeps every type's bases ahead of it, exactly as within one SCC.
+            list.Sort((a, z) => order[a].CompareTo(order[z]));
+            members.Add(list);
+            foreach (var t in list) indexOf[t] = b;
+        }
+
+        // Every chunk is either eager (bucketed in the first sweep) or a member of exactly one
+        // signature class (the second), so this cannot miss one — but a missed chunk would silently
+        // vanish from the output rather than fail, which is worth one pass to rule out.
+        for (var i = 0; i < n; i++)
+            if (bucketOf[i] < 0) return chunks;
+
+        var deps = new List<HashSet<int>>(buckets.Count);
+        for (var b = 0; b < buckets.Count; b++) deps.Add(new HashSet<int>());
+        for (var i = 0; i < n; i++)
+            foreach (var d in chunks.Deps[i])
+                if (bucketOf[d] != bucketOf[i]) deps[bucketOf[i]].Add(bucketOf[d]);
+
+        // The invariant the whole emitter rests on (and the reason no cycle check was needed above):
+        // every import points at a lower index. If the reasoning above is ever wrong, fall back to
+        // the unmerged graph instead of emitting a site whose modules cannot evaluate.
+        for (var b = 0; b < deps.Count; b++)
+            foreach (var d in deps[b])
+                if (d >= b) return chunks;
+
+        coalescedEager = new HashSet<int>(Enumerable.Range(0, eagerBuckets));
+        return new ChunkGraph(members, deps, indexOf);
+    }
+
+    /// <summary>
+    /// The order the signature classes are laid out in: reverse-topological over the class graph
+    /// (so a class is emitted only after everything it depends on), and among the classes that are
+    /// ready at each step, the one whose root set most resembles the one just emitted. That second
+    /// half is what puts <em>nearly</em>-co-loaded classes next to each other, so that when the
+    /// bucketer has to cross a class boundary it crosses into the closest neighbour rather than an
+    /// arbitrary one. Null if the class graph is not a DAG, which cannot happen (see the type
+    /// remarks) but is not worth being wrong about.
+    /// </summary>
+    private static List<int>? OrderClasses(
+        ChunkGraph chunks, int[] classOf, List<ulong[]> classSig, List<List<int>> classMembers)
+    {
+        var k = classMembers.Count;
+        if (k == 0) return new List<int>();
+
+        var dependsOn = new HashSet<int>[k];
+        var dependents = new List<int>[k];
+        for (var c = 0; c < k; c++) { dependsOn[c] = new HashSet<int>(); dependents[c] = new List<int>(); }
+
+        for (var i = 0; i < classOf.Length; i++)
+        {
+            var c = classOf[i];
+            if (c < 0) continue;                       // eager: bucketed before any of this
+            foreach (var d in chunks.Deps[i])
+            {
+                var e = classOf[d];
+                if (e < 0 || e == c) continue;
+                if (dependsOn[c].Add(e)) dependents[e].Add(c);
+            }
+        }
+
+        // The greedy pick below is quadratic in the class count. That is nothing at the scale this
+        // runs at (a few hundred classes), but a pathologically wide project should not pay for it:
+        // above the cap, fall back to ordering by root-set size descending, which satisfies the same
+        // topological constraint on its own — a dependency's root set is a strict superset of its
+        // dependent's, so it is strictly larger.
+        if (k > 4096)
+            return Enumerable.Range(0, k)
+                .OrderByDescending(c => PopCount(classSig[c]))
+                .ThenBy(c => classMembers[c][0])
+                .ToList();
+
+        var remaining = new int[k];
+        var ready = new List<int>();
+        for (var c = 0; c < k; c++)
+        {
+            remaining[c] = dependsOn[c].Count;
+            if (remaining[c] == 0) ready.Add(c);
+        }
+
+        var result = new List<int>(k);
+        ulong[]? previous = null;
+        while (ready.Count > 0)
+        {
+            var pick = -1;
+            var best = -1d;
+            foreach (var c in ready)
+            {
+                var score = previous is null ? 0d : Jaccard(previous, classSig[c]);
+                if (score > best || (score == best && c < pick)) { best = score; pick = c; }
+            }
+            ready.Remove(pick);
+            result.Add(pick);
+            previous = classSig[pick];
+            foreach (var p in dependents[pick])
+                if (--remaining[p] == 0) ready.Add(p);
+        }
+        return result.Count == k ? result : null;
+    }
+
+    /// <summary>How much two load conditions overlap: |A ∩ B| / |A ∪ B|. 1 means the two classes are
+    /// always fetched together and merging them is free; 0 means they never are.</summary>
+    private static double Jaccard(ulong[] a, ulong[] b)
+    {
+        var both = 0; var either = 0;
+        for (var w = 0; w < a.Length; w++)
+        {
+            both += System.Numerics.BitOperations.PopCount(a[w] & b[w]);
+            either += System.Numerics.BitOperations.PopCount(a[w] | b[w]);
+        }
+        return either == 0 ? 0d : (double)both / either;
+    }
+
+    private static int PopCount(ulong[] a)
+    {
+        var total = 0;
+        foreach (var w in a) total += System.Numerics.BitOperations.PopCount(w);
+        return total;
+    }
+
+    /// <summary>Value equality for the root bitsets, so identical load conditions land in one class.</summary>
+    private sealed class BitsComparer : IEqualityComparer<ulong[]>
+    {
+        public static readonly BitsComparer Instance = new();
+
+        public bool Equals(ulong[]? x, ulong[]? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null || x.Length != y.Length) return false;
+            for (var i = 0; i < x.Length; i++) if (x[i] != y[i]) return false;
+            return true;
+        }
+
+        public int GetHashCode(ulong[] obj)
+        {
+            var hash = new HashCode();
+            foreach (var w in obj) hash.Add(w);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -63,11 +63,17 @@ public sealed partial class Emitter
     /// <param name="packageMode">A library: nothing is eager beyond what its own [Ready] handlers
     /// need, because there is no entry point to be lazy relative to — the consumer's chunks import
     /// what they use, and everything else stays a stub until something asks for it.</param>
+    /// <param name="minChunkBytes">The second pass's target band: an SCC chunk smaller than this is
+    /// merged with whatever loads alongside it (see Emitter.ModuleChunks.cs). 0 emits one chunk per
+    /// SCC, which is what the first pass produces on its own.</param>
+    /// <param name="maxChunkBytes">The ceiling a merged chunk is kept under.</param>
     public ModuleOutput EmitModules(
         string chunkDirectory = "chunks",
         IReadOnlyDictionary<string, string>? externalChunks = null,
         bool packageMode = false,
-        IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null)
+        IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
+        int minChunkBytes = DefaultMinChunkBytes,
+        int maxChunkBytes = DefaultMaxChunkBytes)
     {
         _externalSkipClusterDeps = externalSkipClusterDeps;
         // Reflection metadata is emitted once for the whole assembly, outside the per-type walk, so
@@ -141,6 +147,26 @@ public sealed partial class Emitter
         else
         {
             for (var i = 0; i < chunks.Members.Count; i++) eager.Add(i);
+        }
+
+        // Second pass: merge the SCCs into chunks worth fetching. An SCC is the smallest sound
+        // unit, not a useful one — a real library comes out with a median chunk of a couple of KB,
+        // so a screen that needs twenty types pays twenty requests. Coalesce groups them by what is
+        // loaded together and cuts the result into the target size band. Sizes are exact: the type
+        // bodies are already emitted at this point (chunking needs the graph the emit records), so
+        // nothing is estimated and nothing is emitted twice. See Emitter.ModuleChunks.cs.
+        if (minChunkBytes > 0 && chunks.Members.Count > 1)
+        {
+            var sizes = new int[chunks.Members.Count];
+            for (var i = 0; i < chunks.Members.Count; i++)
+                foreach (var t in chunks.Members[i]) sizes[i] += bodies[t].Length + 1;
+
+            chunks = PhaseTimings.Measure("  ├ coalesce chunks (co-load signature)", () =>
+            {
+                var merged = Coalesce(chunks, sizes, eager, order, minChunkBytes, maxChunkBytes, out var mergedEager);
+                eager = mergedEager;
+                return merged;
+            });
         }
 
         var dir = string.IsNullOrEmpty(chunkDirectory) ? "" : chunkDirectory.TrimEnd('/') + "/";

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -144,6 +144,15 @@ public sealed partial class Emitter
         // metadata is emitted outside the per-type walk), so they join the roots of the eager set.
         if (canDefer && ReflectionEnabled) roots.AddRange(MetadataAttributeClasses(types));
 
+        // [NeverDefer]: something reaches this type purely through reflection — a DTO an activator
+        // builds from a `Type` value, a class resolved by name — so no emitted reference records the
+        // edge and the chunker would leave it a stub that throws when constructed. Prefer
+        // [ConstructsTypeArguments] on the generic method that does the activating, which records the
+        // dependency at the call site instead of making the type eager for everyone; this is the
+        // fallback for what a call site cannot show. See Emitter.ReflectionDeps.cs.
+        if (canDefer)
+            roots.AddRange(types.Where(t => TransposeNaming.HasAttr(t, TransposeNaming.NeverDeferAttr)));
+
         var eager = new HashSet<int>();
         if (canDefer)
         {

--- a/Transpose/Transpose.Translator/Emit/Emitter.ReflectionDeps.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.ReflectionDeps.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// The dependency a reflection-driven activator creates, which nothing in the emitted code shows.
+///
+/// The module chunker records an edge exactly when a type reference is <em>emitted</em>, which is
+/// what makes it sound: a type stays loadable because some code names it. A reflection-driven
+/// deserializer defeats that. <c>JsonConvert.DeserializeObject&lt;Order&gt;(json)</c> emits nothing
+/// about <c>Order</c> beyond its <c>Type</c> object — and a deferred type's stub answers a
+/// <c>Type</c> question perfectly well — then walks that metadata and constructs <c>Order</c> and
+/// every member type below it. Constructing a stub throws, and its module can only be fetched
+/// asynchronously, so by then it is too late.
+///
+/// <c>[ConstructsTypeArguments]</c> puts the edge back at the one place the compiler can see it: the
+/// call site, where the type argument is written down. Each call records its type arguments — and,
+/// transitively, every type reachable from them through the fields and properties reflection
+/// describes — as real dependencies of the type being emitted. So the chunk that deserializes an
+/// <c>Order</c> imports the chunk that defines it, and the DTO stays deferred for every screen that
+/// does not.
+///
+/// This is the same shape as <c>[SkipTypeClustering]</c> (Emitter.SkipClustering.cs): both move a
+/// dependency to the call site, because that is where the code actually runs. The difference is the
+/// direction — that one takes edges away from a facade, this one adds edges an activator hides.
+///
+/// <c>[NeverDefer]</c> is the fallback for what a call site cannot show: a <c>Type</c> value rather
+/// than a static type argument, or a reflective lookup inside a library that cannot be annotated. It
+/// joins the eager roots (Emitter.Modules.cs), like the attribute classes the metadata constructs.
+///
+/// The attribute is read in three places, so an activator can be marked by whoever knows about it:
+/// on the method, on its containing type, or — for a library that cannot be edited or has not been
+/// re-released with the annotation — from the calling assembly, with
+/// <c>[assembly: ConstructsTypeArguments(typeof(JsonConvert))]</c>.
+/// </summary>
+public sealed partial class Emitter
+{
+    /// <summary>Memoizes the walk for the type currently being emitted — Clone() gives each emitted
+    /// type its own Emitter, so this is never shared across the parallel emit.</summary>
+    private readonly Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> _activatedGraphs =
+        new(SymbolEqualityComparer.Default);
+
+    /// <summary>
+    /// At a call to a <c>[ConstructsTypeArguments]</c> method, records the call's type arguments and
+    /// the graph reachable from them as dependencies of the type being emitted. A no-op outside
+    /// module mode, and for every other call.
+    /// </summary>
+    private void RecordActivatedTypeArguments(ISymbol? symbol)
+    {
+        if (_recordedRefs is null && _recordedExternalRefs is null) return;      // not module mode
+        if (symbol is not IMethodSymbol { IsGenericMethod: true } method) return;
+        if (!ConstructsTypeArguments(method)) return;
+
+        foreach (var argument in method.TypeArguments)
+            foreach (var reached in ActivatedGraph(argument))
+                RecordRef(reached);
+    }
+
+    /// <summary>
+    /// Whether calling this method activates its type arguments. Looked up on the method, on its
+    /// containing type — so a binding library can mark one overload or a whole activator class — and
+    /// in this compilation's own assembly attributes, which is how an application marks an activator
+    /// it does not own (<c>[assembly: ConstructsTypeArguments(typeof(JsonConvert))]</c>).
+    /// </summary>
+    private bool ConstructsTypeArguments(IMethodSymbol method) =>
+        TransposeNaming.HasAttr(method.OriginalDefinition, TransposeNaming.ConstructsTypeArgumentsAttr)
+        || TransposeNaming.HasAttr(method.ContainingType, TransposeNaming.ConstructsTypeArgumentsAttr)
+        || (method.ContainingType is { } owner
+            && DeclaredActivators.Contains((INamedTypeSymbol)owner.OriginalDefinition));
+
+    /// <summary>The types this assembly declares as activators, from its own
+    /// <c>[assembly: ConstructsTypeArguments(typeof(X))]</c> attributes. Scanned once and carried
+    /// across Clone(), so the parallel emit reads it rather than rebuilding it per type; empty for
+    /// almost every project, so the lookup above costs nothing when nobody uses the escape hatch.</summary>
+    private HashSet<INamedTypeSymbol> DeclaredActivators =>
+        _declaredActivators ??= CollectDeclaredActivators();
+
+    private HashSet<INamedTypeSymbol>? _declaredActivators;
+
+    private HashSet<INamedTypeSymbol> CollectDeclaredActivators()
+    {
+        var found = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var attribute in _compilation.Assembly.GetAttributes())
+        {
+            if (!TransposeNaming.AttrIs(attribute, TransposeNaming.ConstructsTypeArgumentsAttr)) continue;
+            foreach (var argument in attribute.ConstructorArguments)
+                if (argument.Value is INamedTypeSymbol named)
+                    found.Add((INamedTypeSymbol)named.OriginalDefinition);
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// Every type an activator can reach from <paramref name="root"/>: the type itself, its bases,
+    /// and — recursively — the types of the instance fields and properties reflection describes,
+    /// looking through arrays and generic arguments (a <c>List&lt;Order&gt;</c> member activates
+    /// <c>Order</c>).
+    ///
+    /// Deliberately an over-approximation, for the same reason <c>BuildSkipClusterDeps</c> is one:
+    /// it only has to be a superset of what the deserializer will touch, and over-approximating
+    /// costs an import that was not needed, never a missing one that throws. It stops at anything
+    /// with no module behind it — an external (native JS) type and the always-loaded BCL — and at
+    /// the visited set, which is what terminates a recursive model.
+    /// </summary>
+    private List<INamedTypeSymbol> ActivatedGraph(ITypeSymbol root)
+    {
+        if (Unwrap(root) is not { } start) return new List<INamedTypeSymbol>();
+        if (_activatedGraphs.TryGetValue(start, out var cached)) return cached;
+
+        var reached = new List<INamedTypeSymbol>();
+        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var queue = new Queue<INamedTypeSymbol>();
+        seen.Add(start);
+        queue.Enqueue(start);
+
+        while (queue.Count > 0)
+        {
+            var type = queue.Dequeue();
+            reached.Add(type);
+
+            void Follow(ITypeSymbol? next)
+            {
+                if (Unwrap(next) is { } named && seen.Add(named)) queue.Enqueue(named);
+                // A constructed generic reaches its arguments too — the member is declared as
+                // List<Order>, and Order is what gets built.
+                if (next is INamedTypeSymbol { IsGenericType: true } generic)
+                    foreach (var argument in generic.TypeArguments)
+                        if (Unwrap(argument) is { } arg && seen.Add(arg)) queue.Enqueue(arg);
+                if (next is IArrayTypeSymbol array) Follow(array.ElementType);
+            }
+
+            if (type.BaseType is { SpecialType: not SpecialType.System_Object } baseType) Follow(baseType);
+            foreach (var member in type.GetMembers())
+                switch (member)
+                {
+                    // What a serializer round-trips: instance state. A compiler-generated backing
+                    // field repeats its property, which the visited set absorbs.
+                    case IFieldSymbol { IsStatic: false, IsConst: false } field: Follow(field.Type); break;
+                    case IPropertySymbol { IsStatic: false, Parameters.IsEmpty: true } property: Follow(property.Type); break;
+                }
+        }
+
+        _activatedGraphs[start] = reached;
+        return reached;
+    }
+
+    /// <summary>The named type behind a reference, or null when there is no module to load for it:
+    /// a type parameter (nothing is written down at the call site), an external type (native JS), or
+    /// the BCL (always loaded, and walking <c>string</c>'s members would be a waste).</summary>
+    private static INamedTypeSymbol? Unwrap(ITypeSymbol? type) => type switch
+    {
+        IArrayTypeSymbol array => Unwrap(array.ElementType),
+        INamedTypeSymbol named when !TransposeNaming.IsExternalType(named)
+                                    && (named.Locations.Any(l => l.IsInSource)
+                                        || TransposeNaming.IsTransposeCompiledSource(named))
+            => (INamedTypeSymbol)named.OriginalDefinition,
+        _ => null,
+    };
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -256,6 +256,9 @@ public sealed partial class Emitter
             // Built once before the parallel emit and read-only during it (see Emitter.SkipClustering.cs).
             _skipClusterDeps = _skipClusterDeps,
             _externalSkipClusterDeps = _externalSkipClusterDeps,
+            // Same: the assembly's own [assembly: ConstructsTypeArguments(typeof(X))] list, computed
+            // on the parent here so it is scanned once rather than once per emitted type.
+            _declaredActivators = DeclaredActivators,
         };
     }
 

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -21,6 +21,8 @@ internal static class TransposeNaming
     public const string GlobalMethodsAttr = "Transpose.GlobalMethodsAttribute";
     public const string ReadyAttr = "Transpose.ReadyAttribute";
     public const string SkipTypeClusteringAttr = "Transpose.SkipTypeClusteringAttribute";
+    public const string ConstructsTypeArgumentsAttr = "Transpose.ConstructsTypeArgumentsAttribute";
+    public const string NeverDeferAttr = "Transpose.NeverDeferAttribute";
 
     /// <summary>Allocation-free equivalent of <c>a.AttributeClass?.ToDisplayString() == fullName</c>.
     /// Attribute matching runs for every symbol reference during emit; <c>ToDisplayString</c> builds a


### PR DESCRIPTION
Two changes to `outputBy: Module`, both about edges the chunker cannot see on its own.

## 1. A second chunking pass — chunks worth fetching

A chunk is a strongly-connected component of the reference graph: the smallest **sound** unit, because `Transpose.define` resolves `inherits` eagerly and a per-class split cannot order a reference cycle. It is also a far too small **useful** one. With `[SkipTypeClustering]` in place, Tesserae's sample gallery emitted **682 chunks with a 2.2 KB median**, half of them under 1 KB — so a screen that needs twenty types paid twenty requests to fetch 30 KB.

`Emitter.ModuleChunks.cs` merges the components back up to a size band, defaulting to **50–100 KB** and set per project through `tps.json` `modules.minChunkSize` / `modules.maxChunkSize` (0 restores one chunk per component). What it merges by is *what loads together*:

- **Load signature.** A chunk nothing imports is a **root**: it is only fetched because the application asked for it. Every other chunk is fetched exactly when one of the roots that reaches it is, so the set of roots reaching a chunk *is* its load condition — two chunks with the same set are always fetched together, and merging them costs nothing.
- **Ordering.** Signature classes come out in a reverse-topological order of the class graph, and among the classes ready at each step the one whose root set is most similar (Jaccard) to the one just emitted goes next, so classes that *nearly* always load together end up adjacent.
- **Bucketing.** That sequence is cut into contiguous buckets inside the band. A bucket only spans a class boundary while it is still under the minimum — the one place over-fetch is traded for size.

**Sizes are exact, not estimated.** The type bodies are already emitted when chunking runs (chunking needs the reference graph the emit records), so every component's byte count is known: no complexity heuristic, no emit-measure-regroup round trip.

**The merged graph is still a DAG by construction, not by checking.** If chunk `i` depends on chunk `d` then every root reaching `i` reaches `d`, i.e. `sig(d) ⊇ sig(i)`; a cycle among signature classes would force all of them equal, so the class graph is acyclic and reverse-topological order places every dependency first. Within a class — and within the eager group — members keep the first pass's index order, which is already topological, and a contiguous run of a topological order cannot contain a forward edge. The invariant that every import points at a lower-numbered chunk is re-checked before the merged graph is returned; a violation falls back to the unmerged graph rather than emitting a site that cannot evaluate. The eager group is bucketed first and on its own, so deferred code is never pulled into the initial payload.

### Measured on the Tesserae sample gallery

| | chunks | median chunk | eager payload |
| --- | --- | --- | --- |
| one chunk per SCC | 682 | 2.2 KB | 1,055 KB raw / 187 KB gz |
| coalesced 50–100 KB | **56** | **52.4 KB** | 1,816 KB raw / 296 KB gz |

All 132 samples render identically (`textdiff-samples.js`: 127 identical, and the five that differ — `Charts`, `Masonry`, `Pivot`, `Date Time Picker`, `Time Histogram Picker` — differ exactly the same way when the *same* build is compared against itself, i.e. the wall-clock/randomised noise floor). Zero console errors from `all-samples.js`.

### The eager growth is information, not algorithm — worth reading before merging

The two halves of that build behave completely differently:

- The **application** goes 161 → 18 chunks with its eager payload **untouched**. It knows its entry point, so it knows which chunks are eager, and the pass never merges across that line.
- The **library** goes 521 → 38 chunks, and that is where the whole +761 KB comes from. A package has no entry point and cannot see its consumer, so it does not know which of its chunks that consumer needs at start-up. Of the 116 library chunks in the app's eager set, 92 are the widely-reached core (>16 roots — that tier is 100% eager and merges cleanly); the other 24 are near-leaves the app's shell happens to use directly, and nothing in the library's own graph distinguishes them from the 331 leaves nobody loads at start-up.

Simulating the same pass with an oracle for the app's eager set gives **53 chunks *and* 1,055 KB raw / 160 KB gz** — the same chunk count and *fewer* bytes than the unmerged build, because larger files compress better. So the ceiling is the missing information, and closing it means coalescing across assemblies in the site build, where the whole program is visible. `TODO.modules.md` §7g records the measurements, the per-project band curve as a stopgap (521→329 chunks at +60 KB eager for a 5 KB band, 521→201 at +133 KB for 10 KB), and what the cross-assembly pass would take.

The build summary now also reports the median and largest chunk, so the band can be judged from the build's own output.

## 2. `[ConstructsTypeArguments]` and `[NeverDefer]`

The chunker records an edge exactly when a reference is *emitted*, so a reflection-driven deserializer defeats it — the case §7f ran into. `JsonConvert.DeserializeObject<Order>(json)` emits nothing about `Order` beyond its `Type` object (which a stub answers perfectly well), then walks that metadata and constructs `Order` and every member type below it. Constructing a stub throws, and its module can only be fetched asynchronously.

**`[ConstructsTypeArguments]`** goes on the activating generic method and puts the edge back at the **call site**, where the type argument is written down. Each call records its type arguments — and, transitively, everything reachable through the fields and properties reflection describes, through arrays and generic arguments so a `List<Line>` member reaches `Line` — as dependencies of the type being emitted. The DTO is fetched with the code that deserializes it and stays deferred for every screen that does not. Same move `[SkipTypeClustering]` makes, in the other direction. It is read on the method, on its containing type, or from the calling assembly:

```csharp
[assembly: Transpose.ConstructsTypeArguments(typeof(Newtonsoft.Json.JsonConvert))]
[assembly: Transpose.ConstructsTypeArguments(typeof(System.Text.Json.JsonSerializer))]
```

That form covers every generic method of the named type, applies only within the assembly declaring it (it is a statement about how *this* code calls the activator, so it neither travels to a consumer nor needs to), and is how an application marks an activator it does not own.

**`[NeverDefer]`** is the blunt fallback for what a call site cannot show — `DeserializeObject(json, someType)` with a `Type` *value*, a class resolved from a string. The type joins the eager roots, the same machinery `MetadataAttributeClasses` uses.

**The shipped JSON bindings are not annotated yet, and cannot be in this PR.** Every `Packages/*` project pins a published `Transpose.BCL` (26.7.3303), so `[ConstructsTypeArguments]` on Newtonsoft's four `DeserializeObject<T>`/`DeserializeAnonymousType<T>` overloads and System.Text.Json's two `Deserialize<TValue>` overloads only compiles once a BCL carrying the attribute is released and those pins are bumped. `TODO.modules.md` §7h lists exactly what to add; until then the assembly-level declaration is the supported route, and it is the only route for a third-party activator anyway.

## Testing

- `ModuleChunkCoalescingTests` (8) — co-loaded components merge, the eager group is never mixed with the deferred one, every import still points at a lower-numbered chunk, no define is duplicated or dropped, the chunk map and manifest follow the merged chunks, the ceiling holds, output is deterministic, and two features that never load together stay apart.
- `ModuleReflectionDepsTests` (11) — starts from the failing case (without the attribute nothing reaches the DTO's members), then the member graph, the containing-type and assembly-level forms, serialization being unaffected, a `Type`-valued argument writing nothing down, `[NeverDefer]` and its closure, and the cross-assembly shape with the activator compiled into a package and the attribute read back out of its metadata.
- Full translator suite green (944 passed, 17 skipped) with `TRANSPOSE_DLL_PATH` pointing at a locally built `Transpose.dll` — these snippets apply attributes only a rebuilt BCL carries, the same requirement the runtime-behaviour tests have and what CI already sets.
- Tesserae built and rendered in headless Chromium as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LxFGsWjPmfvdnQhqYgKkv