### PR TITLE
Remove outputFormatting setting; derive JS variants from build profile

### DIFF
--- a/BCL/Transpose.BCL/tps.json
+++ b/BCL/Transpose.BCL/tps.json
@@ -1,7 +1,6 @@
-﻿{
+{
   "output": "Resources/.generated",
   "cleanOutputFolderBeforeBuild": true,
-  "outputFormatting": "Formatted",
   "outputBy": "ClassPath",
   "generateDocumentation": "None",
   "assembly": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,28 +402,45 @@ The short version:
   (`lib/netstandard2.0/Transpose.dll`), and the translator tests run end-to-end against it.
 - **`outputBy` file-layout modes** (Class/ClassPath/Namespace/…): `ClassPath` (used by the runtime
   build above) is implemented; the other layouts still emit a single bundle.
-- **Bundle minification (done).** `outputFormatting` (`Formatted`/`Minified`/`Both`, read from
-  `tps.json` and a merged `tps.<Configuration>.json` overlay) drives NUglify-based minification
-  (pinned to `NUglify 1.21.15`; the legacy compiler used 1.20.7, but that version mis-parenthesised
-  a `??` operand of `&&`/`||` and emitted invalid JS, fixed in NUglify 1.21.14 — not the newer
-  1.22.0, which regressed by inserting a stray empty statement when unwrapping a braced if/else
-  body) via `JsMinifier`. Packages ship
-  their compiled JS in both a formatted and a pre-minified variant — the runtime (`tps.min.js` /
-  `tps.meta.min.js`, embedded by `tps --build-runtime`) and library packages (`CollectEmbeddableItems`)
-  — so a site build reuses those and only minifies the per-project bundle/metadata/shim itself; a
-  package's JavaScript is never re-minified. `OutputBuilder` emits
-  `index.html` (formatted) and `index.min.html` (minified) and collapses them per build configuration
-  (Release keeps the minified one as `index.html`, Debug the formatted one) — a port of the legacy
-  `HtmlGenerator`. **Source maps** for the emitted bundle are still remaining.
+- **The output shape follows the build, not tps.json (`JsOutputProfile`).** There is no
+  `outputFormatting` setting; it was removed because it let a project decide something that is not its
+  to decide. A **Debug** site is one formatted bundle and is *never* chunked, whatever `outputBy` says
+  — stepping through one readable file is what a Debug build is for, and a stack trace spread over
+  sixty on-demand chunks is not. A **Release** site is one minified bundle, or the chunked module
+  output when `outputBy: "Module"` asks for it. A **package** (`--emit-package`, i.e. any library)
+  ships **all three** — the formatted bundle, the pre-minified bundle, and the module entry with its
+  chunks — because it cannot know how it will be consumed; each is tagged with a `JsVariant` in
+  `Transpose.Resources.json`, and a referencing site build keeps exactly the set its own profile calls
+  for. That is what lets one published Tesserae be debugged as a single readable bundle by one
+  application and fetched in pieces by another, with no rebuild in between.
 
-  **The `.js` ⇄ `.min.js` switch only applies to a file that exists in both variants.** That is what a
-  compiled bundle always looks like, and it is also how a library declares an authored bundle it wants
-  both variants of (Curiosity's `ExternalBundle.js` + `.min.js`). A resource that ships in **one**
-  variant — Monaco's `editor.main.js`, a vendored `d3.min.js` — has no other variant to switch to and
-  is copied through under its authored name in *every* configuration, whether the site build reads it
-  from disk or extracts it from a referenced package. Renaming it would break the app: a module loader,
-  a `new Worker(...)` or an import map fetches that file by a path the compiler does not rewrite
-  (`PackageResourceVariantTests`).
+  Two consequences worth knowing. The three variants need distinct names *inside* the DLL and the same
+  name *in the site* (application code fetches the bundle by name), so the module entry travels as
+  `<Assembly>.mjs` and the manifest's `SiteName` renames it to `<Assembly>.js` on the way out. And a
+  library no longer declares its own compiled output in `resources` to force both variants into the
+  package — that was a Bridge-era workaround for a consumer that could not choose, and such a group now
+  contributes only its load flag; `"loadCompiledOutput": false` is the direct way to say "copy my
+  bundle but do not script it" (Curiosity's Admin package, which the app fetches itself).
+
+  Minification is NUglify-based (`JsMinifier`), pinned to `NUglify 1.21.15`; the legacy compiler used
+  1.20.7, but that version mis-parenthesised a `??` operand of `&&`/`||` and emitted invalid JS, fixed
+  in NUglify 1.21.14 — not the newer 1.22.0, which regressed by inserting a stray empty statement when
+  unwrapping a braced if/else body. A package's JavaScript is never re-minified by its consumer: the
+  pre-minified variant it ships is simply extracted (the runtime's `tps.min.js` / `tps.meta.min.js` come
+  from `tps --build-runtime`, a library's from `CollectEmbeddableItems`). A module entry and its chunks
+  are emitted **formatted only** — they carry `import` syntax the minifier does not handle.
+  `OutputBuilder` writes exactly one `index.html`, linking the variant this build produced.
+  **Source maps** for the emitted bundle are still remaining.
+
+  **The `.js` ⇄ `.min.js` switch only applies to a file that exists in both variants.** For a compiled
+  bundle that is now decided by the variant tag; for *authored* JavaScript it is still decided by the
+  name, which is how a library declares a vendored bundle it wants both variants of (Tesserae's
+  `tss-dep.js` + `tss-dep.min.js`, Curiosity's `ExternalBundle` pair) — and the same rule applies
+  whether the site build reads the pair from disk or extracts it from a package, so neither path
+  scripts both halves. A resource that ships in **one** variant — Monaco's `editor.main.js`, a vendored
+  `d3.min.js` — has no other variant to switch to and is copied through under its authored name in
+  *every* configuration. Renaming it would break the app: a module loader, a `new Worker(...)` or an
+  import map fetches that file by a path the compiler does not rewrite (`PackageResourceVariantTests`).
 
   Two NUglify transforms are switched off through `CodeSettings.KillSwitch` because they are unsound
   for the JavaScript we emit, and `JsMinifierTests` guards both. Besides the `??`-under-`&&` collapse
@@ -566,7 +583,7 @@ The short version:
   constructor, which compiles its arguments as source. Module mode only; a single-bundle build is
   byte-identical.
 
-  **`[SkipTypeClustering]` keeps a static facade from fusing the library (prototype).** A chunk is an
+  **`[SkipTypeClustering]` keeps a static facade from fusing the library.** A chunk is an
   SCC, so a facade whose members construct half the library fuses that half into one chunk — the
   facade reaches every component and every component calls back into it. The attribute drops the edges
   *out of* the facade and attributes each member's dependencies to its callers, which is where a
@@ -575,7 +592,22 @@ The short version:
   source, produces the same imports. Measured on Tesserae **master**, facade intact: the largest
   library chunk drops from 193 types / 1,612 KB to 5 types / 67 KB and the eager payload from
   2,304 KB to 1,055 KB raw — better than deleting the facade (1,788 KB), which is the invasive change
-  it makes unnecessary. See `TODO.modules.md` §7e for what is not yet settled.
+  it makes unnecessary. See `TODO.modules.md` §7e.
+
+  Two edges of that move are load-bearing, and both fail at *runtime* (`… lives in module
+  './chunks/…', which has not been loaded`) rather than at build time, which is why they were only
+  found by applying the attribute to a second facade:
+
+  - **A call to a sibling on the same facade.** The sibling's containing type IS the facade, the one
+    type the pass removes from every dependency set, so member `A` calling `B` contributed only `B`'s
+    return type — never what `B`'s own body constructs — and nothing then imported it. So
+    `BuildSkipClusterDeps` takes a **transitive closure over the facade's own members** (a worklist
+    fixpoint, because facade members freely form cycles) before attributing anything to a call site.
+    This is the shape that used to kill `Mosaik.UI`, `App.Sidenav` and `App.DefaultRouting`.
+  - **Eager static state.** A static field/property initializer or a static constructor runs when the
+    facade's chunk evaluates — there is no call site to move that edge to — so `ClusterRefsFor` keeps
+    exactly those members' dependencies on the facade and drops only the ones that really do wait for
+    a call.
 
   **A second pass merges the components into chunks worth fetching.** An SCC is the smallest *sound*
   unit and a far too small *useful* one: Tesserae's gallery emitted 682 chunks with a **2.2 KB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -630,8 +630,29 @@ The short version:
   while the library's 521 → 38 raises it from 1,055 KB to 1,816 KB raw, because a package has no
   entry point and cannot see which of its chunks a consumer needs at start-up. With an oracle for
   that set the same pass gives 53 chunks *and* 1,055 KB raw / 160 KB gz, so the ceiling is the
-  missing information: the fix is to coalesce across assemblies in the site build, where the whole
-  program is visible. See `TODO.modules.md` §7g.
+  missing information. See `TODO.modules.md` §7g.
+
+  **`tps.chunks.json` supplies that missing information by measurement.** The load signature — the
+  set of roots that reach a chunk — is as good as static analysis gets at guessing what is fetched
+  together, and it is still a guess: a screen showing a chart beside a table pulls two subtrees the
+  reference graph has no reason to associate. A run of the real application knows exactly. The file
+  lists one group of emitted type names per captured step (a route, a view, boot), the chunker
+  propagates group membership down the dependency edges and folds it into the load signature as extra
+  bits, and the existing coalescer does the rest — so the addition can only *refine* the partition,
+  which is what keeps the pass's acyclicity argument intact. A group marked `"eager": true` becomes
+  eager roots in a **package** build, which is the one thing a library genuinely cannot work out for
+  itself.
+
+  **Parsing it never fails.** The file is generated from a running application and checked in beside
+  code that keeps moving, so a stale group, a renamed type or a hand-broken comma costs the oracle a
+  hint and never costs anyone a build: a malformed file reads as empty and an unmatched name is
+  skipped. Covered by `ChunkOracleTests`.
+
+  The capture itself needs `--no-chunk-coalescing` (or `TRANSPOSE_NO_CHUNK_COALESCING=1`, which
+  reaches an MSBuild-driven build), which restores one chunk per component — 522 chunks at a 1.0 KB
+  median for Tesserae, against 37 coalesced. That is the wrong thing to *serve* and the only thing
+  worth *measuring*: a coalesced build has already made the grouping decision, so a capture of it can
+  only confirm it. See the **`chunk-oracle`** skill for the whole loop.
 
   **`[ConstructsTypeArguments]` and `[NeverDefer]` cover the edge an activator hides.** The chunker
   records an edge exactly when a reference is *emitted*, so a reflection-driven deserializer defeats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,20 +594,31 @@ The short version:
   2,304 KB to 1,055 KB raw — better than deleting the facade (1,788 KB), which is the invasive change
   it makes unnecessary. See `TODO.modules.md` §7e.
 
-  Two edges of that move are load-bearing, and both fail at *runtime* (`… lives in module
-  './chunks/…', which has not been loaded`) rather than at build time, which is why they were only
-  found by applying the attribute to a second facade:
+  Two edges of that move are load-bearing. Both fail at *runtime* (`… lives in module './chunks/…',
+  which has not been loaded`) rather than at build time, which is why each was only found by applying
+  the attribute to another facade and then clicking through the app:
 
-  - **A call to a sibling on the same facade.** The sibling's containing type IS the facade, the one
-    type the pass removes from every dependency set, so member `A` calling `B` contributed only `B`'s
-    return type — never what `B`'s own body constructs — and nothing then imported it. So
-    `BuildSkipClusterDeps` takes a **transitive closure over the facade's own members** (a worklist
-    fixpoint, because facade members freely form cycles) before attributing anything to a call site.
-    This is the shape that used to kill `Mosaik.UI`, `App.Sidenav` and `App.DefaultRouting`.
-  - **Eager static state.** A static field/property initializer or a static constructor runs when the
-    facade's chunk evaluates — there is no call site to move that edge to — so `ClusterRefsFor` keeps
-    exactly those members' dependencies on the facade and drops only the ones that really do wait for
-    a call.
+  - **A call to another skipped member** — a sibling on the same facade, or a member of a second
+    facade. Either way the callee's containing type is one whose edges are being dropped, so `A`
+    calling `B` contributed only `B`'s return type, never what `B`'s own body constructs, and nothing
+    imported it. `BuildSkipClusterDeps` therefore takes a **transitive closure over every skipped
+    member** (a worklist fixpoint, because they freely form cycles) before attributing anything to a
+    call site. The sibling half killed `#/home` (a route lambda calling `ShowHomeView`); the
+    cross-facade half killed `App.Sidenav.Initialize` once `App` and `AppSidenav` were both
+    attributed.
+  - **Static state.** A static field/property initializer and a static constructor do not run with the
+    member that happens to be called — but they do not run when the facade's chunk *evaluates* either.
+    The runtime hangs `$staticInit` off the getter of the type's global slot (`Class.js`), so it fires
+    the first time anything **reads** the class, which is a call site like any other. Those
+    dependencies are therefore folded into every member's set. Keeping them on the facade instead is
+    sound and rebuilds the very cycle the attribute exists to break: on the Curiosity front-end the
+    app shell's static tables alone re-fused 170 types into one chunk.
+
+  Measured on the Curiosity front-end, attributing `App`, `AppRouting`, `AppSidebar`, `AppSidenav` and
+  `CommandManager`: the boot closure's single largest contributor drops from **768 of 782 chunks to
+  11**, and the biggest chunk from 3,900 KB to 3,375 KB. What is left is a genuine view↔view cycle
+  the attribute cannot help with — a route table that constructs its views synchronously — not a
+  facade.
 
   **A second pass merges the components into chunks worth fetching.** An SCC is the smallest *sound*
   unit and a far too small *useful* one: Tesserae's gallery emitted 682 chunks with a **2.2 KB

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -88,8 +88,8 @@ Notes:
 ## Step 2 — Rename `h5.json` → `tps.json`
 
 Rename the config file and update the token inside it. The schema is otherwise
-the same (`output`, `fileName`, `html`, `reflection`, `resources`,
-`outputFormatting`, …).
+the same (`output`, `fileName`, `html`, `reflection`, `resources`, …) minus
+`outputFormatting`, which no longer exists — see below.
 
 - `output`: `"$(OutDir)/h5/"` → `"$(OutDir)/tps/"`
 - Any resource `files`/paths that referenced an `h5/…` asset folder now
@@ -100,7 +100,6 @@ the same (`output`, `fileName`, `html`, `reflection`, `resources`,
 {
     "output": "$(OutDir)/tps/",
     "fileName": "app.js",
-    "outputFormatting": "Both",          // Formatted + Minified
     "resources": [
         { "name": "app.css", "files": [ "tps/assets/css/app.css" ] }
     ]
@@ -109,6 +108,16 @@ the same (`output`, `fileName`, `html`, `reflection`, `resources`,
 
 A per-configuration overlay is supported: `tps.Release.json` (or
 `tps.<Configuration>.json`) is merged on top of `tps.json` for that build.
+
+**`outputFormatting` is gone.** What shape the JavaScript takes follows from the
+build instead: a Debug site is one formatted bundle (and never chunked modules,
+whatever `outputBy` says), a Release site is one minified bundle — or chunked
+modules if `outputBy` asks for them — and a **library ships all three**, so the
+application referencing it picks the variant matching its own configuration. An
+h5/Bridge project that declared its own compiled `.js` and `.min.js` as resources
+to force both into the package can simply delete those entries; if such an entry
+was there to keep the bundle *out* of index.html (a `.dontload` name), say
+`"loadCompiledOutput": false` instead.
 
 ### Resources you load yourself
 
@@ -206,8 +215,8 @@ dotnet build
 ```
 
 Output lands under `bin/<Configuration>/<tfm>/tps/` (a runnable site: the `tps.js`
-runtime + your `app.js` bundle + resources + `index.html`, in both formatted and
-minified variants per `outputFormatting`). Serve it like before:
+runtime + your `app.js` bundle + resources + `index.html`, formatted in Debug and
+minified in Release). Serve it like before:
 
 ```bash
 cd bin/Debug/netstandard2.0/tps/
@@ -236,8 +245,7 @@ than recompiling **A**'s sources into **B**'s bundle. `dotnet build` compiles
 - **Source maps** for the emitted bundle are not emitted yet.
 - Some `tps.json` surface is still narrowing in (module formats, locales,
   before/after-build hooks); the common `output` / `fileName` / `html` /
-  `reflection` / `resources` / `outputFormatting` / `cleanOutputFolder` fields
-  are supported.
+  `reflection` / `resources` / `cleanOutputFolder` fields are supported.
 - Reference resolution beyond the NuGet cache (`<Reference HintPath>` and
   `tps.json` `references`/`referencesPath`) is partial; the `tps --reference`
   flag covers the common cases.

--- a/Packages/Transpose.HttpClient/tps.json
+++ b/Packages/Transpose.HttpClient/tps.json
@@ -1,20 +1,7 @@
-﻿{
+{
   "sourceMap": {
     "enabled": false
   },
-  "resources": [
-    {
-      "name": "tps.httpclient.js",
-      "files": [ "$(OutDir)tps/tps.httpclient.js" ]
-    },
-    {
-      "name": "tps.httpclient.min.js",
-      "files": [ "$(OutDir)tps/tps.httpclient.min.js" ]
-    }
-  ],
-  // Always build both minified and non-minified versions of the code so that resource for both versions are always included
-  // in the binary and so referencing projects can decide whether to use the minified versions or the non-minified versions
-  "outputFormatting": "Both",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   "loader": {
     "type": "Global"

--- a/Packages/Transpose.Newtonsoft.Json/tps.json
+++ b/Packages/Transpose.Newtonsoft.Json/tps.json
@@ -1,7 +1,6 @@
-﻿{
+{
   "output": "Resources/.generated",
   "cleanOutputFolderBeforeBuild": true,
-  "outputFormatting": "Formatted",
   "outputBy": "ClassPath",
   "generateDocumentation": "None",
   "logging": {

--- a/Packages/Transpose.System.Text.Json/tps.json
+++ b/Packages/Transpose.System.Text.Json/tps.json
@@ -1,7 +1,6 @@
 {
   "output": "Resources/.generated",
   "cleanOutputFolderBeforeBuild": true,
-  "outputFormatting": "Formatted",
   "outputBy": "ClassPath",
   "generateDocumentation": "None",
   "logging": {

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ dotnet new transpose
 resolves `PackageReference`s from the NuGet cache, transpiles, and writes either
 a runnable site or — for a library — a .NET DLL with the compiled JS embedded.
 Behavior is configured per project by a **`tps.json`** file (output path,
-`fileName`, `html`, `reflection`, `resources`, `outputFormatting`).
+`fileName`, `html`, `reflection`, `resources`). Whether the emitted JavaScript is
+formatted, minified or split into on-demand modules is *not* configured there: it
+follows from the build — formatted in Debug, minified (or chunked) in Release, and
+all three variants in a library package, so each consumer picks its own.
 
 When a project references another project, the site build consumes the
 referenced project's already-built package DLL (extracting its compiled JS)

--- a/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
+++ b/Transpose/Transpose.Build.Target/Sdk/Sdk.targets
@@ -481,9 +481,19 @@
        online check. It is invoked once per project. Install it as a global dotnet tool
        (`dotnet tool install -g Transpose.Compiler`) or reference it as a local tool and set
        UseLocalTranspose=true. -->
+  <!-- The compiler's own configuration files are build inputs like any source file: tps.json decides
+       what is emitted and what is embedded, its per-configuration overlay refines that, and
+       tps.chunks.json changes how the emitted modules are grouped. Without them here, editing one and
+       rebuilding is a no-op — MSBuild judges the project up to date and never invokes tps at all. -->
+  <ItemGroup>
+    <_TransposeConfigFile Include="$(ProjectDir)tps.json"                      Condition="Exists('$(ProjectDir)tps.json')" />
+    <_TransposeConfigFile Include="$(ProjectDir)tps.$(Configuration).json"     Condition="Exists('$(ProjectDir)tps.$(Configuration).json')" />
+    <_TransposeConfigFile Include="$(ProjectDir)tps.chunks.json"               Condition="Exists('$(ProjectDir)tps.chunks.json')" />
+  </ItemGroup>
+
   <Target Name="_TransposeBuild"
       DependsOnTargets="SourceFilesProjectOutputGroup;GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles;_ComputeReferenceAssemblies;_ComputeUserRuntimeAssemblies;_CopyReferenceOnlyAssembliesForBuild"
-      Inputs="@(UserRuntimeAssembly);@(_ReferenceAssemblies);@(SourceFilesProjectOutputGroupOutput);$(MSBuildAllProjects);$(ProjectDepsFilePath)"
+      Inputs="@(UserRuntimeAssembly);@(_ReferenceAssemblies);@(SourceFilesProjectOutputGroupOutput);$(MSBuildAllProjects);$(ProjectDepsFilePath);@(_TransposeConfigFile)"
       Outputs="$(ProjectDir)$(OutputPath)$(TargetName)$(TargetExt)">
 
     <Message Importance="high" Text="Deleting previous assembly: $(ProjectDir)$(OutputPath)$(TargetName)$(TargetExt)"/>

--- a/Transpose/Transpose.Compiler.Core/JsOutputProfile.cs
+++ b/Transpose/Transpose.Compiler.Core/JsOutputProfile.cs
@@ -1,0 +1,109 @@
+namespace Transpose.Compiler;
+
+/// <summary>
+/// Which variants of the emitted JavaScript a build produces. This is derived <em>entirely</em> from
+/// what is being built and in which configuration — there is no <c>tps.json</c> setting for it, and
+/// deliberately so: the old <c>outputFormatting</c> key let a project ship a Debug-only site or a
+/// package with no minified half, and every consumer then inherited that choice instead of making
+/// its own.
+///
+/// <list type="bullet">
+/// <item><b>Debug</b> — a site build in the Debug configuration. Formatted JavaScript, and
+/// <b>module chunking is off</b> however the project's tps.json is written: one readable bundle is
+/// what makes a debugger and a stack trace usable, and hunting a symbol across sixty on-demand
+/// chunks is what makes them not.</item>
+/// <item><b>Release</b> — a site build in any other configuration. Module chunks when the project
+/// asked for <c>outputBy: "Module"</c> (emitted formatted — they carry <c>import</c> syntax the
+/// minifier does not handle), otherwise one minified bundle.</item>
+/// <item><b>Package</b> — <c>--emit-package</c>, i.e. a library. It cannot know how it will be
+/// consumed, so it ships <b>all three</b>: the formatted bundle, the minified bundle, and — when its
+/// tps.json asks for it — the module entry plus its chunks. A consuming site build then takes the
+/// variant matching <em>its own</em> profile, which is what lets an application be debugged as one
+/// readable bundle and shipped as chunks without the library being rebuilt in between.</item>
+/// </list>
+/// </summary>
+internal enum JsOutputProfile
+{
+    Debug,
+    Release,
+    Package,
+}
+
+internal static class JsOutputProfiles
+{
+    /// <summary>The profile a build of these options runs under. <paramref name="emitPackage"/> wins:
+    /// a library is packaged the same way in every configuration, because the choice belongs to
+    /// whoever consumes it.</summary>
+    public static JsOutputProfile For(bool emitPackage, string? configuration)
+        => emitPackage ? JsOutputProfile.Package
+         : IsDebug(configuration) ? JsOutputProfile.Debug
+         : JsOutputProfile.Release;
+
+    /// <summary>Debug is the named configuration and nothing else — an unnamed or custom
+    /// configuration behaves like Release, so a site never ships unminified by accident.</summary>
+    public static bool IsDebug(string? configuration)
+        => string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether this build emits chunked ES modules. Debug never does — see the type
+    /// remarks — and neither does a project whose tps.json did not ask for it.</summary>
+    public static bool WantsModules(this JsOutputProfile profile, bool outputByModule)
+        => outputByModule && profile != JsOutputProfile.Debug;
+
+    /// <summary>Whether the formatted variant of a classic (non-module) bundle is produced/consumed.</summary>
+    public static bool WantsFormatted(this JsOutputProfile profile)
+        => profile != JsOutputProfile.Release;
+
+    /// <summary>Whether the minified variant of a classic (non-module) bundle is produced/consumed.</summary>
+    public static bool WantsMinified(this JsOutputProfile profile)
+        => profile != JsOutputProfile.Debug;
+}
+
+/// <summary>
+/// The role a piece of JavaScript embedded in a package plays, recorded in the package's
+/// <c>Transpose.Resources.json</c> so a consuming site build can pick by intent rather than by
+/// guessing from file names.
+///
+/// A package emits every variant (see <see cref="JsOutputProfile.Package"/>) and the consumer keeps
+/// exactly one set: the formatted bundle in Debug, the minified bundle in Release, or the module
+/// entry and its chunks when the consumer is itself chunked and the package offers them.
+///
+/// An entry with <b>no</b> variant is an authored resource — Monaco's <c>editor.main.js</c>, a
+/// vendored <c>d3.min.js</c>, a hand-declared bundle — which belongs to no such set and is copied
+/// through in every configuration under the name it was authored with.
+/// </summary>
+internal enum JsVariant
+{
+    /// <summary>The compiled single bundle (or its reflection metadata), beautified.</summary>
+    Formatted,
+    /// <summary>The same bundle, minified.</summary>
+    Minified,
+    /// <summary>The ES-module entry: the eager imports, the reflection metadata and the manifest of
+    /// what was deferred. Scripted as <c>&lt;script type="module"&gt;</c>.</summary>
+    ModuleEntry,
+    /// <summary>One on-demand chunk file. Copied to the site but never scripted — the entry imports
+    /// the ones it needs and <c>Transpose.Modules</c> fetches the rest.</summary>
+    ModuleChunk,
+}
+
+internal static class JsVariants
+{
+    public static string ToJson(this JsVariant variant) => variant switch
+    {
+        JsVariant.Formatted   => "Formatted",
+        JsVariant.Minified    => "Minified",
+        JsVariant.ModuleEntry => "ModuleEntry",
+        _                     => "ModuleChunk",
+    };
+
+    /// <summary>Parses a manifest <c>Variant</c>. Null for an absent or unrecognised value, which is
+    /// also what a package built before variants existed produces — such a package is routed by the
+    /// older file-name pairing instead, so it keeps working unchanged.</summary>
+    public static JsVariant? Parse(string? s) => s switch
+    {
+        "Formatted"   => JsVariant.Formatted,
+        "Minified"    => JsVariant.Minified,
+        "ModuleEntry" => JsVariant.ModuleEntry,
+        "ModuleChunk" => JsVariant.ModuleChunk,
+        _             => null,
+    };
+}

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -9,13 +9,11 @@ namespace Transpose.Compiler;
 /// assembly's <c>Transpose.Resources.json</c>), copies the tps.json resource files (CSS/images), and
 /// generates index.html — mirroring what the existing tps compiler produces.
 ///
-/// When <c>outputFormatting</c> is <c>Minified</c> or <c>Both</c>, the JS this compilation itself
-/// produces — the compiled bundle, its reflection metadata and the TransposeR shim — is minified with
-/// NUglify into a <c>.min.js</c> sibling. A referenced package's JS is never minified here: the
-/// package already ships a pre-minified variant of its own compiled code, and that pair is simply
-/// reused. The generated HTML then follows the legacy compiler's rule: index.html links the formatted
-/// variants, index.min.html links the minified variants, and the active build configuration collapses
-/// the pair to a single index.html (Release keeps the minified one, Debug the formatted one).
+/// Which variants are produced is decided by <see cref="JsOutputProfile"/> — the build, not the
+/// tps.json: a Debug site is one formatted bundle, a Release site is one minified bundle or (when the
+/// project asked for <c>outputBy: Module</c>) the chunked module output. A referenced package's JS is
+/// never minified here: a package ships every variant, and this build extracts the one matching its
+/// own profile. Exactly one <c>index.html</c> is generated, linking that variant.
 ///
 /// tps.json resource files are taken as authored — never minified, and never renamed — whether this
 /// build reads them from disk or extracts them from a referenced package: a project ships both a
@@ -89,10 +87,15 @@ internal static class OutputBuilder
     {
         Directory.CreateDirectory(outputDir);
 
-        var fmt = config.OutputFormatting;
-        var wantFormatted = fmt != JsOutputFormatting.Minified;   // Formatted or Both
-        var wantMinified  = fmt != JsOutputFormatting.Formatted;  // Minified or Both
+        // A site build is Debug or Release; a package never reaches here (it goes through
+        // CollectEmbeddableItems instead), so exactly one of the two flags below is set.
+        var profile       = JsOutputProfiles.For(emitPackage: false, configuration);
+        var wantFormatted = profile.WantsFormatted();
+        var wantMinified  = profile.WantsMinified();
         var minifyLocals  = project.MinifyLocalVariables;
+        // Whether this site is itself chunked. A package's module entry + chunks are only worth
+        // extracting when they are — otherwise its classic bundle is the right payload.
+        var siteIsChunked = modules is not null;
 
         var jsOuts = new List<JsOut>();    // JS in load order (runtime → libs → resources → app)
         var cssLinks = new List<string>();
@@ -132,12 +135,50 @@ internal static class OutputBuilder
             jsOuts.Add(o);
         }
 
+        // The variant-tagged form of the routing below: a package ships the formatted bundle, the
+        // minified bundle and (when it was built as modules) the entry plus its chunks, and this build
+        // keeps exactly one of those sets — the one its own profile calls for. A package that offers
+        // no module variant falls back to its minified/formatted bundle even in a chunked site, which
+        // is how a plain library (Transpose.Newtonsoft.Json, a vendored binding) keeps working.
+        void RouteTaggedPackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
+        {
+            var takeModules = siteIsChunked && jsFiles.Any(f => f.Variant == JsVariant.ModuleEntry);
+
+            foreach (var f in jsFiles)
+            {
+                switch (f.Variant)
+                {
+                    case JsVariant.ModuleEntry or JsVariant.ModuleChunk:
+                        if (!takeModules) continue;
+                        break;
+                    case JsVariant.Formatted:
+                        if (takeModules || !wantFormatted) continue;
+                        break;
+                    case JsVariant.Minified:
+                        if (takeModules || !wantMinified) continue;
+                        break;
+                }
+
+                WriteText(f.Rel, f.Text);
+                if (!f.Load) continue;
+                jsOuts.Add(new JsOut
+                {
+                    Path = f.Rel,
+                    IsModule = f.Module,
+                    // A minified bundle belongs in the minified HTML only; everything else this build
+                    // kept is what the formatted HTML wants, and WriteHtml then emits whichever list
+                    // matches the configuration.
+                    IsMinified = f.Variant == JsVariant.Minified,
+                });
+            }
+        }
+
         // Routes a package's embedded JS into the output — the runtime bundles and compiled library
         // code, and the authored JavaScript the library shipped through its own tps.json `resources`.
         //
         // Only a file that ships in BOTH variants — `x.js` next to `x.min.js` — takes part in the
         // formatted/minified switch: the formatted one is written and linked from index.html, the
-        // pre-minified one from index.min.html, and neither is re-minified here. That pair is exactly
+        // pre-minified one in a Release build, and neither is re-minified here. That pair is exactly
         // what a Transpose-compiled bundle looks like (CollectEmbeddableItems embeds both), and it is
         // also how a library declares an authored bundle it wants both variants of.
         //
@@ -150,6 +191,19 @@ internal static class OutputBuilder
         // does when it is built from disk rather than extracted from a package (ProcessResourceGroup).
         void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
         {
+            // A package says which of ITS OWN compiled files are interchangeable and what each one is
+            // for, so those are chosen by a filter rather than a guess. Its authored resources carry no
+            // such tag — nor does any file of a package published before variants existed — and go on
+            // being paired by file name below. Tagged first, which is the order they are embedded in
+            // (the compiled bundle leads the manifest), so the load order in index.html is unchanged.
+            var tagged = jsFiles.Where(f => f.Variant is not null).ToList();
+            if (tagged.Count > 0)
+            {
+                RouteTaggedPackageJs(tagged);
+                jsFiles = jsFiles.Where(f => f.Variant is null).ToList();
+                if (jsFiles.Count == 0) return;
+            }
+
             var present = jsFiles.Select(f => f.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
             // Tolerate a duplicate file name in an older/hand-authored manifest (last wins) instead of
             // throwing — the embed side dedupes, but a package built before that fix could still carry one.
@@ -158,7 +212,10 @@ internal static class OutputBuilder
 
             foreach (var f in jsFiles)
             {
-                if (!present.Contains(CounterpartName(f.FileName)))
+                var counterpart = CounterpartName(f.FileName);
+                // No distinct counterpart to switch to — an .mjs chunk, or a name the pairing rule
+                // does not recognise — is an authored resource, same as one whose sibling is absent.
+                if (counterpart == f.FileName || !present.Contains(counterpart))
                 {
                     // An authored resource: one variant, copied through under its own name, always.
                     WriteText(f.Rel, f.Text);
@@ -176,7 +233,7 @@ internal static class OutputBuilder
                 if (wantFormatted) WriteText(f.Rel, f.Text); else o.IsEmpty = true;
                 if (wantMinified)
                 {
-                    var pre = byName[CounterpartName(f.FileName)];   // pre-built .min.js from the package
+                    var pre = byName[counterpart];   // pre-built .min.js from the package
                     WriteText(pre.Rel, pre.Text);
                     o.MinifiedPath = pre.Rel;
                 }
@@ -208,14 +265,18 @@ internal static class OutputBuilder
         //    first (a library's JS deps load before the app that uses them). A resource group
         //    whose name is a .js/.css file concatenates its files into that one bundle; other
         //    groups (globbed images, etc.) copy each file through. Resource JS is taken as authored:
-        //    a .js group routes to index.html, a .min.js group to index.min.html. Resource CSS is
+        //    a .js group is scripted in a Debug build, a .min.js group in a Release one. Resource CSS is
         //    taken as authored too, minus its comments (CssProcessor).
         foreach (var projectDir in Enumerable.Reverse(project.ProjectDirs))
         {
             var cfg = projectDir == project.ProjectDir ? config : TransposeJson.TryLoad(projectDir, configuration);
             if (cfg is null) continue;
+            // Which bundle names this project declares, so a group that has a declared counterpart
+            // (an authored `x.js` next to an authored `x.min.js`) takes part in the variant switch
+            // instead of both halves being written and both being scripted.
+            var declared = cfg.Resources.Select(g => ResolveResource(g).fileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var group in cfg.Resources)
-                ProcessResourceGroup(projectDir, outputDir, group, jsOuts, cssLinks, written);
+                ProcessResourceGroup(projectDir, outputDir, group, jsOuts, cssLinks, written, declared, wantFormatted, wantMinified);
         }
 
         // 3. The compiled bundle — loads last, after runtime + library deps are in place.
@@ -246,7 +307,7 @@ internal static class OutputBuilder
             EmitCompilerJs(metaName, metadataJavascript);
         }
 
-        // 4. index.html (and index.min.html when both variants exist).
+        // 4. index.html — one per build, linking the variant this configuration produced.
         if (!config.HtmlDisabled)
             WriteHtml(project, config, outputDir, jsOuts, cssLinks, configuration, utf8, written, liveReloadScript);
 
@@ -266,10 +327,16 @@ internal static class OutputBuilder
 
     /// <summary>
     /// The resources a library assembly embeds so a referencing project can extract them: the
-    /// compiled JS (and its .meta.js) plus every tps.json resource group (bundled or copied),
-    /// each tagged with its output subdirectory. The compiled JS is embedded in both a formatted
-    /// and a pre-minified (<c>.min.js</c>) variant, so a referencing build never has to minify
-    /// library code itself — it just extracts the variant the build configuration calls for.
+    /// compiled JS (and its .meta.js) plus every tps.json resource group (bundled or copied), each
+    /// tagged with its output subdirectory.
+    ///
+    /// A package cannot know how it will be consumed, so it ships <b>every</b> variant of its own
+    /// compiled code and lets the consumer choose: the formatted bundle, the pre-minified bundle, and
+    /// — when its tps.json asked for <c>outputBy: Module</c> — the module entry plus its chunk files.
+    /// Each is tagged with a <see cref="JsVariant"/> in the manifest, so a referencing site build
+    /// keeps exactly the set its own <see cref="JsOutputProfile"/> calls for and never minifies
+    /// library code itself. This is what lets one published package be debugged as a single readable
+    /// bundle by one application and shipped as on-demand chunks by another.
     /// </summary>
     public static List<EmbeddedItem> CollectEmbeddableItems(
         string projectDir, TransposeJson config, string mainJsName, string javascript, string? metadataJavascript,
@@ -293,35 +360,40 @@ internal static class OutputBuilder
                     Name: rel.Substring(slash + 1),
                     Content: utf8.GetBytes(chunkJs),
                     Output: slash < 0 ? null : rel.Substring(0, slash),
-                    Load: false));
+                    Load: false,
+                    Variant: JsVariant.ModuleChunk));
             }
         }
         var metaName = metadataJavascript is not null
             ? Path.GetFileNameWithoutExtension(mainJsName) + ".meta.js"
             : null;
+        // The module entry needs a name of its own inside the DLL — `<Assembly>.js` is already taken
+        // by the formatted bundle — but has to land in the site under the name a consumer's own code
+        // fetches, which is the bundle's. That is what the manifest's SiteName carries.
+        var moduleEntryName = Path.GetFileNameWithoutExtension(mainJsName) + ".mjs";
 
-        // A tps.json `resources` group may re-declare the project's OWN compiled output — e.g.
+        // Whether index.html should reference the compiled output at all. `loadCompiledOutput: false`
+        // says it should not — the application fetches its own bundle (Curiosity's Admin package is
+        // loaded on demand, long after the page is up).
+        //
+        // A tps.json `resources` group may also re-declare the project's OWN compiled output — e.g.
         //   { "name": "<Assembly>.js.dontload", "files": [ "$(OutDir)tps/<Assembly>.js" ] } —
-        // which isn't on disk during compilation. Such a self-reference maps to the in-memory bundle
-        // (or its .meta.js), and its parsed name/load flag win: the `.dontload` variant is embedded so
-        // consumers copy it but don't auto-load it (the module is lazy-loaded at runtime). When the
-        // resources section re-declares a bundle this way, the default auto-embed of that same bundle
-        // is suppressed — matching the legacy compiler, where a `resources` section opts out of the
-        // default embed and must re-list exactly what it wants (min and/or formatted).
-        bool mainDeclared = false, metaDeclared = false;
+        // which is the older spelling of exactly that, and is still honoured: such a group contributes
+        // nothing but its load flag. It no longer suppresses the default embed the way the legacy
+        // compiler's did, because a package now always ships every variant: re-listing them by hand
+        // was only ever a workaround for a consumer that could not pick, and picking is now the
+        // consumer's job.
+        bool mainLoad = config.LoadCompiledOutput, metaLoad = config.LoadCompiledOutput;
 
-        // Maps a self-referenced compiled-output leaf name to its in-memory text, or null if the leaf
-        // isn't one of this project's own outputs. Also records which bundle was referenced.
-        string? SelfText(string leaf)
+        // Whether a leaf name is one of this project's own compiled outputs, in any variant. Such a
+        // file is not on disk during compilation, and it is embedded by the defaults below regardless.
+        bool IsSelf(string leaf, out bool isMeta)
         {
-            if (SameFile(leaf, mainJsName)) { mainDeclared = true; return javascript; }
-            if (SameFile(leaf, ToMinName(mainJsName))) { mainDeclared = true; return JsMinifier.Minify(javascript, mainJsName, minifyLocalVariables); }
-            if (metaName is not null)
-            {
-                if (SameFile(leaf, metaName)) { metaDeclared = true; return metadataJavascript!; }
-                if (SameFile(leaf, ToMinName(metaName))) { metaDeclared = true; return JsMinifier.Minify(metadataJavascript!, metaName, minifyLocalVariables); }
-            }
-            return null;
+            isMeta = false;
+            if (SameFile(leaf, mainJsName) || SameFile(leaf, ToMinName(mainJsName)) || SameFile(leaf, moduleEntryName)) return true;
+            if (metaName is null) return false;
+            isMeta = SameFile(leaf, metaName) || SameFile(leaf, ToMinName(metaName));
+            return isMeta;
         }
 
         foreach (var group in config.Resources)
@@ -342,15 +414,23 @@ internal static class OutputBuilder
 
             if (isBundle)
             {
-                // Resolve each declared file to text, mapping a self-reference to the in-memory bundle.
+                // Resolve each declared file to text. A file that IS one of this project's own compiled
+                // outputs contributes only its load flag: the defaults below embed every variant of it,
+                // so re-listing one here would duplicate it — untagged, which is worse, because the
+                // consumer would no longer know which variant it is looking at.
                 var texts = new List<string>();
+                var selfOnly = group.Files.Count > 0;
                 foreach (var raw in group.Files)
                 {
-                    var self = SelfText(Path.GetFileName(raw.Replace('\\', '/')));
-                    if (self is not null) texts.Add(self);
-                    else texts.AddRange(ExpandGlob(projectDir, raw).Select(m => ReadResourceText(m.FullPath, css)));
+                    if (IsSelf(Path.GetFileName(raw.Replace('\\', '/')), out var isMeta))
+                    {
+                        if (isMeta) metaLoad = load; else mainLoad = load;
+                        continue;
+                    }
+                    selfOnly = false;
+                    texts.AddRange(ExpandGlob(projectDir, raw).Select(m => ReadResourceText(m.FullPath, css)));
                 }
-                if (texts.Count == 0) continue;
+                if (selfOnly || texts.Count == 0) continue;
                 items.Add(new EmbeddedItem(name, utf8.GetBytes(string.Join("\n", texts)), destSub, load));
             }
             else
@@ -373,24 +453,32 @@ internal static class OutputBuilder
             }
         }
 
-        // Default embed of the compiled bundle + reflection metadata (each in a formatted and a
-        // pre-minified variant), prepended so the main bundle stays first — UNLESS the resources
-        // section already re-declared it above. Shipping the .min.js is deliberate: minifying library
-        // code is work the consumer would otherwise repeat on every build.
+        // Every variant of the compiled output, prepended so the main bundle stays first. Shipping the
+        // .min.js is deliberate: minifying library code is work the consumer would otherwise repeat on
+        // every build. Shipping the formatted one alongside it is what lets a Debug application step
+        // through this library; shipping the module entry and its chunks is what lets a Release one
+        // fetch it in pieces. None of the three is conditional — the choice belongs to the consumer.
         var defaults = new List<EmbeddedItem>();
-        if (!mainDeclared)
+
+        // The module entry is emitted formatted only: it carries `import` syntax the minifier is not
+        // set up for, so there is no minified sibling of it to choose between.
+        if (modules is not null)
+            defaults.Add(new EmbeddedItem(moduleEntryName, utf8.GetBytes(modules.EntryJs), null,
+                Load: mainLoad, Module: true, Variant: JsVariant.ModuleEntry, SiteName: mainJsName));
+
+        defaults.Add(new EmbeddedItem(mainJsName, utf8.GetBytes(javascript), null,
+            Load: mainLoad, Variant: JsVariant.Formatted));
+        defaults.Add(new EmbeddedItem(ToMinName(mainJsName),
+            utf8.GetBytes(JsMinifier.Minify(javascript, mainJsName, minifyLocalVariables)), null,
+            Load: mainLoad, Variant: JsVariant.Minified));
+
+        if (metaName is not null)
         {
-            defaults.Add(new EmbeddedItem(mainJsName, utf8.GetBytes(javascript), null, Module: modules is not null));
-            // No minified sibling for a module entry: it carries `import` syntax the minifier is not
-            // set up for, and with only one variant the consumer copies it through in both configs.
-            if (config.OutputFormatting != JsOutputFormatting.Formatted && modules is null)
-                defaults.Add(new EmbeddedItem(ToMinName(mainJsName), utf8.GetBytes(JsMinifier.Minify(javascript, mainJsName, minifyLocalVariables)), null));
-        }
-        if (metaName is not null && !metaDeclared)
-        {
-            defaults.Add(new EmbeddedItem(metaName, utf8.GetBytes(metadataJavascript!), null));
-            if (config.OutputFormatting != JsOutputFormatting.Formatted)
-                defaults.Add(new EmbeddedItem(ToMinName(metaName), utf8.GetBytes(JsMinifier.Minify(metadataJavascript!, metaName, minifyLocalVariables)), null));
+            defaults.Add(new EmbeddedItem(metaName, utf8.GetBytes(metadataJavascript!), null,
+                Load: metaLoad, Variant: JsVariant.Formatted));
+            defaults.Add(new EmbeddedItem(ToMinName(metaName),
+                utf8.GetBytes(JsMinifier.Minify(metadataJavascript!, metaName, minifyLocalVariables)), null,
+                Load: metaLoad, Variant: JsVariant.Minified));
         }
 
         defaults.AddRange(items);
@@ -412,8 +500,10 @@ internal static class OutputBuilder
 
     /// <summary>A JavaScript resource loaded from a package (a runtime bundle or embedded library
     /// code), with its file name (for pairing a formatted variant with its <c>.min.js</c>), the
-    /// output-relative path it extracts to, and its text.</summary>
-    private readonly record struct EmbeddedJs(string FileName, string Rel, string Text, bool Load = true, bool Module = false);
+    /// output-relative path it extracts to, and its text. <see cref="Variant"/> is what the package
+    /// declared this file to be (null for an authored resource, and for every file of a package built
+    /// before variants were recorded).</summary>
+    private readonly record struct EmbeddedJs(string FileName, string Rel, string Text, bool Load = true, bool Module = false, JsVariant? Variant = null);
 
     /// <summary>
     /// Read-only access to one assembly's embedded resources, opened and closed around the extraction —
@@ -480,20 +570,12 @@ internal static class OutputBuilder
         var manifestName = names.FirstOrDefault(n => n.EndsWith("Transpose.Resources.json", StringComparison.OrdinalIgnoreCase));
         if (manifestName is null) return jsFiles;
 
-        List<(string fileName, string? path, bool load, bool module)> entries;
+        List<ManifestEntry> entries;
         using (var ms = asm.Open(manifestName))
         using (var sr = new StreamReader(ms))
         using (var doc = JsonDocument.Parse(sr.ReadToEnd(), new JsonDocumentOptions { AllowTrailingCommas = true }))
         {
-            entries = doc.RootElement.EnumerateArray()
-                .Select(e => (
-                    fileName: e.TryGetProperty("FileName", out var f) ? f.GetString() : null,
-                    path: e.TryGetProperty("Path", out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null,
-                    load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False,   // absent → true
-                    module: e.TryGetProperty("Module", out var mo) && mo.ValueKind == JsonValueKind.True))
-                .Where(x => !string.IsNullOrEmpty(x.fileName))
-                .Select(x => (x.fileName!, x.path, x.load, x.module))
-                .ToList();
+            entries = ReadManifestEntries(doc.RootElement);
         }
 
         // The entry's Path already carries the sub-directory a recursive glob matched under, so the
@@ -502,25 +584,29 @@ internal static class OutputBuilder
         string Rel(string fileName, string? path)
             => string.IsNullOrEmpty(path) ? Path.GetFileName(fileName) : path!.Replace('\\', '/').TrimEnd('/') + "/" + Path.GetFileName(fileName);
 
-        foreach (var (fileName, path, load, module) in entries)
+        foreach (var entry in entries)
         {
-            var resName = names.FirstOrDefault(n => n.Equals(fileName, StringComparison.OrdinalIgnoreCase))
-                          ?? names.FirstOrDefault(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+            var resName = names.FirstOrDefault(n => n.Equals(entry.FileName, StringComparison.OrdinalIgnoreCase))
+                          ?? names.FirstOrDefault(n => n.EndsWith(entry.FileName, StringComparison.OrdinalIgnoreCase));
             if (resName is null) continue;
 
-            var rel = Rel(fileName, path);
+            // SiteName renames a resource on the way out: the three interchangeable bundles need
+            // distinct names inside the DLL and the same name in the site, so the module entry travels
+            // as <Assembly>.mjs and lands as <Assembly>.js — the name a consumer's own code fetches.
+            var rel = Rel(entry.SiteName ?? entry.FileName, entry.Path);
 
-            if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+            if (IsJavaScript(rel))
             {
                 using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
-                jsFiles.Add(new EmbeddedJs(Path.GetFileName(fileName), rel, reader.ReadToEnd(), load, module));
+                jsFiles.Add(new EmbeddedJs(Path.GetFileName(entry.SiteName ?? entry.FileName), rel,
+                                           reader.ReadToEnd(), entry.Load, entry.Module, entry.Variant));
             }
             else
             {
                 // CSS and copy-through resources (images, fonts): write to disk now.
                 ExtractResourceFile(asm, resName, outputDir, rel, written);
-                if (load && IsCss(rel)) cssLinks.Add(rel);
+                if (entry.Load && IsCss(rel)) cssLinks.Add(rel);
             }
         }
         return jsFiles;
@@ -603,6 +689,47 @@ internal static class OutputBuilder
         return (name, load);
     }
 
+    /// <summary>One row of a package's <c>Transpose.Resources.json</c>, as a site build reads it:
+    /// the embedded resource's key (<see cref="FileName"/>), the output sub-directory it extracts to,
+    /// the name to write it under when that differs, whether index.html references it, whether it is
+    /// scripted as an ES module, and which interchangeable variant it is (null for an authored
+    /// resource — and for every row of a package built before variants were recorded, which is what
+    /// keeps such a package routing by the older file-name pairing).</summary>
+    private readonly record struct ManifestEntry(
+        string FileName, string? Path, string? SiteName, bool Load, bool Module, JsVariant? Variant);
+
+    private static List<ManifestEntry> ReadManifestEntries(JsonElement root)
+    {
+        var entries = new List<ManifestEntry>();
+        if (root.ValueKind != JsonValueKind.Array) return entries;
+
+        static string? Str(JsonElement e, string name)
+            => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+        foreach (var e in root.EnumerateArray())
+        {
+            if (e.ValueKind != JsonValueKind.Object) continue;
+            var fileName = Str(e, "FileName");
+            if (string.IsNullOrEmpty(fileName)) continue;
+            entries.Add(new ManifestEntry(
+                FileName: fileName!,
+                Path: Str(e, "Path"),
+                SiteName: Str(e, "SiteName"),
+                Load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False,   // absent → true
+                Module: e.TryGetProperty("Module", out var mo) && mo.ValueKind == JsonValueKind.True,
+                Variant: JsVariants.Parse(Str(e, "Variant"))));
+        }
+        return entries;
+    }
+
+    /// <summary>Whether a file name is JavaScript the site build routes rather than copies blind —
+    /// a classic bundle (<c>.js</c>) or an ES module (<c>.mjs</c>, i.e. a chunk or a module entry).
+    /// Both have to go through the variant filter, or a Debug site would carry the chunk files of
+    /// every module-mode package it references and never load one of them.</summary>
+    private static bool IsJavaScript(string name)
+        => name.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
+           || name.EndsWith(".mjs", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>A file name for a minified bundle (ends in <c>.min.js</c>/<c>.min.css</c>).</summary>
     private static bool IsMinifiedName(string name)
         => name.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
@@ -640,13 +767,25 @@ internal static class OutputBuilder
 
     private static void ProcessResourceGroup(
         string projectDir, string outputDir, TransposeJson.ResourceGroup group,
-        List<JsOut> jsOuts, List<string> cssLinks, HashSet<string> written)
+        List<JsOut> jsOuts, List<string> cssLinks, HashSet<string> written,
+        IReadOnlySet<string> declaredNames, bool wantFormatted, bool wantMinified)
     {
         // The output name (the group name minus its "module#" grouping prefix and ".dontload" suffix)
         // plus the effective load flag: a non-loaded resource is written to the output but never
         // referenced from index.html — neither as a <script> nor as a stylesheet <link>.
         var (name, load) = ResolveResource(group);
         var isBundle = IsBundleName(name);
+
+        // A JavaScript bundle the project declares in BOTH variants is one resource with two spellings
+        // — Tesserae's `tss-dep.js` / `tss-dep.min.js`, Curiosity's `ExternalBundle` pair — so only the
+        // one this build wants is produced. (Writing both put 700 KB on disk twice and, once a build
+        // generates a single index.html, scripted the same library twice.) A group with no declared
+        // counterpart is an authored resource in the only variant that exists, and is written always.
+        if (name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && declaredNames.Contains(CounterpartName(name)))
+        {
+            var wanted = IsMinifiedName(name) ? wantMinified : wantFormatted;
+            if (!wanted) return;
+        }
 
         foreach (var (rel, sources) in ResourceGroupOutputs(projectDir, group))
         {
@@ -655,7 +794,7 @@ internal static class OutputBuilder
 
             if (IsCss(rel)) cssLinks.Add(rel);
             // Resource JS is taken as authored (never re-minified): a .min.js links only from
-            // index.min.html; a plain .js links only from index.html — matching the legacy compiler.
+            // a Release build; a plain .js is scripted in both — matching the legacy compiler.
             else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
                 jsOuts.Add(new JsOut { Path = rel, IsMinified = IsMinifiedName(rel) });
         }
@@ -870,55 +1009,47 @@ internal static class OutputBuilder
         // (Path — null/empty means the site root), and whether it is injected into index.html (Load).
         // A package without a manifest (the base runtime) surfaces only its .js/.css resources at the
         // site root — other resource types can't be identified, nor their output path recovered, without it.
-        List<(string fileName, string? path, bool load, bool module)> entries;
+        List<ManifestEntry> entries;
         if (manifest is not null)
         {
             using var ms = asm.Open(manifest);
             using var sr = new StreamReader(ms);
             using var doc = JsonDocument.Parse(sr.ReadToEnd(), new JsonDocumentOptions { AllowTrailingCommas = true });
-            entries = doc.RootElement.EnumerateArray()
-                .Select(e => (
-                    fileName: e.TryGetProperty("FileName", out var f) ? f.GetString() : null,
-                    path: e.TryGetProperty("Path", out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null,
-                    load: !e.TryGetProperty("Load", out var l) || l.ValueKind != JsonValueKind.False,   // absent → true
-                    module: e.TryGetProperty("Module", out var mo) && mo.ValueKind == JsonValueKind.True))
-                .Where(x => !string.IsNullOrEmpty(x.fileName))
-                .Select(x => (x.fileName!, x.path, x.load, x.module))
-                .ToList();
+            entries = ReadManifestEntries(doc.RootElement);
         }
         else
         {
             entries = resourceNames
-                .Where(n => n.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
-                            || n.EndsWith(".css", StringComparison.OrdinalIgnoreCase))
-                .Select(n => (n, (string?)null, true, false))
+                .Where(n => IsJavaScript(n) || n.EndsWith(".css", StringComparison.OrdinalIgnoreCase))
+                .Select(n => new ManifestEntry(n, null, null, true, false, null))
                 .ToList();
         }
 
-        foreach (var (fileName, path, load, module) in entries)
+        foreach (var entry in entries)
         {
-            var resName = resourceNames.FirstOrDefault(n => n.Equals(fileName, StringComparison.OrdinalIgnoreCase))
-                          ?? resourceNames.FirstOrDefault(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+            var resName = resourceNames.FirstOrDefault(n => n.Equals(entry.FileName, StringComparison.OrdinalIgnoreCase))
+                          ?? resourceNames.FirstOrDefault(n => n.EndsWith(entry.FileName, StringComparison.OrdinalIgnoreCase));
             if (resName is null) continue;
 
             // Place the resource under its declared output subdirectory (Path). The manifest FileName
             // may carry an assembly-qualified prefix, so use just its leaf; an empty Path (runtime
             // bundles, or a resource group without an `output`) leaves the resource at the site root.
-            var leaf = Path.GetFileName(fileName);
-            var rel = string.IsNullOrEmpty(path) ? leaf : path!.Replace('\\', '/').TrimEnd('/') + "/" + leaf;
+            // SiteName, when present, is the name to write it under instead (see the project-DLL path).
+            var leaf = Path.GetFileName(entry.SiteName ?? entry.FileName);
+            var rel = string.IsNullOrEmpty(entry.Path) ? leaf : entry.Path!.Replace('\\', '/').TrimEnd('/') + "/" + leaf;
 
-            if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+            if (IsJavaScript(rel))
             {
                 using var s = asm.Open(resName);
                 using var reader = new StreamReader(s);
-                jsFiles.Add(new EmbeddedJs(leaf, rel, reader.ReadToEnd(), load, module));   // JS: placed/minified by RoutePackageJs
+                jsFiles.Add(new EmbeddedJs(leaf, rel, reader.ReadToEnd(), entry.Load, entry.Module, entry.Variant));   // placed by RoutePackageJs
             }
             else
             {
                 // CSS and copy-through resources (fonts, images): copy the raw bytes to disk so binary
                 // assets stay intact, and link stylesheets. These must never reach the JS minifier.
                 ExtractResourceFile(asm, resName, outputDir, rel, written);
-                if (load && IsCss(rel)) cssLinks.Add(rel);
+                if (entry.Load && IsCss(rel)) cssLinks.Add(rel);
             }
         }
         return jsFiles;
@@ -1005,10 +1136,10 @@ internal static class OutputBuilder
         => relativeDir.Length == 0 ? fileName : relativeDir + "/" + fileName;
 
     /// <summary>
-    /// Writes index.html (formatted scripts) and/or index.min.html (minified scripts), then collapses
-    /// the pair to a single index.html for the active build configuration — a port of the legacy
-    /// HtmlGenerator: Release keeps the minified variant as index.html, Debug keeps the formatted one,
-    /// and an empty configuration keeps both (index.html + index.min.html).
+    /// Writes index.html, linking the script variant this build produced — one file, because one build
+    /// now produces one set of scripts. (The legacy compiler wrote index.html and index.min.html side
+    /// by side and collapsed the pair afterwards, which only made sense while a single build emitted
+    /// both variants of everything.)
     /// </summary>
     private static void WriteHtml(
         ResolvedProject project, TransposeJson config, string outputDir,
@@ -1053,18 +1184,13 @@ internal static class OutputBuilder
             ? $"<script type=\"module\" src=\"{path}\"></script>"
             : $"<script src=\"{path}\" defer></script>";
 
-        string? htmlName = (js.Length > 0 || css.Length > 0) ? "index.html" : null;
-        string? htmlMinName = jsMin.Length > 0 ? (htmlName is null ? "index.html" : "index.min.html") : null;
-
-        // Collapse to a single index.html for the requested configuration (legacy behaviour).
-        if (string.Equals(configuration, "Release", StringComparison.OrdinalIgnoreCase))
-        {
-            if (htmlMinName is not null) { htmlName = null; htmlMinName = "index.html"; }
-        }
-        else if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase))
-        {
-            if (htmlMinName is not null && htmlName is not null) htmlMinName = null;
-        }
+        // One HTML per build, because one build now produces one set of scripts. The two lists above
+        // are still both assembled — a resource group can declare a script for only one of them — and
+        // the build's configuration picks which one is written. (The legacy compiler emitted
+        // index.html and index.min.html side by side and collapsed the pair afterwards; there is
+        // nothing left to collapse now that the scripts themselves come in one variant.)
+        var scripts = JsOutputProfiles.IsDebug(configuration) ? js : jsMin;
+        string? htmlName = (scripts.Length > 0 || css.Length > 0) ? "index.html" : null;
 
         // Watch mode (--watch) passes a small inline script that opens a websocket back to the tps
         // dev server and reloads the page when a rebuild completes. Appended right before </body> so
@@ -1085,13 +1211,7 @@ internal static class OutputBuilder
         if (htmlName is not null)
         {
             var dest = Path.Combine(outputDir, htmlName);
-            File.WriteAllText(dest, Render(js.ToString()), utf8);
-            written.Add(Path.GetFullPath(dest));
-        }
-        if (htmlMinName is not null)
-        {
-            var dest = Path.Combine(outputDir, htmlMinName);
-            File.WriteAllText(dest, Render(jsMin.ToString()), utf8);
+            File.WriteAllText(dest, Render(scripts.ToString()), utf8);
             written.Add(Path.GetFullPath(dest));
         }
     }

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -78,6 +78,19 @@ internal sealed record BuildOptions
     /// decision to the csproj property and then the configuration default.</summary>
     public bool? MetadataOnlyAssembly { get; init; }
 
+    /// <summary>
+    /// Emit one chunk per strongly-connected component instead of coalescing them into the size band
+    /// (<c>--no-chunk-coalescing</c>, or <c>TRANSPOSE_NO_CHUNK_COALESCING=1</c>).
+    ///
+    /// This is a build for <em>measuring</em>, not for shipping: hundreds of ~2 KB chunks are the
+    /// wrong thing to serve, but they are the only way to see what is really fetched together. A
+    /// coalesced build has already made the grouping decision, so a capture of it can only confirm
+    /// that decision — the fine-grained build is what produces the evidence a <c>tps.chunks.json</c>
+    /// oracle is written from. See the <c>chunk-oracle</c> skill.
+    /// </summary>
+    public bool NoChunkCoalescing { get; init; }
+        = Environment.GetEnvironmentVariable("TRANSPOSE_NO_CHUNK_COALESCING") is "1" or "true" or "TRUE";
+
     /// <summary>Reuse the previous build of this project where its inputs are unchanged.</summary>
     public bool Incremental { get; init; }
 
@@ -293,7 +306,7 @@ internal static class ProjectBuild
                 // else about the build did, and an "up to date" verdict skips writing it altogether.
                 BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
                     metadataOnly, options.EmitPackage, isSiteBuild, options.SeparateAssemblies, options.WithRuntime,
-                    options.OutPath, options.SiteDir, options.AssemblyVersion)
+                    options.OutPath, options.SiteDir, options.AssemblyVersion, options.NoChunkCoalescing)
                     .Append($"watch={options.LiveReloadScript is not null}"),
                 BuildContentFingerprint(project),
                 options.CacheDir);
@@ -342,6 +355,11 @@ internal static class ProjectBuild
         // A package emits the single bundle alongside its chunks, because it cannot know whether the
         // application that references it will be built Debug (one bundle) or Release (chunks).
         var alsoEmitBundle = wantsModules && options.EmitPackage;
+        // Measured co-load groups from a capture of the running application, if the project keeps one.
+        // Never fails a build: an unreadable or stale file simply contributes nothing (ChunkOracle).
+        var chunkOracle = wantsModules ? ChunkOracle.TryLoad(project.ProjectDir) : null;
+        if (chunkOracle is { IsEmpty: false })
+            log.Info($"  chunks:     {ChunkOracle.FileName} — {chunkOracle.Groups.Count} measured group(s)");
         // Every referenced assembly that was itself built as modules contributes its type → chunk map.
         var externalChunks = wantsModules ? ModuleMap.Read(project.ReferencePaths) : null;
         // ...and, for a [SkipTypeClustering] facade in one of them, the per-member dependency sets a
@@ -373,9 +391,10 @@ internal static class ProjectBuild
                 // A library has no entry point to be lazy relative to: nothing is eager beyond its
                 // [Ready] handlers, and its consumers pull in what they actually use.
                 packageModules: options.EmitPackage,
-                minChunkBytes: tpscfg?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
+                minChunkBytes: MinChunkBytes(options, tpscfg),
                 maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes,
-                alsoEmitBundle: alsoEmitBundle);
+                alsoEmitBundle: alsoEmitBundle,
+                chunkOracle: chunkOracle);
         }
         catch (Exception ex)
         {
@@ -462,6 +481,13 @@ internal static class ProjectBuild
         return BuildOutcome.NoSite(0, result.Diagnostics);
     }
 
+    /// <summary>The coalescing floor for this build: the project's <c>modules.minChunkSize</c>, or 0
+    /// when the build asked for one chunk per component (see <see cref="BuildOptions.NoChunkCoalescing"/>).
+    /// The switch is applied to the whole project closure, so a capture sees every assembly at the
+    /// same granularity.</summary>
+    private static int MinChunkBytes(BuildOptions options, TransposeJson? config)
+        => options.NoChunkCoalescing ? 0 : config?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes;
+
     /// <summary>The directory a site build writes to: <c>--site-dir</c> when given, otherwise the path
     /// tps.json's <c>output</c> resolves to.</summary>
     private static string SiteDirectory(BuildOptions options, TransposeJson config, ResolvedProject project)
@@ -525,7 +551,8 @@ internal static class ProjectBuild
     private static IEnumerable<string> BuildSettingsFingerprint(
         ResolvedProject project, string configuration, TransposeJson? tpscfg, bool reflectionEnabled,
         MetadataTarget metadataTarget, bool metadataOnly, bool emitPackage, bool isSiteBuild,
-        bool separateAssemblies, bool withRuntime, string? outPath, string? siteDir, string? assemblyVersion)
+        bool separateAssemblies, bool withRuntime, string? outPath, string? siteDir, string? assemblyVersion,
+        bool noChunkCoalescing)
     {
         yield return $"configuration={configuration}";
         yield return $"assembly={project.AssemblyName}";
@@ -538,9 +565,11 @@ internal static class ProjectBuild
         yield return $"minifyLocals={project.MinifyLocalVariables}";
         yield return $"assemblyVersion={assemblyVersion}";
         yield return $"mode={OutputMode(emitPackage, isSiteBuild)}";
+        yield return $"chunkCoalescing={!noChunkCoalescing}";
         yield return $"separate={separateAssemblies};runtime={withRuntime}";
         yield return $"out={outPath};siteDir={siteDir}";
         yield return $"tpsjson={tpscfg is null}";
+        yield return "tps.chunks.json=" + BuildCache.FileContentFingerprint(Path.Combine(project.ProjectDir, ChunkOracle.FileName));
 
         // The project file and its tps.json (plus the per-configuration overlay) by content: they
         // decide which files compile, what gets embedded and how the site is laid out.
@@ -792,7 +821,8 @@ internal static class ProjectBuild
                 OutputMode(emitPackage: true, isSiteBuild: false),
                 BuildSettingsFingerprint(project, configuration, tpscfg, reflectionEnabled, metadataTarget,
                     metadataOnly, emitPackage: true, isSiteBuild: false, separateAssemblies: true,
-                    withRuntime: false, outPath: null, siteDir: null, assemblyVersion: assemblyVersion),
+                    withRuntime: false, outPath: null, siteDir: null, assemblyVersion: assemblyVersion,
+                    noChunkCoalescing: options.NoChunkCoalescing),
                 BuildContentFingerprint(project),
                 options.CacheDir);
             (verdict, changedSources, var reason) = cache.Decide();
@@ -833,8 +863,9 @@ internal static class ProjectBuild
                 externalChunks: tpscfg is { OutputByModule: true } ? ModuleMap.Read(project.ReferencePaths) : null,
                 externalSkipClusterDeps: tpscfg is { OutputByModule: true } ? ModuleMap.ReadSkipClusterDeps(project.ReferencePaths) : null,
                 packageModules: true,
-                minChunkBytes: tpscfg?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
+                minChunkBytes: MinChunkBytes(options, tpscfg),
                 maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes,
+                chunkOracle: ChunkOracle.TryLoad(project.ProjectDir),
                 // …and the single bundle alongside them, for the same reason: a package ships every
                 // variant, because which one is wanted is the consuming build's decision.
                 alsoEmitBundle: tpscfg is { OutputByModule: true });

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -328,9 +328,20 @@ internal static class ProjectBuild
 
         var plan = replayed is not null ? null : cache?.CreatePlan(verdict, changedSources, canReuseAssembly: metadataOnly);
 
+        // What shape of JavaScript this build produces — derived from the build itself, never from
+        // tps.json (see JsOutputProfile). A package ships every variant; a Release site ships one; a
+        // Debug site ships one readable bundle and no chunks at all.
+        var profile = JsOutputProfiles.For(options.EmitPackage, configuration);
+
         // Module mode applies to a site build AND to a package (--emit-package): a library emits its
         // chunks and publishes the map, and its consumer imports the chunks behind the types it uses.
-        var wantsModules = tpscfg is { OutputByModule: true } && (isSiteBuild || options.EmitPackage);
+        // A Debug site build opts out however tps.json is written: stepping through one bundle is the
+        // point of a Debug build, and a stack trace spread over sixty on-demand chunks is not.
+        var wantsModules = tpscfg is { OutputByModule: true } && (isSiteBuild || options.EmitPackage)
+                           && profile.WantsModules(true);
+        // A package emits the single bundle alongside its chunks, because it cannot know whether the
+        // application that references it will be built Debug (one bundle) or Release (chunks).
+        var alsoEmitBundle = wantsModules && options.EmitPackage;
         // Every referenced assembly that was itself built as modules contributes its type → chunk map.
         var externalChunks = wantsModules ? ModuleMap.Read(project.ReferencePaths) : null;
         // ...and, for a [SkipTypeClustering] facade in one of them, the per-member dependency sets a
@@ -363,7 +374,8 @@ internal static class ProjectBuild
                 // [Ready] handlers, and its consumers pull in what they actually use.
                 packageModules: options.EmitPackage,
                 minChunkBytes: tpscfg?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
-                maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes);
+                maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes,
+                alsoEmitBundle: alsoEmitBundle);
         }
         catch (Exception ex)
         {
@@ -822,7 +834,10 @@ internal static class ProjectBuild
                 externalSkipClusterDeps: tpscfg is { OutputByModule: true } ? ModuleMap.ReadSkipClusterDeps(project.ReferencePaths) : null,
                 packageModules: true,
                 minChunkBytes: tpscfg?.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
-                maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes);
+                maxChunkBytes: tpscfg?.ModuleMaxChunkBytes ?? Emitter.DefaultMaxChunkBytes,
+                // …and the single bundle alongside them, for the same reason: a package ships every
+                // variant, because which one is wanted is the consuming build's decision.
+                alsoEmitBundle: tpscfg is { OutputByModule: true });
         }
         catch (Exception ex) { ReportCrash($"Translator on '{Path.GetFileName(csproj)}'", ex, log); return false; }
 
