### PR TITLE
Always emit a resolvable .min.js, and add Transpose.Require

### DIFF
--- a/BCL/Transpose.BCL/Resources/Require.js
+++ b/BCL/Transpose.BCL/Resources/Require.js
@@ -1,0 +1,209 @@
+    // ---- require: fetching a script, a module or a stylesheet at run time --------------------
+    //
+    // One loader for every "the page needs this file now" case: a vendored bundle only the screen
+    // that shows a chart wants, a stylesheet, an ES module. Every application built on Transpose
+    // grew its own version of this — each one a <script> element, an onload handler and a slightly
+    // different set of things it got wrong — so it lives here instead, once.
+    //
+    // What it does that hand-rolled injection does not:
+    //
+    //   * picks the element from the URL: `.css` -> <link rel=stylesheet>, `.mjs` -> a module
+    //     <script>, anything else -> a classic <script>. A `.js` file that is really a module (a
+    //     Transpose module entry, which keeps the bundle's name) is asked for explicitly, since
+    //     nothing about the URL says so;
+    //   * resolves the URL against document.baseURI first, so "assets/x.js", "./assets/x.js" and the
+    //     absolute form are one entry — and a file index.html already carries is recognised rather
+    //     than fetched a second time;
+    //   * falls back between the `.js` / `.min.js` (and `.css` / `.min.css`) spellings of the same
+    //     file. A site keeps whichever variant its own build called for, and a library published
+    //     once cannot know which build is consuming it, so asking for either name has to work;
+    //   * remembers what it loaded, so N callers share one fetch — and forgets what failed, so a
+    //     later caller can retry rather than inheriting a poisoned result forever.
+    //
+    // Loading is sequential when several URLs are given: a plugin that extends a library has to
+    // arrive after it, and that is the common case (d3 then d3.lasso). A caller that genuinely wants
+    // them in parallel asks for them in separate calls.
+
+    var require = {
+        // resolved url -> the in-flight (or settled) load, so concurrent callers share one fetch
+        $pending: {},
+        // resolved url -> true once it is on the page
+        $loaded: {},
+
+        /// Loads one or more URLs, in order, and completes when the last one has run. `kind` is one
+        /// of Transpose.Require.kinds; 0 (auto) picks the element from the URL.
+        loadAsync: function (urls, kind) {
+            if (urls == null) return Promise.resolve(true);
+            if (typeof urls === "string") urls = [urls];
+
+            var i = -1;
+            function next() {
+                i++;
+                if (i >= urls.length) return Promise.resolve(true);
+                return require.$one(urls[i], kind || 0).then(next);
+            }
+            return next();
+        },
+
+        /// True once <paramref name="url"/> is on the page — loaded through here, or scripted by
+        /// index.html before anything asked for it.
+        isLoaded: function (url) {
+            var resolved = require.$resolve(url);
+            return !!require.$loaded[resolved] || require.$find(resolved) != null;
+        },
+
+        kinds: { auto: 0, script: 1, module: 2, style: 3 },
+
+        $one: function (url, kind) {
+            if (typeof document === "undefined") {
+                return Promise.reject(new System.NotSupportedException.$ctor1(
+                    "Transpose.Require needs a document; there is none in this JavaScript engine."));
+            }
+
+            var resolved = require.$resolve(url);
+            if (require.$pending[resolved]) return require.$pending[resolved];
+
+            var effective = require.$kindOf(resolved, kind);
+
+            // Already on the page: index.html scripted it, or a host loaded it its own way. Wait for
+            // it rather than adding a second element that fetches the same file.
+            var existing = require.$find(resolved);
+            var p = existing != null
+                ? require.$waitFor(existing)
+                : require.$inject(resolved, effective).then(null, function (error) {
+                    // The other spelling of the same file. A build keeps one of the pair, so this is
+                    // the answer whenever a library asks for the variant this site did not keep — and
+                    // it is a specific fallback, not a swallowed error: if there is no counterpart, or
+                    // it fails too, the original failure is what the caller sees.
+                    var counterpart = require.$counterpart(resolved);
+                    if (counterpart == null) throw error;
+                    return require.$inject(counterpart, require.$kindOf(counterpart, kind)).then(function () {
+                        require.$loaded[counterpart] = true;
+                        return true;
+                    }, function () {
+                        throw error;
+                    });
+                });
+
+            p = p.then(function () {
+                require.$loaded[resolved] = true;
+                return true;
+            }, function (error) {
+                // Nothing was loaded, so leave no trace of the attempt: a fetch that failed once
+                // (offline, a half-deployed site) must not make every later caller fail too.
+                delete require.$pending[resolved];
+                throw System.Exception.create(error);
+            });
+
+            require.$pending[resolved] = p;
+            return p;
+        },
+
+        /// The URL as the browser sees it. Hand-assembling one from window.location goes wrong the
+        /// moment the app is served as a file rather than a directory, or under a <base href>.
+        $resolve: function (url) {
+            if (typeof document === "undefined" || typeof URL === "undefined") return url;
+            try {
+                return new URL(url, document.baseURI).href;
+            } catch (e) {
+                return url;
+            }
+        },
+
+        /// script / module / style, from the URL when the caller did not say.
+        $kindOf: function (url, kind) {
+            if (kind) return kind;
+            var path = require.$path(url).toLowerCase();
+            if (require.$endsWith(path, ".css")) return require.kinds.style;
+            if (require.$endsWith(path, ".mjs")) return require.kinds.module;
+            return require.kinds.script;
+        },
+
+        /// The path part of a URL — a cache-busting "?v=…" is part of what is fetched but says
+        /// nothing about what kind of file it is.
+        $path: function (url) {
+            var cut = url.length;
+            var q = url.indexOf("?"), h = url.indexOf("#");
+            if (q >= 0 && q < cut) cut = q;
+            if (h >= 0 && h < cut) cut = h;
+            return url.substring(0, cut);
+        },
+
+        $endsWith: function (s, suffix) {
+            return s.length >= suffix.length && s.substring(s.length - suffix.length) === suffix;
+        },
+
+        /// The other spelling of the same file: x.js <-> x.min.js, x.css <-> x.min.css. null when the
+        /// URL is neither (a .mjs chunk, an extensionless endpoint), so there is nothing to retry.
+        $counterpart: function (url) {
+            var path = require.$path(url), tail = url.substring(path.length);
+            var lower = path.toLowerCase();
+            var exts = [".js", ".css"];
+            for (var i = 0; i < exts.length; i++) {
+                var ext = exts[i], min = ".min" + ext;
+                if (require.$endsWith(lower, min)) return path.substring(0, path.length - min.length) + ext + tail;
+                if (require.$endsWith(lower, ext)) return path.substring(0, path.length - ext.length) + min + tail;
+            }
+            return null;
+        },
+
+        /// The element already serving this URL, if any. Compared on the resolved src/href — the
+        /// attribute is whatever spelling the page was written with, the property is absolute.
+        $find: function (resolved) {
+            if (typeof document === "undefined") return null;
+            var i, nodes = document.getElementsByTagName("script");
+            for (i = 0; i < nodes.length; i++) {
+                if (nodes[i].src && nodes[i].src === resolved) return nodes[i];
+            }
+            nodes = document.getElementsByTagName("link");
+            for (i = 0; i < nodes.length; i++) {
+                if (nodes[i].rel === "stylesheet" && nodes[i].href === resolved) return nodes[i];
+            }
+            return null;
+        },
+
+        /// Waits on an element this loader did not create. Once the document is complete every
+        /// element in it has settled, so there is nothing left to wait for; before that, its own
+        /// load/error is the signal. A foreign element that errors is not this caller's failure —
+        /// whoever put it there owns it — so the wait ends either way.
+        $waitFor: function (element) {
+            if (element.$tpsLoad) return element.$tpsLoad;
+            var p = new Promise(function (resolve) {
+                if (document.readyState === "complete") return resolve(true);
+                var done = function () { resolve(true); };
+                element.addEventListener("load", done);
+                element.addEventListener("error", done);
+                window.addEventListener("load", done);
+            });
+            element.$tpsLoad = p;
+            return p;
+        },
+
+        $inject: function (url, kind) {
+            return new Promise(function (resolve, reject) {
+                var element;
+                if (kind === require.kinds.style) {
+                    element = document.createElement("link");
+                    element.rel = "stylesheet";
+                    element.href = url;
+                } else {
+                    element = document.createElement("script");
+                    if (kind === require.kinds.module) element.type = "module";
+                    else element.type = "text/javascript";
+                    element.src = url;
+                }
+
+                element.addEventListener("load", function () { resolve(true); });
+                element.addEventListener("error", function () {
+                    // Leave nothing behind: a failed element still matches a src/href lookup, and the
+                    // next attempt would then wait on an element that is never going to load.
+                    if (element.parentNode) element.parentNode.removeChild(element);
+                    reject(new System.Exception("Transpose.Require: failed to load '" + url + "'."));
+                });
+
+                (document.head || document.getElementsByTagName("head")[0] || document.body).appendChild(element);
+            });
+        }
+    };
+
+    Transpose.Require = require;

