### PR TITLE
Truthful size reporting, a smaller dense-enum payload, and a silent miscompile from a duplicate base library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,9 @@ property is not guessed at: such an import or item is skipped, which is why SDK-
 `--define/-D <SYM>`, `--assembly-version <v>`, `--project/-p`, `--quiet/-q`,
 `--incremental` / `--no-incremental` / `--cache-dir <dir>` (reuse the previous build; off by default),
 `--timing` (per-phase time + allocations), `--timing-json <file>`,
+`--type-sizes [n]` / `--type-sizes-json <file>` (how many bytes of JavaScript each type emitted, largest
+first; also `TRANSPOSE_TYPE_SIZES=1`/`=20` and `TRANSPOSE_TYPE_SIZES_JSON=<file>`, which reach an
+MSBuild-driven build),
 `--metadata-only-assembly` / `--no-metadata-only-assembly`,
 `--max-errors <n>` (a cap; by default **every** error is reported, ordered by file and line),
 `--watch` / `--watch-port <n>` (rebuild a site on every source change — root project and every

--- a/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
@@ -48,19 +48,20 @@ internal static class MsBuildDiagnostic
     // Codes for the compiler's own diagnostics — the ones that are not Roslyn's and so have no id of
     // their own. TPS0001-0099 are errors, TPS0100+ warnings. They are part of the tool's contract
     // once shipped (a build can suppress or escalate by code), so retire a code rather than reuse it.
-    public const string CodeInvalidCommandLine     = "TPS0001";
-    public const string CodeProjectNotFound        = "TPS0002";
-    public const string CodeProjectResolveFailed   = "TPS0003";
-    public const string CodeInternalError          = "TPS0004";
-    public const string CodeDependencyBuildFailed  = "TPS0005";
-    public const string CodeAssemblyEmitFailed     = "TPS0006";
-    public const string CodeWatchRequiresSiteBuild = "TPS0007";
-    public const string CodeCompilerTooOld         = "TPS0008";
-    public const string CodeReferenceNotFound      = "TPS0100";
-    public const string CodeMissingRuntimeBundle   = "TPS0101";
-    public const string CodeTimingJsonNotWritten   = "TPS0102";
-    public const string CodeCacheNotWritten        = "TPS0103";
-    public const string CodeWatchServerFailed      = "TPS0104";
+    public const string CodeInvalidCommandLine      = "TPS0001";
+    public const string CodeProjectNotFound         = "TPS0002";
+    public const string CodeProjectResolveFailed    = "TPS0003";
+    public const string CodeInternalError           = "TPS0004";
+    public const string CodeDependencyBuildFailed   = "TPS0005";
+    public const string CodeAssemblyEmitFailed      = "TPS0006";
+    public const string CodeWatchRequiresSiteBuild  = "TPS0007";
+    public const string CodeCompilerTooOld          = "TPS0008";
+    public const string CodeReferenceNotFound       = "TPS0100";
+    public const string CodeMissingRuntimeBundle    = "TPS0101";
+    public const string CodeTimingJsonNotWritten    = "TPS0102";
+    public const string CodeCacheNotWritten         = "TPS0103";
+    public const string CodeWatchServerFailed       = "TPS0104";
+    public const string CodeTypeSizesJsonNotWritten = "TPS0105";
 
     /// <summary>Formats a Roslyn diagnostic, pointing at its source location when it has one.</summary>
     public static string Format(Diagnostic d)

--- a/Transpose/Transpose.Compiler/Program.cs
+++ b/Transpose/Transpose.Compiler/Program.cs
@@ -66,6 +66,19 @@ public static class Program
                 case "--define" or "-D": extraDefines.Add(args[++i]); break;
                 case "--timing": PhaseTimings.Enabled = true; break;
                 case "--timing-json": _timingJsonPath = args[++i]; PhaseTimings.Enabled = true; break;
+                case "--type-sizes":
+                    TypeSizeReport.Enabled = true;
+                    // The count is optional, so only swallow the next argument when it is one.
+                    if (i + 1 < args.Length && int.TryParse(args[i + 1], out var typeSizeLimit) && typeSizeLimit > 0)
+                    {
+                        TypeSizeReport.Limit = typeSizeLimit;
+                        i++;
+                    }
+                    break;
+                case "--type-sizes-json":
+                    TypeSizeReport.JsonPath = args[++i];
+                    TypeSizeReport.Enabled = true;
+                    break;
                 case "--no-chunk-coalescing": noChunkCoalescing = true; break;
                 case "--chunk-coalescing": noChunkCoalescing = false; break;
                 case "--incremental": incremental = true; break;
@@ -141,8 +154,72 @@ public static class Program
         }
 
         var outcome = ProjectBuild.Run(options);