@@ -867,14 +882,6 @@ internal static class ProjectBuild
             ? OutputBuilder.CollectEmbeddableItems(project.ProjectDir, config, mainJsName, result.Javascript!, result.MetadataJavascript, project.MinifyLocalVariables, result.Modules)
             : new List<EmbeddedItem> { new(mainJsName, System.Text.Encoding.UTF8.GetBytes(result.Javascript!), null) });
 
-        // A module-mode package's entry file is an ES module (it imports its eager chunks), so the
-        // consumer has to script it as one rather than as a classic deferred script.
-        if (result.Modules is not null)
-        {
-            for (var i = 0; i < items.Count; i++)
-                if (string.Equals(items[i].Name, mainJsName, StringComparison.OrdinalIgnoreCase))
-                    items[i] = items[i] with { Module = true };
-        }
         // Cecil re-serializes the assembly's metadata when embedding the resources; encoding a
         // parameter's default value whose type lives in a referenced assembly (e.g. a Tesserae enum)
         // makes it resolve that assembly. Seed the resolver with the reference directories so those

--- a/Transpose/Transpose.Compiler.Core/ProjectResolver.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectResolver.cs
@@ -105,6 +105,18 @@ internal static class ProjectResolver
         // DEBUG in the Debug configuration. Without these, `#if DEBUG` never compiles in a `-c Debug`
         // build (it silently took the #else branch — e.g. loading the minified bundle instead of the
         // dev one). Additive with the project's own <DefineConstants>; add only if not already present.