--- a/BCL/Transpose.BCL/Transpose/Require.cs
+++ b/BCL/Transpose.BCL/Transpose/Require.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Transpose
+{
+    /// <summary>How <see cref="Require.RequireAsync(RequireKind, string[])"/> loads a URL.</summary>
+    [Enum(Emit.Value)]
+    public enum RequireKind
+    {
+        /// <summary>Picked from the URL: <c>.css</c> is a stylesheet, <c>.mjs</c> a module, anything
+        /// else a classic script. This is what nearly every call wants.</summary>
+        Auto = 0,
+
+        /// <summary>A classic <c>&lt;script&gt;</c>.</summary>
+        Script = 1,
+
+        /// <summary>A <c>&lt;script type="module"&gt;</c>. Needed for a module whose name does not say
+        /// so — a Transpose module entry keeps the bundle's <c>.js</c> name, because that is the name
+        /// the application fetches it by.</summary>
+        Module = 2,
+
+        /// <summary>A <c>&lt;link rel="stylesheet"&gt;</c>.</summary>
+        Style = 3,
+    }
+
+    /// <summary>
+    /// Fetches a script, an ES module or a stylesheet at run time — the one loader for everything a
+    /// page pulls in after it has started.
+    ///
+    /// <para>
+    /// It picks the element from the URL (see <see cref="RequireKind"/>), resolves the URL against
+    /// the document's base first — so <c>assets/x.js</c>, <c>./assets/x.js</c> and the absolute form
+    /// are one entry, and a file <c>index.html</c> already carries is waited on rather than fetched
+    /// again — and shares one fetch between every caller that asks for the same file. A load that
+    /// failed is forgotten, so a later caller retries instead of inheriting the failure.
+    /// </para>
+    ///
+    /// <para>
+    /// It also falls back between the <c>.js</c> / <c>.min.js</c> (and <c>.css</c> / <c>.min.css</c>)
+    /// spellings of the same file: a site keeps whichever variant its own build called for, and a
+    /// library published once cannot know which build is consuming it, so asking for either name
+    /// works. Only if both spellings fail does the task fault, reporting the URL that was asked for.
+    /// </para>
+    ///
+    /// <para>
+    /// Several URLs load <em>in order</em>: a plugin that extends a library has to arrive after it
+    /// (<c>d3.js</c> then <c>d3.lasso.js</c>), which is the common case. Ask in separate calls, and
+    /// await them together, when they are genuinely independent.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// await Require.RequireAsync("assets/js/graph-kit.min.js");           // .js is tried if it 404s
+    /// await Require.RequireAsync("assets/css/fullcalendar.css", "assets/js/fullcalendar.js");
+    /// await Require.RequireAsync(RequireKind.Module, "./pdf.mjs");
+    /// </code>
+    /// </example>
+    [External]
+    [Name("Transpose.Require")]
+    public static class Require
+    {
+        /// <summary>
+        /// Loads <paramref name="urls"/> in order, each as its extension says, and completes when the
+        /// last one has run.
+        /// </summary>
+        [Template("System.Threading.Tasks.Task.fromPromise(Transpose.Require.loadAsync({urls:array}, 0), 0, System.Exception.create)")]
+        public static extern Task RequireAsync(params string[] urls);
+
+        /// <summary>
+        /// Loads <paramref name="urls"/> in order as <paramref name="kind"/>, for the file whose
+        /// extension does not say what it is — a module entry named <c>.js</c>, a stylesheet served
+        /// from an extensionless endpoint.
+        /// </summary>
+        [Template("System.Threading.Tasks.Task.fromPromise(Transpose.Require.loadAsync({urls:array}, {kind}), 0, System.Exception.create)")]
+        public static extern Task RequireAsync(RequireKind kind, params string[] urls);
+
+        /// <summary>
+        /// True once <paramref name="url"/> is on the page — loaded through here, or scripted by
+        /// <c>index.html</c> before anything asked for it. Awaiting <see cref="RequireAsync(string[])"/>
+        /// again is free, so this is for a caller that wants to branch rather than wait.
+        /// </summary>
+        [Template("Transpose.Require.isLoaded({url})")]
+        public static extern bool IsLoaded(string url);
+    }
+}

