### PR TITLE
Fix static initializers for constructed generics

### DIFF
--- a/BCL/Transpose.BCL/Resources/Class.js
+++ b/BCL/Transpose.BCL/Resources/Class.js
@@ -260,6 +260,26 @@
                     key = Transpose.Class.getCachedType(fn, arguments);
 
                     if (key) {
+                        // A cache hit re-offers the static initializer instead of handing the type
+                        // straight back. A constructed generic has no global slot, so unlike a named
+                        // type it has no Class.set getter to run its statics on first read: it used
+                        // to get exactly two chances — the Transpose.get below, which does nothing
+                        // while the runtime is still defining types (staticInitAllow false), and the
+                        // $queue drain in Transpose.init(). Miss both and the type was handed out
+                        // uninitialized for the life of the page, every static field left at its
+                        // declared default — List$1(X)._emptyArray reading null, so every list of
+                        // that element type was built with a null _items. Both misses happen in
+                        // practice: a type created while queueIsBlocked is never queued at all, and
+                        // a throw anywhere in the drain strands everything queued behind it.
+                        //
+                        // Re-offering is free once it has run ($staticInit is nulled first thing).
+                        // The typeof guard is not defensive padding: the cache entry is published
+                        // before $staticInit is attached, so a self-referential base
+                        // (ValueTuple$1 : IValueTuple) comes back through here to a half-built type.
+                        if (typeof key.type.$staticInit === "function") {
+                            key.type.$staticInit();
+                        }
+
                         return key.type;
                     }
 
@@ -1062,11 +1082,18 @@
                 Transpose.Class.staticInitAllow = false;
                 Transpose.Class.queueIsBlocked = true;
 
-                var cfg = prop.apply(null, fn.$typeArguments),
-                    extend = cfg.$inherits || cfg.inherits;
+                // Restored in a finally: both flags are process-wide, so a config that throws here
+                // used to leave the runtime permanently "still defining types" — after which no
+                // constructed generic ever ran its static initializer again.
+                var cfg, extend;
 
-                Transpose.Class.staticInitAllow = old;
-                Transpose.Class.queueIsBlocked = oldIsBlocked;
+                try {
+                    cfg = prop.apply(null, fn.$typeArguments);
+                    extend = cfg.$inherits || cfg.inherits;
+                } finally {
+                    Transpose.Class.staticInitAllow = old;
+                    Transpose.Class.queueIsBlocked = oldIsBlocked;
+                }
 
                 if (extend && Transpose.isFunction(extend)) {
                     extend = extend();

--- a/BCL/Transpose.BCL/Resources/ReflectionAssembly.js
+++ b/BCL/Transpose.BCL/Resources/ReflectionAssembly.js
@@ -26,9 +26,14 @@
             var old = Transpose.Class.staticInitAllow;
             Transpose.Class.staticInitAllow = false;
 
-            callback.call(Transpose.global, asm, Transpose.global);
-
-            Transpose.Class.staticInitAllow = old;
+            // Restored in a finally: staticInitAllow is process-wide, so a define that throws while
+            // this assembly is being registered would otherwise leave the runtime stuck in its
+            // "defining types" state for every script loaded afterwards.
+            try {
+                callback.call(Transpose.global, asm, Transpose.global);
+            } finally {
+                Transpose.Class.staticInitAllow = old;
+            }
         }
 
         Transpose.init();

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -3818,5 +3818,50 @@ public class Program
         Console.WriteLine(""elementType="" + frames.GetType().GetElementType().Name);
     }
 }";
+
+        /// <summary>
+        /// A constructed generic type must run its static initializer before it is used, even when
+        /// the creation that first cached it happened at a moment the runtime could not initialize
+        /// it (still defining types) and it never reached the static-init queue.
+        ///
+        /// The failure this guards was reported as `new List&lt;Box&lt;ITracesProperty&gt;&gt;()`
+        /// producing a list whose `_items` was null: List$1(T)'s ctor reads the static
+        /// `_emptyArray`, which was still at its declared `null` because nothing had run the
+        /// constructed type's static field initializers. Only the FIRST application of a generic
+        /// definition used to offer them — every later one returned the cached type untouched — so
+        /// one bad moment stranded the type for the life of the page.
+        /// </summary>
+        [TestMethod]
+        public async Task ConstructedGenericInitializesStaticsEvenIfItMissedTheQueue()
+        {
+            var output = await RunTest(@"
+using System;
+using System.Collections.Generic;
+using Transpose;
+
+public class Marker { }
+
+public class Program
+{
+    public static void Main()
+    {
+        // Reproduce the runtime state a type is created in while the bundle is still defining
+        // types, with the static-init queue blocked — the same shape a throw part-way through
+        // Transpose.init() leaves behind for everything queued after it.
+        Script.Write(""Transpose.Class.staticInitAllow = false; Transpose.Class.queueIsBlocked = true"");
+        Script.Write(""System.Collections.Generic.List$1(Marker)"");
+        Script.Write(""Transpose.Class.staticInitAllow = true; Transpose.Class.queueIsBlocked = false"");
+
+        var list = new List<Marker>();
+        Console.WriteLine(""items null? "" + Script.Write<bool>(""list._items === null""));
+
+        list.Add(new Marker());
+        Console.WriteLine(""count="" + list.Count);
+    }
+}", skipRoslyn: true);
+
+            StringAssert.Contains(output, "items null? False");
+            StringAssert.Contains(output, "count=1");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a critical bug where constructed generic types (e.g., `List<Box<ITracesProperty>>`) could be handed out uninitialized, leaving static fields at their declared defaults. This occurred when a type was created while the runtime was still defining types or when the static-init queue was blocked, causing it to miss both initialization opportunities.

## Key Changes

- **Class.js**: Added logic to re-offer the static initializer (`$staticInit`) on cache hits for constructed generics. Since these types have no global slot (unlike named types), they lack a Class.set getter to run statics on first read. Re-offering ensures initialization happens even if both the initial `Transpose.get` and the `$queue` drain were missed.

- **Class.js**: Wrapped the type configuration call in a try/finally block to ensure `staticInitAllow` and `queueIsBlocked` flags are always restored, even if the config throws. These are process-wide flags, so a throw during type definition would otherwise leave the runtime permanently in "still defining types" state.

- **ReflectionAssembly.js**: Wrapped the assembly registration callback in a try/finally block to ensure `staticInitAllow` is always restored. A throw during assembly definition would otherwise strand the runtime in its "defining types" state for all subsequently loaded scripts.

- **EmitRegressionTests.cs**: Added regression test `ConstructedGenericInitializesStaticsEvenIfItMissedTheQueue()` that reproduces the runtime state where a type is created while the bundle is still defining types with the static-init queue blocked, verifying that `List<Marker>._items` is properly initialized.

## Implementation Details

The fix leverages the fact that re-offering the static initializer is free once it has run—`$staticInit` is nulled immediately upon execution. The typeof guard against `$staticInit` being a function is necessary because cache entries are published before `$staticInit` is attached, so self-referential base types (e.g., `ValueTuple$1 : IValueTuple`) can come back through the cache path to a half-built type.

https://claude.ai/code/session_01DAqgEdqJSBHfeUeKowKUb9