+        // TRANSPOSE_DEFINE: extra preprocessor symbols for the whole build, semicolon- or
+        // comma-separated. tps reads the csproj as raw XML and evaluates no conditions (see
+        // ProjectXml), so a project cannot express "define X for this build only" the way MSBuild
+        // would — a conditional <DefineConstants> is either always applied or never seen. This is the
+        // way in for a build variant that has to reach every project in a closure at once: an
+        // instrumented build, a capture run. Equivalent to passing --define to each project by hand.
+        foreach (var symbol in (Environment.GetEnvironmentVariable("TRANSPOSE_DEFINE") ?? "")
+                     .Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries)
+                     .Select(x => x.Trim())
+                     .Where(x => x.Length > 0))
+            if (!defines.Contains(symbol)) defines.Add(symbol);
+
         if (!defines.Contains("TRACE")) defines.Add("TRACE");
         if (string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase) && !defines.Contains("DEBUG"))
             defines.Add("DEBUG");

--- a/Transpose/Transpose.Compiler.Core/ResourceEmbedder.cs
+++ b/Transpose/Transpose.Compiler.Core/ResourceEmbedder.cs
@@ -5,8 +5,16 @@ using Mono.Cecil;
 namespace Transpose.Compiler;
 
 /// <summary>One embedded Transpose resource: the file bytes plus its manifest entry. <see cref="Output"/>