--- a/BCL/Transpose.BCL/tps.json
+++ b/BCL/Transpose.BCL/tps.json
@@ -149,6 +149,9 @@
             // After Task.js: the module loader resolves with Promises the Task layer adapts, and
             // after Reflection/Class so its stubs can register into an assembly's $types map.
             "Resources/Modules.js",
+            // After Modules.js for the same reason: it hands back Promises the Task layer adapts,
+            // and it reports a failure as a System.Exception.
+            "Resources/Require.js",
             "Resources/Validation.js",
             "Resources/Attribute.js",
             "Resources/.generated/System/SerializableAttribute.js",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,10 +447,22 @@ The short version:
   name, which is how a library declares a vendored bundle it wants both variants of (Tesserae's
   `tss-dep.js` + `tss-dep.min.js`, Curiosity's `ExternalBundle` pair) — and the same rule applies
   whether the site build reads the pair from disk or extracts it from a package, so neither path
-  scripts both halves. A resource that ships in **one** variant — Monaco's `editor.main.js`, a vendored
-  `d3.min.js` — has no other variant to switch to and is copied through under its authored name in
-  *every* configuration. Renaming it would break the app: a module loader, a `new Worker(...)` or an
-  import map fetches that file by a path the compiler does not rewrite (`PackageResourceVariantTests`).
+  **scripts** both halves. A resource that ships in **one** variant — Monaco's `editor.main.js`, a
+  vendored `d3.min.js` — has no other variant to switch to and is copied through under its authored
+  name in *every* configuration. Renaming it would break the app: a module loader, a `new Worker(...)`
+  or an import map fetches that file by a path the compiler does not rewrite
+  (`PackageResourceVariantTests`).
+
+  What the switch decides is which half index.html **links**, not which halves exist. The minified
+  name of a declared pair is **written in every configuration**, because code that fetches a bundle on
+  demand asks for it by name (GraphKit's `assets/js/graph-kit.min.js`, Monaco's loader) and cannot
+  know which configuration built the site around it — a Debug site that carried only the formatted
+  half answered those fetches with a 404. The formatted half stays Debug-only: nothing fetches the
+  readable copy of a bundle a Release site already minified. And when a pair is declared but its
+  minified half **matches no file** — a bundler that was never run, only the readable artifact checked
+  in — the formatted file is copied under the minified name, both into a site and into a package.
+  Before that, the `.js` group stepped aside for a sibling that produced nothing and a Release build
+  emitted *neither* half.
 
   Two NUglify transforms are switched off through `CodeSettings.KillSwitch` because they are unsound
   for the JavaScript we emit, and `JsMinifierTests` guards both. Besides the `??`-under-`&&` collapse
@@ -734,6 +746,20 @@ The short version:
 
   A host can also drive this itself — `Modules.Register` takes a manifest from anywhere — which is how
   it was validated before the emitter half existed.
+- **`Transpose.Require` is the one run-time loader (`Resources/Require.js`).** `Require.RequireAsync`
+  fetches a script, an ES module or a stylesheet after the page has started — the "load this library
+  the first time a chart is shown" case every application on Transpose had grown its own version of
+  (Tesserae's `Require`, GraphKit's `GK.LoadAsync`, Curiosity's `ExternalLibraries`, Monaco's
+  loader), each a `<script>` element and a slightly different set of things it got wrong. It picks the
+  element from the URL (`.css` → a stylesheet link, `.mjs` → a module, anything else → a classic
+  script; `RequireKind` says so explicitly for a module entry, which keeps the bundle's `.js` name),
+  resolves the URL against `document.baseURI` first — so every spelling of one file is one entry, and
+  a file index.html already carries is waited on rather than fetched again — shares one fetch between
+  every caller, forgets a failed one so a later caller retries, and **falls back between the `.js` and
+  `.min.js` spellings** of the same file. That last part is the run-time half of the variant rule
+  above: a library published once cannot know which build is consuming it, so asking for either name
+  has to work. Several URLs load in order, because a plugin has to arrive after the library it
+  extends. Covered by `RequireLoaderTests`, which runs the real runtime against a DOM stub.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 - **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
   reuses the previous build of a project: nothing at all is compiled when every input hashes the same

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -260,12 +260,15 @@ internal static class OutputBuilder
 
                 var o = new JsOut { Path = f.Rel, IsModule = f.Module };
                 if (wantFormatted) WriteText(f.Rel, f.Text); else o.IsEmpty = true;
-                if (wantMinified)
-                {
-                    var pre = byName[counterpart];   // pre-built .min.js from the package
-                    WriteText(pre.Rel, pre.Text);
-                    o.MinifiedPath = pre.Rel;
-                }
+
+                // The minified half goes to disk in EVERY configuration, and is linked from
+                // index.html only by a minified build. A library's on-demand loader fetches its
+                // bundle by the minified name (GraphKit's `assets/js/graph-kit.min.js`) and has no
+                // way to know which configuration built the consuming site, so a Debug site that
+                // kept only the formatted half answered that fetch with a 404.
+                var pre = byName[counterpart];   // pre-built .min.js from the package
+                WriteText(pre.Rel, pre.Text);
+                if (wantMinified) o.MinifiedPath = pre.Rel;
                 if (f.Load) jsOuts.Add(o);
             }
         }
