### PR TITLE
Stop losing a browser error's message and stack when it is handled

### DIFF
--- a/BCL/Transpose.BCL/Resources/AggregateException.js
+++ b/BCL/Transpose.BCL/Resources/AggregateException.js
@@ -4,7 +4,12 @@
         ctor: function (message, innerExceptions) {
             this.$initialize();
             this.innerExceptions = new(System.Collections.ObjectModel.ReadOnlyCollection$1(System.Exception))(Transpose.hasValue(innerExceptions) ? Transpose.toArray(innerExceptions) : []);
-            System.Exception.ctor.call(this, message || 'One or more errors occurred.', this.innerExceptions.Count > 0 ? this.innerExceptions.getItem(0) : null);
+
+            // The text this was constructed with, before the inner messages are appended - .NET's
+            // `base.Message`, which is what Flatten() carries over to the flattened aggregate.
+            this.baseMessage = message ? message : "One or more errors occurred.";
+
+            System.Exception.ctor.call(this, System.AggregateException.composeMessage(this.baseMessage, this.innerExceptions), this.innerExceptions.Count > 0 ? this.innerExceptions.getItem(0) : null);
         },
 
         handle: function (predicate) {
@@ -16,8 +21,12 @@
                 unhandledExceptions = [];
 
             for (var i = 0; i < count; i++) {
-                if (!predicate(this.innerExceptions.get(i))) {
-                    unhandledExceptions.push(this.innerExceptions.getItem(i));
+                // getItem, not get: the ReadOnlyCollection indexer is emitted as getItem, so this
+                // threw "this.innerExceptions.get is not a function" for every call to Handle.
+                var inner = this.innerExceptions.getItem(i);
+
+                if (!predicate(inner)) {
+                    unhandledExceptions.push(inner);
                 }
             }
 
@@ -83,7 +92,52 @@
                 }
             }
 
-            return new System.AggregateException(this.Message, flattenedExceptions);
+            // base.Message, not Message: composing again over the flattened list would repeat
+            // every inner message the composed text already names.
+            return new System.AggregateException(this.baseMessage, flattenedExceptions);
+        },
+
+        toString: function () {
+            // base.ToString() reports the type, the composed message and the FIRST inner exception
+            // (which is InnerException). Every other inner exception is unreachable from it, so
+            // .NET lists them afterwards - and they are exactly what the reader is looking for
+            // when several tasks failed at once.
+            var text = System.Exception.prototype.toString.call(this);
+            var count = this.innerExceptions.Count;
+
+            for (var i = 0; i < count; i++) {
+                var inner = this.innerExceptions.getItem(i);
+
+                if (inner === this.InnerException) {
+                    continue;
+                }
+
+                text += "\n---> (Inner Exception #" + i + ") " + Transpose.toString(inner) + "<---\n";
+            }
+
+            return text;
+        },
+
+        statics: {
+            // "One or more errors occurred. (first) (second)" - the message .NET reports, which is
+            // the base text followed by every inner message in parentheses. Composed once, in the
+            // constructor, because generated code reads Message as the `message` FIELD (through
+            // TransposeR.message) rather than through a property getter it could override.
+            composeMessage: function (baseMessage, innerExceptions) {
+                var count = innerExceptions ? innerExceptions.Count : 0;
+
+                if (count === 0) {
+                    return baseMessage;
+                }
+
+                var text = baseMessage;
+
+                for (var i = 0; i < count; i++) {
+                    text += " (" + System.Exception.describe(innerExceptions.getItem(i)) + ")";
+                }
+
+                return text;
+            }
         }
     });
 

--- a/BCL/Transpose.BCL/Resources/Exception.js
+++ b/BCL/Transpose.BCL/Resources/Exception.js
@@ -15,7 +15,14 @@
 
                 StackTrace: {
                     get: function () {
-                        return this.errorStack.stack;
+                        // errorStack holds whatever carried the frames: the Error captured by the
+                        // constructor, or - for an exception wrapping something the engine threw -
+                        // that value itself. A thrown non-Error has no `stack`, and a caller may
+                        // have assigned anything at all, so answer null rather than throwing or
+                        // handing C# an undefined.
+                        var carrier = this.errorStack;
+
+                        return (carrier && typeof carrier.stack === "string") ? carrier.stack : null;
                     }
                 },
 
@@ -24,7 +31,9 @@
                 // exist as lowercase fields; StackTrace/HResult need explicit camelCase accessors.
                 stackTrace: {
                     get: function () {
-                        return this.errorStack.stack;
+                        var carrier = this.errorStack;
+
+                        return (carrier && typeof carrier.stack === "string") ? carrier.stack : null;
                     }
                 },
 
@@ -83,6 +92,15 @@
                 builder += "\n";
             }
 
+            // .NET reports the whole chain. Without this an exception that wraps the error that
+            // actually failed - a browser error behind an HttpRequestException, say - printed
+            // nothing at all about it, which is the one thing the reader needs.
+            var inner = this.InnerException;
+
+            if (inner != null && inner !== this) {
+                builder += " ---> " + Transpose.toString(inner) + "\n   --- End of inner exception stack trace ---\n";
+            }
+
             if (this.StackTrace != null) {
                 builder += this.StackTrace + "\n";
             }
@@ -91,28 +109,96 @@
         },
 
         statics: {
+            // Wrap a value the engine handed us - something thrown across an interop boundary, a
+            // rejected promise's reason, a DOM error event - in a System.Exception without losing
+            // what it carried. Two things a browser gives us are the whole diagnostic and both were
+            // easy to drop here: the message (which has to reach C# as a *string*, not as the Error
+            // object itself) and the stack, whose frames point at the real throw site rather than at
+            // this wrapper.
             create: function (error) {
                 if (Transpose.is(error, System.Exception)) {
                     return error;
                 }
 
-                var ex;
+                // An ErrorEvent (window.onerror, worker.onerror) or a PromiseRejectionEvent wraps
+                // the value that was actually thrown; that value is the one carrying the stack, so
+                // unwrap it and keep the event as a fallback for the message.
+                var source = (error && !(error instanceof Error)) ? (error.error || error.reason || error) : error;
+                var carrier = System.Exception.stackCarrier(source) || System.Exception.stackCarrier(error);
+                var message = System.Exception.describe(source);
 
-                if (error instanceof TypeError) {
-                    ex = new System.NullReferenceException.$ctor1(error.message);
-                } else if (error instanceof RangeError) {
-                    ex = new System.ArgumentOutOfRangeException.$ctor1(error.message);
-                } else if (error instanceof Error) {
-                    return new System.SystemException.$ctor1(error);
-                } else if (error && error.error && error.error.stack) {
-                    ex = new System.Exception(error.error.stack);
-                } else {
-                    ex = new System.Exception(error ? error.message ? error.message : error.toString() : null);
+                if (message == null && source !== error) {
+                    message = System.Exception.describe(error);
                 }
 
-                ex.errorStack = error;
+                var ex;
+
+                if (source instanceof TypeError) {
+                    ex = new System.NullReferenceException.$ctor1(message);
+                } else if (source instanceof RangeError) {
+                    // (message, innerException), not (paramName): the browser's message is a
+                    // sentence about what went wrong, and reporting it as a parameter name buried it
+                    // inside "Specified argument was out of the range of valid values.".
+                    ex = new System.ArgumentOutOfRangeException.$ctor2(message, null);
+                } else if (source instanceof Error || carrier) {
+                    ex = new System.SystemException.$ctor1(message);
+                } else {
+                    ex = new System.Exception(message);
+                }
+
+                if (carrier) {
+                    // Report the browser's own frames: left alone, the only stack on the exception is
+                    // the one its constructor just captured, every frame of which is inside tps.js.
+                    // Conversely a thrown non-Error has no frames to take, and that captured stack -
+                    // taken in the handler, close to the throw - is then the best there is, so
+                    // assigning unconditionally (as this did) left it with no stack trace at all.
+                    ex.errorStack = carrier;
+                }
+
+                // The value exactly as it arrived, so nothing it carried is unreachable: an
+                // ErrorEvent's filename/lineno, a CloseEvent's code/reason, a DOMException's name.
+                ex.errorSource = error;
 
                 return ex;
+            },
+
+            // The value carrying a JavaScript stack, if any. Duck-typed rather than
+            // `instanceof Error`, because instanceof is per-realm: an error from an iframe or a
+            // worker is a real Error that fails the test.
+            stackCarrier: function (value) {
+                return (value && typeof value.stack === "string" && value.stack.length > 0) ? value : null;
+            },
+
+            // A description of a raw JavaScript value as a string - Exception.Message is a string in
+            // C#, and handing back the Error object instead made every string operation on it
+            // (Length, Contains, IsNullOrEmpty) answer for an object.
+            describe: function (value) {
+                if (value === null || value === undefined) {
+                    return null;
+                }
+
+                if (typeof value === "string") {
+                    return value;
+                }
+
+                if (typeof value.message === "string" && value.message.length > 0) {
+                    return value.message;
+                }
+
+                // A DOM event - a WebSocket or XHR `error`, a failed <script> - carries no message
+                // and stringifies to "[object Event]", which says nothing. Name the event and what
+                // raised it instead.
+                if (typeof value.type === "string" && value.type.length > 0 && "target" in value) {
+                    var raisedBy = (value.target && value.target.constructor && value.target.constructor.name !== "Object") ? value.target.constructor.name : null;
+
+                    return "A JavaScript '" + value.type + "' event was raised" + (raisedBy ? " by " + raisedBy : "") + ".";
+                }
+
+                try {
+                    return String(value);
+                } catch (e) {
+                    return null;
+                }
             }
         }
     });