-/// is the output subdirectory a consumer extracts it to (null for a top-level script).</summary>
-internal sealed record EmbeddedItem(string Name, byte[] Content, string? Output, bool Load = true, bool Module = false);
+/// is the output subdirectory a consumer extracts it to (null for a top-level script).
+///
+/// <see cref="Variant"/> says which of the package's interchangeable JavaScript variants this is (see
+/// <see cref="JsVariant"/>) so a consuming site build keeps the set matching its own configuration
+/// rather than pairing file names; null marks an authored resource, which belongs to no set and is
+/// copied through in every configuration. <see cref="SiteName"/> is the name the consumer writes it
+/// under when that differs from <see cref="Name"/> — only the module entry needs it, because the
+/// three variants must have distinct names inside the DLL and the same name in the site.</summary>
+internal sealed record EmbeddedItem(string Name, byte[] Content, string? Output, bool Load = true, bool Module = false,
+    JsVariant? Variant = null, string? SiteName = null);
 
 /// <summary>
 /// Embeds the compiled JavaScript (and tps.json resource files) into a .NET assembly as private
@@ -114,6 +122,11 @@ internal static class ResourceEmbedder
             Path = i.Output,
             Parts = (object?)null,
             Load = i.Load,   // false → copied to the site but not injected into index.html (.dontload)
+            // Which interchangeable variant this is, and (module entry only) the name the consumer
+            // writes it under. Both absent for an authored resource and for a package built before
+            // variants existed, which is what makes the consumer fall back to file-name pairing.
+            Variant = i.Variant?.ToJson(),
+            SiteName = i.SiteName,
         }).ToArray();
         var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
         Replace(ManifestName, Utf8NoBom.GetBytes(json));

--- a/Transpose/Transpose.Compiler.Core/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler.Core/TransposeJson.cs
@@ -3,29 +3,19 @@ using System.Text.Json;
 namespace Transpose.Compiler;
 
 /// <summary>
-/// Which variants of the emitted JavaScript the build produces — mirrors the legacy compiler's
-/// <c>JavaScriptOutputType</c> (the <c>outputFormatting</c> tps.json setting).
-/// </summary>
-internal enum JsOutputFormatting
-{
-    /// <summary>Only the formatted (beautified) JS. Good for debugging.</summary>
-    Formatted = 1,
-    /// <summary>Only the minified JS. Good for production.</summary>
-    Minified = 2,
-    /// <summary>Both variants — a referencing build (or index.html generation) then picks one.</summary>
-    Both = 3,
-}
-
-/// <summary>
 /// The subset of a project's <c>tps.json</c> the CLI acts on: where output goes, the bundle
 /// file name, HTML generation, and the resource files (CSS/images) copied into the output
 /// and linked from index.html. JSONC (comments + trailing commas) is tolerated.
 ///
 /// A configuration-specific overlay (<c>tps.&lt;Configuration&gt;.json</c>, e.g. <c>tps.Release.json</c>)
-/// is merged on top of the base <c>tps.json</c> when present, matching the legacy compiler's
-/// <c>ConfigHelper.ReadConfig</c>: scalar settings from the overlay win, and resource arrays are
-/// concatenated (base first, then overlay). This is how the front-end projects flip
-/// <c>outputFormatting</c> to <c>Both</c> for Release while keeping <c>Formatted</c> for Debug.
+/// is merged on top of the base <c>tps.json</c> when present: scalar settings from the overlay win,
+/// and resource arrays are concatenated (base first, then overlay). It is the hook for a resource
+/// that only one configuration ships.
+///
+/// What it deliberately cannot configure is the <em>shape</em> of the emitted JavaScript — formatted
+/// vs minified vs chunked modules. That follows from the build alone (see
+/// <see cref="JsOutputProfile"/>), so a project cannot ship a Release site unminified, and a package
+/// always carries every variant its consumers might ask for.
 /// </summary>
 internal sealed class TransposeJson
 {
@@ -43,12 +33,6 @@ internal sealed class TransposeJson
     public List<ResourceGroup> Resources { get; init; } = new();
 
     /// <summary>
-    /// <c>outputFormatting</c> — whether to emit the formatted JS, the minified JS, or both.
-    /// Defaults to <see cref="JsOutputFormatting.Both"/>, matching the legacy compiler.
-    /// </summary>
-    public JsOutputFormatting OutputFormatting { get; init; } = JsOutputFormatting.Both;
-
-    /// <summary>
     /// <c>outputBy</c> — the file-layout mode (Class/ClassPath/Namespace/…). The base runtime
     /// library (Transpose.BCL) uses <c>ClassPath</c>: this is the marker that the project *defines*
     /// the BCL and must be compiled self-contained (no Transpose.dll reference) into the tps.js
@@ -57,7 +41,8 @@ internal sealed class TransposeJson
     public string? OutputBy { get; init; }
 
     /// <summary>True when <c>outputBy</c> asks for the ES-module layout: one file per chunk plus an
-    /// entry module, instead of a single bundle. See TODO.modules.md.</summary>
+    /// entry module, instead of a single bundle. See TODO.modules.md. This is a <em>request</em>, not
+    /// the verdict: a Debug site build ignores it (<see cref="JsOutputProfile"/>).</summary>
     public bool OutputByModule => string.Equals(OutputBy, "Module", System.StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
@@ -92,6 +77,19 @@ internal sealed class TransposeJson
     /// of the legacy h5 <c>!</c> skip patterns, but only consulted for files the build didn't write.
     /// </summary>
     public List<string> CleanOutputFolderExclude { get; init; } = new();
+
+    /// <summary>
+    /// <c>loadCompiledOutput</c> — whether a project that <em>references</em> this one references its
+    /// compiled bundle from the generated <c>index.html</c>. Defaults to <c>true</c>, which is what a
+    /// normal library wants. Set it to <c>false</c> for a package the application fetches itself: the
+    /// bundle (in every variant) is still embedded and still copied into the site, it is simply not
+    /// scripted — Curiosity's Admin package is loaded on demand, long after the page is up.
+    ///
+    /// This replaces the older spelling of the same intent, a resource group re-declaring the
+    /// project's own output under a <c>.dontload</c> name. That still works and still only sets this
+    /// flag, but it no longer has to be written out per variant: the package ships all of them.
+    /// </summary>
+    public bool LoadCompiledOutput { get; init; } = true;
 
     /// <summary>reflection.disabled — when true, no reflection metadata is emitted.</summary>
     public bool ReflectionDisabled { get; init; }
@@ -147,7 +145,6 @@ internal sealed class TransposeJson
             OutputBy = merged.OutputBy,
             FileName = merged.FileName ?? "app.js",
             ExplicitFileName = merged.FileName,
-            OutputFormatting = merged.OutputFormatting ?? JsOutputFormatting.Both,
             HtmlDisabled = merged.HtmlDisabled ?? false,
             HtmlTitle = merged.HtmlTitle,
             HtmlBody = merged.HtmlBody ?? "",
@@ -155,6 +152,7 @@ internal sealed class TransposeJson
             HtmlMeta = merged.HtmlMeta ?? "",
             Resources = merged.Resources,
             CleanOutputFolder = merged.CleanOutputFolder ?? true,
+            LoadCompiledOutput = merged.LoadCompiledOutput ?? true,
             CleanOutputFolderExclude = merged.CleanOutputFolderExclude,
             ReflectionDisabled = merged.ReflectionDisabled ?? false,
             ReflectionTarget = merged.ReflectionTarget ?? "file",
@@ -170,7 +168,6 @@ internal sealed class TransposeJson
         public string? Output;
         public string? OutputBy;
         public string? FileName;
-        public JsOutputFormatting? OutputFormatting;
         public bool? HtmlDisabled;
         public string? HtmlTitle;
         public string? HtmlBody;
@@ -178,6 +175,7 @@ internal sealed class TransposeJson
         public string? HtmlMeta;
         public List<ResourceGroup> Resources = new();
         public bool? CleanOutputFolder;
+        public bool? LoadCompiledOutput;
         public List<string> CleanOutputFolderExclude = new();
         public bool? ReflectionDisabled;
         public string? ReflectionTarget;
@@ -192,13 +190,13 @@ internal sealed class TransposeJson
                 Output           = o.Output           ?? b.Output,
                 OutputBy         = o.OutputBy          ?? b.OutputBy,
                 FileName         = o.FileName          ?? b.FileName,
-                OutputFormatting = o.OutputFormatting  ?? b.OutputFormatting,
                 HtmlDisabled     = o.HtmlDisabled      ?? b.HtmlDisabled,
                 HtmlTitle        = o.HtmlTitle         ?? b.HtmlTitle,
                 HtmlBody         = o.HtmlBody          ?? b.HtmlBody,
                 HtmlHead         = o.HtmlHead          ?? b.HtmlHead,
                 Resources        = b.Resources.Concat(o.Resources).ToList(),
                 CleanOutputFolder = o.CleanOutputFolder ?? b.CleanOutputFolder,
+                LoadCompiledOutput = o.LoadCompiledOutput ?? b.LoadCompiledOutput,
                 CleanOutputFolderExclude = b.CleanOutputFolderExclude.Concat(o.CleanOutputFolderExclude).ToList(),
                 ReflectionDisabled = o.ReflectionDisabled ?? b.ReflectionDisabled,
                 ReflectionTarget = o.ReflectionTarget  ?? b.ReflectionTarget,
@@ -258,7 +256,6 @@ internal sealed class TransposeJson
             Output = Str(root, "output"),
             OutputBy = Str(root, "outputBy"),
             FileName = Str(root, "fileName"),
-            OutputFormatting = ParseFormatting(Str(root, "outputFormatting")),
             HtmlDisabled = html.ValueKind == JsonValueKind.Object && html.TryGetProperty("disabled", out var d)
                 ? d.ValueKind == JsonValueKind.True
                 : (bool?)null,
@@ -268,6 +265,7 @@ internal sealed class TransposeJson
             HtmlMeta = html.ValueKind == JsonValueKind.Object ? Str(html, "meta") : null,
             Resources = resources,
             CleanOutputFolder = Bool(root, "cleanOutputFolder"),
+            LoadCompiledOutput = Bool(root, "loadCompiledOutput"),
             CleanOutputFolderExclude = cleanExclude,
             ReflectionDisabled = reflection.ValueKind == JsonValueKind.Object && reflection.TryGetProperty("disabled", out var rd)
                 ? rd.ValueKind == JsonValueKind.True
@@ -277,14 +275,4 @@ internal sealed class TransposeJson
             ModuleMaxChunkBytes = Int(modules, "maxChunkSize"),
         };
     }
-
-    /// <summary>Parses the <c>outputFormatting</c> string (case-insensitive) into the enum; null/unknown → absent.</summary>
-    private static JsOutputFormatting? ParseFormatting(string? s)
-        => s?.Trim().ToLowerInvariant() switch
-        {
-            "formatted" => JsOutputFormatting.Formatted,
-            "minified" => JsOutputFormatting.Minified,
-            "both" => JsOutputFormatting.Both,
-            _ => null,
-        };
 }

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -44,6 +44,7 @@ public static class Program
         // rules in BuildCache/IncrementalPlan hold, and a stale cache is a silently wrong build rather
         // than a failed one. TRANSPOSE_INCREMENTAL=1 turns it on for a whole session.
         var incremental = Environment.GetEnvironmentVariable("TRANSPOSE_INCREMENTAL") is "1" or "true";