@@ -300,12 +303,21 @@ internal static class OutputBuilder
         {
             var cfg = projectDir == project.ProjectDir ? config : TransposeJson.TryLoad(projectDir, configuration);
             if (cfg is null) continue;
-            // Which bundle names this project declares, so a group that has a declared counterpart
-            // (an authored `x.js` next to an authored `x.min.js`) takes part in the variant switch
-            // instead of both halves being written and both being scripted.
-            var declared = cfg.Resources.Select(g => ResolveResource(g).fileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            // Which bundle names this project declares, and which of them it can actually produce. A
+            // group that has a *producible* counterpart (an authored `x.js` next to an authored
+            // `x.min.js`) takes part in the variant switch; one whose declared counterpart matches no
+            // file on disk has that counterpart synthesised from its own files instead. Declaring
+            // `x.min.js` and shipping only `x.js` used to make a Release build emit neither — the
+            // `.js` group stepped aside for a sibling that wrote nothing (see ProcessResourceGroup).
+            var declared = cfg.Resources
+                .Select(g => ResolveResource(g).fileName)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var producible = cfg.Resources
+                .Where(g => ResourceGroupOutputs(projectDir, g).Count > 0)
+                .Select(g => ResolveResource(g).fileName)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var group in cfg.Resources)
-                ProcessResourceGroup(projectDir, outputDir, group, jsOuts, cssLinks, written, declared, wantFormatted, wantMinified);
+                ProcessResourceGroup(projectDir, outputDir, group, jsOuts, cssLinks, written, declared, producible, wantFormatted, wantMinified);
         }
 
         // 3. The compiled bundle — loads last, after runtime + library deps are in place.
@@ -479,6 +491,24 @@ internal static class OutputBuilder
                         load));
                 }
             }
+        }
+
+        // A `.min.js` group whose files are missing — its bundler never ran, or only the readable
+        // artifact was checked in — produced nothing above, so the package would ship one half of a
+        // pair the author declared and every consumer expects. Copy the formatted item under the
+        // minified name instead: the consumer then picks a variant as usual, and the site it builds
+        // answers a fetch of either name. (Copied, not minified: an authored resource is embedded
+        // exactly as it was written, and squeezing a vendored bundle here is not this build's call.)
+        var embeddedNames = items.Select(i => i.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var declaredResourceNames = config.Resources
+            .Select(g => ResolveResource(g).fileName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items.ToList())
+        {
+            if (!item.Name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) || IsMinifiedName(item.Name)) continue;
+            var minName = ToMinName(item.Name);
+            if (!declaredResourceNames.Contains(minName) || !embeddedNames.Add(minName)) continue;
+            items.Add(item with { Name = minName });
         }
 
         // Every variant of the compiled output, prepended so the main bundle stays first. Shipping the