--- a/BCL/Transpose.BCL/Resources/Task.js
+++ b/BCL/Transpose.BCL/Resources/Task.js
@@ -125,7 +125,9 @@
                         if (Transpose.is(result, System.Threading.Tasks.Task)) {
                             result.continueWith(function () {
                                 if (result.isFaulted() || result.isCanceled()) {
-                                    tcs.setException(result.exception.innerExceptions.Count > 0 ? result.exception.innerExceptions.getItem(0) : result.exception);
+                                    // As in _getResult: the inner task may have been faulted with a
+                                    // bare exception, which has no innerExceptions to read.
+                                    tcs.setException(result.exception && result.exception.innerExceptions && result.exception.innerExceptions.Count > 0 ? result.exception.innerExceptions.getItem(0) : result.exception);
                                 } else {
                                     tcs.setResult(result.getAwaitedResult());
                                 }
@@ -504,7 +506,20 @@
                     var ex = new System.Threading.Tasks.TaskCanceledException.$ctor3(this);
                     throw awaiting ? ex : new System.AggregateException(null, [ex]);
                 case System.Threading.Tasks.TaskStatus.faulted:
-                    throw awaiting ? (this.exception.innerExceptions.Count > 0 ? this.exception.innerExceptions.getItem(0) : null) : this.exception;
+                    // A task can be faulted with a bare exception rather than an AggregateException
+                    // (Task.FromException does exactly that), and an AggregateException can carry no
+                    // inner exception at all. Rethrow whatever there is: reading `.innerExceptions`
+                    // blindly raised a TypeError over the real fault, and the `null` this used to
+                    // fall back to discarded it outright.
+                    if (!awaiting) {
+                        throw this.exception;
+                    }
+
+                    if (this.exception && this.exception.innerExceptions && this.exception.innerExceptions.Count > 0) {
+                        throw this.exception.innerExceptions.getItem(0);
+                    }
+
+                    throw this.exception ? this.exception : new System.Exception("A task failed without reporting an exception.");
                 default:
                     throw new System.InvalidOperationException.$ctor1("Task is not yet completed.");
             }
@@ -602,6 +617,15 @@
         trySetException: function (exception) {
             if (Transpose.is(exception, System.Exception)) {
                 exception = [exception];
+            } else if (Array.isArray(exception)) {
+                exception = exception.map(function (item) { return System.Exception.create(item); });
+            } else if (exception === null || exception === undefined || typeof exception.getEnumerator !== "function") {
+                // A value that crossed from JavaScript - a rejected promise's reason, a raw browser
+                // Error bound by `catch (Exception)` - is not a System.Exception, and constructing
+                // the AggregateException below out of it threw "Cannot create Enumerator." from
+                // inside the setter: the task then stayed un-completed forever (so every awaiter
+                // hung) and the error itself was gone. Wrap whatever arrived instead.
+                exception = [System.Exception.create(exception)];
             }
 
             exception = new System.AggregateException(null, exception);

--- a/BCL/Transpose.BCL/Resources/Task.js
+++ b/BCL/Transpose.BCL/Resources/Task.js
@@ -110,21 +110,60 @@
                 var t = new (System.Threading.Tasks.Task$1(T || System.Object))();
 
                 t.status = System.Threading.Tasks.TaskStatus.faulted;
-                t.exception = exception;
+                // Task.Exception is an AggregateException in .NET, always - and it wraps whatever it
+                // is given, an AggregateException included. Storing the bare exception left
+                // task.Exception.InnerException null, so the fault was simply unreachable from the
+                // Task, and made every reader of `.innerExceptions` a special case (WhenAll's
+                // continuation died on one, silently).
+                t.exception = new System.AggregateException(null, [System.Exception.create(exception)]);
 
                 return t;
             },            
 
-            run: function (fn) {
+            fromCanceled: function (token, T) {
+                // .NET refuses a token that is not already cancelled - the task has to BE cancelled,
+                // and there is nothing to cancel it later.
+                if (!token || !token.getIsCancellationRequested()) {
+                    throw new System.ArgumentOutOfRangeException.$ctor1("cancellationToken");
+                }
+
+                var t = new (System.Threading.Tasks.Task$1(T || System.Object))();
+
+                t.cancel();
+
+                return t;
+            },
+
+            run: function (fn, token) {
                 var tcs = new System.Threading.Tasks.TaskCompletionSource();
 
                 System.Threading.Tasks.Task.schedule(function () {
+                    // Task.Run(fn, token)'s token cancels the SCHEDULING, not the body: it is read
+                    // when the work reaches the front of the queue, and a cancellation by then means
+                    // fn is never invoked. Deliberately not short-circuited before the schedule -
+                    // .NET reports IsCanceled false immediately after the call even for an
+                    // already-cancelled token, because the transition happens on the scheduler.
+                    if (token && token.getIsCancellationRequested()) {
+                        tcs.setCanceled();
+
+                        return;
+                    }
+
                     try {
-                        var result = fn();
+                        // asTask, so a body that hands back a native promise - a [Script]-bound JS
+                        // async function, which is what Func<Task> often is here - is awaited rather
+                        // than becoming the task's RESULT, with its rejection unobserved.
+                        var result = System.Threading.Tasks.Task.asTask(fn());
 
                         if (Transpose.is(result, System.Threading.Tasks.Task)) {
                             result.continueWith(function () {
-                                if (result.isFaulted() || result.isCanceled()) {
+                                if (result.isCanceled()) {
+                                    // Unwrapping keeps the KIND of the inner completion: reporting a
+                                    // cancelled inner task as a fault turned "the caller changed
+                                    // their mind" into an error, and the OperationCanceledException
+                                    // a caller catches into an unexpected one.
+                                    tcs.setCanceled();
+                                } else if (result.isFaulted()) {
                                     // As in _getResult: the inner task may have been faulted with a
                                     // bare exception, which has no innerExceptions to read.
                                     tcs.setException(result.exception && result.exception.innerExceptions && result.exception.innerExceptions.Count > 0 ? result.exception.innerExceptions.getItem(0) : result.exception);
@@ -143,6 +182,39 @@
                 return tcs.task;
             },
 
+            // Each element as a real Task. `await` accepts a native promise (Transpose.toPromise),
+            // so a [Script] binding that returns one - the natural way to bind a JS async function -
+            // behaves like a working Task right up until it is handed to WhenAll/WhenAny, which
+            // drive their arguments through continueWith: the call died on "continueWith is not a
+            // function" and, being inside a promise, took the rejection out of reach with it.
+            asTasks: function (tasks) {
+                var out = new Array(tasks.length),
+                    i;
+
+                for (i = 0; i < tasks.length; i++) {
+                    out[i] = System.Threading.Tasks.Task.asTask(tasks[i]);
+                }
+
+                return out;
+            },
+
+            asTask: function (awaitable) {
+                if (!awaitable || typeof awaitable.continueWith === "function" || typeof awaitable.then !== "function") {
+                    return awaitable;
+                }
+
+                var tcs = new System.Threading.Tasks.TaskCompletionSource();
+
+                awaitable.then(
+                    function (value) { tcs.trySetResult(value); },
+                    // Normalised, so an awaiter of the WhenAll sees the same System.Exception it
+                    // would have seen awaiting the promise directly.
+                    function (reason) { tcs.trySetException(System.Exception.create(reason)); }
+                );
+
+                return tcs.task;
+            },
+
             whenAll: function (tasks) {
                 var tcs = new System.Threading.Tasks.TaskCompletionSource(),
                     result,
@@ -156,6 +228,8 @@
                 } else if (!Transpose.isArray(tasks)) {
                     tasks = Array.prototype.slice.call(arguments, 0);
                 }
+
+                tasks = System.Threading.Tasks.Task.asTasks(tasks);
 
                 if (tasks.length === 0) {
                     tcs.setResult([]);
@@ -177,7 +251,17 @@
                                     cancelled = true;
                                     break;
                                 case System.Threading.Tasks.TaskStatus.faulted:
-                                    System.Array.addRange(exceptions, t.exception.innerExceptions);
+                                    // A task can be faulted with a bare exception rather than an
+                                    // AggregateException (Task.FromException does exactly that), so
+                                    // there may be no innerExceptions to range over. Reading it
+                                    // blindly threw from inside this continuation, which left the
+                                    // WhenAll task un-completed forever: every awaiter hung and the
+                                    // program simply stopped, with nothing reported anywhere.
+                                    if (t.exception && t.exception.innerExceptions) {
+                                        System.Array.addRange(exceptions, t.exception.innerExceptions);
+                                    } else if (t.exception) {
+                                        exceptions.push(t.exception);
+                                    }
                                     break;
                                 default:
                                     throw new System.InvalidOperationException.$ctor1("Invalid task status: " + t.status);
@@ -209,6 +293,8 @@
                 if (!tasks.length) {
                     throw new System.ArgumentException.$ctor1("At least one task is required");
                 }
+
+                tasks = System.Threading.Tasks.Task.asTasks(tasks);
 
                 var tcs = new System.Threading.Tasks.TaskCompletionSource(),
                     i;
@@ -523,6 +609,23 @@
                 default:
                     throw new System.InvalidOperationException.$ctor1("Task is not yet completed.");
             }
+        },
+
+        // Task.Wait(). JavaScript cannot block, so a wait on a task that has NOT completed can only
+        // answer "still running" - but a wait on one that HAS must do what .NET's Wait does and
+        // observe it, throwing the AggregateException for a fault or a cancellation. Emitted as a
+        // bare `wait()` whose returned Task nobody ever looked at, Wait() discarded that exception
+        // outright: the single thing it exists for. The bool is Wait(timeout)'s "did it complete",
+        // and answering false for a pending task is right for the same reason - no time can pass
+        // while a single-threaded runtime is inside this call.
+        waitSync: function () {
+            if (!this.isCompleted()) {
+                return false;
+            }
+
+            this._getResult(false);
+
+            return true;
         },
 
         getResult: function () {
@@ -878,7 +981,17 @@
         }
 
         if (awaitable instanceof Promise || typeof awaitable.then === 'function') {
-            return awaitable;
+            // A native promise rejects with whatever JavaScript threw - an Error, a string, a DOM
+            // event - and `await`ing it binds that raw value to `catch (Exception e)`: GetType()
+            // answered "Error", `e is IOException` was false, and GetBaseException()/Data/ToString
+            // were simply absent. Normalise it the way every other JS->C# seam already does
+            // (Task.Run, TransposeR.fromPromise, ContinueWith), which also keeps the browser's
+            // message and frames. A value that is already a System.Exception is returned unchanged,
+            // so nothing is double-wrapped - including the exception an awaited C# Task rejected
+            // with below.
+            return Promise.resolve(awaitable).catch(function (reason) {
+                throw System.Exception.create(reason);
+            });
         }
 
         if (Transpose.is(awaitable, System.Threading.Tasks.Task) || (awaitable && typeof awaitable.continueWith === 'function')) {

--- a/BCL/Transpose.BCL/System/Exception.cs
+++ b/BCL/Transpose.BCL/System/Exception.cs
@@ -18,8 +18,15 @@ namespace System
         /// <summary>
         /// Gets a message that describes the current exception.
         /// </summary>
+        /// <remarks>
+        /// Read through a helper for the same reason as <see cref="StackTrace"/>: a value caught by
+        /// <c>catch (Exception)</c> may be a real <see cref="Exception"/>, a raw JavaScript error
+        /// (both carry a <c>message</c>) or a bare value someone threw - a string, an object - which
+        /// has no <c>message</c> field, so reading the member directly reported no message at all.
+        /// </remarks>
         public virtual extern string Message
         {
+            [Transpose.Template("TransposeR.message({this})")]
             get;
         }
 

--- a/BCL/Transpose.BCL/System/Threading/Tasks/Task.cs
+++ b/BCL/Transpose.BCL/System/Threading/Tasks/Task.cs
@@ -64,31 +64,38 @@ namespace System.Threading.Tasks
 
         public extern void Complete(object result = null);
 
-        [ToAwait]
+        // Wait bound to `waitSync`, which observes an already-completed task the way .NET does -
+        // throwing the AggregateException of a faulted or cancelled one - and answers false for a
+        // task still running. [ToAwait] (h5's rewrite of the call into an `await`) is not
+        // implemented by the Roslyn translator, so these were emitted as a plain `wait()` whose returned
+        // Task nobody looked at, which threw nothing at all for a faulted task. Blocking until a
+        // pending task completes remains impossible in a single-threaded runtime; observing one that
+        // has already finished never needed to block.
+        [Template("{this}.waitSync()")]
         public extern void Wait();
 
         [Name("wait")]
         public extern Task WaitTask();
 
-        [ToAwait]
+        [Template("{this}.waitSync()")]
         public extern void Wait(CancellationToken cancellationToken);
 
         [Name("wait")]
         public extern Task WaitTask(CancellationToken cancellationToken);
 
-        [ToAwait]
+        [Template("{this}.waitSync()")]
         public extern bool Wait(int millisecondsTimeout);
 
         [Name("waitt")]
         public extern Task<bool> WaitTask(int millisecondsTimeout);
 
-        [ToAwait]
+        [Template("{this}.waitSync()")]
         public extern bool Wait(int millisecondsTimeout, CancellationToken cancellationToken);
 
         [Name("waitt")]
         public extern Task<bool> WaitTask(int millisecondsTimeout, CancellationToken cancellationToken);
 
-        [ToAwait]
+        [Template("{this}.waitSync()")]
         public extern bool Wait(TimeSpan timeout);
 
         [Name("waitt")]
@@ -127,9 +134,33 @@ namespace System.Threading.Tasks
         [Transpose.Template("System.Threading.Tasks.Task.fromException({exception}, {TResult})")]
         public static extern Task<TResult> FromException<TResult>(Exception exception);        
 
+        /// <summary>A task already in the cancelled state. The token must already be cancelled -
+        /// there is nothing to cancel the task later - which is what .NET checks for too.</summary>
+        public static extern Task FromCanceled(CancellationToken cancellationToken);
+
+        [Transpose.Template("System.Threading.Tasks.Task.fromCanceled({cancellationToken}, {TResult})")]
+        public static extern Task<TResult> FromCanceled<TResult>(CancellationToken cancellationToken);
+
+        // All eight overloads bind to the one runtime `run`, the way Delay's four bind to `delay`:
+        // it takes an optional token and unwraps a Task the body handed back, so Func<Task> and
+        // Func<Task<TResult>> need no separate implementation. Declaring them matters anyway -
+        // without them `Task.Run(async () => …)` bound to Action/Func<TResult> and its declared type
+        // came out as Task<Task<TResult>>, and the CancellationToken forms did not compile at all.
         public static extern Task Run(Action action);
 
+        public static extern Task Run(Action action, CancellationToken cancellationToken);
+
         public static extern Task<TResult> Run<TResult>(Func<TResult> function);
+
+        public static extern Task<TResult> Run<TResult>(Func<TResult> function, CancellationToken cancellationToken);
+
+        public static extern Task Run(Func<Task> function);
+
+        public static extern Task Run(Func<Task> function, CancellationToken cancellationToken);
+
+        public static extern Task<TResult> Run<TResult>(Func<Task<TResult>> function);
+
+        public static extern Task<TResult> Run<TResult>(Func<Task<TResult>> function, CancellationToken cancellationToken);
 
         public static extern Task WhenAll(params Task[] tasks);
 

--- a/Transpose/Transpose.Translator.Tests/AggregateExceptionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/AggregateExceptionTests.cs
@@ -1,0 +1,526 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <c>AggregateException</c> and the task faults that produce one. This is where a failure gets
+    /// lost most easily, because a task's exception is reported through three different shapes
+    /// depending on how it is observed — <c>await</c> throws the first inner exception unwrapped,
+    /// <c>.Result</c> and <c>.Wait()</c> throw the aggregate, and <c>task.Exception</c> hands it to
+    /// you without throwing — and every one of them has to agree about what actually failed.
+    ///
+    /// Every case runs natively as well and the two outputs are diffed, which is what pins the
+    /// message text and the shapes down rather than an opinion about them.
+    /// </summary>
+    [TestClass]
+    public class AggregateExceptionTests : TranslatorTestBase
+    {
+        /// <summary>
+        /// The aggregate's own surface: its inner list, that <c>InnerException</c> is the first of
+        /// them, and — the part that is easy to leave out and expensive to leave out — that its
+        /// <c>Message</c> NAMES every inner message. "One or more errors occurred." on its own is
+        /// what a logger prints, and it says nothing whatsoever about what failed.
+        /// </summary>
+        [TestMethod]
+        public async Task AnAggregatesMessageNamesEveryInnerExceptionAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var a = new AggregateException(""two failed"",
+            new FormatException(""first""),
+            new InvalidOperationException(""second""));
+
+        Console.WriteLine(""count: "" + a.InnerExceptions.Count);
+        Console.WriteLine(""[0]: "" + a.InnerExceptions[0].GetType().FullName + "" / "" + a.InnerExceptions[0].Message);
+        Console.WriteLine(""[1]: "" + a.InnerExceptions[1].GetType().FullName + "" / "" + a.InnerExceptions[1].Message);
+        Console.WriteLine(""InnerException is the first: "" + ReferenceEquals(a.InnerException, a.InnerExceptions[0]));
+        Console.WriteLine(""message: |"" + a.Message + ""|"");
+
+        Console.WriteLine(""default message: |"" + new AggregateException(new FormatException(""only"")).Message + ""|"");
+        Console.WriteLine(""no inner: |"" + new AggregateException(""nothing inside"").Message + ""|"");
+        Console.WriteLine(""nothing at all: |"" + new AggregateException().Message + ""|"");
+
+        // ToString lists the inner exceptions base.ToString() cannot reach - i.e. all but the first.
+        var text = a.ToString();
+        Console.WriteLine(""prints the composed message: "" + text.Contains(""System.AggregateException: two failed (first) (second)""));
+        Console.WriteLine(""prints the first as the chain: "" + text.Contains("" ---> System.FormatException: first""));
+        Console.WriteLine(""prints the second by index: "" + text.Contains(""(Inner Exception #1) System.InvalidOperationException: second""));
+        Console.WriteLine(""does not index the first: "" + !text.Contains(""(Inner Exception #0)""));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// <c>Flatten()</c> collapses an arbitrarily deep tree of aggregates into one level, and
+        /// carries over the text the aggregate was CONSTRUCTED with rather than its composed
+        /// <c>Message</c> — composing again over the flattened list would repeat every message the
+        /// composed text already names. <c>GetBaseException()</c> digs through single-inner
+        /// aggregates to the one real exception and gives up as soon as there is more than one.
+        /// </summary>
+        [TestMethod]
+        public async Task FlattenCollapsesNestedAggregatesAndKeepsTheBaseMessageAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+
+public class Program
+{
+    public static void Main()
+    {
+        var nested = new AggregateException(""outer"",
+            new AggregateException(""middle"",
+                new FormatException(""leaf one""),
+                new AggregateException(""deep"", new NotSupportedException(""leaf two""))),
+            new ArgumentException(""leaf three""));
+
+        Console.WriteLine(""nested count: "" + nested.InnerExceptions.Count);
+        Console.WriteLine(""nested message: |"" + nested.Message + ""|"");
+
+        var flat = nested.Flatten();
+
+        Console.WriteLine(""flat count: "" + flat.InnerExceptions.Count);
+        Console.WriteLine(""no aggregate left: "" + !flat.InnerExceptions.Any(e => e is AggregateException));
+        Console.WriteLine(""flat messages: "" + string.Join("","", flat.InnerExceptions.Select(e => e.Message).OrderBy(m => m)));
+        Console.WriteLine(""flat message: |"" + flat.Message + ""|"");
+
+        var single = new AggregateException(new AggregateException(new FormatException(""only one"")));
+        Console.WriteLine(""base of nested singles: "" + single.GetBaseException().GetType().FullName + "" / "" + single.GetBaseException().Message);
+
+        var many = new AggregateException(new FormatException(""x""), new FormatException(""y""));
+        Console.WriteLine(""base of many: "" + many.GetBaseException().GetType().FullName);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// <c>Handle</c>: the predicate consumes what it answers true for, and anything left is
+        /// rethrown as a NEW aggregate carrying only those. Note the message of that new aggregate —
+        /// .NET builds it from the composed <c>Message</c>, so an already-named inner message is
+        /// named twice; that is .NET's behaviour and the native diff is what says so.
+        /// </summary>
+        [TestMethod]
+        public async Task HandleConsumesWhatThePredicateAcceptsAndRethrowsTheRestAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var partly = new AggregateException(new FormatException(""handled""), new NotSupportedException(""unhandled""));
+
+        try
+        {
+            partly.Handle(e => e is FormatException);
+            Console.WriteLine(""NOT REACHED"");
+        }
+        catch (AggregateException rest)
+        {
+            Console.WriteLine(""rethrown count: "" + rest.InnerExceptions.Count);
+            Console.WriteLine(""rethrown: "" + rest.InnerExceptions[0].GetType().Name + "" / "" + rest.InnerExceptions[0].Message);
+            Console.WriteLine(""rethrown message: |"" + rest.Message + ""|"");
+        }
+
+        new AggregateException(new FormatException(""a""), new FormatException(""b"")).Handle(e => true);
+        Console.WriteLine(""everything handled, nothing thrown"");
+
+        var seen = 0;
+        try { new AggregateException(new FormatException(""x""), new FormatException(""y"")).Handle(e => { seen++; return true; }); }
+        catch (Exception) { Console.WriteLine(""NOT REACHED""); }
+        Console.WriteLine(""predicate saw: "" + seen);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// <c>Task.WhenAll</c> with more than one task failing. Three separate things have to hold:
+        /// awaiting throws ONE exception unwrapped (which of them is not specified — the aggregate
+        /// is built in completion order, so this asserts the set rather than the pick), the WhenAll
+        /// task's own <c>Exception</c> carries every failure, and the tasks that succeeded still
+        /// have their results.
+        /// </summary>
+        [TestMethod]
+        public async Task WhenAllCollectsEveryFailureWhileKeepingTheSuccessesAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class Program
+{
+    static async Task<int> Fail(string message, int delay)
+    {
+        await Task.Delay(delay);
+        throw new InvalidOperationException(message);
+    }
+
+    static async Task<int> Succeed(int value, int delay)
+    {
+        await Task.Delay(delay);
+        return value;
+    }
+
+    public static async Task Main()
+    {
+        var a = Fail(""first failure"", 10);
+        var b = Fail(""second failure"", 20);
+        var c = Succeed(3, 5);
+        var all = Task.WhenAll(a, b, c);
+
+        try { await all; Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""await threw one, unwrapped: "" + e.GetType().FullName); }
+
+        Console.WriteLine(""faulted: "" + all.IsFaulted);
+        Console.WriteLine(""aggregate count: "" + all.Exception.InnerExceptions.Count);
+        Console.WriteLine(""aggregate messages: "" + string.Join("","", all.Exception.InnerExceptions.Select(e => e.Message).OrderBy(m => m)));
+        Console.WriteLine(""aggregate message names both: ""
+            + (all.Exception.Message.Contains(""first failure"") && all.Exception.Message.Contains(""second failure"")));
+        Console.WriteLine(""per task: "" + a.IsFaulted + "" "" + b.IsFaulted + "" "" + c.IsFaulted);
+        Console.WriteLine(""the success kept its result: "" + c.Result);
+        Console.WriteLine(""each task's own aggregate: "" + a.Exception.InnerExceptions.Count + "" / "" + a.Exception.InnerException.Message);
+
+        // WhenAll<T> throws before it can return the array, but the tasks that finished are intact.
+        var ok = Task.FromResult(7);
+        var bad = Fail(""in WhenAll<T>"", 1);
+        try { var r = await Task.WhenAll(ok, bad); Console.WriteLine(""NOT REACHED "" + r.Length); }
+        catch (InvalidOperationException e) { Console.WriteLine(""WhenAll<T> threw: "" + e.Message); }
+        Console.WriteLine(""ok still has its result: "" + ok.Result);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A <c>WhenAll</c> of <c>WhenAll</c>s: the outer aggregate holds the leaves rather than a
+        /// tree of aggregates (WhenAll ranges over its antecedents' inner exceptions), and
+        /// <c>Flatten()</c> is a no-op on it. A <c>TaskCompletionSource</c> faulted with several
+        /// exceptions at once behaves the same way, and refuses to be completed a second time.
+        /// </summary>
+        [TestMethod]
+        public async Task NestedWhenAllAndAMultiExceptionCompletionSourceReportEveryLeafAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class Program
+{
+    static async Task Fail(string m) { await Task.Yield(); throw new FormatException(m); }
+
+    public static async Task Main()
+    {
+        var outer = Task.WhenAll(Task.WhenAll(Fail(""a1""), Fail(""a2"")), Task.WhenAll(Fail(""b1"")));
+
+        try { await outer; Console.WriteLine(""NOT REACHED""); }
+        catch (FormatException) { Console.WriteLine(""await threw a leaf, unwrapped""); }
+
+        var agg = outer.Exception;
+        Console.WriteLine(""leaves, not a tree: "" + agg.InnerExceptions.Count
+            + "" / "" + string.Join("","", agg.InnerExceptions.Select(x => x.GetType().Name).Distinct()));
+        Console.WriteLine(""messages: "" + string.Join("","", agg.InnerExceptions.Select(x => x.Message).OrderBy(x => x)));
+        Console.WriteLine(""flatten changes nothing: "" + agg.Flatten().InnerExceptions.Count);
+
+        var tcs = new TaskCompletionSource<int>();
+        Console.WriteLine(""set two at once: "" + tcs.TrySetException(new Exception[] { new FormatException(""tcs one""), new NotSupportedException(""tcs two"") }));
+
+        try { await tcs.Task; Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""awaited: "" + e.GetType().Name + "" / "" + e.Message); }
+
+        Console.WriteLine(""tcs count: "" + tcs.Task.Exception.InnerExceptions.Count);
+        Console.WriteLine(""tcs message names both: ""
+            + (tcs.Task.Exception.Message.Contains(""tcs one"") && tcs.Task.Exception.Message.Contains(""tcs two"")));
+        Console.WriteLine(""a completed task refuses a result: "" + tcs.TrySetResult(1));
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// The three ways of observing a faulted task disagree on purpose, and all three have to be
+        /// right: <c>await</c> and <c>GetAwaiter().GetResult()</c> throw the inner exception
+        /// unwrapped, while <c>.Result</c> and <c>.Wait()</c> throw the <c>AggregateException</c>.
+        /// <c>Wait()</c> is the one that used to report nothing at all — it was emitted as a call
+        /// whose returned task nobody looked at, so a faulted task's exception was discarded by the
+        /// single method that exists to observe it.
+        /// </summary>
+        [TestMethod]
+        public async Task ResultAndWaitThrowTheAggregateWhereAwaitUnwrapsItAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading.Tasks;
+
+public class Program
+{
+    static async Task<int> Fail(string m) { await Task.Yield(); throw new FormatException(m); }
+
+    public static async Task Main()
+    {
+        var viaResult = Fail(""via Result"");
+        try { await viaResult; } catch (Exception) { }
+        try { var _ = viaResult.Result; Console.WriteLine(""NOT REACHED""); }
+        catch (AggregateException e) { Console.WriteLine(""Result threw the aggregate: "" + e.InnerExceptions.Count + "" / "" + e.InnerException.Message); }
+
+        var viaGetResult = Fail(""via GetResult"");
+        try { await viaGetResult; } catch (Exception) { }
+        try { viaGetResult.GetAwaiter().GetResult(); Console.WriteLine(""NOT REACHED""); }
+        catch (AggregateException) { Console.WriteLine(""GetResult threw an aggregate - it should not""); }
+        catch (FormatException e) { Console.WriteLine(""GetResult threw it unwrapped: "" + e.Message); }
+
+        var viaWait = Fail(""via Wait"");
+        try { await viaWait; } catch (Exception) { }
+        try { viaWait.Wait(); Console.WriteLine(""NOT REACHED""); }
+        catch (AggregateException e) { Console.WriteLine(""Wait threw the aggregate: "" + e.InnerExceptions.Count + "" / "" + e.InnerException.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// <c>Task.FromException</c> and the readers of what it produces. <c>Task.Exception</c> is an
+        /// <c>AggregateException</c> in .NET always — it wraps whatever it is given, an aggregate
+        /// included — and everything downstream leans on that: awaiting unwraps one level, and
+        /// <c>WhenAll</c>/<c>WhenAny</c> range over the inner list. A bare exception stored there
+        /// instead left the fault unreachable from the task and took WhenAll's continuation down with
+        /// it, which completed nothing and hung every awaiter in silence.
+        /// </summary>
+        [TestMethod]
+        public async Task FromExceptionAlwaysReportsAnAggregateThatWhenAllCanReadAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Main()
+    {
+        var bare = Task.FromException(new FormatException(""bare fault""));
+        Console.WriteLine(""Exception is an aggregate: "" + (bare.Exception is AggregateException));
+        Console.WriteLine(""count: "" + bare.Exception.InnerExceptions.Count + "" / "" + bare.Exception.InnerException.Message);
+        try { await bare; Console.WriteLine(""NOT REACHED""); }
+        catch (FormatException e) { Console.WriteLine(""awaited: "" + e.Message); }
+
+        // Even an AggregateException is wrapped rather than adopted.
+        var inner = new AggregateException(""agg"", new FormatException(""leaf""));
+        var wrapped = Task.FromException(inner);
+        Console.WriteLine(""wraps an aggregate too: "" + wrapped.Exception.InnerException.GetType().FullName
+            + "" / same instance: "" + ReferenceEquals(wrapped.Exception.InnerException, inner));
+
+        // WhenAll and WhenAny over it: both used to be fed a task with no inner list to read.
+        var all = Task.WhenAll(Task.FromException(new FormatException(""bare in WhenAll"")), Task.CompletedTask);
+        try { await all; Console.WriteLine(""NOT REACHED""); }
+        catch (FormatException e) { Console.WriteLine(""WhenAll: "" + e.Message); }
+        Console.WriteLine(""WhenAll count: "" + all.Exception.InnerExceptions.Count);
+
+        var any = await Task.WhenAny(Task.FromException(new NotSupportedException(""bare in WhenAny"")));
+        Console.WriteLine(""WhenAny: "" + any.IsFaulted + "" / "" + any.Exception.InnerException.Message);
+
+        // The typed form, and a task faulted through a continuation that threw.
+        var typed = Task.FromException<int>(new FormatException(""typed""));
+        Console.WriteLine(""typed: "" + typed.IsFaulted + "" / "" + typed.Exception.InnerException.Message);
+
+        var chained = Task.FromResult(1).ContinueWith<int>(t => throw new NotSupportedException(""from the continuation""));
+        try { await chained; Console.WriteLine(""NOT REACHED""); }
+        catch (NotSupportedException e) { Console.WriteLine(""continuation faulted the continuation: "" + e.Message); }
+
+        // A continuation over a faulted antecedent OBSERVES it rather than throwing.
+        var observed = Task.FromException(new FormatException(""seen by ContinueWith""))
+            .ContinueWith(t => t.IsFaulted + "" / "" + t.Exception.InnerException.Message);
+        Console.WriteLine(""continuation saw: "" + await observed);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A cancelled task reports <c>TaskCanceledException</c> (an
+        /// <c>OperationCanceledException</c>) and <c>IsCanceled</c>, and a <c>WhenAll</c> over a
+        /// cancelled task beside a faulted one is FAULTED, not cancelled — a fault outranks a
+        /// cancellation, so the failure is not quietly reclassified as "the user changed their mind".
+        /// </summary>
+        [TestMethod]
+        public async Task CancellationIsReportedAsCancelledAndAFaultOutranksItAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading.Tasks;
+
+public class Program
+{
+    static async Task Fail(string m) { await Task.Yield(); throw new FormatException(m); }
+
+    public static async Task Main()
+    {
+        var tcs = new TaskCompletionSource<int>();
+        tcs.TrySetCanceled();
+
+        try { await tcs.Task; Console.WriteLine(""NOT REACHED""); }
+        catch (OperationCanceledException e)
+        {
+            Console.WriteLine(""cancelled: is TaskCanceledException="" + (e is TaskCanceledException)
+                + "" IsCanceled="" + tcs.Task.IsCanceled + "" IsFaulted="" + tcs.Task.IsFaulted);
+        }
+
+        var mixed = Task.WhenAll(Fail(""a fault beside a cancel""), tcs.Task);
+        try { await mixed; Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""mixed threw: "" + e.GetType().Name); }
+        Console.WriteLine(""mixed faulted: "" + mixed.IsFaulted + "" cancelled: "" + mixed.IsCanceled);
+
+        var onlyCancelled = Task.WhenAll(tcs.Task, Task.CompletedTask);
+        try { await onlyCancelled; Console.WriteLine(""NOT REACHED""); }
+        catch (OperationCanceledException) { Console.WriteLine(""all-cancelled threw a cancellation""); }
+        Console.WriteLine(""all-cancelled: faulted="" + onlyCancelled.IsFaulted + "" cancelled="" + onlyCancelled.IsCanceled);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// The <c>Task.Run</c> overloads. <c>Func&lt;Task&gt;</c> and <c>Func&lt;Task&lt;TResult&gt;&gt;</c>
+        /// matter for more than compiling: with only the <c>Action</c>/<c>Func&lt;TResult&gt;</c> forms
+        /// declared, <c>Task.Run(async () =&gt; 1)</c> bound to the synchronous one and came out typed
+        /// <c>Task&lt;Task&lt;int&gt;&gt;</c>, and the <c>CancellationToken</c> forms did not exist at
+        /// all. Unwrapping the inner task also has to keep the KIND of its completion — a cancelled
+        /// inner task cancels the outer one rather than faulting it.
+        /// </summary>
+        [TestMethod]
+        public async Task TaskRunUnwrapsAnAsyncBodyAndHonoursItsTokenAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Main()
+    {
+        // Func<Task>: the inner task is unwrapped, so its exception surfaces on the outer one.
+        try { await Task.Run(async () => { await Task.Yield(); throw new FormatException(""from Func<Task>""); }); Console.WriteLine(""NOT REACHED""); }
+        catch (FormatException e) { Console.WriteLine(""Func<Task>: "" + e.Message); }
+
+        // Func<Task<T>>: declared Task<int>, not Task<Task<int>>.
+        Task<int> typed = Task.Run(async () => { await Task.Yield(); return 41; });
+        Console.WriteLine(""Func<Task<T>>: "" + await typed);
+
+        try { await Task.Run(async () => { await Task.Yield(); throw new NotSupportedException(""typed body""); }); Console.WriteLine(""NOT REACHED""); }
+        catch (NotSupportedException e) { Console.WriteLine(""Func<Task<T>> throwing: "" + e.Message); }
+
+        // The synchronous forms are unchanged.
+        Console.WriteLine(""Func<T>: "" + await Task.Run(() => 7));
+        await Task.Run(() => Console.WriteLine(""Action: ran""));
+
+        // A token cancels the SCHEDULING: the body never runs, and the task is cancelled.
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ran = false;
+        var cancelled = Task.Run(() => { ran = true; }, cts.Token);
+
+        try { await cancelled; Console.WriteLine(""NOT REACHED""); }
+        catch (OperationCanceledException e)
+        {
+            Console.WriteLine(""cancelled: body ran="" + ran + "" IsCanceled="" + cancelled.IsCanceled
+                + "" is TaskCanceledException="" + (e is TaskCanceledException));
+        }
+
+        // A live token does not get in the way of any form.
+        var live = new CancellationTokenSource();
+        Console.WriteLine(""live token, Func<T>: "" + await Task.Run(() => 5, live.Token));
+        await Task.Run(async () => { await Task.Yield(); }, live.Token);
+        Console.WriteLine(""live token, Func<Task>: ok"");
+        Console.WriteLine(""live token, Func<Task<T>>: "" + await Task.Run(async () => { await Task.Yield(); return 6; }, live.Token));
+
+        try { await Task.Run(() => { throw new FormatException(""with a token""); }, live.Token); Console.WriteLine(""NOT REACHED""); }
+        catch (FormatException e) { Console.WriteLine(""throwing with a token: "" + e.Message); }
+
+        // Unwrapping keeps the kind of the inner completion.
+        var innerCancelled = Task.Run(() => Task.FromCanceled(cts.Token));
+        try { await innerCancelled; Console.WriteLine(""NOT REACHED""); }
+        catch (OperationCanceledException) { Console.WriteLine(""inner cancel: cancelled="" + innerCancelled.IsCanceled + "" faulted="" + innerCancelled.IsFaulted); }
+
+        var innerFaulted = Task.Run(() => Task.FromException(new FormatException(""inner fault"")));
+        try { await innerFaulted; Console.WriteLine(""NOT REACHED""); }
+        catch (FormatException e) { Console.WriteLine(""inner fault: "" + e.Message + "" faulted="" + innerFaulted.IsFaulted); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// <c>Task.FromCanceled</c>: a task already in the cancelled state, which is the counterpart
+        /// of <c>FromException</c> and the only way to hand back "the caller changed their mind"
+        /// without a source to cancel. The token has to be cancelled ALREADY — nothing will cancel
+        /// the task later — and .NET refuses a live one, which is worth pinning down because it is
+        /// the kind of argument check that is easy to leave out and then relied on.
+        /// </summary>
+        [TestMethod]
+        public async Task FromCanceledProducesAnAlreadyCancelledTaskAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Main()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var t = Task.FromCanceled(cts.Token);
+        Console.WriteLine(""IsCanceled="" + t.IsCanceled + "" IsCompleted="" + t.IsCompleted + "" IsFaulted="" + t.IsFaulted);
+
+        try { await t; Console.WriteLine(""NOT REACHED""); }
+        catch (OperationCanceledException e) { Console.WriteLine(""awaited: is TaskCanceledException="" + (e is TaskCanceledException)); }
+
+        var typed = Task.FromCanceled<int>(cts.Token);
+        Console.WriteLine(""typed: IsCanceled="" + typed.IsCanceled);
+
+        try { var v = await typed; Console.WriteLine(""NOT REACHED "" + v); }
+        catch (TaskCanceledException) { Console.WriteLine(""awaited typed: cancelled""); }
+
+        // A token that is not cancelled is refused: there would be nothing to cancel the task.
+        var live = new CancellationTokenSource();
+        try { Task.FromCanceled(live.Token); Console.WriteLine(""NOT REACHED""); }
+        catch (ArgumentOutOfRangeException) { Console.WriteLine(""a live token is refused""); }
+
+        try { Task.FromCanceled<int>(live.Token); Console.WriteLine(""NOT REACHED""); }
+        catch (ArgumentOutOfRangeException) { Console.WriteLine(""a live token is refused for the typed form too""); }
+
+        // It behaves as a cancelled task everywhere a cancelled task is read.
+        var all = Task.WhenAll(Task.FromCanceled(cts.Token), Task.CompletedTask);
+        try { await all; Console.WriteLine(""NOT REACHED""); }
+        catch (OperationCanceledException) { Console.WriteLine(""WhenAll cancelled: "" + all.IsCanceled); }
+
+        var beside = Task.WhenAll(Task.FromCanceled(cts.Token), Task.FromException(new FormatException(""a fault beside it"")));
+        try { await beside; Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""a fault outranks it: "" + e.GetType().Name + "" faulted="" + beside.IsFaulted); }
+
+        var any = await Task.WhenAny(Task.FromCanceled(cts.Token));
+        Console.WriteLine(""WhenAny: "" + any.IsCanceled);
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ExceptionControlFlowTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ExceptionControlFlowTests.cs
@@ -1,0 +1,606 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// The control flow around <c>throw</c> — which handler runs, in what order the
+    /// <c>finally</c> blocks unwind, what a rethrow carries with it, and what an exception filter
+    /// is allowed to do. Every case here runs natively as well and the two outputs are diffed, so
+    /// what is asserted is .NET's behaviour rather than a reading of it.
+    ///
+    /// These sit alongside <see cref="Ported.ExceptionsTests"/> (the basic shapes, ported from h5)
+    /// and <see cref="ExceptionStackTraceTests"/> (what survives the JavaScript → C# boundary): this
+    /// file is the deep end of the language semantics — several frames, several handlers, and the
+    /// interaction with <c>using</c>, iterators and <c>async</c>.
+    /// </summary>
+    [TestClass]
+    public class ExceptionControlFlowTests : TranslatorTestBase
+    {
+        /// <summary>
+        /// Four frames, each doing something different on the way out: a non-matching catch, a bare
+        /// rethrow, a wrap-and-throw, and a finally on every one of them. The order the log comes
+        /// out in is the whole assertion — a finally that runs too early or a rethrow that loses the
+        /// original type shows up as a diff against native.
+        /// </summary>
+        [TestMethod]
+        public async Task NestedFramesUnwindInOrderAndARethrowKeepsTheOriginalAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    static List<string> log = new List<string>();
+
+    static void Inner()
+    {
+        try
+        {
+            log.Add(""inner try"");
+            throw new InvalidOperationException(""from inner"");
+        }
+        catch (FormatException)
+        {
+            log.Add(""inner WRONG catch"");
+        }
+        finally
+        {
+            log.Add(""inner finally"");
+        }
+    }
+
+    static void Middle()
+    {
+        try { Inner(); }
+        catch (InvalidOperationException e)
+        {
+            log.Add(""middle catch: "" + e.Message);
+            throw;
+        }
+        finally { log.Add(""middle finally""); }
+    }
+
+    static void Wrapper()
+    {
+        try { Middle(); }
+        catch (Exception e)
+        {
+            log.Add(""wrapper wraps: "" + e.Message);
+            throw new ApplicationException(""wrapped"", e);
+        }
+        finally { log.Add(""wrapper finally""); }
+    }
+
+    public static void Main()
+    {
+        try { Wrapper(); }
+        catch (ApplicationException e)
+        {
+            log.Add(""outer: "" + e.Message);
+            log.Add(""outer inner type: "" + e.InnerException.GetType().FullName);
+            log.Add(""outer inner msg: "" + e.InnerException.Message);
+        }
+        finally { log.Add(""outer finally""); }
+
+        log.Add(""returned: "" + WithReturn());
+
+        try { NestedFinallyThrows(); }
+        catch (Exception e) { log.Add(""replaced by: "" + e.GetType().Name + "" / "" + e.Message); }
+
+        foreach (var line in log) Console.WriteLine(line);
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    // finally runs even when the try returns, and the returned value is the one computed first.
+    static int WithReturn()
+    {
+        try { log.Add(""wr try""); return 1; }
+        finally { log.Add(""wr finally""); }
+    }
+
+    // A finally that throws while an exception is already in flight REPLACES it: the original is
+    // gone, which is why a finally is the wrong place to do anything that can fail.
+    static void NestedFinallyThrows()
+    {
+        try { throw new FormatException(""original""); }
+        finally { throw new NotSupportedException(""from finally""); }
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A three-level inner-exception chain: every level's message and type is reachable,
+        /// <c>GetBaseException()</c> digs to the bottom, and <c>ToString()</c> reports the whole
+        /// chain outermost-first with a marker per level. The <c>ToString()</c> half is what makes a
+        /// wrapped failure legible at all in a log — before it reported the outer exception and
+        /// nothing about the one that actually failed.
+        /// </summary>
+        [TestMethod]
+        public async Task AThreeLevelInnerChainIsFullyReachableAndPrintedAsync()
+        {
+            await RunTest(@"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var l1 = new FormatException(""level one"");
+        var l2 = new InvalidOperationException(""level two"", l1);
+        var l3 = new ApplicationException(""level three"", l2);
+
+        Console.WriteLine(""outer: "" + l3.Message);
+        Console.WriteLine(""inner: "" + l3.InnerException.Message);
+        Console.WriteLine(""inner.inner: "" + l3.InnerException.InnerException.Message);
+        Console.WriteLine(""bottom of the chain: "" + (l3.InnerException.InnerException.InnerException == null));
+        Console.WriteLine(""base: "" + l3.GetBaseException().GetType().FullName + "" / "" + l3.GetBaseException().Message);
+
+        var text = l3.ToString();
+
+        Console.WriteLine(""chain markers: "" + Count(text, "" ---> ""));
+        Console.WriteLine(""chain ends: "" + Count(text, ""--- End of inner exception stack trace ---""));
+        Console.WriteLine(""names all three: "" + (text.Contains(""level one"") && text.Contains(""level two"") && text.Contains(""level three"")));
+        Console.WriteLine(""outermost first: "" + (text.IndexOf(""level three"") < text.IndexOf(""level two"") && text.IndexOf(""level two"") < text.IndexOf(""level one"")));
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    static int Count(string s, string needle)
+    {
+        int n = 0, i = 0;
+        while ((i = s.IndexOf(needle, i)) >= 0) { n++; i += needle.Length; }
+        return n;
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// Exception filters. Three properties are being pinned down, and each was a real
+        /// possibility of getting wrong: the filters run in source order and only until one answers
+        /// true; a clause whose filter answers false does not handle the exception (so the frame's
+        /// finally still runs and the exception keeps going); and a filter that THROWS is swallowed
+        /// by the CLR and read as "does not match", leaving the exception already in flight to carry
+        /// on. That last one is the one that matters in practice — a null dereference inside a
+        /// <c>when</c> clause replacing the error the handler existed to report is a fault nobody
+        /// can debug, and it is what evaluating the filter inline used to do.
+        /// </summary>
+        [TestMethod]
+        public async Task ExceptionFiltersRunInOrderAndAThrowingFilterDoesNotMatchAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+public class MyException : Exception
+{
+    public int Code { get; }
+    public MyException(string message, int code) : base(message) { Code = code; }
+    public MyException(string message, int code, Exception inner) : base(message, inner) { Code = code; }
+}
+
+public class Program
+{
+    static List<string> log = new List<string>();
+
+    static bool Probe(string name, bool answer) { log.Add(""filter "" + name + "" -> "" + answer); return answer; }
+
+    public static void Main()
+    {
+        try
+        {
+            try { throw new MyException(""code 42"", 42); }
+            catch (MyException e) when (Probe(""code==7"", e.Code == 7)) { log.Add(""WRONG""); }
+            catch (MyException e) when (Probe(""code==42"", e.Code == 42)) { log.Add(""right: "" + e.Message); }
+            catch (MyException) when (Probe(""never evaluated"", true)) { log.Add(""WRONG""); }
+            finally { log.Add(""inner finally""); }
+        }
+        catch (Exception) { log.Add(""NOT REACHED""); }
+
+        // No filter matches: the exception propagates, and this frame's finally still runs.
+        try
+        {
+            try { throw new MyException(""code 1"", 1); }
+            catch (MyException e) when (Probe(""code==2"", e.Code == 2)) { log.Add(""WRONG""); }
+            finally { log.Add(""unmatched finally""); }
+        }
+        catch (MyException e) { log.Add(""propagated: "" + e.Message); }
+
+        // A filter can inspect the whole chain, and a pattern variable declared in it is in scope
+        // in the handler body.
+        try { throw new MyException(""outer"", 9, new FormatException(""the cause"")); }
+        catch (MyException e) when (e.InnerException is FormatException f && f.Message == ""the cause"")
+        {
+            log.Add(""filter matched on the chain: "" + f.Message);
+        }
+
+        // A throwing filter is swallowed and counts as false: the ORIGINAL exception is the one
+        // that reaches the outer handler, not the filter's.
+        try
+        {
+            try { throw new FormatException(""under a throwing filter""); }
+            catch (Exception) when (Throws()) { log.Add(""WRONG""); }
+        }
+        catch (Exception e) { log.Add(""after a throwing filter: "" + e.GetType().Name + "" / "" + e.Message); }
+
+        foreach (var line in log) Console.WriteLine(line);
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    static bool Throws() { log.Add(""filter throws""); throw new NotSupportedException(""inside the filter""); }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// What the engine itself throws is not a <c>System.Exception</c> — a null dereference raises
+        /// a native <c>TypeError</c> — so the value a <c>catch</c> binds is normalised on entry into
+        /// the exception the handlers are written against. Without that the single most common
+        /// exception in any program did not match the handler that names it:
+        /// <c>catch (NullReferenceException)</c> was skipped, <c>e is NullReferenceException</c> was
+        /// false and <c>e.GetType()</c> answered "TypeError".
+        ///
+        /// The two properties that make normalising safe are asserted here too, because they are the
+        /// reason it can be done at all: a rethrow is still a rethrow of the SAME exception instance
+        /// (so anything the inner handler recorded on it survives), and a C#-thrown exception passes
+        /// through untouched. That a bare rethrow hands JavaScript back the value it actually threw —
+        /// the other half of the bargain — is asserted in
+        /// <see cref="InteropExceptionTests.AThrowSurvivesEveryHopBetweenCSharpAndJavaScriptAsync"/>.
+        /// </summary>
+        [TestMethod]
+        public async Task AnEngineLevelFailureMatchesTheHandlerThatNamesItAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+public class Program
+{
+    public static void Main()
+    {
+        string nothing = null;
+
+        try { var _ = nothing.Length; }
+        catch (NullReferenceException e)
+        {
+            Console.WriteLine(""typed catch: "" + e.GetType().FullName + "" / is NRE="" + (e is NullReferenceException));
+        }
+
+        try { nothing.ToUpper(); }
+        catch (Exception e) { Console.WriteLine(""catch(Exception): "" + e.GetType().FullName + "" / stack="" + (e.StackTrace != null)); }
+
+        // A handler that does not apply still lets it through to the one that does.
+        try
+        {
+            try { var _ = nothing.Length; }
+            catch (FormatException) { Console.WriteLine(""WRONG""); }
+        }
+        catch (NullReferenceException) { Console.WriteLine(""passed through to the right handler""); }
+
+        // A filter over it, and the inner chain it can be wrapped into.
+        try { var _ = nothing.Length; }
+        catch (Exception e) when (e is NullReferenceException) { Console.WriteLine(""matched by a filter""); }
+
+        try
+        {
+            try { var _ = nothing.Length; }
+            catch (Exception e) { throw new InvalidOperationException(""wrapped"", e); }
+        }
+        catch (Exception e) { Console.WriteLine(""wrapped inner: "" + e.InnerException.GetType().FullName); }
+
+        // A rethrow is a rethrow of the same instance, so what the inner handler recorded survives.
+        Exception inner = null, outer = null;
+        try
+        {
+            try { var _ = nothing.Length; }
+            catch (Exception e) { inner = e; e.Data[""seen""] = ""yes""; throw; }
+        }
+        catch (Exception e) { outer = e; }
+
+        Console.WriteLine(""same instance after a rethrow: "" + ReferenceEquals(inner, outer));
+        Console.WriteLine(""data survived: "" + outer.Data[""seen""]);
+        Console.WriteLine(""base of it: "" + outer.GetBaseException().GetType().FullName);
+
+        // A C#-thrown exception is untouched by any of this.
+        try { throw new InvalidOperationException(""mine""); }
+        catch (Exception e) { Console.WriteLine(""c#: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// The emit shape of the normalisation: the caught value is normalised ONCE for the whole
+        /// catch, type tests are asked of the normalised exception, and a bare <c>throw;</c> still
+        /// rethrows <c>$ex</c> — what JavaScript threw — rather than the wrapper. A clause that
+        /// cannot observe the value at all (a bare <c>catch { }</c>) gets no normalisation, so the
+        /// swallow-everything case costs nothing.
+        /// </summary>
+        [TestMethod]
+        public void TheCaughtValueIsNormalisedOnceAndARethrowStillThrowsTheOriginal()
+        {
+            var observed = new RoslynTranslator().Translate(@"
+using System;
+
+public class Program
+{
+    public static void Read()
+    {
+        try { throw new InvalidOperationException(""x""); }
+        catch (FormatException) { }
+        catch (Exception e) { Console.WriteLine(e.Message); throw; }
+    }
+    public static void Main() { }
+}");
+
+            Assert.IsTrue(observed.Success, "translation should succeed");
+            StringAssert.Contains(observed.Javascript!, "let $exn = TransposeR.caught($ex);",
+                "the caught value must be normalised on entry, once for the whole catch");
+            StringAssert.Contains(observed.Javascript!, "TransposeR.is($exn, System.FormatException)",
+                "a type test must be asked of the normalised exception, not of the raw thrown value");
+            StringAssert.Contains(observed.Javascript!, "throw $ex;",
+                "a bare rethrow must rethrow what JavaScript threw, so an outer JS handler still "
+                + "sees its own error with its native frames");
+
+            var unobserved = new RoslynTranslator().Translate(@"
+using System;
+
+public class Program
+{
+    public static void Read()
+    {
+        try { throw new InvalidOperationException(""x""); }
+        catch { Console.WriteLine(""swallowed""); }
+    }
+    public static void Main() { }
+}");
+
+            Assert.IsTrue(unobserved.Success, "translation should succeed");
+            Assert.IsFalse(unobserved.Javascript!.Contains("TransposeR.caught("),
+                "a catch clause that cannot observe the value has nothing to normalise");
+        }
+
+        /// <summary>
+        /// The emit-shape half of the case above. A filter has to be evaluated somewhere a throw can
+        /// be caught, so it goes through <c>TransposeR.filter</c>; inline in the guard there is
+        /// nowhere for the CLR's "swallow it and read the filter as false" rule to live. The arrow
+        /// is plain rather than <c>async</c> on purpose — C# forbids <c>await</c> in a filter
+        /// expression, so no <c>await</c> can ever appear inside it.
+        /// </summary>
+        [TestMethod]
+        public void AFilterIsEvaluatedThroughTheHelperThatSwallowsItsOwnThrow()
+        {
+            var code = @"
+using System;
+
+public class Program
+{
+    public static string Read()
+    {
+        try { throw new InvalidOperationException(""x""); }
+        catch (Exception e) when (e.Message == ""x"") { return ""filtered""; }
+        catch (Exception) { return ""not filtered""; }
+    }
+    public static void Main() { }
+}";
+            var result = new RoslynTranslator().Translate(code);
+
+            Assert.IsTrue(result.Success, "translation should succeed");
+            StringAssert.Contains(result.Javascript!, "TransposeR.filter(() => (",
+                "a catch filter must be evaluated through the helper, so a throw inside it reads as "
+                + "\"does not match\" instead of replacing the exception being handled");
+        }
+
+        /// <summary>
+        /// <c>using</c> and iterators, which are both just <c>try</c>/<c>finally</c> underneath:
+        /// nested resources dispose innermost-first while an exception is in flight, a Dispose that
+        /// throws replaces the body's exception (same rule as any other finally), an iterator's
+        /// finally runs when its body throws mid-enumeration, and it runs again when the consumer
+        /// breaks out early — i.e. the enumerator really is disposed.
+        /// </summary>
+        [TestMethod]
+        public async Task UsingAndIteratorFinallyBlocksRunWhileAnExceptionIsInFlightAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+class Res : IDisposable
+{
+    readonly string name; readonly bool failOnDispose;
+    public Res(string name, bool failOnDispose = false) { this.name = name; this.failOnDispose = failOnDispose; Console.WriteLine(""open "" + name); }
+    public void Dispose()
+    {
+        Console.WriteLine(""dispose "" + name);
+        if (failOnDispose) throw new NotSupportedException(""dispose of "" + name + "" failed"");
+    }
+}
+
+public class Program
+{
+    static IEnumerable<int> Numbers()
+    {
+        try
+        {
+            yield return 1;
+            yield return 2;
+            throw new InvalidOperationException(""iterator blew up at 3"");
+        }
+        finally
+        {
+            Console.WriteLine(""iterator finally"");
+        }
+    }
+
+    public static void Main()
+    {
+        try
+        {
+            using (var a = new Res(""a""))
+            using (var b = new Res(""b""))
+            {
+                throw new FormatException(""inside the usings"");
+            }
+        }
+        catch (Exception e) { Console.WriteLine(""caught "" + e.GetType().Name + "": "" + e.Message); }
+
+        try
+        {
+            using (var c = new Res(""c"", failOnDispose: true))
+            {
+                throw new FormatException(""body failed first"");
+            }
+        }
+        catch (Exception e) { Console.WriteLine(""after a throwing dispose: "" + e.GetType().Name + "" / "" + e.Message); }
+
+        try
+        {
+            foreach (var n in Numbers()) Console.WriteLine(""got "" + n);
+        }
+        catch (Exception e) { Console.WriteLine(""iterator threw: "" + e.Message); }
+
+        foreach (var n in Numbers()) { Console.WriteLine(""partial "" + n); break; }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// The same unwinding through <c>async</c> frames, where every one of them is a separate
+        /// state machine: a three-deep chain wraps and keeps the chain, a <c>finally</c> at the top
+        /// of it runs, and both a <c>catch</c> and a <c>finally</c> can themselves <c>await</c> —
+        /// including a catch that throws something new after awaiting, which has to reach the
+        /// handler outside the finally rather than being lost in it.
+        /// </summary>
+        [TestMethod]
+        public async Task ExceptionsUnwindThroughAChainOfAsyncFramesAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Threading.Tasks;
+
+public class Program
+{
+    static async Task<int> Layer3() { await Task.Yield(); throw new FormatException(""deepest""); }
+
+    static async Task<int> Layer2()
+    {
+        try { return await Layer3(); }
+        catch (FormatException e) { throw new InvalidOperationException(""layer 2"", e); }
+    }
+
+    static async Task<int> Layer1()
+    {
+        try { return await Layer2(); }
+        finally { Console.WriteLine(""layer 1 finally""); }
+    }
+
+    public static async Task Main()
+    {
+        try { await Layer1(); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""outer: "" + e.GetType().Name + "" / "" + e.Message);
+            Console.WriteLine(""inner: "" + e.InnerException.GetType().Name + "" / "" + e.InnerException.Message);
+        }
+
+        try
+        {
+            try { await Layer3(); }
+            catch (Exception e)
+            {
+                await Task.Yield();
+                Console.WriteLine(""awaited in catch: "" + e.Message);
+                throw new NotSupportedException(""from the catch"");
+            }
+            finally
+            {
+                await Task.Yield();
+                Console.WriteLine(""awaited in finally"");
+            }
+        }
+        catch (Exception e) { Console.WriteLine(""escaped: "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+}", waitForOutput: "<<DONE>>");
+        }
+
+        /// <summary>
+        /// Which handler a type-matched catch picks out of a hierarchy (most derived first, and the
+        /// first match wins — not the best match), and that the exceptions the runtime itself raises
+        /// for a failed operation are the .NET types a handler names: an out-of-range index, a bad
+        /// parse, a missing dictionary key, a list index. A lambda deep inside a LINQ pipeline
+        /// throwing surfaces where the sequence is enumerated, not where it was declared.
+        /// </summary>
+        [TestMethod]
+        public async Task RuntimeFailuresRaiseTheirDotNetTypesAndMatchTheNearestHandlerAsync()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class BaseError : Exception { public BaseError(string m) : base(m) { } }
+public class MidError : BaseError { public MidError(string m) : base(m) { } }
+public class LeafError : MidError { public LeafError(string m) : base(m) { } }
+
+public class Program
+{
+    static void Throw(Exception e) => throw e;
+
+    static string Classify(Exception e)
+    {
+        try { Throw(e); }
+        catch (LeafError x) { return ""leaf: "" + x.Message; }
+        catch (MidError x) { return ""mid: "" + x.Message; }
+        catch (BaseError x) { return ""base: "" + x.Message; }
+        catch (Exception x) { return ""other: "" + x.GetType().Name; }
+        return ""unreachable"";
+    }
+
+    public static async Task Main()
+    {
+        Console.WriteLine(Classify(new LeafError(""L"")));
+        Console.WriteLine(Classify(new MidError(""M"")));
+        Console.WriteLine(Classify(new BaseError(""B"")));
+        Console.WriteLine(Classify(new FormatException(""F"")));
+
+        Exception any = new LeafError(""cast"");
+        Console.WriteLine(""is MidError: "" + (any is MidError) + "" / is BaseError: "" + (any is BaseError));
+
+        int[] arr = new int[2];
+        try { arr[5] = 1; } catch (IndexOutOfRangeException e) { Console.WriteLine(""index: "" + e.GetType().FullName); }
+
+        try { var _ = int.Parse(""nope""); } catch (FormatException e) { Console.WriteLine(""parse: "" + e.GetType().FullName); }
+
+        var dict = new Dictionary<string, int>();
+        try { var _ = dict[""absent""]; } catch (KeyNotFoundException e) { Console.WriteLine(""key: "" + e.GetType().FullName); }
+
+        var list = new List<int>();
+        try { var _ = list[0]; } catch (ArgumentOutOfRangeException e) { Console.WriteLine(""list: "" + e.GetType().FullName); }
+
+        // A projection that throws surfaces at enumeration, after the elements before it.
+        var q = new[] { 1, 2, 0, 4 }.Select(x => 10 / x);
+        try { foreach (var v in q) Console.WriteLine(""value "" + v); }
+        catch (DivideByZeroException e) { Console.WriteLine(""linq threw: "" + e.GetType().FullName); }
+
+        // A throwing property getter, reached through a Task.Run body.
+        try { await Task.Run(() => { var _ = Bad; }); }
+        catch (Exception e) { Console.WriteLine(""in Task.Run: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        // A closure returned by a closure.
+        Func<Func<int>> nested = () => () => throw new FormatException(""from a nested closure"");
+        try { nested()(); }
+        catch (Exception e) { Console.WriteLine(""closure: "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    static int Bad => throw new InvalidOperationException(""from a property getter"");
+}", waitForOutput: "<<DONE>>");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ExceptionStackTraceTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ExceptionStackTraceTests.cs
@@ -10,10 +10,14 @@ namespace Transpose.Translator.Tests
     /// <c>errorStack</c>. C# matches both, but <c>StackTrace</c> read <c>errorStack.stack</c>
     /// unconditionally, so it came back null for every raw error while a C#-thrown exception worked.
     ///
-    /// The read now goes through <c>TransposeR.stackTrace</c>, which takes whichever shape arrived.
-    /// The alternative — normalising every caught value into a wrapper the way h5 does — was rejected:
-    /// it allocates on entry to every catch clause and makes <c>throw;</c> rethrow the wrapper rather
-    /// than the original error, losing its identity and native stack for any outer JS handler.
+    /// The read goes through <c>TransposeR.stackTrace</c>, which takes whichever shape arrived, and
+    /// the value itself is normalised on entry to the catch by <c>TransposeR.caught</c> — so the
+    /// handler holds a real exception whatever JavaScript threw. Both objections to normalising are
+    /// answered rather than traded away: a real exception is returned unchanged, so a C#-thrown one
+    /// allocates nothing, and a bare <c>throw;</c> still rethrows the ORIGINAL value, keeping its
+    /// identity and native frames usable by an outer JavaScript handler. The wrapper is remembered
+    /// against the value it wraps, so an outer C# catch of that rethrow binds the same instance.
+    /// See <see cref="ExceptionControlFlowTests"/> for the normalisation's own cases.
     /// </summary>
     [TestClass]
     public class ExceptionStackTraceTests : TranslatorTestBase
@@ -65,8 +69,15 @@ public class Program
 }");
         }
 
-        /// <summary>A raw JS error crossing into C# resolves its native stack; a thrown non-Error
-        /// (a bare string, an object literal) has no stack and correctly yields null.</summary>
+        /// <summary>
+        /// A raw JS error crossing into C# resolves its native stack. A thrown non-Error (a bare
+        /// string, an object literal) has no frames of its own, so what is reported is the stack
+        /// captured where the value was normalised — in the handler, close to the throw, which is
+        /// the best there is — and the type is the .NET one the value maps onto rather than
+        /// "String". This is the same answer the Task.Run path gives for the same value (see
+        /// <see cref="NormalisingAThrownNonErrorKeepsTheCapturedStackAsync"/>): the two used to
+        /// disagree, because a direct catch bound the raw value while a task fault normalised it.
+        /// </summary>
         [TestMethod]
         public async Task RawJavaScriptErrorExposesItsNativeStackAsync()
         {
@@ -88,14 +99,23 @@ public class Program
         catch (Exception e) { Console.WriteLine(""error stack: "" + (e.StackTrace ?? """").Split('\n')[0]); }
 
         try { Native.ThrowString(); }
-        catch (Exception e) { Console.WriteLine(""string stack null: "" + (e.StackTrace == null)); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""string type: "" + e.GetType().FullName);
+            Console.WriteLine(""string message: "" + e.Message);
+            Console.WriteLine(""string has a stack: "" + (e.StackTrace != null));
+        }
     }
 }", skipRoslyn: true);
 
             StringAssert.Contains(js, "error stack: TypeError: js boom",
                 "a raw JS error must expose its native stack through Exception.StackTrace");
-            StringAssert.Contains(js, "string stack null: True",
-                "a thrown non-Error has no stack, so StackTrace must be null rather than undefined");
+            StringAssert.Contains(js, "string type: System.Exception",
+                "a thrown non-Error is normalised into the exception a handler is written against");
+            StringAssert.Contains(js, "string message: bare string");
+            StringAssert.Contains(js, "string has a stack: True",
+                "a thrown non-Error has no frames of its own, so the stack captured while normalising "
+                + "it - taken in the handler, close to the throw - is the best there is");
         }
 
         /// <summary>

--- a/Transpose/Transpose.Translator.Tests/ExceptionStackTraceTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ExceptionStackTraceTests.cs
@@ -97,5 +97,338 @@ public class Program
             StringAssert.Contains(js, "string stack null: True",
                 "a thrown non-Error has no stack, so StackTrace must be null rather than undefined");
         }
+
+        /// <summary>
+        /// A browser error that crosses into C# through a Task - a rejected promise, a body that
+        /// throws inside Task.Run - is normalised by System.Exception.create. That normalisation
+        /// used to lose both halves of the diagnostic: it passed the Error OBJECT where a string
+        /// message was expected (so Message was not a string at all), and it returned before
+        /// keeping the error, leaving the exception with the stack its own constructor had just
+        /// captured - every frame of it inside tps.js, none of them the throw site.
+        /// </summary>
+        [TestMethod]
+        public async Task ANormalisedBrowserErrorKeepsItsMessageAndItsOwnStackAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw new Error('inside the task');"")] public static extern void Boom();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Native.Boom()); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""message: "" + e.Message);
+            Console.WriteLine(""message is a string: "" + (e.Message.Length == ""inside the task"".Length));
+            Console.WriteLine(""stack names the thrower: "" + e.StackTrace.Contains(""Boom""));
+            Console.WriteLine(""stack is not the wrapper's: "" + !e.StackTrace.Split('\n')[1].Contains(""ctor""));
+        }
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "message: inside the task",
+                "Message must be the error's message as a string, not the Error object");
+            StringAssert.Contains(js, "message is a string: True", "Message must reach C# as a string");
+            StringAssert.Contains(js, "stack names the thrower: True",
+                "the browser's own frames must survive normalisation");
+            StringAssert.Contains(js, "stack is not the wrapper's: True",
+                "the stack must not be the one captured by the wrapping exception's constructor");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// The engine's own error types map onto their .NET counterparts, and the message they came
+        /// with has to survive that mapping verbatim - a RangeError's message was passed as the
+        /// *paramName* of ArgumentOutOfRangeException, which buried it inside "Specified argument was
+        /// out of the range of valid values.".
+        /// </summary>
+        [TestMethod]
+        public async Task NormalisingAnEngineErrorTypeKeepsItsMessageVerbatimAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw new RangeError('Invalid array length');"")] public static extern void BoomRange();
+    [Script(""throw new TypeError('x is not a function');"")]   public static extern void BoomType();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Native.BoomRange()); }
+        catch (Exception e) { Console.WriteLine(""range: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        try { await Task.Run(() => Native.BoomType()); }
+        catch (Exception e) { Console.WriteLine(""type: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "range: System.ArgumentOutOfRangeException / Invalid array length",
+                "a RangeError's message must be the message, not a parameter name");
+            StringAssert.Contains(js, "type: System.NullReferenceException / x is not a function");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A thrown non-Error carries no frames, so the Error the wrapping exception's constructor
+        /// captures - taken in the handler, close to the throw - is the only stack there is.
+        /// Assigning the thrown value over it left the exception with no stack at all.
+        /// </summary>
+        [TestMethod]
+        public async Task NormalisingAThrownNonErrorKeepsTheCapturedStackAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw 'a bare string';"")]                          public static extern void BoomString();
+    [Script(""throw { type: 'error', target: null };"")]           public static extern void BoomEvent();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Native.BoomString()); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""string message: "" + e.Message);
+            Console.WriteLine(""string has a stack: "" + (e.StackTrace != null));
+        }
+
+        try { await Task.Run(() => Native.BoomEvent()); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""event message: "" + e.Message);
+        }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "string message: a bare string");
+            StringAssert.Contains(js, "string has a stack: True",
+                "the constructor's captured stack must not be replaced by a value that has none");
+            StringAssert.Contains(js, "event message: A JavaScript 'error' event was raised.",
+                "a DOM event carries no message and stringifies to \"[object Event]\": name the event instead");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// An ErrorEvent (window.onerror, worker.onerror) or a PromiseRejectionEvent wraps the value
+        /// that was actually thrown. The wrapped error is what carries the stack, so it is the one to
+        /// report: the event's own `stack` is absent, and reporting the inner error's stack TEXT as
+        /// the message (what this used to do) put the two in each other's place.
+        /// </summary>
+        [TestMethod]
+        public async Task NormalisingAnErrorEventReportsTheWrappedErrorAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw { type: 'error', target: null, message: 'Uncaught Error', filename: 'app.js', error: new Error('the real cause') };"")]
+    public static extern void BoomEvent();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Native.BoomEvent()); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""message: "" + e.Message);
+            Console.WriteLine(""stack starts with the cause: "" + e.StackTrace.Split('\n')[0]);
+        }
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "message: the real cause",
+                "the wrapped error's message must be the message, not its stack text");
+            StringAssert.Contains(js, "stack starts with the cause: Error: the real cause",
+                "the stack must come from the wrapped error, which is the value that has one");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// `catch (Exception)` also binds a value the engine threw that is not an Error at all - a
+        /// string, an object - and those have no `message` field, so reading the member directly
+        /// reported no message for them. Read through TransposeR.message, as StackTrace already is.
+        /// </summary>
+        [TestMethod]
+        public async Task MessageOfARawThrownValueIsNotLostAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw 'a bare string';"")]                                public static extern void ThrowString();
+    [Script(""throw new Error('a real error');"")]                      public static extern void ThrowError();
+    [Script(""throw { type: 'error', target: null };"")]                public static extern void ThrowEvent();
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        try { Native.ThrowString(); } catch (Exception e) { Console.WriteLine(""string: "" + e.Message); }
+        try { Native.ThrowError(); }  catch (Exception e) { Console.WriteLine(""error: "" + e.Message); }
+        try { Native.ThrowEvent(); }  catch (Exception e) { Console.WriteLine(""event: "" + e.Message); }
+
+        try { throw new InvalidOperationException(""from C#""); }
+        catch (Exception e) { Console.WriteLine(""csharp: "" + e.Message); }
+    }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "string: a bare string", "a thrown string is its own message");
+            StringAssert.Contains(js, "error: a real error");
+            StringAssert.Contains(js, "event: A JavaScript 'error' event was raised.");
+            StringAssert.Contains(js, "csharp: from C#", "a real exception's message is unchanged");
+        }
+
+        /// <summary>
+        /// TaskCompletionSource.TrySetException is handed whatever `catch (Exception)` bound, which
+        /// may be a raw browser error (BrowserHttpHandler does exactly this). Building the
+        /// AggregateException out of that value threw "Cannot create Enumerator." from inside the
+        /// setter, which left the task un-completed forever - every awaiter hung - and discarded the
+        /// error on the way.
+        /// </summary>
+        [TestMethod]
+        public async Task TrySetExceptionAcceptsARawBrowserErrorAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw new Error('handler failed');"")] public static extern void Boom();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        var tcs = new TaskCompletionSource<int>();
+
+        try { Native.Boom(); }
+        catch (Exception e) { tcs.TrySetException(e); }
+
+        Console.WriteLine(""task completed: "" + tcs.Task.IsCompleted);
+
+        try { await tcs.Task; }
+        catch (Exception e) { Console.WriteLine(""awaited: "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "task completed: True",
+                "a raw error must fault the task rather than throw out of the setter");
+            StringAssert.Contains(js, "awaited: handler failed", "the error itself must survive");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// ToString() reported the type, the message and the stack, and nothing at all about the
+        /// inner exception - which, for an exception wrapping the error that actually failed, is the
+        /// part the reader needs. .NET reports the whole chain.
+        /// </summary>
+        [TestMethod]
+        public async Task ToStringReportsTheInnerExceptionChainAsync()
+        {
+            var js = await RunTest(@"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var inner = new FormatException(""the inner cause"");
+        var text = new InvalidOperationException(""the outer failure"", inner).ToString();
+
+        Console.WriteLine(""names the outer: "" + text.Contains(""System.InvalidOperationException: the outer failure""));
+        Console.WriteLine(""names the inner: "" + text.Contains(""System.FormatException: the inner cause""));
+        Console.WriteLine(""marks the chain: "" + text.Contains("" ---> ""));
+        Console.WriteLine(""ends the inner trace: "" + text.Contains(""--- End of inner exception stack trace ---""));
+    }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "names the outer: True");
+            StringAssert.Contains(js, "names the inner: True", "an exception's chain must not be dropped");
+            StringAssert.Contains(js, "marks the chain: True");
+            StringAssert.Contains(js, "ends the inner trace: True");
+        }
+
+        /// <summary>
+        /// A task faulted with a bare exception rather than an AggregateException (Task.FromException
+        /// does that) had its fault read as `exception.innerExceptions.Count`, raising a TypeError
+        /// over the real exception; an AggregateException carrying none at all rethrew `null`.
+        /// </summary>
+        [TestMethod]
+        public async Task AwaitingATaskFaultedWithABareExceptionRethrowsItAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Task.FromException(new InvalidOperationException(""bare fault""))); }
+        catch (Exception e) { Console.WriteLine(""nested: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        try { Task.FromException(new FormatException(""direct fault"")).GetAwaiter().GetResult(); }
+        catch (Exception e) { Console.WriteLine(""awaiter: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "nested: System.InvalidOperationException / bare fault");
+            StringAssert.Contains(js, "awaiter: System.FormatException / direct fault",
+                "reading the fault must not raise a TypeError over it");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/InteropExceptionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/InteropExceptionTests.cs
@@ -1,0 +1,427 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Exceptions crossing the JavaScript boundary — a <c>[Script]</c> body that throws, a rejected
+    /// promise, a C# handler invoked from JS — which is where a diagnostic is easiest to lose,
+    /// because the value the engine hands back is not a <c>System.Exception</c> and nothing about it
+    /// is guaranteed: it may be an <c>Error</c>, a subclass of one from another realm, a string, or a
+    /// DOM event with no message at all.
+    ///
+    /// There is no native .NET counterpart for any of this, so these assert on the emitted
+    /// program's output directly (<c>skipRoslyn</c>) rather than diffing against Roslyn. Where a
+    /// case has a pure-C# equivalent it lives in <see cref="AggregateExceptionTests"/> or
+    /// <see cref="ExceptionControlFlowTests"/> instead, and is diffed there.
+    /// <see cref="ExceptionStackTraceTests"/> covers the single-value normalisation itself; this
+    /// file is about a JS failure travelling through the constructs a real application puts around
+    /// it — several frames, a filter, a Task, a WhenAll.
+    /// </summary>
+    [TestClass]
+    public class InteropExceptionTests : TranslatorTestBase
+    {
+        /// <summary>
+        /// A throw at the bottom of C# → JS → C# → JS, and the handler at the top. The interesting
+        /// half is the middle: a C# exception thrown by a callback the JS frame invoked has to travel
+        /// out THROUGH that frame and arrive at the C# handler as itself — same type, same message —
+        /// and a JS frame that catches it instead sees a System.Exception object - not a JS `Error`,
+        /// so `instanceof Error` is false - which nonetheless carries `message`, the field every
+        /// JavaScript handler reads.
+        /// A bare rethrow of a JS error hands the ORIGINAL value back to JavaScript rather than a
+        /// wrapper, which is what keeps its identity and its native frames usable by an outer JS
+        /// handler.
+        /// </summary>
+        [TestMethod]
+        public async Task AThrowSurvivesEveryHopBetweenCSharpAndJavaScriptAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw new Error('deep js failure');"")]
+    public static extern void Boom();
+
+    [Script(""return callback();"")]
+    public static extern int Call(Func<int> callback);
+
+    // What a JavaScript handler sees when the C# callback it invoked throws.
+    [Script(""try { callback(); return 'no throw'; } catch (e) { return (e instanceof Error) + '/' + (e.message || e); }"")]
+    public static extern string CallAndCatch(Action callback);
+
+    // The JS frame does not catch: the C# exception has to pass through it untouched.
+    [Script(""callback();"")]
+    public static extern void CallAndPropagate(Action callback);
+}
+
+public class Program
+{
+    static int Middle() => Native.Call(() => { Native.Boom(); return 1; });
+
+    public static void Main()
+    {
+        try { Middle(); }
+        catch (Exception e) { Console.WriteLine(""js error through both frames: "" + e.Message); }
+
+        Console.WriteLine(""js caught a C# exception: "" + Native.CallAndCatch(() => throw new InvalidOperationException(""from the C# callback"")));
+
+        try { Native.CallAndPropagate(() => throw new FormatException(""through the JS frame"")); }
+        catch (FormatException e) { Console.WriteLine(""round trip kept the type: "" + e.Message); }
+
+        // `throw;` rethrows what was actually thrown, so the outer JS frame gets its own Error back.
+        Console.WriteLine(""rethrown to JS: "" + Native.CallAndCatch(() =>
+        {
+            try { Native.Boom(); }
+            catch (Exception) { throw; }
+        }));
+    }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "js error through both frames: deep js failure");
+            StringAssert.Contains(js, "js caught a C# exception: false/from the C# callback",
+                "a C# exception is not a JS Error - it is a System.Exception object - but it does carry "
+                + "`message`, which is what a JavaScript handler reads");
+            StringAssert.Contains(js, "round trip kept the type: through the JS frame",
+                "a C# exception passing through a JavaScript frame must arrive as itself");
+            StringAssert.Contains(js, "rethrown to JS: true/deep js failure",
+                "a bare rethrow must hand JavaScript back the value that was thrown, not a wrapper");
+        }
+
+        /// <summary>
+        /// A rejected promise. Awaiting one binds whatever JavaScript rejected with, and that value
+        /// is normalised into a real <c>System.Exception</c> on the way in — the same normalisation
+        /// <c>Task.Run</c> and a faulted task already applied, and the reason the handler can use
+        /// <c>GetType()</c>, <c>ToString()</c> and the inner chain at all instead of holding a bare
+        /// <c>Error</c> that only answers to <c>Message</c>. All four reason shapes a browser
+        /// actually produces are covered: an <c>Error</c>, an engine error type, a string, and an
+        /// event with no message.
+        /// </summary>
+        [TestMethod]
+        public async Task AwaitingARejectedPromiseYieldsARealExceptionAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""return Promise.reject(new Error('the promise rejected'));"")]
+    public static extern Task Rejected();
+
+    [Script(""return Promise.reject(new RangeError('out of range'));"")]
+    public static extern Task RejectedWithEngineError();
+
+    [Script(""return Promise.reject('a bare string reason');"")]
+    public static extern Task RejectedWithAString();
+
+    [Script(""return Promise.reject({ type: 'error', target: null });"")]
+    public static extern Task RejectedWithAnEvent();
+
+    [Script(""return Promise.reject(new Error('typed rejection'));"")]
+    public static extern Task<int> RejectedTyped();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Native.Rejected(); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""error: "" + e.GetType().FullName + "" / "" + e.Message);
+            Console.WriteLine(""error is an Exception: "" + (e is Exception) + "" stack: "" + (e.StackTrace != null));
+            Console.WriteLine(""error tostring: "" + e.ToString().Contains(""the promise rejected""));
+        }
+
+        try { await Native.RejectedWithEngineError(); }
+        catch (Exception e) { Console.WriteLine(""range: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        try { await Native.RejectedWithAString(); }
+        catch (Exception e) { Console.WriteLine(""string: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        try { await Native.RejectedWithAnEvent(); }
+        catch (Exception e) { Console.WriteLine(""event: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        try { var v = await Native.RejectedTyped(); Console.WriteLine(""NOT REACHED "" + v); }
+        catch (Exception e) { Console.WriteLine(""typed: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "error: System.SystemException / the promise rejected",
+                "a rejected promise's reason must arrive as a System.Exception, not as the raw Error");
+            StringAssert.Contains(js, "error is an Exception: True stack: True");
+            StringAssert.Contains(js, "error tostring: True");
+            StringAssert.Contains(js, "range: System.ArgumentOutOfRangeException / out of range");
+            StringAssert.Contains(js, "string: System.Exception / a bare string reason",
+                "a rejection reason that is not an Error at all still has to become one");
+            StringAssert.Contains(js, "event: System.Exception / A JavaScript 'error' event was raised.");
+            StringAssert.Contains(js, "typed: System.SystemException / typed rejection");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// <c>Task.WhenAll</c> over promises. A <c>[Script]</c> binding that returns a native promise
+        /// where a <c>Task</c> is declared is the natural way to bind a JS async function, and it
+        /// behaves like a working Task right up until it is handed to <c>WhenAll</c>/<c>WhenAny</c>,
+        /// which drive their arguments through <c>continueWith</c>: the call died on a promise having
+        /// no such method and, being inside a promise itself, took the rejection out of reach with
+        /// it — nothing threw, nothing was logged, and every awaiter hung.
+        /// </summary>
+        [TestMethod]
+        public async Task WhenAllAcceptsPromisesAndCollectsTheirRejectionsAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""return Promise.reject(new Error('rejected ' + tag));"")]
+    public static extern Task Reject(string tag);
+
+    [Script(""return Promise.resolve(41);"")]
+    public static extern Task<int> Resolve();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        var all = Task.WhenAll(Native.Reject(""one""), Native.Reject(""two""));
+
+        try { await all; Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""threw: "" + e.GetType().FullName); }
+
+        Console.WriteLine(""count: "" + all.Exception.InnerExceptions.Count);
+        Console.WriteLine(""messages: "" + string.Join("","", all.Exception.InnerExceptions.Select(x => x.Message).OrderBy(x => x)));
+        Console.WriteLine(""aggregate message: "" + all.Exception.Message);
+        Console.WriteLine(""every inner is an Exception: "" + all.Exception.InnerExceptions.All(x => x is Exception));
+
+        var any = await Task.WhenAny(Native.Reject(""via WhenAny""));
+        Console.WriteLine(""WhenAny: faulted="" + any.IsFaulted + "" / "" + any.Exception.InnerException.Message);
+
+        Console.WriteLine(""a resolving promise still resolves: "" + await Native.Resolve());
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "threw: System.SystemException");
+            StringAssert.Contains(js, "count: 2", "both rejections must reach the aggregate");
+            StringAssert.Contains(js, "messages: rejected one,rejected two");
+            StringAssert.Contains(js, "aggregate message: One or more errors occurred. (rejected one) (rejected two)",
+                "the aggregate's message is the one a logger prints, so it has to name what failed");
+            StringAssert.Contains(js, "every inner is an Exception: True");
+            StringAssert.Contains(js, "WhenAny: faulted=True / rejected via WhenAny");
+            StringAssert.Contains(js, "a resolving promise still resolves: 41");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A JS failure inside the C# constructs that surround it: a <c>WhenAll</c> mixing a JS
+        /// error with a C# exception (both have to land in the aggregate as exceptions, and the
+        /// aggregate's message has to name both), an exception filter reading a JS error's message,
+        /// and wrapping one as an <c>InnerException</c> so that <c>ToString()</c> reports the chain.
+        /// </summary>
+        [TestMethod]
+        public async Task AJsErrorBehavesLikeAnExceptionInsideTasksFiltersAndChainsAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""throw new Error('js failure ' + tag);"")]
+    public static extern void Boom(string tag);
+}
+
+public class Program
+{
+    static async Task<int> JsFails(string tag) { await Task.Yield(); Native.Boom(tag); return 0; }
+    static async Task<int> CSharpFails(string tag) { await Task.Yield(); throw new FormatException(""c# failure "" + tag); }
+
+    public static async Task Run()
+    {
+        var all = Task.WhenAll(JsFails(""A""), CSharpFails(""B""), Task.FromResult(1));
+
+        try { await all; Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""threw: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        Console.WriteLine(""count: "" + all.Exception.InnerExceptions.Count);
+        Console.WriteLine(""kinds: "" + string.Join("","", all.Exception.InnerExceptions.Select(x => x.GetType().FullName)));
+        Console.WriteLine(""aggregate message: "" + all.Exception.Message);
+        Console.WriteLine(""all are exceptions: "" + all.Exception.InnerExceptions.All(x => x is Exception));
+
+        // A filter reading a JS error's message, and one that does not match letting it pass on.
+        try { Native.Boom(""F""); }
+        catch (Exception e) when (e.Message.Contains(""js failure F"")) { Console.WriteLine(""filter matched: "" + e.Message); }
+
+        try
+        {
+            try { Native.Boom(""G""); }
+            catch (Exception) when (false) { Console.WriteLine(""NOT REACHED""); }
+        }
+        catch (Exception e) { Console.WriteLine(""unmatched filter passed it on: "" + e.Message); }
+
+        // Wrapped as an inner exception, the JS error is still what ToString() reports at the bottom.
+        try
+        {
+            try { Native.Boom(""W""); }
+            catch (Exception inner) { throw new InvalidOperationException(""wrapped a JS error"", inner); }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(""wrapper: "" + e.Message + "" / inner: "" + e.InnerException.Message);
+            Console.WriteLine(""tostring names both: "" + (e.ToString().Contains(""wrapped a JS error"") && e.ToString().Contains(""js failure W"")));
+        }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "count: 2");
+            StringAssert.Contains(js, "kinds: System.SystemException,System.FormatException",
+                "a JS error and a C# exception must both reach the aggregate as exceptions");
+            StringAssert.Contains(js, "aggregate message: One or more errors occurred. (js failure A) (c# failure B)");
+            StringAssert.Contains(js, "all are exceptions: True");
+            StringAssert.Contains(js, "filter matched: js failure F");
+            StringAssert.Contains(js, "unmatched filter passed it on: js failure G");
+            StringAssert.Contains(js, "wrapper: wrapped a JS error / inner: js failure W");
+            StringAssert.Contains(js, "tostring names both: True");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// Normalising a browser value must not discard what it carried. The engine's own errors
+        /// arrive with fields no .NET exception has a home for — an <c>ErrorEvent</c>'s
+        /// filename/lineno, a <c>CloseEvent</c>'s code/reason, a custom <c>code</c> on an
+        /// application error — so the value exactly as it arrived stays on the exception as
+        /// <c>errorSource</c>, reachable from JavaScript. An <c>Error</c> subclass (which is what a
+        /// library's own error type is) keeps its message and its frames, and a value from another
+        /// realm is recognised by carrying a stack rather than by <c>instanceof</c>, which is
+        /// per-realm and answers false for an iframe's or a worker's error.
+        /// </summary>
+        [TestMethod]
+        public async Task NormalisationKeepsTheOriginalValueAndItsFieldsReachableAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""var e = new Error('carried'); e.code = 'E_CUSTOM'; e.detail = { line: 12 }; throw e;"")]
+    public static extern void ThrowWithFields();
+
+    [Script(""class AppError extends Error { constructor(m) { super(m); this.name = 'AppError'; } } throw new AppError('a subclassed Error');"")]
+    public static extern void ThrowSubclass();
+
+    // An error from another realm: a real Error that fails `instanceof Error` here.
+    [Script(""var alien = { message: 'from another realm', stack: 'Error: from another realm\\n    at alien (other.js:1:1)' }; throw alien;"")]
+    public static extern void ThrowForeignError();
+
+    [Script(""var s = ex.errorSource; return s ? (s.code + '/' + (s.detail ? s.detail.line : '-')) : 'no source';"")]
+    public static extern string SourceOf(Exception ex);
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Native.ThrowWithFields()); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""message: "" + e.Message);
+            Console.WriteLine(""fields still reachable: "" + Native.SourceOf(e));
+            Console.WriteLine(""frames are the throw site: "" + e.StackTrace.Contains(""ThrowWithFields""));
+        }
+
+        try { await Task.Run(() => Native.ThrowSubclass()); }
+        catch (Exception e) { Console.WriteLine(""subclass: "" + e.Message + "" / stack: "" + (e.StackTrace != null)); }
+
+        try { await Task.Run(() => Native.ThrowForeignError()); }
+        catch (Exception e)
+        {
+            Console.WriteLine(""foreign: "" + e.GetType().FullName + "" / "" + e.Message);
+            Console.WriteLine(""foreign frames kept: "" + e.StackTrace.Contains(""other.js""));
+        }
+
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "message: carried");
+            StringAssert.Contains(js, "fields still reachable: E_CUSTOM/12",
+                "the value as it arrived must stay reachable, or everything it carried is lost");
+            StringAssert.Contains(js, "frames are the throw site: True");
+            StringAssert.Contains(js, "subclass: a subclassed Error / stack: True");
+            StringAssert.Contains(js, "foreign: System.SystemException / from another realm",
+                "an error from another realm carries a stack but fails instanceof, so duck-type it");
+            StringAssert.Contains(js, "foreign frames kept: True");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+
+        /// <summary>
+        /// A <c>Task.Run</c> body that hands back a native promise — which is what a
+        /// <c>[Script]</c>-bound JS async function is, and so what <c>Func&lt;Task&gt;</c> often
+        /// resolves to here. It has to be AWAITED rather than becoming the task's result: stored as
+        /// the result, the outer task completed immediately and the promise's rejection was never
+        /// observed by anyone, so a failure vanished and the code after the await ran as if it had
+        /// succeeded.
+        /// </summary>
+        [TestMethod]
+        public async Task ATaskRunBodyThatReturnsAPromiseIsAwaitedNotStoredAsync()
+        {
+            var js = await RunTest(@"
+using System;
+using System.Threading.Tasks;
+using Transpose;
+
+public class Native
+{
+    [Script(""return Promise.reject(new Error('promise body rejected'));"")]
+    public static extern Task Reject();
+
+    [Script(""return Promise.resolve(19);"")]
+    public static extern Task<int> Resolve();
+}
+
+public class Program
+{
+    public static async Task Run()
+    {
+        try { await Task.Run(() => Native.Reject()); Console.WriteLine(""NOT REACHED""); }
+        catch (Exception e) { Console.WriteLine(""rejecting body: "" + e.GetType().FullName + "" / "" + e.Message); }
+
+        Console.WriteLine(""resolving body: "" + await Task.Run(() => Native.Resolve()));
+        Console.WriteLine(""<<DONE>>"");
+    }
+
+    public static void Main() { Run(); }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(js, "rejecting body: System.SystemException / promise body rejected",
+                "a promise a Task.Run body returned must be awaited, or its rejection reaches nobody");
+            StringAssert.Contains(js, "resolving body: 19");
+            StringAssert.Contains(js, "<<DONE>>");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -679,8 +679,27 @@ public sealed partial class Emitter
             _w.WriteLine("catch ($ex) {");
             _w.Indent();
 
-            // Bind each catch variable to $ex up front so it is in scope for exception
-            // filters (`when (...)`), which are evaluated in the guard before the body.
+            // What JavaScript threw is not necessarily a System.Exception — an interop call, a
+            // rejected promise or the engine itself (a null dereference raises a native TypeError)
+            // hands back a bare value — so it is normalised once, on entry, into the exception the
+            // handlers are written against: without that, `catch (NullReferenceException)` did not
+            // match a null dereference and `e.GetType()` answered "TypeError". `TransposeR.caught`
+            // returns a real exception unchanged, so a C#-thrown one costs nothing, and a bare
+            // `throw;` still rethrows `$ex` — the value as JavaScript threw it — which is what keeps
+            // its identity and native frames usable by an outer JS handler.
+            //
+            // Only emitted when some clause can observe it: a bare `catch { }` or a
+            // `catch (Exception)` with no variable has nothing to ask.
+            var caught = "$ex";
+
+            if (tryStmt.Catches.Any(c => c.Filter is not null || CatchBindsAVariable(c) || !IsCatchAllType(c)))
+            {
+                caught = "$exn";
+                _w.WriteLine("let $exn = TransposeR.caught($ex);");
+            }
+
+            // Bind each catch variable up front so it is in scope for exception filters
+            // (`when (...)`), which are evaluated in the guard before the body.
             var boundNames = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
             foreach (var katch in tryStmt.Catches)
             {
@@ -688,7 +707,7 @@ public sealed partial class Emitter
                 if (id is { RawKind: not 0 } token && !string.IsNullOrEmpty(token.Text))
                 {
                     var jsName = NameMangler.JsIdentifier(token.Text);
-                    if (boundNames.Add(jsName)) _w.WriteLine($"let {jsName} = $ex;");
+                    if (boundNames.Add(jsName)) _w.WriteLine($"let {jsName} = {caught};");
                 }
             }
 
@@ -698,14 +717,9 @@ public sealed partial class Emitter
             {
                 var typeSyntax = katch.Declaration?.Type;
                 var exType = typeSyntax is not null ? _model.GetTypeInfo(typeSyntax).Type : null;
-                var isCatchAll = exType is null || exType.SpecialType == SpecialType.System_Object
-                    || exType.ToDisplayString() == "System.Exception";
+                var isCatchAll = IsCatchAllType(katch);
 
-                var condition = isCatchAll ? null : $"TransposeR.is($ex, {ExceptionTypeRef(exType!)})";
-                if (katch.Filter is not null)
-                {
-                    // exception filter appended
-                }
+                var condition = isCatchAll ? null : $"TransposeR.is({caught}, {ExceptionTypeRef(exType!)})";
 
                 if (condition is null && katch.Filter is null)
                 {
@@ -729,9 +743,14 @@ public sealed partial class Emitter
                     _w.Write(condition);
                     if (katch.Filter is not null)
                     {
-                        _w.Write(" && (");
+                        // Through TransposeR.filter, because the CLR swallows whatever the filter
+                        // itself throws and reads that as "does not match": the exception already in
+                        // flight then keeps propagating, where evaluating the filter inline let a
+                        // fault inside it replace (and so lose) that exception. A C# filter can
+                        // contain no `await`, so a plain arrow is safe.
+                        _w.Write(" && TransposeR.filter(() => (");
                         EmitExpression(katch.Filter.FilterExpression);
-                        _w.Write(")");
+                        _w.Write("))");
                     }
                     _w.Write(") ");
                     EmitCatchBodyBlock(katch);
@@ -752,6 +771,19 @@ public sealed partial class Emitter
             EmitBlock(tryStmt.Finally.Block);
         }
     }
+
+    /// <summary>A clause that catches everything: `catch`, `catch (object)`, `catch (Exception)`.</summary>
+    private bool IsCatchAllType(CatchClauseSyntax katch)
+    {
+        var typeSyntax = katch.Declaration?.Type;
+        var exType = typeSyntax is not null ? _model.GetTypeInfo(typeSyntax).Type : null;
+
+        return exType is null || exType.SpecialType == SpecialType.System_Object
+            || exType.ToDisplayString() == "System.Exception";
+    }
+
+    private static bool CatchBindsAVariable(CatchClauseSyntax katch)
+        => katch.Declaration?.Identifier is { RawKind: not 0 } token && !string.IsNullOrEmpty(token.Text);
 
     private void EmitCatchBody(CatchClauseSyntax katch, string? prefix)
     {

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -82,6 +82,42 @@
         if (e.errorStack && e.errorStack.stack !== null && e.errorStack.stack !== undefined) { return e.errorStack.stack; }
         return (e.stack !== null && e.stack !== undefined) ? e.stack : null;
     };
+    // The value a `catch` clause binds. What the engine threw may be anything at all - an Error, a
+    // string, a DOM event - and a handler that asks `catch (NullReferenceException)`,
+    // `e is IOException`, `e.GetType()` or `e.GetBaseException()` only gets an answer if that value
+    // is a System.Exception. Most of all: a null dereference raises a native TypeError, so the most
+    // common exception in any program did not match the handler that names it. Normalise once, on
+    // entry, exactly as every other JS -> C# seam does (Task.Run, fromPromise, toPromise); a real
+    // exception is returned unchanged, so nothing is allocated for a C#-thrown one.
+    //
+    // A bare `throw;` still rethrows the ORIGINAL value rather than this wrapper, which is what
+    // keeps its identity and its native frames usable by an outer JavaScript handler. The wrapper is
+    // remembered against the value it wraps, so an outer C# catch of that same rethrow binds the
+    // SAME exception instance - reference equality across a rethrow holds, and anything the inner
+    // handler recorded on it (e.Data) survives. A WeakMap rather than a field on the error, so the
+    // value an outer JS handler receives is untouched; a thrown primitive cannot be a key and simply
+    // gets a fresh wrapper, which has no identity to lose.
+    TransposeR.$caught = TransposeR.$caught || new WeakMap();
+    TransposeR.caught = function (e) {
+        if (Transpose.is(e, System.Exception)) { return e; }
+        if (e === null || e === undefined || (typeof e !== "object" && typeof e !== "function")) {
+            return System.Exception.create(e);
+        }
+        var known = TransposeR.$caught.get(e);
+        if (known) { return known; }
+        var ex = System.Exception.create(e);
+        TransposeR.$caught.set(e, ex);
+        return ex;
+    };
+    // An exception filter (`catch (E e) when (expr)`). The CLR runs the filter with the exception
+    // still in flight and SWALLOWS anything the filter itself throws, treating it as "does not
+    // match" - so the exception being handled keeps propagating. Evaluating the filter inline
+    // instead let a fault inside it (the usual one: a null dereference in the `when` clause)
+    // replace the error the handler existed to report, which is the one thing nobody can debug.
+    // Note a C# filter can never contain `await`, so a plain arrow is safe here.
+    TransposeR.filter = function (test) {
+        try { return !!test(); } catch (e) { return false; }
+    };
     TransposeR.is = function (v, t) { return Transpose.is(v, t); };
     TransposeR.as = function (v, t) { return Transpose.as ? Transpose.as(v, t) : (Transpose.is(v, t) ? v : null); };
     TransposeR.equals = function (a, b) { return Transpose.equals ? Transpose.equals(a, b) : a === b; };

--- a/Transpose/Transpose.Translator/Runtime/tps.shim.js
+++ b/Transpose/Transpose.Translator/Runtime/tps.shim.js
@@ -54,6 +54,25 @@
         var fn = TransposeR.toStrFn(t);
         return fn ? fn(v) : TransposeR.toStr(v);
     };
+    // Exception.Message. Same story as stackTrace below: the value caught by `catch (Exception)`
+    // may be a real System.Exception, a raw JS error (both carry a `message`, so both already
+    // worked), or a bare value someone threw - a string, an object literal - whose text was
+    // reported as an empty message because there was no `message` field to read.
+    TransposeR.message = function (e) {
+        if (e === null || e === undefined) { return null; }
+        if (typeof e === "string") { return e; }
+        if (typeof e.message === "string") { return e.message; }
+        // A DOM event - a WebSocket or XHR `error` - carries no message and stringifies to
+        // "[object Event]", which says nothing. Name the event and what raised it, as
+        // System.Exception.create does for the same value (kept here rather than delegating to it:
+        // the shim ships with the application and cannot assume the runtime it loads has that
+        // function).
+        if (typeof e.type === "string" && e.type.length > 0 && "target" in e) {
+            var raisedBy = (e.target && e.target.constructor && e.target.constructor.name !== "Object") ? e.target.constructor.name : null;
+            return "A JavaScript '" + e.type + "' event was raised" + (raisedBy ? " by " + raisedBy : "") + ".";
+        }
+        return TransposeR.toStr(e);
+    };
     // Exception.StackTrace. A value caught by `catch (Exception)` is either a real System.Exception,
     // which captured an Error into `errorStack` when it was constructed, or a raw JS error thrown by
     // interop / a rejected promise, which has a native `stack` and no `errorStack`. C# matches both,


### PR DESCRIPTION
A value the engine hands us - something thrown across an interop boundary, a rejected promise's reason, a DOM error event - is normalised into a System.Exception by `System.Exception.create` (Task.Run, TransposeR.fromPromise, ClientWebSocket, Task.ContinueWith all route through it). That normalisation dropped both halves of the only diagnostic a browser gives:

- For a plain `Error` (and so for SyntaxError, ReferenceError, DOMException - everything that is not a TypeError or RangeError) it returned early, passing the Error OBJECT where a string message was expected. `Message` was therefore not a string at all, so `Message.Length`, `Contains`, `IsNullOrEmpty` all answered for an object, and the exception kept the stack its own constructor had just captured - every frame of it inside tps.js, none of them the throw site. `at Function.Boom (...)` had become `at $ctor1.ctor (tps.js:6324)`.
- For a thrown non-Error (a string, an object, an Event) it assigned that stackless value over the constructor's captured stack, leaving `StackTrace` undefined - i.e. no stack at all, when the capture taken in the handler was the best available.
- An ErrorEvent (window.onerror, worker.onerror) had its inner error's stack TEXT reported as the message, while the stack itself came back null: the two swapped places and both were unusable.
- A DOM event with no message (a WebSocket or XHR `error`) was reported as "[object Event]", and a RangeError's message was passed as the *paramName* of ArgumentOutOfRangeException, which buried it inside "Specified argument was out of the range of valid values.".

`create` now unwraps an event to the value that was actually thrown, describes whatever arrived as a string, keeps the browser's frames only when there are frames to keep, and leaves the original value on the exception as `errorSource` so nothing it carried (an ErrorEvent's filename/lineno, a CloseEvent's code/reason) is unreachable. The `StackTrace` getters answer null instead of throwing on a value with no stack, and `ToString()` reports the inner exception chain the way .NET does, which is what makes a wrapped browser error visible at all.

`Exception.Message` now reads through `TransposeR.message`, for the same reason `StackTrace` already read through a helper: `catch (Exception)` also binds a bare value the engine threw, which has no `message` field, so a thrown string's text was reported as an empty message. A real exception and a raw JS error both carry `message` and are unaffected.

Two task paths destroyed a fault outright:

- `TaskCompletionSource.TrySetException` is handed whatever `catch (Exception)` bound, which may be a raw browser error (BrowserHttpHandler does exactly this). Building the AggregateException out of it threw "Cannot create Enumerator." from inside the setter, which left the task un-completed forever
  - every awaiter hung - and discarded the error on the way out.
- Awaiting a task faulted with a bare exception rather than an AggregateException (Task.FromException) read `.innerExceptions.Count` off it and raised a TypeError over the real exception, and an AggregateException carrying none rethrew `null`.

Covered by eight new cases in ExceptionStackTraceTests.


Claude-Session: https://claude.ai/code/session_01TQyuPrnvtdNHUgHVdjFWXe