+        PrintTypeSizes();
         PrintTimings(sw.ElapsedMilliseconds);
         return outcome.ExitCode;
+    }
+
+    /// <summary>
+    /// Prints how many bytes of JavaScript each type contributed, largest first, when
+    /// <c>--type-sizes</c> (or <c>TRANSPOSE_TYPE_SIZES</c>) is set. The bundle's own size says
+    /// nothing about which declarations produced it, and a chunk is a group of types rather than
+    /// one, so this is the only view that names the code worth shrinking.
+    ///
+    /// The rows sum to the emitted payload minus the prelude and the reflection metadata; the
+    /// footer says how much that is, so a small measured total is visible as such rather than
+    /// mistaken for a small build.
+    /// </summary>
+    private static void PrintTypeSizes()
+    {
+        if (!TypeSizeReport.Enabled) return;
+        var sizes = TypeSizeReport.Snapshot();
+        if (sizes.Count == 0) return;
+
+        long total = 0;
+        foreach (var (_, _, bytes) in sizes) total += bytes;
+        var denom = total == 0 ? 1 : total;
+        var multiAssembly = sizes.Select(x => x.assembly).Distinct().Count() > 1;
+
+        var shown = TypeSizeReport.Limit > 0 ? Math.Min(TypeSizeReport.Limit, sizes.Count) : sizes.Count;
+        Console.WriteLine($"\n  JavaScript emitted per type ({shown:N0} of {sizes.Count:N0} types, largest first):");
+        long running = 0;
+        for (var i = 0; i < shown; i++)
+        {
+            var (assembly, type, bytes) = sizes[i];
+            running += bytes;
+            var name = multiAssembly ? $"{type}  [{assembly}]" : type;
+            Console.WriteLine($"    {i + 1,5}  {Kb(bytes),10}  {bytes * 100.0 / denom,5:F1}%  {running * 100.0 / denom,5:F1}% cum  {name}");
+        }
+        Console.WriteLine($"           {Kb(total),10}  100.0%          total type bodies across {sizes.Count:N0} types");
+
+        if (TypeSizeReport.JsonPath is not null) WriteTypeSizesJson(TypeSizeReport.JsonPath, sizes);
+    }
+
+    private static string Kb(long bytes) => $"{bytes / 1024.0:N1} KB";
+
+    /// <summary>Writes every recorded type — not just the printed rows — so a report over several
+    /// projects can be assembled without re-running the builds.</summary>
+    private static void WriteTypeSizesJson(string path, IReadOnlyList<(string assembly, string type, long bytes)> sizes)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("{\n  \"types\": [\n");
+        for (var i = 0; i < sizes.Count; i++)
+        {
+            var (assembly, type, bytes) = sizes[i];
+            sb.Append($"    {{ \"assembly\": {JsonString(assembly)}, \"type\": {JsonString(type)}, \"bytes\": {bytes} }}");
+            sb.Append(i == sizes.Count - 1 ? "\n" : ",\n");
+        }
+        sb.Append("  ]\n}\n");
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+            File.WriteAllText(path, sb.ToString());
+        }
+        catch (Exception ex)
+        {
+            MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeTypeSizesJsonNotWritten,
+                $"could not write --type-sizes-json: {ex.Message}");
+        }
     }
 
     /// <summary>Prints the per-phase timing breakdown gathered when <c>--timing</c> (or
@@ -309,6 +386,15 @@ public static class Program
               --watch-port <n>      Port for --watch's HTTP server and websocket (default 4300)
               --timing              Print a per-phase timing/allocation breakdown of the build
               --timing-json <file>  Also write that breakdown (plus GC/memory totals) as JSON