@@ -797,7 +827,8 @@ internal static class OutputBuilder
     private static void ProcessResourceGroup(
         string projectDir, string outputDir, TransposeJson.ResourceGroup group,
         List<JsOut> jsOuts, List<string> cssLinks, HashSet<string> written,
-        IReadOnlySet<string> declaredNames, bool wantFormatted, bool wantMinified)
+        IReadOnlySet<string> declaredNames, IReadOnlySet<string> producibleNames,
+        bool wantFormatted, bool wantMinified)
     {
         // The output name (the group name minus its "module#" grouping prefix and ".dontload" suffix)
         // plus the effective load flag: a non-loaded resource is written to the output but never
@@ -806,26 +837,54 @@ internal static class OutputBuilder
         var isBundle = IsBundleName(name);
 
         // A JavaScript bundle the project declares in BOTH variants is one resource with two spellings
-        // — Tesserae's `tss-dep.js` / `tss-dep.min.js`, Curiosity's `ExternalBundle` pair — so only the
-        // one this build wants is produced. (Writing both put 700 KB on disk twice and, once a build
-        // generates a single index.html, scripted the same library twice.) A group with no declared
-        // counterpart is an authored resource in the only variant that exists, and is written always.
-        if (name.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && declaredNames.Contains(CounterpartName(name)))
-        {
-            var wanted = IsMinifiedName(name) ? wantMinified : wantFormatted;
-            if (!wanted) return;
-        }
+        // — Tesserae's `tss-dep.js` / `tss-dep.min.js`, Curiosity's `ExternalBundle` pair — and only the
+        // one this build wants is *scripted*, so a single index.html never loads the same library twice.
+        //
+        // The minified name is nevertheless always written, in every configuration. Code that fetches a
+        // resource on demand asks for it by name (GraphKit's `assets/js/graph-kit.min.js`, Monaco's
+        // loader) and cannot know which configuration built the site, so a Debug site that carried only
+        // the formatted half answered those fetches with a 404. The formatted half stays Debug-only:
+        // nothing fetches the readable copy of a bundle a Release site already minified.
+        //
+        // A group with no *producible* counterpart is an authored resource in the only variant that
+        // exists, and is written always. When the counterpart was declared but its files are missing —
+        // a `.min.js` group whose bundler never ran — the formatted file is copied under the minified
+        // name rather than being dropped: the pair the author declared is what everything downstream
+        // fetches, and a build that emitted neither half was the worst of the three answers.
+        var isJs = name.EndsWith(".js", StringComparison.OrdinalIgnoreCase);
+        var counterpart = isJs ? CounterpartName(name) : name;
+        var hasRealCounterpart = isJs && producibleNames.Contains(counterpart);
+        var minified = IsMinifiedName(name);
+
+        // Whether index.html should carry this group at all: the pairing above decides which half is
+        // scripted, and a half that is not this build's is written to disk silently.
+        var scripted = load && (!isJs || !hasRealCounterpart || (minified ? wantMinified : wantFormatted));
+
+        // The formatted half of a real pair is not written by a minified build — the minified half,
+        // which that build scripts, is the whole of what it needs.
+        if (isJs && hasRealCounterpart && !minified && !wantFormatted) return;
+
+        // A declared-but-unproducible `.min.js` counterpart is synthesised from this group's own files.
+        var synthesiseMinified = isJs && isBundle && !minified && !hasRealCounterpart
+                                 && declaredNames.Contains(counterpart);
 
         foreach (var (rel, sources) in ResourceGroupOutputs(projectDir, group))
         {
             WriteResource(outputDir, rel, sources, concatenate: isBundle, written);
-            if (!load) continue;   // written to disk already; not injected into index.html
+
+            var minRel = synthesiseMinified ? ToMinName(rel) : null;
+            if (minRel is not null && minRel != rel)
+                WriteResource(outputDir, minRel, sources, concatenate: isBundle, written);
+
+            if (!scripted) continue;   // written to disk already; not injected into index.html
 
             if (IsCss(rel)) cssLinks.Add(rel);
             // Resource JS is taken as authored (never re-minified): a .min.js links only from
-            // a Release build; a plain .js is scripted in both — matching the legacy compiler.
+            // a Release build; a plain .js is scripted in both — matching the legacy compiler. A
+            // synthesised counterpart is what the minified HTML links, so both HTMLs name a file
+            // this build actually wrote.
             else if (rel.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
-                jsOuts.Add(new JsOut { Path = rel, IsMinified = IsMinifiedName(rel) });
+                jsOuts.Add(new JsOut { Path = rel, IsMinified = IsMinifiedName(rel), MinifiedPath = minRel });
         }
     }
 

--- a/Transpose/Transpose.Translator.Tests/PackageResourceVariantTests.cs
+++ b/Transpose/Transpose.Translator.Tests/PackageResourceVariantTests.cs
@@ -120,20 +120,64 @@ public sealed class PackageResourceVariantTests
     [TestMethod]
     public void AResourceDeclaredInBothVariantsStillSwitchesPerConfiguration()
     {
-        // A library that deliberately ships both variants of an authored bundle keeps the legacy
-        // behaviour: the minified build takes the .min.js, the formatted build takes the .js.
+        // A library that deliberately ships both variants of an authored bundle is *scripted* in one
+        // of them — index.html never loads the same library twice — and the minified name is on disk
+        // in both, because a library's own on-demand loader fetches its bundle by that name and
+        // cannot know which configuration built the site around it.
         var dll = LibraryPackage();
 
-        BuildSite(dll, "Release");
+        var release = BuildSite(dll, "Release");
         AssertInOutput("assets/js/Lib.ExternalBundle.min.js", "a declared .min.js variant is what a Minified build writes");
-        AssertNotInOutput("assets/js/Lib.ExternalBundle.js", "…and the formatted variant is not materialised");
+        AssertNotInOutput("assets/js/Lib.ExternalBundle.js",
+            "…and the formatted variant is not materialised: nothing fetches the readable copy of a bundle a Release site already minified");
 
         Directory.Delete(_outputDir, recursive: true);
         Directory.CreateDirectory(_outputDir);
 
-        BuildSite(dll, "Debug");
+        var debug = BuildSite(dll, "Debug");
         AssertInOutput("assets/js/Lib.ExternalBundle.js", "a Formatted build writes the formatted variant");
-        AssertNotInOutput("assets/js/Lib.ExternalBundle.min.js", "…and not the minified one");
+        AssertInOutput("assets/js/Lib.ExternalBundle.min.js",
+            "…and the minified one alongside it, so a fetch of `…min.js` at run time resolves in a Debug site too");
+
+        StringAssert.Contains(debug, "Lib.ExternalBundle.js", "the formatted variant is the one a Debug index.html scripts");
+        Assert.IsFalse(debug.Contains("Lib.ExternalBundle.min.js"), "…and the minified one is written but never scripted");
+        StringAssert.Contains(release, "Lib.ExternalBundle.min.js", "a Release index.html scripts the minified variant");
+    }
+
+    [TestMethod]
+    public void AMissingMinifiedVariantIsSynthesisedFromTheFormattedOne()
+    {
+        // The reported bug: a library declares the `.js` / `.min.js` pair but ships only the readable
+        // half (its bundler was never run, or only that artifact was checked in). The `.js` group then
+        // stepped aside for a sibling that produced nothing, and a Release site got NEITHER — so the
+        // library's loader 404'd on both names. The formatted file is copied under the minified name
+        // instead, so both names resolve.
+        Asset(_libDir, "tps/assets/js/only-formatted.js", "// authored, never minified");
+        File.WriteAllText(Path.Combine(_libDir, "tps.json"), @"{
+            ""fileName"": ""Lib.js"",
+            ""resources"": [
+                {
+                    ""name"": ""half-a-pair.js"",
+                    ""files"": [ ""tps/assets/js/only-formatted.js"" ],
+                    ""output"": ""assets/js""
+                },
+                {
+                    ""name"": ""half-a-pair.min.js"",
+                    ""files"": [ ""tps/assets/js/only-formatted.min.js"" ],
+                    ""output"": ""assets/js""
+                }
+            ]
+        }");
+
+        var config = TransposeJson.TryLoad(_libDir, "Release");
+        Assert.IsNotNull(config);
+        var dll = PackageDll("Lib", OutputBuilder.CollectEmbeddableItems(_libDir, config!, "Lib.js", "var lib = 1;", null));
+
+        BuildSite(dll, "Release");
+        AssertInOutput("assets/js/half-a-pair.min.js", "the minified name must resolve even though nothing minified was shipped");
+        Assert.AreEqual("// authored, never minified",
+            File.ReadAllText(Path.Combine(_outputDir, "assets", "js", "half-a-pair.min.js")),
+            "…and its content is the formatted file, copied through rather than minified here");
     }
 
     [TestMethod]
@@ -146,6 +190,48 @@ public sealed class PackageResourceVariantTests
         AssertInOutput("Lib.min.js", "the package's pre-minified bundle is what a Minified build writes");
         AssertNotInOutput("Lib.js", "…and the formatted bundle is not materialised");
         StringAssert.Contains(html, "src=\"Lib.min.js\"", "index.html must link the minified bundle in Release");
+    }
+
+    [TestMethod]
+    public void AProjectsOwnResourcesFollowTheSamePairingRules()
+    {
+        // The same three shapes, read from the building project's own tps.json rather than extracted
+        // from a package: a real pair, a declared pair whose minified half is missing, and a
+        // single-variant authored resource.
+        Asset(_appDir, "js/paired.js", "// readable");
+        Asset(_appDir, "js/paired.min.js", "// squeezed");
+        Asset(_appDir, "js/lonely.js", "// only ever existed once");
+        Asset(_appDir, "js/half.js", "// declared as a pair, shipped as one");
+
+        const string tps = @"{
+            ""fileName"": ""app.js"",
+            ""resources"": [
+                { ""name"": ""paired.js"",     ""files"": [ ""js/paired.js"" ],     ""output"": ""assets"" },
+                { ""name"": ""paired.min.js"", ""files"": [ ""js/paired.min.js"" ], ""output"": ""assets"" },
+                { ""name"": ""lonely.js"",     ""files"": [ ""js/lonely.js"" ],     ""output"": ""assets"" },
+                { ""name"": ""half.js"",       ""files"": [ ""js/half.js"" ],       ""output"": ""assets"" },
+                { ""name"": ""half.min.js"",   ""files"": [ ""js/half.min.js"" ],   ""output"": ""assets"" }
+            ]
+        }";
+
+        var dll = LibraryPackage();
+
+        BuildSite(dll, "Release", appTpsJson: tps);
+        AssertInOutput("assets/paired.min.js", "a Release build writes the minified half of a real pair");
+        AssertNotInOutput("assets/paired.js", "…and not the formatted one");
+        AssertInOutput("assets/lonely.js", "a single-variant authored resource keeps its own name");
+        AssertNotInOutput("assets/lonely.min.js", "…and is not duplicated under a name nobody declared");
+        AssertInOutput("assets/half.js", "a declared pair whose minified half is missing still writes what it has");
+        AssertInOutput("assets/half.min.js", "…under both names, rather than emitting neither");
+        Assert.AreEqual("// declared as a pair, shipped as one",
+            File.ReadAllText(Path.Combine(_outputDir, "assets", "half.min.js")));
+
+        Directory.Delete(_outputDir, recursive: true);
+        Directory.CreateDirectory(_outputDir);
+
+        BuildSite(dll, "Debug", appTpsJson: tps);
+        AssertInOutput("assets/paired.js", "a Debug build writes the formatted half");
+        AssertInOutput("assets/paired.min.js", "…and the minified one, which an on-demand loader may fetch by name");
     }
 
     // ------------------------------------------- a package ships every variant; the consumer picks