+        var noChunkCoalescing = Environment.GetEnvironmentVariable("TRANSPOSE_NO_CHUNK_COALESCING") is "1" or "true" or "TRUE";
         string? cacheDir = null;
         var watch = false;
         var watchPort = 4300;
@@ -65,6 +66,8 @@ public static class Program
                 case "--define" or "-D": extraDefines.Add(args[++i]); break;
                 case "--timing": PhaseTimings.Enabled = true; break;
                 case "--timing-json": _timingJsonPath = args[++i]; PhaseTimings.Enabled = true; break;
+                case "--no-chunk-coalescing": noChunkCoalescing = true; break;
+                case "--chunk-coalescing": noChunkCoalescing = false; break;
                 case "--incremental": incremental = true; break;
                 case "--no-incremental": incremental = false; break;
                 case "--cache-dir": cacheDir = args[++i]; incremental = true; break;
@@ -112,6 +115,7 @@ public static class Program
             AssemblyVersion = assemblyVersion,
             MetadataOnlyAssembly = metadataOnlyAssembly,
             Incremental = incremental,
+            NoChunkCoalescing = noChunkCoalescing,
             CacheDir = cacheDir,
         });
 
@@ -271,6 +275,15 @@ public static class Program
                                     can pin it with <TransposeMetadataOnlyAssembly>. The Transpose SDK
                                     refuses to pack a Debug build, so a metadata-only assembly cannot
                                     reach a NuGet feed.
+              --no-chunk-coalescing Emit one ES module per strongly-connected component instead of
+                                    coalescing them into the size band (outputBy: "Module" only; also
+                                    settable with TRANSPOSE_NO_CHUNK_COALESCING=1, which reaches a
+                                    build driven by MSBuild). This is a build for MEASURING: hundreds
+                                    of ~2 KB chunks are the wrong thing to serve, but they are the
+                                    only way to see what a running application really fetches
+                                    together — a coalesced build has already made that decision, so a
+                                    capture of it can only confirm it. The evidence a
+                                    tps.chunks.json oracle is written from comes from this build.
               --incremental, --no-incremental
                                     Reuse the previous build of this project where its inputs are
                                     unchanged (off by default). A build whose files all hash the same

--- a/Transpose/Transpose.Translator.Tests/ChunkOracleTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ChunkOracleTests.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <c>tps.chunks.json</c> — feeding a measurement of the running application back into the chunker.
+    ///
+    /// Two halves are tested here and they fail in very different ways. The parser must never throw:
+    /// the file is generated from a capture and checked in beside code that keeps moving, so a stale
+    /// or hand-broken one has to cost the oracle a hint rather than cost everyone a build. The
+    /// chunker must actually use it: membership becomes an extra dimension of the load signature, so
+    /// two components the reference graph cannot tell apart end up in one chunk when the application
+    /// really fetched them together, and in different chunks when it did not.
+    /// </summary>
+    [TestClass]
+    public class ChunkOracleTests
+    {
+        // ------------------------------------------------------------------ parsing never throws
+
+        [TestMethod]
+        public void AMalformedFileIsIgnoredRatherThanFailingTheBuild()
+        {
+            foreach (var text in new[]
+            {
+                "",
+                "{",                                            // truncated
+                "not json at all",
+                "null",
+                "42",
+                "{ \"groups\": \"not an array\" }",
+                "{ \"groups\": [ 1, 2, 3 ] }",                  // entries of the wrong kind
+                "{ \"groups\": [ { \"types\": \"nope\" } ] }",
+                "{ \"groups\": [ { \"name\": 7, \"types\": [] } ] }",
+            })
+            {
+                Assert.IsTrue(ChunkOracle.Parse(text).IsEmpty, $"must parse to nothing, not throw: {text}");
+            }
+        }
+
+        [TestMethod]
+        public void AGroupIsReadWithItsNameAndEagerFlag()
+        {
+            var oracle = ChunkOracle.Parse(@"{
+                ""version"": 1,
+                ""groups"": [
+                    { ""name"": ""boot"", ""eager"": true, ""types"": [ ""tss.UI"", ""tss.Stack"", ""tss.UI"" ] },
+                    { ""name"": ""#/search"", ""types"": [ ""App.SearchView"" ] }
+                ]
+            }");
+
+            Assert.AreEqual(2, oracle.Groups.Count);
+            Assert.AreEqual("boot", oracle.Groups[0].Name);
+            Assert.IsTrue(oracle.Groups[0].Eager);
+            CollectionAssert.AreEqual(new[] { "tss.UI", "tss.Stack" }, oracle.Groups[0].Types.ToArray(),
+                "a repeated name is one hint, not two");
+            Assert.IsFalse(oracle.Groups[1].Eager, "absent 'eager' means lazy");
+        }
+
+        [TestMethod]
+        public void ABareArrayOfTypeNamesIsAcceptedAsAGroup()
+        {
+            // A generator that writes the simplest thing that could work should not be a build break.
+            var oracle = ChunkOracle.Parse(@"[ [ ""A"", ""B"" ], { ""types"": [ ""C"" ] } ]");
+            Assert.AreEqual(2, oracle.Groups.Count);
+            CollectionAssert.AreEqual(new[] { "A", "B" }, oracle.Groups[0].Types.ToArray());
+        }
+
+        [TestMethod]
+        public void CommentsAndTrailingCommasAreTolerated()
+        {
+            var oracle = ChunkOracle.Parse(@"{
+                // captured 2026-08-18
+                ""groups"": [ { ""name"": ""boot"", ""types"": [ ""A"", ] }, ]
+            }");
+            Assert.AreEqual(1, oracle.Groups.Count);
+        }
+
+        // ------------------------------------------------------------------ the chunker uses it
+
+        /// <summary>Six independent widgets and a root that touches all of them. Main does not
+        /// reach any of it, so all seven components are deferred and every widget has the same load
+        /// signature — the set of roots that reach it is just {Root}. The coalescer therefore has no
+        /// reason of its own to separate them, which is exactly the situation an oracle improves.
+        ///
+        /// The bodies are padded because the bucketer only respects a group boundary once the bucket
+        /// it would end is worth a request of its own; three widgets have to add up to more than the
+        /// minimum or the split would be traded away for size, which is the correct behaviour and not
+        /// what this is measuring.</summary>
+        private static string Source()
+        {
+            var sb = new StringBuilder();
+            for (var i = 0; i < 6; i++)
+            {
+                sb.Append("public class W").Append(i).Append(" { public int Run(int n) { var t = 0;\n");
+                for (var line = 0; line < 12; line++)
+                    sb.Append("    t += n * ").Append(line).Append(" + (n / ").Append(line + 1).Append(");\n");
+                sb.Append("    return t; } }\n");
+            }
+            sb.Append(@"
+public class Root {
+    public int A(int n) { return new W0().Run(n) + new W1().Run(n) + new W2().Run(n); }
+    public int B(int n) { return new W3().Run(n) + new W4().Run(n) + new W5().Run(n); }
+}
+public class Program { public static void Main() { System.Console.WriteLine(""up""); } }
+");
+            return sb.ToString();
+        }
+
+        private const int Min = 2 * 1024;
+        private const int Max = 16 * 1024;
+
+        [TestMethod]
+        public void WithoutAnOracleTheWidgetsAllShareOneChunk()
+        {
+            // The baseline the next test is measured against: nothing in the graph distinguishes
+            // these six, so the size band packs them together.
+            var m = ModuleEmitTests.Emit(Source(), minChunkBytes: Min, maxChunkBytes: Max);
+            var distinct = Enumerable.Range(0, 6).Select(i => ModuleEmitTests.ChunkOf(m, "W" + i)).Distinct().Count();
+            Assert.AreEqual(1, distinct, "with no measurement to go on the coalescer packs them by size alone");
+        }
+
+        [TestMethod]
+        public void AnOracleSplitsComponentsTheGraphCannotTellApart()
+        {
+            // The measurement says the application fetches W0..W2 on one screen and W3..W5 on
+            // another. Nothing in the source says so, and that is the point.
+            var oracle = ChunkOracle.Parse(@"{ ""groups"": [
+                { ""name"": ""screen-a"", ""types"": [ ""W0"", ""W1"", ""W2"" ] },
+                { ""name"": ""screen-b"", ""types"": [ ""W3"", ""W4"", ""W5"" ] }
+            ] }");
+
+            var m = ModuleEmitTests.Emit(Source(), minChunkBytes: Min, maxChunkBytes: Max, chunkOracle: oracle);
+
+            var a = new[] { "W0", "W1", "W2" }.Select(t => ModuleEmitTests.ChunkOf(m, t)).Distinct().ToList();
+            var b = new[] { "W3", "W4", "W5" }.Select(t => ModuleEmitTests.ChunkOf(m, t)).Distinct().ToList();
+
+            Assert.AreEqual(1, a.Count, "the three the capture saw together belong in one chunk");
+            Assert.AreEqual(1, b.Count, "…and so do the other three");
+            Assert.AreNotEqual(a[0], b[0], "…but the two screens must not be fetched as one");
+        }
+
+        [TestMethod]
+        public void AStaleTypeNameIsSkippedAndTheRestStillApplies()
+        {
+            // A renamed or deleted type is the normal fate of a checked-in capture.
+            var oracle = ChunkOracle.Parse(@"{ ""groups"": [
+                { ""name"": ""screen-a"", ""types"": [ ""W0"", ""W1"", ""W2"", ""TypeThatNoLongerExists"" ] },
+                { ""name"": ""gone"", ""types"": [ ""AlsoGone"" ] },
+                { ""name"": ""screen-b"", ""types"": [ ""W3"", ""W4"", ""W5"" ] }
+            ] }");
+
+            var m = ModuleEmitTests.Emit(Source(), minChunkBytes: Min, maxChunkBytes: Max, chunkOracle: oracle);
+
+            Assert.AreNotEqual(ModuleEmitTests.ChunkOf(m, "W0"), ModuleEmitTests.ChunkOf(m, "W3"),
+                "the groups that still match must be honoured");
+        }
+
+        [TestMethod]
+        public void AnEagerGroupPutsALibrarysStartUpSetInItsInitialPayload()
+        {
+            // A package has no entry point to be lazy relative to, so it defers everything and the
+            // consumer pays for the start-up set in round trips. A capture knows what that set is.
+            var plain = ModuleEmitTests.Emit(Source(), packageModules: true);
+            Assert.AreEqual(0, plain.EagerChunkCount, "a library defers everything on its own");
+
+            var oracle = ChunkOracle.Parse(@"{ ""groups"": [
+                { ""name"": ""boot"", ""eager"": true, ""types"": [ ""W0"" ] }
+            ] }");
+            var measured = ModuleEmitTests.Emit(Source(), packageModules: true, chunkOracle: oracle);
+
+            Assert.IsTrue(measured.EagerChunkCount > 0,
+                "an eager group is the one thing a library cannot work out for itself");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/CssCommentStrippingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/CssCommentStrippingTests.cs
@@ -153,7 +153,6 @@ public sealed class CssCommentStrippingTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""site.css"", ""files"": [ ""css/one.css"", ""css/two.css"" ] }
             ]
@@ -171,7 +170,6 @@ public sealed class CssCommentStrippingTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""vendor"", ""files"": [ ""vendor/*"" ], ""output"": ""vendor"" }
             ]
@@ -192,7 +190,6 @@ public sealed class CssCommentStrippingTests
 
         var config = Config(@"{
             ""fileName"": ""Lib.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""site.css"", ""files"": [ ""css/site.css"" ] },
                 { ""name"": ""assets"",   ""files"": [ ""css/extra.css"" ], ""output"": ""assets"" }
@@ -222,7 +219,7 @@ public sealed class CssCommentStrippingTests
             new("nested.css", utf8.GetBytes("/* also */\n.nested { }\n"), "assets"),
         });
 
-        var html = BuildSite(Config(@"{ ""fileName"": ""app.js"", ""outputFormatting"": ""Formatted"" }"), Project(dll));
+        var html = BuildSite(Config(@"{ ""fileName"": ""app.js"" }"), Project(dll));
 
         Assert.AreEqual(".legacy { color: red }\n", OutputText("legacy.css"));
         Assert.AreEqual(".nested { }\n", OutputText("assets/nested.css"));

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -29,14 +29,15 @@ namespace Transpose.Translator.Tests
             IReadOnlyDictionary<string, string>? externalChunks = null,
             string chunkDirectory = "chunks",
             int minChunkBytes = 0,
