### PR TITLE
Annotate the JSON bindings' deserializers with [ConstructsTypeArguments]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,9 +616,11 @@ The short version:
   activator it does not own or that has not been re-released with the annotation.
   **`[NeverDefer]`** is the blunt fallback for what a call site cannot show — a `Type` *value*, a
   class resolved from a string: the type joins the eager roots, like the attribute classes the
-  metadata constructs. See `Emitter.ReflectionDeps.cs`, `ModuleReflectionDepsTests` and
-  `TODO.modules.md` §7h; the shipped JSON bindings still have to be annotated, which waits on a BCL
-  release carrying the attribute.
+  metadata constructs. The shipped JSON bindings carry the attribute — Newtonsoft's four
+  `DeserializeObject<T>`/`DeserializeAnonymousType<T>` overloads and System.Text.Json's two
+  `Deserialize<TValue>` overloads — so an application needs no declaration of its own; both projects
+  pin `Transpose.BCL` 26.8.4102, the first release carrying the attribute. See
+  `Emitter.ReflectionDeps.cs`, `ModuleReflectionDepsTests` and `TODO.modules.md` §7h.
 
   Still single-bundle: `--incremental` (chunk assignment is a whole-program property — do not combine
   them yet), minification (a module entry and its chunks are emitted formatted only, since they carry

--- a/Packages/Transpose.Newtonsoft.Json/Json/JsonConvert.cs
+++ b/Packages/Transpose.Newtonsoft.Json/Json/JsonConvert.cs
@@ -97,6 +97,7 @@ namespace Newtonsoft.Json
         /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
         /// <param name="value">The JSON to deserialize.</param>
         /// <returns>The deserialized object from the JSON string.</returns>
+        [ConstructsTypeArguments]
         [Template("Newtonsoft.Json.JsonConvert.DeserializeObject({value}, {T})")]
         public static extern T DeserializeObject<T>(string value);
 
@@ -111,6 +112,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The JSON to deserialize.</param>
         /// <param name="anonymousTypeObject">The anonymous type object.</param>
         /// <returns>The deserialized anonymous type from the JSON string.</returns>
+        [ConstructsTypeArguments]
         [Template("Newtonsoft.Json.JsonConvert.DeserializeObject({value}, Transpose.getType({anonymousTypeObject}))")]
         public static extern T DeserializeAnonymousType<T>(string value, T anonymousTypeObject);
 
@@ -129,6 +131,7 @@ namespace Newtonsoft.Json
         /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>The deserialized anonymous type from the JSON string.</returns>
+        [ConstructsTypeArguments]
         [Template("Newtonsoft.Json.JsonConvert.DeserializeObject({value}, Transpose.getType({anonymousTypeObject}), {settings})")]
         public static extern T DeserializeAnonymousType<T>(string value, T anonymousTypeObject, JsonSerializerSettings settings);
 
@@ -142,6 +145,7 @@ namespace Newtonsoft.Json
         /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>The deserialized object from the JSON string.</returns>
+        [ConstructsTypeArguments]
         [Template("Newtonsoft.Json.JsonConvert.DeserializeObject({value}, {T}, {settings})")]
         public static extern T DeserializeObject<T>(string value, JsonSerializerSettings settings);
 

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.System.Text.Json/Json/JsonSerializer.cs
+++ b/Packages/Transpose.System.Text.Json/Json/JsonSerializer.cs
@@ -48,10 +48,12 @@ namespace System.Text.Json
         public static extern string Serialize(object value, Type inputType, JsonSerializerOptions options);
 
         /// <summary>Parses the JSON string into a <typeparamref name="TValue"/>.</summary>
+        [ConstructsTypeArguments]
         [Template("System.Text.Json.JsonSerializer.Deserialize({json}, {TValue}, null)")]
         public static extern TValue Deserialize<TValue>(string json);
 
         /// <summary>Parses the JSON string into a <typeparamref name="TValue"/>, using the supplied options.</summary>
+        [ConstructsTypeArguments]
         [Template("System.Text.Json.JsonSerializer.Deserialize({json}, {TValue}, {options})")]
         public static extern TValue Deserialize<TValue>(string json, JsonSerializerOptions options);
 

--- a/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
+++ b/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -599,22 +599,28 @@ Covered by `ModuleReflectionDepsTests`, which starts from the failing case (with
 nothing reaches the DTO's members) and includes the cross-assembly shape — the activator compiled
 into a package and the attribute read back out of its metadata.
 
-**Still to do: annotate the shipped bindings.** `Transpose.Newtonsoft.Json`'s four
+**The shipped bindings carry it.** `Transpose.Newtonsoft.Json`'s four
 `DeserializeObject<T>`/`DeserializeAnonymousType<T>` overloads and `Transpose.System.Text.Json`'s two
-`Deserialize<TValue>` overloads should carry `[ConstructsTypeArguments]` directly, so an application
-gets the behaviour without the assembly-level declaration. That cannot land in the same commit as
-the attribute itself: every `Packages/*` project pins a published `Transpose.BCL` (26.7.3303 today),
-so the annotation only compiles once a BCL carrying the attribute is released and those pins are
-bumped. Until then the assembly-level form is the supported route, and it is the only route for a
-third-party activator anyway.
+`Deserialize<TValue>` overloads are annotated, so an application gets the behaviour with no
+declaration of its own. That had to wait for `Transpose.BCL` 26.8.4102, the first release carrying
+the attribute; both projects' pins were bumped to it in the same change. The assembly-level form
+stays the route for a third-party activator, and for an application on an older binding.
+
+Measured on a consumer built against each, deserializing an `Order` whose graph is
+`Address → Country` and `List<Line>`:
+
+| binding | the caller's chunk imports | deferred |
+| --- | --- | --- |
+| unannotated (26.8.3954) | `Order` | `Address`, `Country`, `Line` — the deserializer's `new Address()` throws |
+| annotated | `Order`, `Address`, `Country`, `Line` | nothing but the unrelated type |
+
+`Serialize`/`SerializeObject` are deliberately left alone: serialization reads an instance it was
+handed and never constructs the type, so marking it would only inflate what a screen fetches.
 
 ### Not done
 
 - **Coalescing across assemblies at the site build** — see §7g. The pass runs per assembly, so a
   package's chunks are packed without knowing which of them its consumer needs at start-up.
-- **`[ConstructsTypeArguments]` on the shipped JSON bindings** — see §7h. The attribute and the
-  emitter support are in; annotating `Transpose.Newtonsoft.Json` and `Transpose.System.Text.Json`
-  waits on a released `Transpose.BCL` that carries it and a bump of those projects' pins.
 - **`--incremental`.** Chunk assignment is a whole-program property, so a body-only edit that today
   reuses cached per-type JavaScript could still reshuffle chunks. Module mode has not been checked
   against the cache and the two should not be combined yet.


### PR DESCRIPTION
The follow-up #124 left open. The attribute and the emitter support shipped there; annotating the bindings could not, because every `Packages/*` project pins a *published* `Transpose.BCL` and no release carried the attribute yet. **`Transpose.BCL` 26.8.4102 is the first that does** (verified in the published DLL), so both projects' pins move to it here and the deserializers are annotated.

## What changed

- `Transpose.Newtonsoft.Json` — `[ConstructsTypeArguments]` on the four `DeserializeObject<T>` / `DeserializeAnonymousType<T>` overloads.
- `Transpose.System.Text.Json` — on the two `Deserialize<TValue>` overloads.
- Both `Transpose.BCL` pins: `26.7.3303` → `26.8.4102`.

`Serialize` / `SerializeObject` are deliberately left alone: serialization reads an instance it was handed and never constructs the type, so marking it would only inflate what a screen fetches.

An application built with `outputBy: Module` now gets the behaviour with **no declaration of its own**. The assembly-level form — `[assembly: Transpose.ConstructsTypeArguments(typeof(SomeActivator))]` — stays the route for a third-party activator, and for an application still on an older binding.

## Measured

One consumer, built twice, deserializing an `Order` whose member graph is `Address → Country` plus a `List<Line>`, with an unrelated `Nobody` as the control:

| binding | the caller's chunk imports | deferred |
| --- | --- | --- |
| unannotated (26.8.3954) | `Order` | `Address`, `Country`, `Line`, `Nobody` |
| annotated (this PR) | `Order`, `Address`, `Country`, `Line` | `Nobody` |

The first row is the bug: `JsonConvert.DeserializeObject<Order>(json)` reaches `new Address()` against a stub and throws. The second is the fix, and it still leaves the type nothing deserializes deferred.

## Testing

- `Transpose.System.Text.Json.Tests` — 157 passed.
- `Transpose.Newtonsoft.Json.Tests` — 141 passed.

Both run every snippet natively against the real serializer *and* as translated JS on Node and diff the output, so a green run is also the evidence that bumping the BCL reference changed no behaviour on either side.

- Both packages build clean against 26.8.4102.
- The A/B above was run through the real SDK path (`dotnet build` → `tps`), not the test harness.

`TODO.modules.md` §7h and the module-output section of `CLAUDE.md` are updated to say the bindings carry the attribute rather than listing it as outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LxFGsWjPmfvdnQhqYgKkv

---
_Generated by [Claude Code](https://claude.ai/code/session_019LxFGsWjPmfvdnQhqYgKkv)_