@@ -252,9 +338,10 @@ public sealed class PackageResourceVariantTests
 
     /// <summary>Builds a consuming project that has no resources of its own — everything in the site
     /// comes from <paramref name="packageDll"/> — and returns its index.html.</summary>
-    private string BuildSite(string packageDll, string configuration, Emitter.ModuleOutput? modules = null)
+    private string BuildSite(string packageDll, string configuration, Emitter.ModuleOutput? modules = null,
+                             string? appTpsJson = null)
     {
-        File.WriteAllText(Path.Combine(_appDir, "tps.json"), @"{ ""fileName"": ""app.js"" }");
+        File.WriteAllText(Path.Combine(_appDir, "tps.json"), appTpsJson ?? @"{ ""fileName"": ""app.js"" }");
 
         var config = TransposeJson.TryLoad(_appDir, configuration);
         Assert.IsNotNull(config, "the app's tps.json must load");

--- a/Transpose/Transpose.Translator.Tests/RequireLoaderTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RequireLoaderTests.cs
@@ -1,0 +1,213 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <c>Transpose.Require</c> (Resources/Require.js): the run-time loader for a script, an ES module
+    /// or a stylesheet the page fetches after it has started.
+    ///
+    /// Every test runs with <c>skipRoslyn: true</c> — there is no native .NET counterpart of injecting
+    /// a &lt;script&gt; — against a tiny DOM stub installed from C#, which records what was asked for
+    /// and can be told which URLs 404. That is what lets the two behaviours worth guarding be asserted
+    /// without a browser: which element a URL is loaded with, and the <c>.js</c> ⇄ <c>.min.js</c>
+    /// fallback that lets a library published once work in a site built either way.
+    /// </summary>
+    [TestClass]
+    public class RequireLoaderTests : TranslatorTestBase
+    {
+        /// <summary>A DOM just real enough for Require.js: elements that report load or error a tick
+        /// after they are appended, a document whose baseURI relative URLs resolve against, and a log
+        /// of every request in the order it was made.</summary>
+        private const string Preamble = @"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public static class Dom
+{
+    public static void Install()
+    {
+        Script.Write(@""
+            var byTag = { script: [], link: [] };
+            globalThis.__requested = [];
+            globalThis.__missing = {};
+            globalThis.window = { addEventListener: function () { } };
+            globalThis.document = {
+                baseURI: 'https://site.test/app/',
+                readyState: 'loading',
+                createElement: function (tag) {
+                    return {
+                        tagName: tag,
+                        $l: {},
+                        addEventListener: function (type, handler) {
+                            (this.$l[type] = this.$l[type] || []).push(handler);
+                        }
+                    };
+                },
+                getElementsByTagName: function (tag) { return byTag[tag] || []; }
+            };
+            document.head = {
+                appendChild: function (element) {
+                    var url = element.src || element.href;
+                    var kind = element.tagName === 'link' ? 'style' : (element.type === 'module' ? 'module' : 'script');
+                    __requested.push(kind + ' ' + url);
+                    var list = byTag[element.tagName];
+                    list.push(element);
+                    element.parentNode = { removeChild: function (e) { list.splice(list.indexOf(e), 1); } };
+                    setTimeout(function () {
+                        var type = __missing[url] ? 'error' : 'load';
+                        var handlers = element.$l[type] || [];
+                        for (var i = 0; i < handlers.length; i++) handlers[i]({ type: type });
+                    }, 0);
+                }
+            };
+        "");
+    }
+
+    public static void Missing(string url) => Script.Write(""__missing[{0}] = true;"", url);
+
+    public static string Requested => Script.Write<string>(""__requested.join('\\n')"");
+}
+";
+
+        [TestMethod]
+        public async Task EachUrlIsLoadedWithTheElementItsExtensionCallsForAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Dom.Install();
+
+        // One call, several files: they load in order, because a plugin has to arrive after the
+        // library it extends.
+        await Require.RequireAsync(""assets/css/site.css"", ""assets/js/d3.js"", ""./chunks/c0.mjs"");
+
+        // A module entry keeps the bundle's .js name, so nothing about the URL says what it is.
+        await Require.RequireAsync(RequireKind.Module, ""Admin.js?v=7"");
+
+        Console.WriteLine(Dom.Requested);
+    }
+}", skipRoslyn: true);
+
+            Assert.AreEqual(
+                "style https://site.test/app/assets/css/site.css\n"
+                + "script https://site.test/app/assets/js/d3.js\n"
+                + "module https://site.test/app/chunks/c0.mjs\n"
+                + "module https://site.test/app/Admin.js?v=7",
+                output,
+                "a .css is a stylesheet link, a .mjs a module, anything else a classic script — and an "
+                + "explicit kind wins over the extension");
+        }
+
+        [TestMethod]
+        public async Task AMissingMinifiedVariantFallsBackToTheFormattedOneAsync()
+        {
+            // The case this exists for: a library asks for its bundle by the minified name, and the
+            // site it is running in was built formatted, so only the other spelling is there.
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Dom.Install();
+        Dom.Missing(""https://site.test/app/assets/js/graph-kit.min.js"");
+        Dom.Missing(""https://site.test/app/assets/js/only-minified.js"");
+
+        await Require.RequireAsync(""assets/js/graph-kit.min.js"");
+        await Require.RequireAsync(""assets/js/only-minified.js"");
+
+        Console.WriteLine(Dom.Requested);
+    }
+}", skipRoslyn: true);
+
+            Assert.AreEqual(
+                "script https://site.test/app/assets/js/graph-kit.min.js\n"
+                + "script https://site.test/app/assets/js/graph-kit.js\n"
+                + "script https://site.test/app/assets/js/only-minified.js\n"
+                + "script https://site.test/app/assets/js/only-minified.min.js",
+                output,
+                "the fallback goes both ways: a site keeps whichever variant its own build called for");
+        }
+
+        [TestMethod]
+        public async Task OneFetchIsSharedAndAFailedOneIsForgottenAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Dom.Install();
+
+        // The same file asked for three ways: relative, dot-relative, absolute. Every spelling
+        // resolves against the document base first, so it is one entry and one fetch.
+        await Require.RequireAsync(""assets/js/lib.js"");
+        await Require.RequireAsync(""./assets/js/lib.js"");
+        await Require.RequireAsync(""https://site.test/app/assets/js/lib.js"");
+        Console.WriteLine(""loaded: "" + Require.IsLoaded(""assets/js/lib.js""));
+
+        Dom.Missing(""https://site.test/app/gone.js"");
+        Dom.Missing(""https://site.test/app/gone.min.js"");
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                await Require.RequireAsync(""gone.js"");
+                Console.WriteLine(""unexpected success"");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(""failed: "" + e.Message);
+            }
+        }
+
+        Console.WriteLine(Dom.Requested);
+    }
+}", skipRoslyn: true);
+
+            Assert.AreEqual(
+                "loaded: True\n"
+                + "failed: Transpose.Require: failed to load 'https://site.test/app/gone.js'.\n"
+                + "failed: Transpose.Require: failed to load 'https://site.test/app/gone.js'.\n"
+                + "script https://site.test/app/assets/js/lib.js\n"
+                + "script https://site.test/app/gone.js\n"
+                + "script https://site.test/app/gone.min.js\n"
+                + "script https://site.test/app/gone.js\n"
+                + "script https://site.test/app/gone.min.js",
+                output,
+                "a successful load is shared by every later caller; a failed one is forgotten, so the "
+                + "second attempt really tries again — and it reports the URL that was asked for, not "
+                + "the counterpart it also tried");
+        }
+
+        [TestMethod]
+        public async Task AFileTheDocumentAlreadyCarriesIsNotFetchedAgainAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Dom.Install();
+
+        // index.html scripted it before anything asked: the document is complete, so there is
+        // nothing left to wait for and nothing to add.
+        Script.Write(@""
+            document.readyState = 'complete';
+            document.getElementsByTagName('script').push({ src: 'https://site.test/app/tss.js' });
+        "");
+
+        Console.WriteLine(""loaded before: "" + Require.IsLoaded(""tss.js""));
+        await Require.RequireAsync(""tss.js"");
+        Console.WriteLine(""requests: ["" + Dom.Requested + ""]"");
+    }
+}", skipRoslyn: true);
+
+            Assert.AreEqual("loaded before: True\nrequests: []", output,
+                "a file the page already carries is waited on, never fetched a second time");
+        }
+    }
+}