+              --type-sizes [n]      Print how many bytes of JavaScript each type emitted, largest
+                                    first — the view that names which declarations a big bundle is
+                                    made of. Optionally cap the table at <n> rows (the whole table
+                                    otherwise). Also settable with TRANSPOSE_TYPE_SIZES=1 (or =20 for
+                                    the top 20), which reaches a build driven by MSBuild.
+              --type-sizes-json <file>
+                                    Write every type's size as JSON (implies --type-sizes, and dumps
+                                    all types regardless of the printed row cap). Also settable with
+                                    TRANSPOSE_TYPE_SIZES_JSON=<file>.
               -q, --quiet           Suppress warning output
               -h, --help            Show this help
             """);

--- a/Transpose/Transpose.Translator.Tests/TypeSizeReportTests.cs
+++ b/Transpose/Transpose.Translator.Tests/TypeSizeReportTests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <c>--type-sizes</c> / <c>TRANSPOSE_TYPE_SIZES</c> — the per-type JavaScript size report.
+    ///
+    /// Three properties carry the whole feature. It costs nothing when it is off, because the
+    /// recording call sits inside the parallel emit of every type. Its order is total and
+    /// deterministic, because a report whose ties shuffle between runs cannot be diffed against an
+    /// earlier one. And a type emitted twice — which is what a package build does, once as the
+    /// single bundle and once as the module chunks — is one row rather than a doubled one.
+    /// </summary>
+    [TestClass]
+    public class TypeSizeReportTests
+    {
+        [TestInitialize]
+        public void Reset()
+        {
+            TypeSizeReport.Reset();
+            TypeSizeReport.Enabled = false;
+        }
+
+        [TestCleanup]
+        public void Cleanup() => Reset();
+
+        [TestMethod]
+        public void RecordsNothingWhileDisabled()
+        {
+            TypeSizeReport.Record("asm", "A", new string('x', 100));
+            Assert.AreEqual(0, TypeSizeReport.Snapshot().Count);
+        }
+
+        [TestMethod]
+        public void ReportsBytesLargestFirst()
+        {
+            TypeSizeReport.Enabled = true;
+            TypeSizeReport.Record("asm", "Small", new string('x', 10));
+            TypeSizeReport.Record("asm", "Large", new string('x', 1000));
+            TypeSizeReport.Record("asm", "Medium", new string('x', 100));
+
+            CollectionAssert.AreEqual(
+                new[] { "Large", "Medium", "Small" },
+                TypeSizeReport.Snapshot().Select(x => x.type).ToArray());
+            Assert.AreEqual(1000, TypeSizeReport.Snapshot()[0].bytes);
+        }
+
+        [TestMethod]
+        public void TiesAreBrokenByNameSoTwoBuildsAgree()
+        {
+            TypeSizeReport.Enabled = true;
+            TypeSizeReport.Record("asm", "Zeta", new string('x', 50));
+            TypeSizeReport.Record("asm", "Alpha", new string('x', 50));
+
+            CollectionAssert.AreEqual(
+                new[] { "Alpha", "Zeta" },
+                TypeSizeReport.Snapshot().Select(x => x.type).ToArray());
+        }
+
+        [TestMethod]
+        public void TwoEmitPassesOverOneTypeStayOneRow()
+        {
+            TypeSizeReport.Enabled = true;
+            // A package emits every type twice — the single bundle and the module chunks — and the
+            // two texts differ only in indentation. Summing them would report a type at twice its
+            // real weight, and take the whole table with it.
+            TypeSizeReport.Record("asm", "A", new string('x', 100));
+            TypeSizeReport.Record("asm", "A", new string('x', 90));
+
+            var snapshot = TypeSizeReport.Snapshot();
+            Assert.AreEqual(1, snapshot.Count);
+            Assert.AreEqual(100, snapshot[0].bytes);
+        }
+
+        [TestMethod]
+        public void SameTypeNameInTwoAssembliesAreSeparateRows()
+        {
+            TypeSizeReport.Enabled = true;
+            TypeSizeReport.Record("one", "Shared.Thing", new string('x', 100));
+            TypeSizeReport.Record("two", "Shared.Thing", new string('x', 200));
+
+            var snapshot = TypeSizeReport.Snapshot();
+            Assert.AreEqual(2, snapshot.Count);
+            Assert.AreEqual("two", snapshot[0].assembly);
+        }
+
+        [TestMethod]
+        public void SizeIsCountedInUtf8Bytes()
+        {
+            TypeSizeReport.Enabled = true;
+            // The report is about payload, and the payload is UTF-8 — a string literal outside the
+            // ASCII range costs more bytes than it has chars.
+            TypeSizeReport.Record("asm", "A", "€");
+
+            Assert.AreEqual(3, TypeSizeReport.Snapshot()[0].bytes);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -104,6 +104,7 @@ public sealed partial class Emitter
                     var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
                     var ext = externalChunks is null ? null : new HashSet<string>(StringComparer.Ordinal);
                     bodies[type] = EmitOnlyType(this, type, seen, ext).ToString();
+                    TypeSizeReport.Record(_assemblyName, type.ToDisplayString(), bodies[type]);
                     seen.Remove(type);
                     refs[type] = ClusterRefsFor(type, seen);
                     if (ext is not null) extRefs[type] = ext;

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -166,6 +166,7 @@ public sealed partial class Emitter
                             results[type] = EmitOnlyType(this, type).ToString();
                             _plan?.RecordReemitted();
                         }
+                        TypeSizeReport.Record(_assemblyName, type.ToDisplayString(), results[type]);
                         var count = Interlocked.Increment(ref done);
                         CompileProgress.ReportStep("emitting JavaScript", count, types.Count);
                     }));
@@ -296,6 +297,7 @@ public sealed partial class Emitter
                 continue;
             }
             if (js.Length == 0) continue;
+            TypeSizeReport.Record(_assemblyName, type.ToDisplayString(), js);
             outp.Files.Add((ClassPathRelPath(type), js + "\n"));
         }
         return outp;

--- a/Transpose/Transpose.Translator/Support/TypeSizeReport.cs
+++ b/Transpose/Transpose.Translator/Support/TypeSizeReport.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// Process-wide accumulator for <em>how many bytes of JavaScript each type contributed</em>. Off by
+/// default (near-zero cost); the CLI turns it on with <c>--type-sizes</c> or the
+/// <c>TRANSPOSE_TYPE_SIZES</c> environment variable, and prints the result largest-first at the end
+/// of the build.
+///
+/// The number answers a question neither the bundle size nor the chunk report can: a 3 MB payload
+/// says nothing about <em>which</em> declarations produced it, and a chunk is a strongly-connected
+/// component whose size is the sum of a group. The size recorded here is the exact text of that
+/// type's <c>Transpose.define(...)</c> — the same string the chunker measures and the bundle
+/// concatenates — so the column sums to the emitted payload minus the prelude and the reflection
+/// metadata, and a type that dominates the list really is the code to look at.
+///
+/// A <b>package</b> build emits every type twice (the single bundle <i>and</i> the module chunks —
+/// see <c>RoslynTranslator</c>), and the two texts differ only in indentation. Recording keeps the
+/// larger of the two rather than summing them, so one type is one row whatever the output shape.
+/// </summary>
+public static class TypeSizeReport
+{
+    private static readonly object _gate = new();
+    private static readonly Dictionary<(string assembly, string type), long> _sizes = new();
+
+    /// <summary>When false, <see cref="Record"/> is a no-op. Set from
+    /// <c>TRANSPOSE_TYPE_SIZES</c>: <c>1</c>/<c>true</c> reports every type, a positive integer
+    /// reports that many.</summary>
+    public static bool Enabled { get; set; } = ParseEnabled(Environment.GetEnvironmentVariable("TRANSPOSE_TYPE_SIZES"));
+
+    /// <summary>How many rows the report prints, largest first. 0 = every type. Set from the
+    /// numeric form of <c>TRANSPOSE_TYPE_SIZES</c> (e.g. <c>TRANSPOSE_TYPE_SIZES=20</c>).</summary>
+    public static int Limit { get; set; } = ParseLimit(Environment.GetEnvironmentVariable("TRANSPOSE_TYPE_SIZES"));
+
+    /// <summary>Where the machine-readable dump goes, from <c>TRANSPOSE_TYPE_SIZES_JSON</c> or
+    /// <c>--type-sizes-json</c>. Setting it also enables the report — asking for the file is asking
+    /// for the measurement.</summary>
+    public static string? JsonPath { get; set; } = Environment.GetEnvironmentVariable("TRANSPOSE_TYPE_SIZES_JSON") is { Length: > 0 } p ? p : null;
+
+    static TypeSizeReport()
+    {
+        if (JsonPath is not null) Enabled = true;
+    }
+
+    private static bool ParseEnabled(string? v)
+        => v is "1" or "true" or "TRUE" || (int.TryParse(v, out var n) && n > 0);
+
+    private static int ParseLimit(string? v)
+        => int.TryParse(v, out var n) && n > 1 ? n : 0;
+
+    /// <summary>Records the emitted JavaScript of one type. Called once per type per emit pass; the
+    /// larger of two passes over the same type wins (see the type remarks).</summary>
+    public static void Record(string assemblyName, string typeName, string js)
+    {
+        if (!Enabled) return;
+        var bytes = Encoding.UTF8.GetByteCount(js);
+        lock (_gate)
+        {
+            var key = (assemblyName, typeName);
+            if (!_sizes.TryGetValue(key, out var cur) || bytes > cur) _sizes[key] = bytes;
+        }
+    }
+
+    /// <summary>Every recorded type, largest first, ties broken by name so two builds of the same
+    /// sources report the same order.</summary>
+    public static IReadOnlyList<(string assembly, string type, long bytes)> Snapshot()
+    {
+        lock (_gate)
+        {
+            var list = new List<(string, string, long)>(_sizes.Count);
+            foreach (var kv in _sizes) list.Add((kv.Key.assembly, kv.Key.type, kv.Value));
+            list.Sort((a, b) => b.Item3 != a.Item3
+                ? b.Item3.CompareTo(a.Item3)
+                : string.CompareOrdinal(a.Item2, b.Item2));
+            return list;
+        }
+    }
+
+    /// <summary>Clears everything recorded (used between independent builds in one process).</summary>
+    public static void Reset()
+    {
+        lock (_gate) _sizes.Clear();
+    }
+}


### PR DESCRIPTION
Five commits. Each one was found by the one before it.

---

## 1. `--type-sizes` — how many bytes of JavaScript each type emitted

```
tps --project X.csproj -c Release --type-sizes 20
TRANSPOSE_TYPE_SIZES=20 dotnet build X.csproj -c Release     # reaches an MSBuild-driven build
```

```
  JavaScript emitted per type (20 of 534 types, largest first):
      1    227.9 KB    9.3%    9.3% cum  Tesserae.UIcons
      2    130.8 KB    5.3%   14.7% cum  Tesserae.OmniBox
      …
         2,445.6 KB  100.0%          total type bodies across 534 types
```

`--type-sizes-json <file>` / `TRANSPOSE_TYPE_SIZES_JSON=<file>` dumps the whole table so a report
across projects can be assembled without re-running the builds.

Neither number a build already prints answers "which declarations is this payload made of": the
bundle size is one number for everything, and a chunk is a strongly-connected component, so its size
is the sum of a group. `TypeSizeReport` is modelled on `PhaseTimings` — process-wide, off by
default, a no-op when disabled, since the recording call sits inside the parallel emit of every type.
A package emits every type twice (bundle *and* chunks), so recording keeps the larger rather than
summing; ties break by name so two builds produce the same table.

## 2. A package build reported the wrong size

The first thing `--type-sizes` turned up. A package build announced the bytes **Roslyn emitted**, but
the JavaScript, stylesheets and fonts are injected *afterwards* by `ResourceEmbedder`:

| Package | Reported | Actually on disk | |
|---|---:|---:|---:|
| `tss.dll` | 1,818,624 | 17,116,672 | **9.4×** |
| `Curiosity.FrontEnd.API.dll` | 221,696 | 1,050,624 | **4.7×** |

`WritePackage` now returns the size of the file it wrote, measured where the write happens, so the
pre-embedding length is not in scope at the report site. The line also names how much is resources:

```
OK — built package tss.dll (17,116,672 bytes, 15,219,949 of it in 52 embedded resource(s)) in 11922 ms.
```

To be clear about what this was *not*: there is no resource accumulation — four consecutive
`--emit-package` builds produce a byte-identical DLL. The file was always right; only the report lied.

## 3. A large dense enum ships as one string, not one property per member

`UIcons` being 9.3% of Tesserae is what prompted this. An enum whose members are the ordinals
`0…n-1` in declaration order was emitting `{ "fi-rr-abacus": 12, … }` — writing down what the order
already said. Above 64 members it now emits the names as one delimited string and the runtime expands
them back, because in a dense enum a name's value **is** its index.

| | before | after |
|---|---:|---:|
| `Tesserae.UIcons` emitted | 227.9 KB | **97.8 KB** |
| Gallery boot payload, raw | 1,558 KB | **1,423 KB** |
| Gallery boot payload, gzip | 247 KB | **226 KB** |

…with the table still fully loaded, which is the constraint: it is reached from every component that
draws an icon and cannot be deferred. `UIcons` stops being the largest type in the library. The parse
side matters as much as the bytes — the object form made the JS parser build 5,372 properties and the
runtime sort 5,372 pairs of them before anything rendered.

Expansion is eager so a member stays an ordinary own property of the type: `getValues`, `parse`,
`valueNames` and hand-written JS keep working with no idea which form the enum arrived in. It is
still strictly less work than the form it replaces. The encoding refuses anything it could not
round-trip — a gap, an alias, a `[Flags]` bit pattern, a string-backed enum, a `[Name]` holding the
delimiter, a quote, a backslash or a line break — and below the threshold an enum emits exactly as
before, so almost every type in a program is byte-identical.

## 4. A duplicate base library silently miscompiled overload calls

Verifying (3) in a browser surfaced a page error in Tesserae's diagram sample, which turned out to
predate all of this.

A project's resolved references include the `Transpose.BCL` package it pins. When that is not the
same file `TransposeAssemblies` discovered — a newer one in the NuGet cache, or a
`TRANSPOSE_DLL_PATH` pointing at a locally built runtime — the de-duplication compared **paths**, saw
two different ones, and referenced both.

Overload numbering asks whether a method has an IL body by looking its metadata **token** up in a set
read from `TransposeDllPath`. A token from the other build names an unrelated method, so members get
misread as extern JS-backed ones and emitted under their bare, unsuffixed names — and a call binds to
whichever overload happens to hold that name. Nothing fails until it runs:
`List<T>.Sort(Comparison<T>)` had compiled to `Sort()`, silently sorting with the default comparer,
throwing **"Cannot compare items"** on a node type that is not `IComparable`. Both `Sort` call sites
in Tesserae were affected, and the same applies to any overload set in the BCL.

This is not an exotic configuration: until recently this very repo's benchmark project pinned
`Transpose.BCL 26.8.4093` while the library pinned `26.8.4102`, and discovery takes the newest in the
cache. Matching on the **assembly name** is the whole fix — the base library ships as the assembly
`Transpose` whatever its package id, version or file name.

## 5. Two more emissions that named a type for no reason

Same idea as (4)'s consequence: in module mode an emitted type reference is a dependency edge.

- **`default(T?)` now emits `null`.** The null state is the default whatever `T` is, and the
  runtime's `Nullable$1(T).getDefaultValue()` returns `null` for every `T` — the same value by a
  shorter route. Every `UIcons? icon = null` optional parameter in Tesserae recorded an edge against
  its icon table, ten of them across the library, and none survive. A non-nullable struct default is
  untouched.
- **`ToString()` on a string-backed enum now emits the value.** Its runtime value already *is* the
  string, so `System.Enum.toString` could only return the key it was handed. Boxing is deliberately
  unchanged and still names the enum, because `GetType()` and a later `ToString()` off `object` are
  answered from it.

## Verification

- Full translator suite: **974 passed, 0 failed, 17 skipped (991 total)** — the 971 baseline plus 20
  new tests.
- **Emitted output is untouched by (1)**: the same project built with the report on and off produces
  a byte-identical DLL (same SHA-256).
- Every new test was checked to **fail** against the code it guards before being kept — the package
  size against the old expression, the dense-enum runtime by breaking the expansion on purpose, the
  duplicate base library by disabling the filter, and both emissions in (5) by reverting them. Four
  of these five changes are behaviour-preserving by construction, so a passing suite alone would not
  distinguish them from doing nothing.
- The dense-enum test compares `ToString`/`GetName`/`GetNames`/`GetValues`/`Parse`/`IsDefined`/casting
  against native .NET; the duplicate-library test compares emitted JavaScript with and without a
  genuinely different build of the base library (an identical copy cannot show it — Roslyn unifies
  two references of one assembly identity).
- Driven in a real browser: the Tesserae gallery boots with **401 icons rendered and zero console or
  page errors**, and twelve samples open and render — including the diagram sample that used to throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1ApbzAXFovgmCfPfeVfkd