-            int maxChunkBytes = 0)
+            int maxChunkBytes = 0,
+            ChunkOracle? chunkOracle = null)
         {
             var result = new RoslynTranslator().BuildAssembly(
                 new[] { ("App.cs", source) }, CompilationBuilder.DefaultAssemblyName,
                 extraReferencePaths: null, preprocessorSymbols: new[] { "DEBUG", "TRACE" },
                 emitAssembly: false, emitModules: true,
                 chunkDirectory: chunkDirectory, externalChunks: externalChunks, packageModules: packageModules,
-                minChunkBytes: minChunkBytes, maxChunkBytes: maxChunkBytes);
+                minChunkBytes: minChunkBytes, maxChunkBytes: maxChunkBytes, chunkOracle: chunkOracle);
             if (!result.Success)
                 Assert.Fail("translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));
             return result.Modules!;

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -206,6 +206,85 @@ public class Program { public static void Main() { Console.WriteLine(new UsesCar
         }
 
         [TestMethod]
+        public void SkipTypeClusteringFollowsACallToASiblingOnTheSameFacade()
+        {
+            // The shape that broke Mosaik.UI and DefaultRouting: a facade member does not construct
+            // the type itself, it delegates to a sibling that does. The sibling reference names only
+            // the facade — the one type this pass removes from every set — so without a transitive
+            // closure over the facade's members the caller imports the facade and nothing else, and
+            // Card's chunk is left with no importer at all.
+            var m = Emit(@"
+using System;
+public class Card { public int N; }
+public class Badge { public int N; }
+[Transpose.SkipTypeClustering]
+public class Hub
+{
+    public static Card MakeCard() { return new Card(); }
+    public static object Build() { return MakeCard(); }
+    public static Badge MakeBadge() { return new Badge(); }
+}
+public class UsesBuild { public object Get() { return Hub.Build(); } }
+public class Program { public static void Main() { Console.WriteLine(new UsesBuild().Get()); } }
+");
+            var caller = m.Chunks.First(c => c.relPath == ChunkOf(m, "UsesBuild"));
+            var imports = ImportsOf(caller.js).ToList();
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Card")),
+                "Hub.Build() calls the sibling that makes a Card, so its caller has to import Card's chunk");
+            CollectionAssert.DoesNotContain(imports, System.IO.Path.GetFileName(ChunkOf(m, "Badge")),
+                "...and still only that one: nothing on the path to Build() reaches MakeBadge()");
+        }
+
+        [TestMethod]
+        public void SkipTypeClusteringFollowsASiblingCycle()
+        {
+            // Members of a facade call each other freely, cycles included, so the closure is a
+            // fixpoint rather than a topological walk. Both directions must see Card either way.
+            var m = Emit(@"
+using System;
+public class Card { public int N; }
+[Transpose.SkipTypeClustering]
+public class Hub
+{
+    public static object A(int n) { return n > 0 ? B(n - 1) : new Card(); }
+    public static object B(int n) { return A(n - 1); }
+}
+public class UsesB { public object Get() { return Hub.B(3); } }
+public class Program { public static void Main() { Console.WriteLine(new UsesB().Get()); } }
+");
+            CollectionAssert.Contains(
+                ImportsOf(m.Chunks.First(c => c.relPath == ChunkOf(m, "UsesB")).js).ToList(),
+                System.IO.Path.GetFileName(ChunkOf(m, "Card")),
+                "B -> A -> new Card() has to survive the cycle between A and B");
+        }
+
+        [TestMethod]
+        public void SkipTypeClusteringKeepsEagerStaticStateOnTheFacade()
+        {
+            // A static field initializer runs when the facade's own chunk evaluates — there is no
+            // call site to move that edge to — so it stays on the facade and the two land together.
+            var m = Emit(@"
+using System;
+public class Registry { public int N; }
+[Transpose.SkipTypeClustering]
+public class Hub
+{
+    private static readonly Registry _all = new Registry();
+    public static int Count() { return _all.N; }
+}
+public class Program { public static void Main() { Console.WriteLine(Hub.Count()); } }
+");
+            var hubChunk = ChunkOf(m, "Hub");
+            var registryChunk = ChunkOf(m, "Registry");
+            Assert.IsTrue(
+                hubChunk == registryChunk
+                || ImportsOf(m.Chunks.First(c => c.relPath == hubChunk).js)
+                       .Contains(System.IO.Path.GetFileName(registryChunk)),
+                "the facade's static initializer needs Registry the moment Hub is defined, so Hub's "
+                + $"chunk ({hubChunk}) has to carry or import Registry's ({registryChunk})");
+        }
+
+        [TestMethod]
         public void SkipTypeClusteringPublishesItsMemberDepsForConsumers()
         {
             var m = Emit(@"

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -237,6 +237,30 @@ public class Program { public static void Main() { Console.WriteLine(new UsesBui
         }
 
         [TestMethod]
+        public void SkipTypeClusteringFollowsACallIntoASecondFacade()
+        {
+            // The same hole as the sibling case, one type over: the callee's containing type is also
+            // one whose edges are dropped, so its dependencies have nowhere to live either. Found by
+            // running the app after attributing a second facade — App.Sidenav.Initialize built a
+            // LogoSidenavItem whose chunk nothing had imported.
+            var m = Emit(@"
+using System;
+public class Logo { public int N; }
+[Transpose.SkipTypeClustering]
+public class Rail { public static object Build() { return new Logo(); } }
+[Transpose.SkipTypeClustering]
+public class Shell { public static object Start() { return Rail.Build(); } }
+public class UsesShell { public object Get() { return Shell.Start(); } }
+public class Program { public static void Main() { Console.WriteLine(new UsesShell().Get()); } }
+");
+            var imports = ImportsOf(m.Chunks.First(c => c.relPath == ChunkOf(m, "UsesShell")).js).ToList();
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Logo")),
+                "Shell.Start() reaches Rail.Build(), which builds a Logo — the call site has to import it");
+            CollectionAssert.Contains(imports, System.IO.Path.GetFileName(ChunkOf(m, "Rail")),
+                "...and Rail itself, which it names directly");
+        }
+
+        [TestMethod]
         public void SkipTypeClusteringFollowsASiblingCycle()
         {
             // Members of a facade call each other freely, cycles included, so the closure is a
@@ -260,10 +284,13 @@ public class Program { public static void Main() { Console.WriteLine(new UsesB()
         }
 
         [TestMethod]
-        public void SkipTypeClusteringKeepsEagerStaticStateOnTheFacade()
+        public void SkipTypeClusteringCarriesStaticStateToEveryCaller()
         {
-            // A static field initializer runs when the facade's own chunk evaluates — there is no
-            // call site to move that edge to — so it stays on the facade and the two land together.
+            // A static field initializer does not run with the member that happens to be called — the
+            // runtime hangs $staticInit off the getter of the type's global slot, so it fires the
+            // first time anything reads the class. Following sibling calls alone would therefore miss
+            // it, and keeping it on the facade would rebuild the cycle the attribute exists to break.
+            // So it belongs to every way in: whoever touches Hub first must have Registry.
             var m = Emit(@"
 using System;
 public class Registry { public int N; }
@@ -273,16 +300,15 @@ public class Hub
     private static readonly Registry _all = new Registry();
     public static int Count() { return _all.N; }
 }
-public class Program { public static void Main() { Console.WriteLine(Hub.Count()); } }
+public class UsesCount { public int Get() { return Hub.Count(); } }
+public class Program { public static void Main() { Console.WriteLine(new UsesCount().Get()); } }
 ");
-            var hubChunk = ChunkOf(m, "Hub");
-            var registryChunk = ChunkOf(m, "Registry");
-            Assert.IsTrue(
-                hubChunk == registryChunk
-                || ImportsOf(m.Chunks.First(c => c.relPath == hubChunk).js)
-                       .Contains(System.IO.Path.GetFileName(registryChunk)),
-                "the facade's static initializer needs Registry the moment Hub is defined, so Hub's "
-                + $"chunk ({hubChunk}) has to carry or import Registry's ({registryChunk})");
+            CollectionAssert.Contains(
+                ImportsOf(m.Chunks.First(c => c.relPath == ChunkOf(m, "UsesCount")).js).ToList(),
+                System.IO.Path.GetFileName(ChunkOf(m, "Registry")),
+                "reading Hub at all runs its static initializer, so its caller has to import Registry");
+            Assert.AreNotEqual(ChunkOf(m, "Registry"), ChunkOf(m, "Hub"),
+                "...and the facade itself must not keep the edge, or it is back in Registry's component");
         }
 
         [TestMethod]

--- a/Transpose/Transpose.Translator.Tests/PackageResourceVariantTests.cs
+++ b/Transpose/Transpose.Translator.Tests/PackageResourceVariantTests.cs
@@ -4,8 +4,9 @@ using Transpose.Compiler;
 namespace Transpose.Translator.Tests;
 
 /// <summary>
-/// Covers which name a referenced package's embedded JavaScript lands under in a site build, per
-/// <c>outputFormatting</c> — the <c>.js</c> / <c>.min.js</c> switch in <c>OutputBuilder.RoutePackageJs</c>.
+/// Covers which name a referenced package's embedded JavaScript lands under in a site build — the
+/// <c>.js</c> / <c>.min.js</c> switch in <c>OutputBuilder.RoutePackageJs</c>, driven by the build's
+/// configuration (see <c>JsOutputProfile</c>).
 ///
 /// The rule the reported bug broke: the switch applies only to a file the package ships in BOTH
 /// variants (the compiled bundle, or an authored bundle a library deliberately declares twice). An
@@ -55,7 +56,6 @@ public sealed class PackageResourceVariantTests
 
         File.WriteAllText(Path.Combine(_libDir, "tps.json"), @"{
             ""fileName"": ""Lib.js"",
-            ""outputFormatting"": ""Both"",
             ""resources"": [
                 {
                     ""name"": ""monaco#editor.main.js.dontload"",
@@ -91,7 +91,7 @@ public sealed class PackageResourceVariantTests
     [TestMethod]
     public void AMinifiedBuildKeepsASingleVariantPackageResourceUnderItsAuthoredName()
     {
-        var html = BuildSite(LibraryPackage(), "Minified", "Release");
+        var html = BuildSite(LibraryPackage(), "Release");
 
         AssertInOutput("assets/js/monaco/vs/editor/editor.main.js",
             "an authored package resource must keep the name it was authored with — Monaco's loader fetches it by path");
@@ -111,7 +111,7 @@ public sealed class PackageResourceVariantTests
         // The mirror image: a vendored library that only ever existed as `d3.min.js` is not a Release
         // variant of anything, so a Formatted build must still put it on disk — the app lazy-loads it
         // by that path in every configuration.
-        BuildSite(LibraryPackage(), "Formatted", "Debug");
+        BuildSite(LibraryPackage(), "Debug");
 
         AssertInOutput("assets/js/d3.min.js", "a standalone .min.js resource must be extracted in a Formatted build too");
         AssertNotInOutput("assets/js/d3.js", "and must not be renamed to a formatted variant that does not exist");
@@ -124,14 +124,14 @@ public sealed class PackageResourceVariantTests
         // behaviour: the minified build takes the .min.js, the formatted build takes the .js.
         var dll = LibraryPackage();
 
-        BuildSite(dll, "Minified", "Release");
+        BuildSite(dll, "Release");
         AssertInOutput("assets/js/Lib.ExternalBundle.min.js", "a declared .min.js variant is what a Minified build writes");
         AssertNotInOutput("assets/js/Lib.ExternalBundle.js", "…and the formatted variant is not materialised");
 
         Directory.Delete(_outputDir, recursive: true);
         Directory.CreateDirectory(_outputDir);
 
-        BuildSite(dll, "Formatted", "Debug");
+        BuildSite(dll, "Debug");
         AssertInOutput("assets/js/Lib.ExternalBundle.js", "a Formatted build writes the formatted variant");
         AssertNotInOutput("assets/js/Lib.ExternalBundle.min.js", "…and not the minified one");
     }
@@ -141,11 +141,98 @@ public sealed class PackageResourceVariantTests
     {
         // Unchanged, and the reason the switch exists at all: the library's own compiled JS ships in
         // both variants, so a Minified consumer build links the pre-minified one.
-        var html = BuildSite(LibraryPackage(), "Minified", "Release");
+        var html = BuildSite(LibraryPackage(), "Release");
 
         AssertInOutput("Lib.min.js", "the package's pre-minified bundle is what a Minified build writes");
         AssertNotInOutput("Lib.js", "…and the formatted bundle is not materialised");
         StringAssert.Contains(html, "src=\"Lib.min.js\"", "index.html must link the minified bundle in Release");
+    }
+
+    // ------------------------------------------- a package ships every variant; the consumer picks
+
+    /// <summary>A module-mode library, i.e. one that emits chunks. It embeds all three shapes of its
+    /// own compiled code, because it cannot know how it will be consumed.</summary>
+    private string ModuleLibraryPackage()
+    {
+        File.WriteAllText(Path.Combine(_libDir, "tps.json"), @"{ ""fileName"": ""Lib.js"", ""outputBy"": ""Module"" }");
+        var config = TransposeJson.TryLoad(_libDir, "Release");
+        Assert.IsNotNull(config);
+
+        var modules = new Emitter.ModuleOutput { EntryJs = "import './chunks/Lib/c0.mjs';\n" };
+        modules.Chunks.Add(("chunks/Lib/c0.mjs", "/* chunk zero */"));
+
+        return PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(
+            _libDir, config!, "Lib.js", "var lib = 1;", "var libMeta = 1;", modules: modules));
+    }
+
+    [TestMethod]
+    public void APackageShipsEveryVariantOfItsOwnCompiledCode()
+    {
+        using var asm = AssemblyDefinition.ReadAssembly(ModuleLibraryPackage());
+        var names = asm.MainModule.Resources.Select(r => r.Name).ToList();
+
+        // A library is built once and consumed by applications that are not: an application being
+        // debugged wants one readable bundle, a shipping one wants minified or chunked, and neither
+        // should require the library to be rebuilt. So all of it travels.
+        CollectionAssert.Contains(names, "Lib.js",          "the formatted bundle");
+        CollectionAssert.Contains(names, "Lib.min.js",      "the minified bundle");
+        CollectionAssert.Contains(names, "Lib.meta.js",     "the formatted reflection metadata");
+        CollectionAssert.Contains(names, "Lib.meta.min.js", "the minified reflection metadata");
+        CollectionAssert.Contains(names, "Lib.mjs",         "the module entry, under a name of its own");
+        CollectionAssert.Contains(names, "c0.mjs",          "and its chunk files");
+    }
+
+    [TestMethod]
+    public void ADebugConsumerTakesThePackagesFormattedBundleAndNoChunks()
+    {
+        var html = BuildSite(ModuleLibraryPackage(), "Debug");
+
+        AssertInOutput("Lib.js", "a Debug build takes the readable bundle");
+        Assert.AreEqual("var lib = 1;", File.ReadAllText(Path.Combine(_outputDir, "Lib.js")),
+            "…the bundle itself, not the module entry that happens to land under the same name in Release");
+        AssertNotInOutput("Lib.min.js", "…not the minified one");
+        AssertNotInOutput("chunks/Lib/c0.mjs",
+            "…and none of the chunks: a Debug build is not chunked, so they would be dead weight");
+        StringAssert.Contains(html, "src=\"Lib.js\" defer", "and it is scripted as a classic bundle");
+    }
+
+    [TestMethod]
+    public void AReleaseConsumerThatIsNotChunkedTakesThePackagesMinifiedBundle()
+    {
+        var html = BuildSite(ModuleLibraryPackage(), "Release");
+
+        AssertInOutput("Lib.min.js", "an unchunked Release build takes the minified bundle");
+        AssertNotInOutput("Lib.js", "…not the formatted one");
+        AssertNotInOutput("chunks/Lib/c0.mjs", "…and not the chunks, which it has no entry module to reach");
+        StringAssert.Contains(html, "src=\"Lib.min.js\"", "index.html links the minified bundle");
+    }
+
+    [TestMethod]
+    public void AChunkedReleaseConsumerTakesThePackagesModuleEntryAndChunks()
+    {
+        var modules = new Emitter.ModuleOutput { EntryJs = "// app entry" };
+        var html = BuildSite(ModuleLibraryPackage(), "Release", modules);
+
+        AssertInOutput("chunks/Lib/c0.mjs", "a chunked consumer takes the package's chunks");
+        // The entry lands under the bundle's name: three variants need three names inside the DLL and
+        // one name in the site, because application code fetches it by that name.
+        AssertInOutput("Lib.js", "…and its module entry, under the name a consumer's own code fetches");
+        Assert.AreEqual("import './chunks/Lib/c0.mjs';\n", File.ReadAllText(Path.Combine(_outputDir, "Lib.js")));
+        AssertNotInOutput("Lib.min.js", "…and neither classic bundle");
+        AssertNotInOutput("Lib.mjs", "the in-DLL name of the entry is not a name the site uses");
+        StringAssert.Contains(html, "<script type=\"module\" src=\"Lib.js\">",
+            "the entry has to be scripted as a module — it carries import statements");
+    }
+
+    [TestMethod]
+    public void AChunkedConsumerFallsBackToTheBundleOfAPackageThatHasNoChunks()
+    {
+        // Not every dependency is module-mode (a binding library, a vendored package). A chunked app
+        // still has to load those, and the minified bundle is what it takes.
+        var modules = new Emitter.ModuleOutput { EntryJs = "// app entry" };
+        BuildSite(LibraryPackage(), "Release", modules);
+
+        AssertInOutput("Lib.min.js", "a package with no module variant contributes its minified bundle");
     }
 
     // ---------------------------------------------------------------- helpers
@@ -160,10 +247,9 @@ public sealed class PackageResourceVariantTests
 
     /// <summary>Builds a consuming project that has no resources of its own — everything in the site
     /// comes from <paramref name="packageDll"/> — and returns its index.html.</summary>
-    private string BuildSite(string packageDll, string outputFormatting, string configuration)
+    private string BuildSite(string packageDll, string configuration, Emitter.ModuleOutput? modules = null)
     {
-        File.WriteAllText(Path.Combine(_appDir, "tps.json"),
-            @"{ ""fileName"": ""app.js"", ""outputFormatting"": """ + outputFormatting + @""" }");
+        File.WriteAllText(Path.Combine(_appDir, "tps.json"), @"{ ""fileName"": ""app.js"" }");
 
         var config = TransposeJson.TryLoad(_appDir, configuration);
         Assert.IsNotNull(config, "the app's tps.json must load");
@@ -181,7 +267,8 @@ public sealed class PackageResourceVariantTests
             ProjectDirs     = new List<string> { _appDir },
         };
 
-        OutputBuilder.Build(project, config!, "var app = 1;", _outputDir, configuration);
+        OutputBuilder.Build(project, config!, modules?.EntryJs ?? "var app = 1;", _outputDir, configuration,
+                            modules: modules);
 
         var html = Path.Combine(_outputDir, "index.html");
         Assert.IsTrue(File.Exists(html), "the build must generate index.html");

--- a/Transpose/Transpose.Translator.Tests/RecursiveResourceGlobTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RecursiveResourceGlobTests.cs
@@ -103,7 +103,6 @@ public sealed class RecursiveResourceGlobTests
 
     private const string ImagesRecursively = @"{
         ""fileName"": ""app.js"",
-        ""outputFormatting"": ""Formatted"",
         ""resources"": [
             { ""name"": ""images"", ""files"": [ ""tps/assets/img/**"" ], ""output"": ""assets/img/"" }
         ]
@@ -120,7 +119,6 @@ public sealed class RecursiveResourceGlobTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""images"", ""files"": [ ""tps/assets/img/*"" ], ""output"": ""assets/img/"" }
             ]
@@ -153,7 +151,6 @@ public sealed class RecursiveResourceGlobTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""images"", ""files"": [ ""tps/assets/img/**/*.svg"" ], ""output"": ""assets/img/"" }
             ]
@@ -171,7 +168,6 @@ public sealed class RecursiveResourceGlobTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""images"", ""files"": [ ""tps/assets/img/**"" ] }
             ]
@@ -191,7 +187,6 @@ public sealed class RecursiveResourceGlobTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""bundle.css"", ""files"": [ ""tps/assets/css/**/*.css"" ], ""output"": ""assets/css"" }
             ]
@@ -246,7 +241,6 @@ public sealed class RecursiveResourceGlobTests
 
         var items = OutputBuilder.CollectEmbeddableItems(_projectDir, Config(@"{
             ""fileName"": ""Lib.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""images"", ""files"": [ ""tps/assets/img/*"" ] }
             ]
@@ -267,7 +261,6 @@ public sealed class RecursiveResourceGlobTests
 
         var libConfig = Config(@"{
             ""fileName"": ""Lib.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""images"", ""files"": [ ""tps/assets/img/**"" ], ""output"": ""assets/img/"" }
             ]
@@ -275,7 +268,7 @@ public sealed class RecursiveResourceGlobTests
         var dll = PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(_projectDir, libConfig, "Lib.js", "var lib = 1;", null));
 
         // The consuming project declares no resources of its own — everything below comes from the package.
-        BuildSite(Config(@"{ ""fileName"": ""app.js"", ""outputFormatting"": ""Formatted"" }"), Project(dll));
+        BuildSite(Config(@"{ ""fileName"": ""app.js"" }"), Project(dll));
 
         Assert.AreEqual("<svg id='logo'/>", SiteFile("assets/img/logo.svg"));
         Assert.AreEqual("<svg id='icons-api'/>", SiteFile("assets/img/icons/api.svg"));
@@ -293,7 +286,6 @@ public sealed class RecursiveResourceGlobTests
 
         BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""styles"", ""files"": [ ""tps/assets/css/**/*.css"" ], ""output"": ""assets/css"" }
             ]

--- a/Transpose/Transpose.Translator.Tests/ResourceLoadFlagTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ResourceLoadFlagTests.cs
@@ -126,7 +126,6 @@ public sealed class ResourceLoadFlagTests
 
         var html = BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""eager.js"", ""files"": [ ""assets/eager.js"" ] },
                 { ""name"": ""lazy.js"",  ""files"": [ ""assets/lazy.js"" ], ""load"": false }
@@ -147,7 +146,6 @@ public sealed class ResourceLoadFlagTests
 
         var html = BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""site.css"",       ""files"": [ ""assets/site.css"" ] },
                 { ""name"": ""theme-dark.css"", ""files"": [ ""assets/theme-dark.css"" ], ""load"": false }
@@ -170,7 +168,6 @@ public sealed class ResourceLoadFlagTests
 
         var html = BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""vendor"", ""files"": [ ""vendor/*.js"", ""vendor/*.css"" ], ""output"": ""vendor"", ""load"": false }
             ]
@@ -189,7 +186,6 @@ public sealed class ResourceLoadFlagTests
 
         var html = BuildSite(Config(@"{
             ""fileName"": ""app.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""lazy.js.dontload"", ""files"": [ ""assets/lazy.js"" ] }
             ]
@@ -209,7 +205,6 @@ public sealed class ResourceLoadFlagTests
 
         var config = Config(@"{
             ""fileName"": ""Lib.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""site.css"", ""files"": [ ""assets/site.css"" ] },
                 { ""name"": ""lazy.js"",  ""files"": [ ""assets/lazy.js"" ], ""load"": false }
@@ -241,7 +236,6 @@ public sealed class ResourceLoadFlagTests
 
         var libConfig = Config(@"{
             ""fileName"": ""Lib.js"",
-            ""outputFormatting"": ""Formatted"",
             ""resources"": [
                 { ""name"": ""site.css"",       ""files"": [ ""assets/site.css"" ] },
                 { ""name"": ""lazy.js"",        ""files"": [ ""assets/lazy.js"" ], ""load"": false },
@@ -252,7 +246,7 @@ public sealed class ResourceLoadFlagTests
         var dll = PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(_projectDir, libConfig, "Lib.js", "var lib = 1;", null));
 
         // The consuming project has no resources of its own — everything below comes from the package.
-        var appConfig = Config(@"{ ""fileName"": ""app.js"", ""outputFormatting"": ""Formatted"" }");
+        var appConfig = Config(@"{ ""fileName"": ""app.js"" }");
         var html = BuildSite(appConfig, Project(dll));
 
         AssertInOutput("lazy.js", "a non-loaded package script must still be extracted");

--- a/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
+++ b/Transpose/Transpose.Translator/Compilation/AssemblyBuildResult.cs
@@ -33,11 +33,18 @@ public sealed class AssemblyBuildResult
     public IReadOnlyDictionary<string, string>? DeclarationHashes { get; init; }
 
     /// <summary>
-    /// The ES-module form of the same output, when the build asked for it (<c>outputBy: Module</c>).
-    /// <see cref="Javascript"/> then holds the entry module rather than a single bundle, and this
-    /// carries the chunk files alongside it. Null for an ordinary single-bundle build.
+    /// The ES-module form of the same output, when the build asked for it (<c>outputBy: Module</c>):
+    /// the entry module and the chunk files. Null for an ordinary single-bundle build.
     /// </summary>
     public Emitter.ModuleOutput? Modules { get; init; }
+
+    /// <summary>
+    /// Whether <see cref="Javascript"/> is a classic single bundle (with <see cref="MetadataJavascript"/>
+    /// beside it) rather than <see cref="Modules"/>' entry module. A package emits both — it cannot know
+    /// which one its consumers will want — so the two are not mutually exclusive; false means this build
+    /// produced <em>only</em> modules, and <see cref="Javascript"/> is then the entry module itself.
+    /// </summary>
+    public bool HasBundle { get; init; } = true;
 
     public IEnumerable<Diagnostic> Errors => Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
     public bool Success => Javascript is not null && !Errors.Any();

--- a/Transpose/Transpose.Translator/Compilation/ChunkOracle.cs
+++ b/Transpose/Transpose.Translator/Compilation/ChunkOracle.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// <c>tps.chunks.json</c> — measured evidence of which types are used together, fed back into the
+/// chunker.
+///
+/// The chunker knows the reference graph, which tells it what <em>can</em> be reached, and it
+/// approximates what is <em>actually</em> fetched together with the chunk's load signature: the set
+/// of roots that reach it. That approximation is as good as static analysis gets, and it is still
+/// only an approximation — a screen that shows a chart and a table pulls two subtrees a reference
+/// graph has no reason to associate, while a facade's reachable set spans screens nobody visits in
+/// one session.
+///
+/// A run of the real application knows the answer exactly: it fetched these chunks, in this order,
+/// on this screen. This file is how that observation comes back. Each group names the types seen
+/// together at one step of a capture (a route, a view, boot), and the chunker treats membership as
+/// an extra dimension of the load signature — so two chunks the application always fetches together
+/// end up in one chunk, and two it never does stay apart even when the graph cannot tell them apart.
+///
+/// <code>
+/// {
+///   "version": 1,
+///   "groups": [
+///     { "name": "boot",      "eager": true, "types": [ "tss.UI", "tss.Stack", … ] },
+///     { "name": "#/search",                 "types": [ "Mosaik.Components.SearchView", … ] }
+///   ]
+/// }
+/// </code>
+///
+/// <b>Parsing never fails.</b> This file is generated from a running application and checked in
+/// beside a codebase that keeps moving: a type gets renamed, a group is written by an older capture,
+/// someone hand-edits it and drops a comma. None of that may break a build — the file is an
+/// optimization hint, and a build that cannot read it must produce a correct site, just a
+/// less-well-packed one. So a malformed file yields <see cref="Empty"/>, and a name that matches no
+/// emitted type is skipped silently.
+/// </summary>
+public sealed class ChunkOracle
+{
+    /// <summary>One captured step: the emitted type names observed together.</summary>
+    /// <param name="Name">Human-readable label — the route or view the capture was on. Diagnostic
+    /// only; nothing keys off it.</param>
+    /// <param name="Eager">The types are needed before the application is usable at all, so a
+    /// <em>package</em> build puts them in its initial payload. A library otherwise has no way to
+    /// know which of its chunks a consumer needs at start-up, which is the single biggest source of
+    /// over-fetch in a chunked package.</param>
+    /// <param name="Types">Emitted define names (<c>tss.UI</c>, <c>Mosaik.Components.HomeView</c>) —
+    /// the names the runtime and the chunk map use, which is what a capture can observe.</param>
+    public readonly record struct Group(string Name, bool Eager, IReadOnlyList<string> Types);
+
+    public static readonly ChunkOracle Empty = new(Array.Empty<Group>());
+
+    private ChunkOracle(IReadOnlyList<Group> groups) => Groups = groups;
+
+    public IReadOnlyList<Group> Groups { get; }
+
+    public bool IsEmpty => Groups.Count == 0;
+
+    public const string FileName = "tps.chunks.json";
+
+    /// <summary>Reads <c>tps.chunks.json</c> from <paramref name="projectDir"/>. Returns
+    /// <see cref="Empty"/> when the file is absent, unreadable, or not in a shape this understands —
+    /// see the type remarks for why that is never an error.</summary>
+    public static ChunkOracle TryLoad(string projectDir)
+    {
+        try
+        {
+            var path = Path.Combine(projectDir, FileName);
+            return File.Exists(path) ? Parse(File.ReadAllText(path)) : Empty;
+        }
+        catch { return Empty; }
+    }
+
+    /// <summary>Parses the file's text. Every step is defensive on purpose: an entry of the wrong
+    /// JSON kind is skipped rather than rejected, so one stale group cannot cost a build the rest of
+    /// the file.</summary>
+    public static ChunkOracle Parse(string json)
+    {
+        try
+        {
+            var options = new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
+            using var doc = JsonDocument.Parse(json, options);
+            var root = doc.RootElement;
+
+            // Both shapes are accepted: the documented object with a "groups" array, and a bare
+            // array of groups — a generator that writes the simpler one should not be a build break.
+            var array = root.ValueKind switch
+            {
+                JsonValueKind.Array => root,
+                JsonValueKind.Object when root.TryGetProperty("groups", out var g) && g.ValueKind == JsonValueKind.Array => g,
+                _ => default,
+            };
+            if (array.ValueKind != JsonValueKind.Array) return Empty;
+
+            var groups = new List<Group>();
+            var index = 0;
+            foreach (var element in array.EnumerateArray())
+            {
+                index++;
+                var types = new List<string>();
+                var name = $"group{index}";
+                var eager = false;
+
+                if (element.ValueKind == JsonValueKind.Array)
+                {
+                    // A bare array of type names is a group with no metadata.
+                    types.AddRange(Names(element));
+                }
+                else if (element.ValueKind == JsonValueKind.Object)
+                {
+                    if (element.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String)
+                        name = n.GetString() ?? name;
+                    if (element.TryGetProperty("eager", out var e) && e.ValueKind is JsonValueKind.True or JsonValueKind.False)
+                        eager = e.ValueKind == JsonValueKind.True;
+                    if (element.TryGetProperty("types", out var t) && t.ValueKind == JsonValueKind.Array)
+                        types.AddRange(Names(t));
+                }
+
+                if (types.Count > 0) groups.Add(new Group(name, eager, types));
+            }
+            return groups.Count == 0 ? Empty : new ChunkOracle(groups);
+        }
+        catch { return Empty; }
+    }
+
+    private static IEnumerable<string> Names(JsonElement array)
+        => array.EnumerateArray()
+                .Where(x => x.ValueKind == JsonValueKind.String)
+                .Select(x => x.GetString()!)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct(StringComparer.Ordinal);
+}

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -92,7 +92,8 @@ public sealed class RoslynTranslator
         IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
         int minChunkBytes = Emitter.DefaultMinChunkBytes,
         int maxChunkBytes = Emitter.DefaultMaxChunkBytes,
-        bool alsoEmitBundle = false)
+        bool alsoEmitBundle = false,
+        ChunkOracle? chunkOracle = null)
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -232,7 +233,7 @@ public sealed class RoslynTranslator
                 CompileProgress.Report("emitting JavaScript modules");
                 moduleOutput = PhaseTimings.Measure("emit JavaScript (modules)",
                     () => emitter.EmitModules(chunkDirectory, externalChunks, packageModules, externalSkipClusterDeps,
-                                              minChunkBytes, maxChunkBytes));
+                                              minChunkBytes, maxChunkBytes, chunkOracle));
                 js = moduleOutput.EntryJs;
             }
 

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -91,7 +91,8 @@ public sealed class RoslynTranslator
         bool packageModules = false,
         IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
         int minChunkBytes = Emitter.DefaultMinChunkBytes,
-        int maxChunkBytes = Emitter.DefaultMaxChunkBytes)
+        int maxChunkBytes = Emitter.DefaultMaxChunkBytes,
+        bool alsoEmitBundle = false)
     {
         CompileProgress.Report("parsing sources + resolving references");
         var compilation = PhaseTimings.Measure("build compilation (parse + references)", () =>
@@ -216,12 +217,13 @@ public sealed class RoslynTranslator
         TranslationException? emitterFailure = null;
         try
         {
-            var emitter = new Emitter(compilation, assemblyName, models, incremental)
+            Emitter NewEmitter() => new Emitter(compilation, assemblyName, models, incremental)
             {
                 ReflectionEnabled = reflectionEnabled,
                 MetadataTarget = metadataTarget,
                 AssemblyVersion = string.IsNullOrWhiteSpace(assemblyVersion) ? "1.0.0.0" : assemblyVersion!,
             };
+            var emitter = NewEmitter();
             if (emitModules)
             {
                 // Module mode carries its reflection metadata inside the entry module (it has to be
@@ -233,11 +235,19 @@ public sealed class RoslynTranslator
                                               minChunkBytes, maxChunkBytes));
                 js = moduleOutput.EntryJs;
             }
-            else
+
+            // A package ships every variant a consumer might ask for, so it emits the single bundle
+            // ALONGSIDE the chunks: whoever references it decides, at their own build time, whether
+            // they want one readable file or on-demand modules, and neither answer should require
+            // rebuilding the library. The second pass is a second walk of an already-bound
+            // compilation — the expensive half (parse, references, Roslyn's own emit) is shared — and
+            // it runs on its own Emitter because EmitModules leaves per-run state behind.
+            if (!emitModules || alsoEmitBundle)
             {
                 CompileProgress.Report("emitting JavaScript");
-                js = PhaseTimings.Measure("emit JavaScript", () => emitter.Emit());
-                metadataJs = emitter.MetadataScript;
+                var bundleEmitter = emitModules ? NewEmitter() : emitter;
+                js = PhaseTimings.Measure("emit JavaScript", () => bundleEmitter.Emit());
+                metadataJs = bundleEmitter.MetadataScript;
             }
         }
         catch (TranslationException ex)
@@ -286,6 +296,7 @@ public sealed class RoslynTranslator
         {
             DeclarationHashes = declarationHashes,
             Modules = moduleOutput,
+            HasBundle = !emitModules || alsoEmitBundle,
         };
     }
 

--- a/Transpose/Transpose.Translator/Emit/Emitter.ModuleChunks.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.ModuleChunks.cs
@@ -83,6 +83,9 @@ public sealed partial class Emitter
     /// <param name="eager">Chunks the entry module imports. Never merged with the rest.</param>
     /// <param name="order">The emitter's dependency-depth ordering, which decides the order of types
     /// inside a merged chunk — it already guarantees a type's bases are defined before it.</param>
+    /// <param name="oracleBits">Per chunk, the <c>tps.chunks.json</c> groups it belongs to, already
+    /// propagated down the dependency edges. Null when there is no oracle. See
+    /// <see cref="OracleBits"/> for what it means and why it is safe to fold into the signature.</param>
     private static ChunkGraph Coalesce(
         ChunkGraph chunks,
         IReadOnlyList<int> sizes,
@@ -90,7 +93,8 @@ public sealed partial class Emitter
         Dictionary<INamedTypeSymbol, int> order,
         int minBytes,
         int maxBytes,
-        out HashSet<int> coalescedEager)
+        out HashSet<int> coalescedEager,
+        ulong[][]? oracleBits = null)
     {
         coalescedEager = eager;
         var n = chunks.Members.Count;
@@ -122,11 +126,21 @@ public sealed partial class Emitter
         // sweep is a complete propagation: when i is read, every chunk that could contribute to it
         // has already been read.
         var words = Math.Max(1, (rootCount + 63) / 64);
+        // A measured oracle contributes extra bits of the same kind: "the running application
+        // fetched this chunk on screen X" is a load condition exactly like "root R reaches it", and
+        // OracleBits has already propagated it down the dependency edges so the sig(d) ⊇ sig(i)
+        // property the whole pass rests on still holds. Appending them therefore only *refines* the
+        // partition — it can split a signature class, never merge two — so the acyclicity argument in
+        // the type remarks carries over unchanged.
+        var oracleWords = oracleBits is null ? 0 : oracleBits[0].Length;
+        var total = words + oracleWords;
         var sig = new ulong[n][];
         for (var i = 0; i < n; i++)
         {
-            sig[i] = new ulong[words];
+            sig[i] = new ulong[total];
             if (rootId[i] >= 0) sig[i][rootId[i] >> 6] |= 1UL << (rootId[i] & 63);
+            if (oracleBits is not null)
+                Array.Copy(oracleBits[i], 0, sig[i], words, oracleWords);
         }
         for (var i = n - 1; i >= 0; i--)
             foreach (var d in chunks.Deps[i])
@@ -233,6 +247,60 @@ public sealed partial class Emitter
 
         coalescedEager = new HashSet<int>(Enumerable.Range(0, eagerBuckets));
         return new ChunkGraph(members, deps, indexOf);
+    }
+
+    /// <summary>
+    /// Turns a <c>tps.chunks.json</c> oracle into one bit per group per chunk: bit <c>g</c> is set on
+    /// chunk <c>i</c> when the application, at capture step <c>g</c>, had a type of <c>i</c> loaded.
+    ///
+    /// The bits are then propagated <b>down the dependency edges</b> — if step <c>g</c> loaded chunk
+    /// <c>i</c>, it necessarily also loaded everything <c>i</c> imports — which is both true of the
+    /// run being described and the property <see cref="Coalesce"/> needs: its acyclicity argument
+    /// rests on <c>sig(d) ⊇ sig(i)</c> for every edge <c>i → d</c>, and a bit set on <c>i</c> but not
+    /// on its dependency would break exactly that.
+    ///
+    /// Names that match no emitted type are skipped: a checked-in capture goes stale as the code
+    /// moves, and a renamed type must cost the oracle one hint, not the build.
+    /// Null when there is no oracle to apply, so nothing is allocated on the normal path.
+    /// </summary>
+    private ulong[][]? OracleBits(ChunkGraph chunks, ChunkOracle? oracle)
+    {
+        if (oracle is null || oracle.IsEmpty) return null;
+
+        var n = chunks.Members.Count;
+        var groups = oracle.Groups;
+        var words = (groups.Count + 63) / 64;
+
+        // Emitted define name → chunk. The name is what a capture can see (it is what the chunk map
+        // and the runtime registry are keyed by), so it is what the file records.
+        var chunkOfName = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < n; i++)
+            foreach (var t in chunks.Members[i])
+            {
+                var name = DefineName(t);
+                if (!string.IsNullOrEmpty(name)) chunkOfName[name] = i;
+            }
+
+        var bits = new ulong[n][];
+        for (var i = 0; i < n; i++) bits[i] = new ulong[words];
+
+        var matched = 0;
+        for (var g = 0; g < groups.Count; g++)
+            foreach (var name in groups[g].Types)
+                if (chunkOfName.TryGetValue(name, out var i))
+                {
+                    bits[i][g >> 6] |= 1UL << (g & 63);
+                    matched++;
+                }
+
+        if (matched == 0) return null;
+
+        // Deps always have a lower index, so one descending sweep is a complete propagation.
+        for (var i = n - 1; i >= 0; i--)
+            foreach (var d in chunks.Deps[i])
+                for (var w = 0; w < words; w++) bits[d][w] |= bits[i][w];
+
+        return bits;
     }
 
     /// <summary>

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -67,13 +67,17 @@ public sealed partial class Emitter
     /// merged with whatever loads alongside it (see Emitter.ModuleChunks.cs). 0 emits one chunk per
     /// SCC, which is what the first pass produces on its own.</param>
     /// <param name="maxChunkBytes">The ceiling a merged chunk is kept under.</param>
+    /// <param name="oracle">Measured co-load groups from <c>tps.chunks.json</c> — what a run of the
+    /// real application actually fetched together. Refines the chunker's static guess; see
+    /// <see cref="ChunkOracle"/>.</param>
     public ModuleOutput EmitModules(
         string chunkDirectory = "chunks",
         IReadOnlyDictionary<string, string>? externalChunks = null,
         bool packageMode = false,
         IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
         int minChunkBytes = DefaultMinChunkBytes,
-        int maxChunkBytes = DefaultMaxChunkBytes)
+        int maxChunkBytes = DefaultMaxChunkBytes,
+        ChunkOracle? oracle = null)
     {
         _externalSkipClusterDeps = externalSkipClusterDeps;
         // Reflection metadata is emitted once for the whole assembly, outside the per-type walk, so
@@ -153,6 +157,18 @@ public sealed partial class Emitter
         if (canDefer)
             roots.AddRange(types.Where(t => TransposeNaming.HasAttr(t, TransposeNaming.NeverDeferAttr)));
 
+        // A capture can also record what the application needed before it was usable at all. That is
+        // the one thing a *package* cannot work out for itself — it has no entry point to be lazy
+        // relative to, so it defers everything and its consumer pays for the start-up set in extra
+        // round trips. An "eager" group in tps.chunks.json is that missing information.
+        if (canDefer && oracle is { IsEmpty: false })
+        {
+            var eagerNames = new HashSet<string>(
+                oracle.Groups.Where(g => g.Eager).SelectMany(g => g.Types), StringComparer.Ordinal);
+            if (eagerNames.Count > 0)
+                roots.AddRange(types.Where(t => eagerNames.Contains(DefineName(t))));
+        }
+
         var eager = new HashSet<int>();
         if (canDefer)
         {
@@ -180,9 +196,11 @@ public sealed partial class Emitter
             for (var i = 0; i < chunks.Members.Count; i++)
                 foreach (var t in chunks.Members[i]) sizes[i] += bodies[t].Length + 1;
 
+            var oracleBits = OracleBits(chunks, oracle);
+
             chunks = PhaseTimings.Measure("  ├ coalesce chunks (co-load signature)", () =>
             {
-                var merged = Coalesce(chunks, sizes, eager, order, minChunkBytes, maxChunkBytes, out var mergedEager);
+                var merged = Coalesce(chunks, sizes, eager, order, minChunkBytes, maxChunkBytes, out var mergedEager, oracleBits);
                 eager = mergedEager;
                 return merged;
             });

--- a/Transpose/Transpose.Translator/Emit/Emitter.SkipClustering.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.SkipClustering.cs
@@ -8,7 +8,7 @@ namespace Transpose.Translator;
 /// <summary>
 /// <c>[SkipTypeClustering]</c> — keeping a static facade out of the chunker's reference graph.
 ///
-/// A chunk is a strongly-connected component of the graph <c>TypeRef</c> records, so a type whose
+/// A chunk is a strongly-connected component of the reference graph, so a type whose
 /// members construct half the library fuses that half into one chunk: the facade reaches every
 /// component and every component reaches the facade, and the cycle makes them a single unit. That is
 /// exactly what Tesserae's <c>UI</c> class did — 300 static factories, and every component calling
@@ -24,6 +24,22 @@ namespace Transpose.Translator;
 ///
 /// The facade still becomes a chunk and its callers still import it; only the direction of the
 /// component edges changes.
+///
+/// Two things the naive form of that move gets wrong, both of which fail at runtime with
+/// "<c>… lives in module './chunks/…', which has not been loaded</c>" rather than at build time:
+///
+/// <list type="number">
+/// <item><b>A call to a sibling on the same facade.</b> The sibling's containing type IS the facade,
+/// which is exactly the edge being dropped — so member <c>A</c> calling <c>B</c> contributed only
+/// <c>B</c>'s return type, never the types <c>B</c>'s own body constructs. Nothing then imported
+/// them: the facade's chunk doesn't (its edges are dropped) and <c>A</c>'s callers didn't know to.
+/// <see cref="BuildSkipClusterDeps"/> therefore takes a <b>transitive closure over the facade's own
+/// members</b> before attributing anything to a call site, so <c>deps(A) ⊇ deps(B)</c>.</item>
+/// <item><b>Eager static state.</b> A static field initializer or a static constructor runs when the
+/// facade's own chunk evaluates, not when someone calls into it — there is no call site to move that
+/// edge to. <see cref="ClusterRefsFor"/> therefore keeps exactly those members' dependencies on the
+/// facade itself, and drops only the ones that genuinely wait for a call.</item>
+/// </list>
 /// </summary>
 public sealed partial class Emitter
 {
@@ -31,48 +47,150 @@ public sealed partial class Emitter
     /// compilation, built once before the parallel emit and only read during it.</summary>
     private IReadOnlyDictionary<ISymbol, HashSet<INamedTypeSymbol>>? _skipClusterDeps;
 
+    /// <summary>For each <c>[SkipTypeClustering]</c> facade, the dependencies that must exist when
+    /// the facade's own chunk evaluates: everything reached from a static field/property initializer
+    /// or a static constructor, closed over sibling calls. <see cref="ClusterRefsFor"/> hands these
+    /// back to the graph instead of dropping them.</summary>
+    private IReadOnlyDictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>? _skipClusterEagerDeps;
+
     internal static bool IsSkipClustered(INamedTypeSymbol? type) =>
         type is not null && TransposeNaming.HasAttr(type, TransposeNaming.SkipTypeClusteringAttr);
 
     /// <summary>
     /// Maps each member of each <c>[SkipTypeClustering]</c> type to the source types its body
-    /// reaches. Deliberately a syntax walk over the member rather than a trial emission: it only has
-    /// to be a superset of what the body will touch, and over-approximating costs a slightly larger
-    /// import list, never a missing one.
+    /// reaches, <b>including everything reached through the siblings it calls</b>. Deliberately a
+    /// syntax walk over the member rather than a trial emission: it only has to be a superset of what
+    /// the body will touch, and over-approximating costs a slightly larger import list, never a
+    /// missing one.
+    ///
+    /// The sibling closure is the load-bearing half. A facade is written as a facade — members call
+    /// each other constantly (<c>UI.Card</c> building on <c>UI.Div</c>, a route table calling the
+    /// method that constructs the view) — and a reference to a sibling names only the facade, the one
+    /// type this pass is removing from every set. Without the closure, a caller of <c>A</c> imports
+    /// the facade's chunk and nothing else, while the type <c>B</c> constructs is left to a chunk no
+    /// module imports.
     /// </summary>
     private Dictionary<ISymbol, HashSet<INamedTypeSymbol>> BuildSkipClusterDeps(
         IReadOnlyList<INamedTypeSymbol> types)
     {
         var result = new Dictionary<ISymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+        var eager = new Dictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
 
         foreach (var type in types)
         {
             if (!IsSkipClustered(type)) continue;
 
-            foreach (var member in type.GetMembers())
-            {
-                if (member is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)) continue;
+            // Pass 1 — each member's own syntax: the types it names directly, and the siblings on
+            // this same facade it reaches (whose dependencies are transitively its own).
+            var members = new List<ISymbol>();
+            var siblingCalls = new Dictionary<ISymbol, HashSet<ISymbol>>(SymbolEqualityComparer.Default);
+            var deps = new Dictionary<ISymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
 
-                var deps = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-                foreach (var syntaxRef in member.DeclaringSyntaxReferences)
+            foreach (var raw in type.GetMembers())
+            {
+                if (raw is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)) continue;
+                var member = MemberKey(raw);
+                if (deps.ContainsKey(member)) continue;
+
+                var own = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+                var calls = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+                foreach (var syntaxRef in raw.DeclaringSyntaxReferences)
                 {
                     var node = syntaxRef.GetSyntax();
                     foreach (var descendant in node.DescendantNodesAndSelf())
                     {
-                        Add(deps, _model.GetTypeInfo(descendant).Type);
+                        Add(own, _model.GetTypeInfo(descendant).Type);
                         var symbol = _model.GetSymbolInfo(descendant).Symbol;
                         // The *declaring* type of whatever is called or read: `new Card(...)`,
                         // `Card.Something`, an extension method's own class.
-                        Add(deps, symbol?.ContainingType);
-                        if (symbol is IMethodSymbol m) Add(deps, m.ReturnType);
+                        Add(own, symbol?.ContainingType);
+                        if (symbol is IMethodSymbol m) Add(own, m.ReturnType);
+
+                        // …unless that declaring type is this very facade, in which case the edge
+                        // being followed is a sibling call and the dependency is the sibling's set.
+                        if (symbol is (IMethodSymbol or IPropertySymbol or IFieldSymbol)
+                            && SymbolEqualityComparer.Default.Equals(symbol.ContainingType?.OriginalDefinition, type))
+                        {
+                            var sibling = MemberKey(symbol);
+                            if (!SymbolEqualityComparer.Default.Equals(sibling, member)) calls.Add(sibling);
+                        }
                     }
                 }
-                deps.Remove(type);
-                if (deps.Count > 0) result[member] = deps;
+
+                own.Remove(type);
+                members.Add(member);
+                deps[member] = own;
+                siblingCalls[member] = calls;
             }
+
+            // Pass 2 — transitive closure over the sibling graph. A facade's members freely form
+            // cycles (A calls B, B calls A), so this is a plain worklist fixpoint rather than a
+            // topological walk: a member is re-queued whenever one of its callees grows, and the sets
+            // only ever grow within a finite universe, so it terminates.
+            var callers = new Dictionary<ISymbol, List<ISymbol>>(SymbolEqualityComparer.Default);
+            foreach (var member in members)
+            {
+                foreach (var callee in siblingCalls[member])
+                {
+                    if (!deps.ContainsKey(callee)) continue;
+                    if (!callers.TryGetValue(callee, out var waiting)) callers[callee] = waiting = new List<ISymbol>();
+                    waiting.Add(member);
+                }
+            }
+
+            var queue = new Queue<ISymbol>(members);
+            var queued = new HashSet<ISymbol>(members, SymbolEqualityComparer.Default);
+            while (queue.Count > 0)
+            {
+                var member = queue.Dequeue();
+                queued.Remove(member);
+
+                var set = deps[member];
+                var grew = false;
+                foreach (var callee in siblingCalls[member])
+                    if (deps.TryGetValue(callee, out var calleeDeps))
+                        foreach (var dep in calleeDeps) grew |= set.Add(dep);
+
+                if (!grew || !callers.TryGetValue(member, out var waiting)) continue;
+                foreach (var caller in waiting)
+                    if (queued.Add(caller)) queue.Enqueue(caller);
+            }
+
+            foreach (var member in members)
+                if (deps[member].Count > 0) result[member] = deps[member];
+
+            // Whatever the facade's own definition needs before anyone calls into it. A static
+            // initializer has no call site, so its edges stay where the graph can see them.
+            var eagerDeps = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            foreach (var member in members)
+                if (RunsAtTypeDefinition(member)) eagerDeps.UnionWith(deps[member]);
+            if (eagerDeps.Count > 0) eager[type] = eagerDeps;
         }
+
+        _skipClusterEagerDeps = eager;
         return result;
     }
+
+    /// <summary>The symbol a member is keyed by, matching what <see cref="RecordSkipClusterCall"/>
+    /// looks up at a call site: the original (unconstructed) definition.</summary>
+    private static ISymbol MemberKey(ISymbol member) => member.OriginalDefinition;
+
+    /// <summary>
+    /// Whether this member's dependencies are needed the moment the facade's type is defined, rather
+    /// than when something calls it: a static constructor, or a static field/property with an
+    /// initializer. Those run as part of the define, so there is no call site to move their edges to
+    /// and <see cref="ClusterRefsFor"/> keeps them on the facade.
+    /// </summary>
+    private static bool RunsAtTypeDefinition(ISymbol member) => member switch
+    {
+        IMethodSymbol { MethodKind: MethodKind.StaticConstructor } => true,
+        IFieldSymbol { IsStatic: true } f => f.DeclaringSyntaxReferences
+            .Any(r => r.GetSyntax() is VariableDeclaratorSyntax { Initializer: not null }),
+        IPropertySymbol { IsStatic: true } p => p.DeclaringSyntaxReferences
+            .Any(r => r.GetSyntax() is PropertyDeclarationSyntax { Initializer: not null }),
+        _ => false,
+    };
 
     private static void Add(HashSet<INamedTypeSymbol> into, ITypeSymbol? type)
     {
@@ -98,7 +216,7 @@ public sealed partial class Emitter
     private void RecordSkipClusterCall(ISymbol? member)
     {
         if (member is null || !IsSkipClustered(member.ContainingType)) return;
-        var key = member is IMethodSymbol { OriginalDefinition: { } original } ? original : member;
+        var key = MemberKey(member);
 
         // The facade is in this compilation: its member deps were computed from source.
         if (_recordedRefs is not null && _skipClusterDeps is not null
@@ -120,12 +238,19 @@ public sealed partial class Emitter
     /// module-mode package that has a <c>[SkipTypeClustering]</c> facade.</summary>
     private IReadOnlyDictionary<string, List<string>>? _externalSkipClusterDeps;
 
-    /// <summary>The reference set a type contributes to the graph. A skipped type contributes
-    /// nothing: its members' dependencies were attributed to the callers instead, and keeping them
-    /// here as well would re-form the very cycle the attribute exists to break.</summary>
-    private static HashSet<INamedTypeSymbol> ClusterRefsFor(
-        INamedTypeSymbol type, HashSet<INamedTypeSymbol> recorded) =>
-        IsSkipClustered(type) ? new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default) : recorded;
+    /// <summary>The reference set a type contributes to the graph. A skipped type contributes only
+    /// what its own definition needs — static initializers and a static constructor, which run
+    /// without anyone calling in. Everything else was attributed to the callers instead, and keeping
+    /// it here as well would re-form the very cycle the attribute exists to break.</summary>
+    private HashSet<INamedTypeSymbol> ClusterRefsFor(
+        INamedTypeSymbol type, HashSet<INamedTypeSymbol> recorded)
+    {
+        if (!IsSkipClustered(type)) return recorded;
+        var kept = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        if (_skipClusterEagerDeps is not null && _skipClusterEagerDeps.TryGetValue(type, out var eager))
+            kept.UnionWith(eager);
+        return kept;
+    }
 }
 
 public sealed partial class Emitter

--- a/Transpose/Transpose.Translator/Emit/Emitter.SkipClustering.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.SkipClustering.cs
@@ -29,16 +29,23 @@ namespace Transpose.Translator;
 /// "<c>… lives in module './chunks/…', which has not been loaded</c>" rather than at build time:
 ///
 /// <list type="number">
-/// <item><b>A call to a sibling on the same facade.</b> The sibling's containing type IS the facade,
-/// which is exactly the edge being dropped — so member <c>A</c> calling <c>B</c> contributed only
-/// <c>B</c>'s return type, never the types <c>B</c>'s own body constructs. Nothing then imported
-/// them: the facade's chunk doesn't (its edges are dropped) and <c>A</c>'s callers didn't know to.
-/// <see cref="BuildSkipClusterDeps"/> therefore takes a <b>transitive closure over the facade's own
-/// members</b> before attributing anything to a call site, so <c>deps(A) ⊇ deps(B)</c>.</item>
-/// <item><b>Eager static state.</b> A static field initializer or a static constructor runs when the
-/// facade's own chunk evaluates, not when someone calls into it — there is no call site to move that
-/// edge to. <see cref="ClusterRefsFor"/> therefore keeps exactly those members' dependencies on the
-/// facade itself, and drops only the ones that genuinely wait for a call.</item>
+/// <item><b>A call to another skipped member</b> — a sibling on the same facade, or a member of a
+/// second facade. Either way the callee's containing type is one whose edges are being dropped, so
+/// member <c>A</c> calling <c>B</c> contributed only <c>B</c>'s return type, never the types
+/// <c>B</c>'s own body constructs. Nothing then imported them: <c>B</c>'s chunk doesn't (its edges
+/// are dropped), and <c>A</c>'s callers didn't know to. <see cref="BuildSkipClusterDeps"/> therefore
+/// takes a <b>transitive closure over every skipped member</b> before attributing anything to a call
+/// site, so <c>deps(A) ⊇ deps(B)</c>. Both halves were found by running it: the sibling case killed
+/// <c>#/home</c>, and the cross-facade case killed <c>App.Sidenav.Initialize</c> once <c>App</c> and
+/// <c>AppSidenav</c> were both attributed.</item>
+/// <item><b>Static state.</b> A static field initializer and a static constructor do not run with the
+/// member that happens to be called, so following sibling calls alone misses them. They are not
+/// needed when the facade's chunk <em>evaluates</em> either: the runtime hangs <c>$staticInit</c> off
+/// the getter of the type's global slot (<c>Class.js</c>), so it fires the first time anything reads
+/// the class — which is a call site like any other. So those dependencies are folded into
+/// <b>every</b> member's set, and reach whoever touches the facade first. Keeping them on the facade
+/// instead would be sound and would rebuild the very cycle the attribute exists to break: the app
+/// shell's static tables alone re-fused 170 types into one chunk.</item>
 /// </list>
 /// </summary>
 public sealed partial class Emitter
@@ -46,12 +53,6 @@ public sealed partial class Emitter
     /// <summary>Per-member dependency sets for every <c>[SkipTypeClustering]</c> type in this
     /// compilation, built once before the parallel emit and only read during it.</summary>
     private IReadOnlyDictionary<ISymbol, HashSet<INamedTypeSymbol>>? _skipClusterDeps;
-
-    /// <summary>For each <c>[SkipTypeClustering]</c> facade, the dependencies that must exist when
-    /// the facade's own chunk evaluates: everything reached from a static field/property initializer
-    /// or a static constructor, closed over sibling calls. <see cref="ClusterRefsFor"/> hands these
-    /// back to the graph instead of dropping them.</summary>
-    private IReadOnlyDictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>? _skipClusterEagerDeps;
 
     internal static bool IsSkipClustered(INamedTypeSymbol? type) =>
         type is not null && TransposeNaming.HasAttr(type, TransposeNaming.SkipTypeClusteringAttr);
@@ -73,19 +74,21 @@ public sealed partial class Emitter
     private Dictionary<ISymbol, HashSet<INamedTypeSymbol>> BuildSkipClusterDeps(
         IReadOnlyList<INamedTypeSymbol> types)
     {
+        var facades = types.Where(IsSkipClustered).ToList();
         var result = new Dictionary<ISymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
-        var eager = new Dictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+        if (facades.Count == 0) return result;
 
-        foreach (var type in types)
+        // Pass 1 — each member's own syntax: the types it names directly, and the skipped members it
+        // calls (whose dependencies are transitively its own). "Skipped member" spans every facade,
+        // not just this one: a call from one facade into another loses the callee's dependencies the
+        // same way a sibling call does, because both callees' edges are being dropped.
+        var members = new List<ISymbol>();
+        var owner = new Dictionary<ISymbol, INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var skippedCalls = new Dictionary<ISymbol, HashSet<ISymbol>>(SymbolEqualityComparer.Default);
+        var deps = new Dictionary<ISymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+
+        foreach (var type in facades)
         {
-            if (!IsSkipClustered(type)) continue;
-
-            // Pass 1 — each member's own syntax: the types it names directly, and the siblings on
-            // this same facade it reaches (whose dependencies are transitively its own).
-            var members = new List<ISymbol>();
-            var siblingCalls = new Dictionary<ISymbol, HashSet<ISymbol>>(SymbolEqualityComparer.Default);
-            var deps = new Dictionary<ISymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
-
             foreach (var raw in type.GetMembers())
             {
                 if (raw is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)) continue;
@@ -107,68 +110,77 @@ public sealed partial class Emitter
                         Add(own, symbol?.ContainingType);
                         if (symbol is IMethodSymbol m) Add(own, m.ReturnType);
 
-                        // …unless that declaring type is this very facade, in which case the edge
-                        // being followed is a sibling call and the dependency is the sibling's set.
+                        // …and when that declaring type is a facade, the call also inherits whatever
+                        // the callee's body reaches — nothing else is going to import it.
                         if (symbol is (IMethodSymbol or IPropertySymbol or IFieldSymbol)
-                            && SymbolEqualityComparer.Default.Equals(symbol.ContainingType?.OriginalDefinition, type))
+                            && IsSkipClustered(symbol.ContainingType?.OriginalDefinition))
                         {
-                            var sibling = MemberKey(symbol);
-                            if (!SymbolEqualityComparer.Default.Equals(sibling, member)) calls.Add(sibling);
+                            var callee = MemberKey(symbol);
+                            if (!SymbolEqualityComparer.Default.Equals(callee, member)) calls.Add(callee);
                         }
                     }
                 }
 
                 own.Remove(type);
                 members.Add(member);
+                owner[member] = type;
                 deps[member] = own;
-                siblingCalls[member] = calls;
+                skippedCalls[member] = calls;
             }
-
-            // Pass 2 — transitive closure over the sibling graph. A facade's members freely form
-            // cycles (A calls B, B calls A), so this is a plain worklist fixpoint rather than a
-            // topological walk: a member is re-queued whenever one of its callees grows, and the sets
-            // only ever grow within a finite universe, so it terminates.
-            var callers = new Dictionary<ISymbol, List<ISymbol>>(SymbolEqualityComparer.Default);
-            foreach (var member in members)
-            {
-                foreach (var callee in siblingCalls[member])
-                {
-                    if (!deps.ContainsKey(callee)) continue;
-                    if (!callers.TryGetValue(callee, out var waiting)) callers[callee] = waiting = new List<ISymbol>();
-                    waiting.Add(member);
-                }
-            }
-
-            var queue = new Queue<ISymbol>(members);
-            var queued = new HashSet<ISymbol>(members, SymbolEqualityComparer.Default);
-            while (queue.Count > 0)
-            {
-                var member = queue.Dequeue();
-                queued.Remove(member);
-
-                var set = deps[member];
-                var grew = false;
-                foreach (var callee in siblingCalls[member])
-                    if (deps.TryGetValue(callee, out var calleeDeps))
-                        foreach (var dep in calleeDeps) grew |= set.Add(dep);
-
-                if (!grew || !callers.TryGetValue(member, out var waiting)) continue;
-                foreach (var caller in waiting)
-                    if (queued.Add(caller)) queue.Enqueue(caller);
-            }
-
-            foreach (var member in members)
-                if (deps[member].Count > 0) result[member] = deps[member];
-
-            // Whatever the facade's own definition needs before anyone calls into it. A static
-            // initializer has no call site, so its edges stay where the graph can see them.
-            var eagerDeps = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-            foreach (var member in members)
-                if (RunsAtTypeDefinition(member)) eagerDeps.UnionWith(deps[member]);
-            if (eagerDeps.Count > 0) eager[type] = eagerDeps;
         }
 
-        _skipClusterEagerDeps = eager;
+        // Pass 2 — transitive closure over the call graph among skipped members. They freely form
+        // cycles (A calls B, B calls A), so this is a plain worklist fixpoint rather than a
+        // topological walk: a member is re-queued whenever one of its callees grows, and the sets
+        // only ever grow within a finite universe, so it terminates.
+        var callers = new Dictionary<ISymbol, List<ISymbol>>(SymbolEqualityComparer.Default);
+        foreach (var member in members)
+        {
+            foreach (var callee in skippedCalls[member])
+            {
+                if (!deps.ContainsKey(callee)) continue;
+                if (!callers.TryGetValue(callee, out var waiting)) callers[callee] = waiting = new List<ISymbol>();
+                waiting.Add(member);
+            }
+        }
+
+        var queue = new Queue<ISymbol>(members);
+        var queued = new HashSet<ISymbol>(members, SymbolEqualityComparer.Default);
+        while (queue.Count > 0)
+        {
+            var member = queue.Dequeue();
+            queued.Remove(member);
+
+            var set = deps[member];
+            var grew = false;
+            foreach (var callee in skippedCalls[member])
+                if (deps.TryGetValue(callee, out var calleeDeps))
+                    foreach (var dep in calleeDeps) grew |= set.Add(dep);
+
+            if (!grew || !callers.TryGetValue(member, out var waiting)) continue;
+            foreach (var caller in waiting)
+                if (queued.Add(caller)) queue.Enqueue(caller);
+        }
+
+        // Pass 3 — the static state, per facade. It runs on the first *read* of the type's global
+        // slot rather than with any particular member, so it belongs to every way into that facade.
+        var onFirstTouch = new Dictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+        foreach (var member in members)
+        {
+            if (!RunsOnFirstTouch(member)) continue;
+            var type = owner[member];
+            if (!onFirstTouch.TryGetValue(type, out var set))
+                onFirstTouch[type] = set = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            set.UnionWith(deps[member]);
+        }
+
+        foreach (var member in members)
+        {
+            var set = deps[member];
+            if (onFirstTouch.TryGetValue(owner[member], out var touch)) set.UnionWith(touch);
+            if (set.Count > 0) result[member] = set;
+        }
+
         return result;
     }
 
@@ -177,12 +189,13 @@ public sealed partial class Emitter
     private static ISymbol MemberKey(ISymbol member) => member.OriginalDefinition;
 
     /// <summary>
-    /// Whether this member's dependencies are needed the moment the facade's type is defined, rather
-    /// than when something calls it: a static constructor, or a static field/property with an
-    /// initializer. Those run as part of the define, so there is no call site to move their edges to
-    /// and <see cref="ClusterRefsFor"/> keeps them on the facade.
+    /// Whether this member runs on the first *touch* of the facade rather than with a call to it: a
+    /// static constructor, or a static field/property with an initializer. The runtime hangs
+    /// <c>$staticInit</c> off the getter of the type's global slot, so reading the class at all runs
+    /// the lot — which means these dependencies belong to every member's set rather than to any one
+    /// of them.
     /// </summary>
-    private static bool RunsAtTypeDefinition(ISymbol member) => member switch
+    private static bool RunsOnFirstTouch(ISymbol member) => member switch
     {
         IMethodSymbol { MethodKind: MethodKind.StaticConstructor } => true,
         IFieldSymbol { IsStatic: true } f => f.DeclaringSyntaxReferences
@@ -238,19 +251,13 @@ public sealed partial class Emitter
     /// module-mode package that has a <c>[SkipTypeClustering]</c> facade.</summary>
     private IReadOnlyDictionary<string, List<string>>? _externalSkipClusterDeps;
 
-    /// <summary>The reference set a type contributes to the graph. A skipped type contributes only
-    /// what its own definition needs — static initializers and a static constructor, which run
-    /// without anyone calling in. Everything else was attributed to the callers instead, and keeping
-    /// it here as well would re-form the very cycle the attribute exists to break.</summary>
-    private HashSet<INamedTypeSymbol> ClusterRefsFor(
-        INamedTypeSymbol type, HashSet<INamedTypeSymbol> recorded)
-    {
-        if (!IsSkipClustered(type)) return recorded;
-        var kept = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        if (_skipClusterEagerDeps is not null && _skipClusterEagerDeps.TryGetValue(type, out var eager))
-            kept.UnionWith(eager);
-        return kept;
-    }
+    /// <summary>The reference set a type contributes to the graph. A skipped type contributes
+    /// nothing: every one of its dependencies — including the ones its static state needs — was
+    /// attributed to the callers instead, and keeping any of them here would re-form the very cycle
+    /// the attribute exists to break.</summary>
+    private static HashSet<INamedTypeSymbol> ClusterRefsFor(
+        INamedTypeSymbol type, HashSet<INamedTypeSymbol> recorded) =>
+        IsSkipClustered(type) ? new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default) : recorded;
 }
 
 public sealed partial class Emitter

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -255,7 +255,6 @@ public sealed partial class Emitter
         {
             // Built once before the parallel emit and read-only during it (see Emitter.SkipClustering.cs).
             _skipClusterDeps = _skipClusterDeps,
-            _skipClusterEagerDeps = _skipClusterEagerDeps,
             _externalSkipClusterDeps = _externalSkipClusterDeps,
             // Same: the assembly's own [assembly: ConstructsTypeArguments(typeof(X))] list, computed
             // on the parent here so it is scanned once rather than once per emitted type.

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -255,6 +255,7 @@ public sealed partial class Emitter
         {
             // Built once before the parallel emit and read-only during it (see Emitter.SkipClustering.cs).
             _skipClusterDeps = _skipClusterDeps,
+            _skipClusterEagerDeps = _skipClusterEagerDeps,
             _externalSkipClusterDeps = _externalSkipClusterDeps,
             // Same: the assembly's own [assembly: ConstructsTypeArguments(typeof(X))] list, computed
             // on the parent here so it is scanned once rather than once per emitted type.


### PR DESCRIPTION
## Summary

Removes the `outputFormatting` tps.json setting and replaces it with a build-driven `JsOutputProfile` that derives the JavaScript output shape entirely from the build configuration and target (Debug/Release/Package), not from project configuration. This prevents projects from making decisions that should belong to their consumers.

## Key Changes

- **New `JsOutputProfile` enum** (`JsOutputProfile.cs`): Replaces `JsOutputFormatting`. Profiles are:
  - **Debug**: Always one formatted bundle, never chunked (for debuggability)
  - **Release**: One minified bundle, or chunked modules if `outputBy: "Module"` is set
  - **Package**: Ships all three variants (formatted, minified, and modules) so consumers choose

- **Package variant routing** (`OutputBuilder.cs`): 
  - Packages now embed all three JS variants tagged with `JsVariant` (Formatted/Minified/ModuleEntry/ModuleChunk)
  - New `RouteTaggedPackageJs()` method selects the variant matching the consuming site's profile
  - Fallback to classic bundle pairing for packages without variant tags (backward compatibility)

- **Resource group variant switching** (`OutputBuilder.cs`):
  - Authored resource groups (CSS/JS) now participate in the formatted/minified switch only when both variants are declared
  - Single-variant resources (e.g., `d3.min.js`, Monaco's `editor.main.js`) are always extracted under their authored name

- **`ChunkOracle` support** (`ChunkOracle.cs`, new):
  - Reads `tps.chunks.json` — measured co-load groups from running applications
  - Feeds back into the chunker to refine static analysis (types fetched together stay together)
  - Parsing never fails; malformed files yield `Empty` rather than breaking the build

- **`SkipTypeClustering` improvements** (`Emitter.SkipClustering.cs`):
  - Now computes transitive closure over sibling calls on the same facade
  - Includes static field initializers and constructors in every member's dependency set
  - Fixes runtime errors where called siblings' types were not imported

- **Module chunking refinements** (`Emitter.ModuleChunks.cs`):
  - Coalescer now accepts oracle bits to refine chunk boundaries
  - `NoChunkCoalescing` build option for measurement builds (one chunk per SCC)

- **Removed from tps.json**:
  - `outputFormatting` setting (was Formatted/Minified/Both)
  - Configuration-specific overlays no longer used to flip this setting

## Implementation Details

- The profile is computed once per build in `OutputBuilder.Build()` from `emitPackage` flag and configuration name
- Debug is the only named configuration that gets special treatment; custom/unnamed configurations behave like Release
- A site build now produces exactly one `index.html` (not `index.html` + `index.min.html`)
- Package builds still produce all variants; the consuming site's profile determines which are used
- Backward compatibility: packages built before variants existed (no `JsVariant` tags) fall back to filename-based pairing

## Testing

- New `ChunkOracleTests` covers parsing robustness and chunker integration
- `ModuleEmitTests` extended with sibling-call and cross-facade skip-clustering tests
- `PackageResourceVariantTests` updated to remove `outputFormatting` from test configs
- All existing resource and variant tests pass with the new profile-driven logic

https://claude.ai/code/session_01BQgPAJDgRqXo32raLBuoeB