### PR DESCRIPTION
Two halves of one problem: code that fetches a bundle at run time asks for it by name, and the name it asks for was not always in the site.

## The compiler side — the `.js` / `.min.js` pair

A pair declared in `tps.json` is still **scripted** in one variant (index.html must not load the same library twice), but:

- **The minified half is now written to disk in every configuration**, and the formatted half stays Debug-only. A Debug site that carried only `graph-kit.js` answered a fetch of `graph-kit.min.js` with a 404 — and a package compiled once cannot know which configuration built the site around it. Applies to both paths: a project's own `tps.json` resources and a referenced package's embedded ones.
- **A pair whose minified half matches no file on disk now synthesises it from the formatted one.** That case (a bundler that was never run, only the readable artifact checked in) used to emit *neither* half in a Release build: the `.js` group stepped aside for a sibling that wrote nothing. The copy is made both when writing a site and when embedding a package, so the pair the author declared is the pair everything downstream finds. Copied, not minified — an authored resource is taken exactly as written.

Unchanged: a resource that ships in **one** variant (Monaco's `editor.main.js`, a vendored `d3.min.js`) still keeps its authored name in every configuration, and the compiled bundle's variant tags decide as before.

## The runtime side — `Transpose.Require`

`Require.RequireAsync` (`BCL/Transpose.BCL/Resources/Require.js`) is one loader for fetching a script, an ES module or a stylesheet after the page has started. Every application on Transpose had grown its own version of this — Tesserae's `Require`, GraphKit's `GK.LoadAsync`, Curiosity's `ExternalLibraries`, Monaco's loader — each a `<script>` element and a slightly different set of things it got wrong.

```csharp
await Require.RequireAsync("assets/js/graph-kit.min.js");            // .js is tried if it 404s
await Require.RequireAsync("assets/css/fullcalendar.css", "assets/js/fullcalendar.js");
await Require.RequireAsync(RequireKind.Module, "./Admin.js?v=7");     // a module keeping a .js name
```

It:

- picks the element from the URL — `.css` → a stylesheet link, `.mjs` → a module script, anything else → a classic script — with `RequireKind` for the file whose extension does not say (a Transpose module entry keeps the bundle's `.js` name);
- resolves the URL against `document.baseURI` first, so `assets/x.js`, `./assets/x.js` and the absolute form are one entry, and a file `index.html` already carries is waited on rather than fetched again;
- shares one fetch between every caller and forgets a failed one, so a later caller retries instead of inheriting the failure;
- loads several URLs **in order** (a plugin has to arrive after the library it extends);
- **falls back between the `.js` and `.min.js` spellings** — the run-time half of the rule above. Only if both fail does the task fault, reporting the URL that was asked for.

## Testing

- `PackageResourceVariantTests` — extended for both new behaviours, plus a case covering the building project's own resources.
- `RequireLoaderTests` (new) — runs the real runtime on Node against a DOM stub: element per extension, the fallback in both directions, one-fetch-shared / failure-forgotten, and a file the document already carries.
- Full translator suite: 960 passed, 0 failed. (The run ends in a "test host process crashed" abort, which reproduces identically on `master` with no changes — pre-existing, and it happens after every test has reported.)
- Verified in a browser end to end on the GraphKit sample: the Debug site now carries both `graph-kit.js` and `graph-kit.min.js` and loads with no 404; with the minified one deleted from the site, the loader falls back to the formatted one and the bundle still loads.

## Follow-up

The library repos (tesserae, graph-kit, tesserae-monaco, mosaik) drop their own loaders in favour of this one; those changes need a published `Transpose.BCL` carrying `Transpose.Require` to pin against, which is why this PR comes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4V2aD4KX78rtdZ74RGThB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4V2aD4KX78rtdZ74RGThB)_