### PR TITLE
Default a long/ulong/decimal slot to the type's zero, not the literal 0

### DIFF
--- a/Packages/Transpose.Newtonsoft.Json.Tests/BclTypeTests.cs
+++ b/Packages/Transpose.Newtonsoft.Json.Tests/BclTypeTests.cs
@@ -209,6 +209,91 @@ public class App
             nativePrints: "{\"L\":9007199254740993,\"U\":18446744073709551615}\n9007199254740993|18446744073709551615");
     }
 
+    /// <summary>
+    /// An UNASSIGNED 64-bit / decimal member. The serializer switches on the DECLARED type and then
+    /// calls the runtime object's <c>toJSON()</c>, so a slot holding a plain JavaScript number
+    /// instead of a System.Int64 killed the whole call with "obj.toJSON is not a function" — while
+    /// the same type with the member explicitly set to 0 serialized fine, because an assigned
+    /// literal IS wrapped. The compiler now defaults such a slot to the type's zero instance; the
+    /// serializer also rebuilds one from a bare number, so a value arriving from JavaScript keeps
+    /// the declared type's wire format.
+    /// </summary>
+    [TestMethod]
+    public async Task UnassignedSixtyFourBitAndDecimalMembersSerialize()
+    {
+        var code = Header + @"
+public class Probe { public long V { get; set; } public ulong U; public decimal M { get; set; } }
+public class App
+{
+    public static void Main()
+    {
+        Console.WriteLine(JsonConvert.SerializeObject(new Probe()));
+        Console.WriteLine(JsonConvert.SerializeObject(new Probe { V = 0 }));
+        Console.WriteLine(JsonConvert.SerializeObject(new Probe { V = 7L, U = 8UL, M = 1.5m }));
+
+        var back = JsonConvert.DeserializeObject<Probe>(JsonConvert.SerializeObject(new Probe()));
+        Console.WriteLine(back.V + ""|"" + back.U);
+    }
+}";
+        await RunJs(code,
+            expected:     "{\"U\":0,\"M\":0,\"V\":0}\n{\"U\":0,\"M\":0,\"V\":0}\n{\"U\":8,\"M\":1.5,\"V\":7}\n0|0",
+            nativePrints: "{\"U\":0,\"V\":0,\"M\":0.0}\n{\"U\":0,\"V\":0,\"M\":0.0}\n{\"U\":8,\"V\":7,\"M\":1.5}\n0|0");
+    }
+
+    /// <summary>
+    /// The same unassigned 64-bit/decimal slot, reached through every shape an inheritance hierarchy
+    /// puts it in: an abstract get-only property implemented by an override, a virtual auto-property
+    /// overridden by a field-backed one (base and derived hold SEPARATE slots), an interface
+    /// implementation, a `new`-shadowed property, a closed generic base, and a record's positional
+    /// members. Each of those is a different slot-emission path in the compiler, and one of them —
+    /// the abstract auto-property — had no slot at all yet was still being assigned a default.
+    /// Only the 64-bit members are compared against Json.NET here: an unassigned <c>decimal</c>
+    /// carries the separate scale divergence Json.NET has (it writes <c>0.0</c>), and is pinned by
+    /// <see cref="UnassignedSixtyFourBitAndDecimalMembersSerialize"/> instead.
+    /// </summary>
+    [TestMethod]
+    public async Task UnassignedSixtyFourBitMembersRoundTripThroughEveryInheritanceShape()
+    {
+        var code = Header + @"
+public abstract class Doc
+{
+    public abstract long Size { get; }        // abstract: no slot of its own
+    public long Version { get; set; }         // plain auto-property on an abstract base
+    public long Cost;                         // plain field on an abstract base
+    public virtual long Rank { get; set; }    // virtual: the derived override gets its own slot
+}
+public class Report : Doc
+{
+    public override long Size { get { return 3L; } }
+    public override long Rank { get; set; }
+    public ulong Pages { get; set; }
+}
+public interface IStamped { long Stamp { get; set; } }
+public class Stamped : IStamped { public long Stamp { get; set; } }
+public class ShadowBase { public long Key { get; set; } }
+public class Shadowed : ShadowBase { public new long Key { get; set; } }
+public abstract class Box<T> { public T Value { get; set; } }
+public class LongBox : Box<long> { }
+public class App
+{
+    public static void Main()
+    {
+        Console.WriteLine(JsonConvert.SerializeObject(new Report()));
+        Console.WriteLine(JsonConvert.SerializeObject(new Stamped()));
+        Console.WriteLine(JsonConvert.SerializeObject(new Shadowed()));
+        Console.WriteLine(JsonConvert.SerializeObject(new LongBox()));
+
+        var back = JsonConvert.DeserializeObject<Report>(JsonConvert.SerializeObject(new Report { Version = 4L, Rank = 5L, Pages = 6UL }));
+        Console.WriteLine(back.Version + ""|"" + back.Rank + ""|"" + back.Pages + ""|"" + back.Size);
+
+        // The base slot and the override slot are distinct; neither leaks into the other.
+        var r = new Report { Rank = 7L };
+        Console.WriteLine(((Doc)r).Rank + ""|"" + r.Rank);
+    }
+}";
+        await RunAndCompare(code);
+    }
+
     [TestMethod]
     public async Task SixtyFourBitIntegersReadBackFromNumbersAndStrings()
     {

--- a/Packages/Transpose.Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/Packages/Transpose.Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -870,6 +870,17 @@
                             var version = Transpose.toString(obj);
                             return returnRaw ? version : Newtonsoft.Json.JsonConvert.stringify(version, formatting, settings);
                         } else if (type === System.Int64 || type === System.UInt64 || type === System.Decimal) {
+                            // A value declared long/ulong/decimal is normally a runtime OBJECT
+                            // (System.Int64/UInt64/Decimal), but a plain JavaScript number can still
+                            // reach here — from JS interop, or from an assembly built by a compiler
+                            // that emitted the literal 0 for an unassigned `long` slot. Rebuild the
+                            // declared type from it so the wire format is decided by the
+                            // declaration rather than by what the value happens to be; a bare number
+                            // has no toJSON and threw "obj.toJSON is not a function" instead.
+                            if (typeof obj !== "object") {
+                                obj = type(obj);
+                            }
+
                             return returnRaw ? obj.toJSON() : obj.toString();
                         } else if (type === System.DateTime) {
                             var d = System.DateTime.format(obj, "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK");

--- a/Packages/Transpose.System.Text.Json.Tests/BclTypeTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/BclTypeTests.cs
@@ -208,6 +208,92 @@ public sealed class BclTypeTests : JsonTestBase
         expected:     """{"D":1.5,"L":"9007199254740993","U":"18446744073709551615"}""",
         nativePrints: """{"L":9007199254740993,"U":18446744073709551615,"D":1.5}""");
 
+    /// <summary>
+    /// An UNASSIGNED 64-bit / decimal member. long, ulong and decimal are runtime OBJECTS here and
+    /// the shape above is chosen by the DECLARED type, so a slot left holding a plain JavaScript
+    /// number bypassed that shape entirely — this package fell through to writing the bare number,
+    /// while Transpose.Newtonsoft.Json, which calls the object's toJSON(), died on
+    /// "obj.toJSON is not a function" (see its UnassignedSixtyFourBitAndDecimalMembersSerialize).
+    /// The compiler now defaults such a slot to the type's zero instance; this package also rebuilds
+    /// the declared type from a bare number, so a value arriving from JavaScript takes the declared
+    /// wire format rather than whichever one the value's runtime shape happens to select.
+    /// </summary>
+    [TestMethod]
+    public async Task UnassignedSixtyFourBitAndDecimalMembersTakeTheDeclaredWireFormat() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public class Probe { public long V { get; set; } public ulong U { get; set; } public decimal M { get; set; } }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new Probe()));
+                Console.WriteLine(JsonSerializer.Serialize(new Probe { V = 0 }));
+
+                var back = JsonSerializer.Deserialize<Probe>(JsonSerializer.Serialize(new Probe()));
+                Console.WriteLine(back.V + "/" + back.U);
+            }
+        }
+        """);
+
+    /// <summary>
+    /// The same unassigned 64-bit slot, reached through every shape an inheritance hierarchy puts it
+    /// in: an abstract get-only property implemented by an override, a virtual auto-property
+    /// overridden by a field-backed one (base and derived hold SEPARATE slots), an interface
+    /// implementation, a `new`-shadowed property and a closed generic base. Each is a different
+    /// slot-emission path in the compiler, and one of them — the abstract auto-property — had no slot
+    /// at all yet was still being assigned a default, which is what broke System.IO.Stream.Length.
+    /// </summary>
+    [TestMethod]
+    public async Task UnassignedSixtyFourBitMembersRoundTripThroughEveryInheritanceShape() => await RunAndCompare("""
+        using System;
+        using System.Text.Json;
+
+        public abstract class Doc
+        {
+            public abstract long Size { get; }        // abstract: no slot of its own
+            public long Version { get; set; }         // plain auto-property on an abstract base
+            public virtual long Rank { get; set; }    // virtual: the derived override gets its own slot
+        }
+
+        public class Report : Doc
+        {
+            public override long Size => 3L;
+            public override long Rank { get; set; }
+            public ulong Pages { get; set; }
+        }
+
+        public interface IStamped { long Stamp { get; set; } }
+        public class Stamped : IStamped { public long Stamp { get; set; } }
+
+        public class ShadowBase { public long Key { get; set; } }
+        public class Shadowed : ShadowBase { public new long Key { get; set; } }
+
+        public abstract class Box<T> { public T Value { get; set; } }
+        public class LongBox : Box<long> { }
+
+        public static class Program
+        {
+            public static void Main()
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new Report()));
+                Console.WriteLine(JsonSerializer.Serialize(new Stamped()));
+                Console.WriteLine(JsonSerializer.Serialize(new Shadowed()));
+                Console.WriteLine(JsonSerializer.Serialize(new LongBox()));
+
+                var json = JsonSerializer.Serialize(new Report { Version = 4L, Rank = 5L, Pages = 6UL });
+                var back = JsonSerializer.Deserialize<Report>(json);
+                Console.WriteLine(back.Version + "|" + back.Rank + "|" + back.Pages + "|" + back.Size);
+
+                // The base slot and the override slot are distinct; neither leaks into the other.
+                var r = new Report { Rank = 7L };
+                Console.WriteLine(((Doc)r).Rank + "|" + r.Rank);
+            }
+        }
+        """);
+
     [TestMethod]
     public async Task SixtyFourBitIntegersRoundTripThroughTheirStringForm() => await RunJs("""
         using System;

--- a/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
+++ b/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
@@ -825,6 +825,15 @@
                             return String.fromCharCode(value);
                         }
 
+                        // long/ulong/decimal are runtime OBJECTS, so a plain number in a slot
+                        // declared as one (JS interop, or an assembly an older compiler built, which
+                        // emitted the literal 0 for an unassigned `long`) has skipped the 64-bit
+                        // shape below. Rebuild the declared type so the wire format still follows
+                        // the declaration — a 64-bit integer is written as a string.
+                        if (type === System.Int64 || type === System.UInt64 || type === System.Decimal) {
+                            return type(value).toJSON();
+                        }
+
                         return value;
                     }
 

--- a/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
+++ b/Transpose/Transpose.Translator.Tests/EmitRegressionTests.cs
@@ -3916,5 +3916,196 @@ public class Program
             StringAssert.Contains(output, "items null? False");
             StringAssert.Contains(output, "count=1");
         }
+
+        // ---- default(long) / default(decimal) are runtime OBJECTS, not the literal 0 ------------
+
+        /// <summary>
+        /// long, ulong and decimal are modelled by tps.js as OBJECTS (System.Int64/UInt64/Decimal),
+        /// not as JavaScript numbers, so their default has to be that type's zero instance. Emitting
+        /// the literal <c>0</c> for an unassigned slot left a `long` field holding a plain number,
+        /// which reports System.Int32 from GetType() and carries none of the Int64 methods the rest
+        /// of the runtime calls on it — Newtonsoft's serializer, which switches on the DECLARED type,
+        /// died on `obj.toJSON is not a function` for `JsonConvert.SerializeObject(new Probe())`
+        /// while the identical `new Probe { V = 0 }` (an assigned literal, which the emitter DOES
+        /// wrap) worked.
+        /// </summary>
+        [TestMethod]
+        public async Task DefaultSixtyFourBitAndDecimalSlotsAreRuntimeObjects()
+        {
+            await RunTest(@"
+using System;
+public class Probe
+{
+    public long Field;
+    public ulong UField;
+    public decimal MField;
+    public long Prop { get; set; }
+    public decimal MProp { get; set; }
+}
+public struct Holder { public long L; public decimal M; }
+public class Program
+{
+    public static void Main()
+    {
+        var p = new Probe();
+        Console.WriteLine(p.Field.GetType().FullName);
+        Console.WriteLine(p.UField.GetType().FullName);
+        Console.WriteLine(p.MField.GetType().FullName);
+        Console.WriteLine(p.Prop.GetType().FullName);
+        Console.WriteLine(p.MProp.GetType().FullName);
+
+        // A struct slot, an array element and a local `default` take the same route.
+        Console.WriteLine(new Holder().L.GetType().FullName);
+        var arr = new long[2];
+        Console.WriteLine(arr[0].GetType().FullName);
+        long local = default;
+        Console.WriteLine(local.GetType().FullName);
+
+        // ... and the zero has to BE zero, and still support the Int64/Decimal operations.
+        Console.WriteLine(p.Field + 1L);
+        Console.WriteLine(p.MField + 1.5m);
+        Console.WriteLine(p.Field == 0L);
+        Console.WriteLine(p.Prop.ToString());
+    }
+}");
+        }
+
+        /// <summary>
+        /// The default-init above assigns the zero in the constructor, so it must skip members that
+        /// have no slot to assign to. An ABSTRACT auto-property is one: the runtime installs a real
+        /// accessor at that name, so `this.Length = …` throws "Cannot set property Length of
+        /// #&lt;ctor&gt; which has only a getter" — which is what System.IO.Stream, whose
+        /// `public abstract long Length { get; }` is exactly this shape, did.
+        /// </summary>
+        [TestMethod]
+        public async Task AbstractAutoPropertyOfAnObjectNumericTypeGetsNoConstructorDefault()
+        {
+            await RunTest(@"
+using System;
+using System.IO;
+public abstract class Sized
+{
+    public abstract long Length { get; }
+    public abstract decimal Weight { get; }
+}
+public class Fixed : Sized
+{
+    public override long Length { get { return 7L; } }
+    public override decimal Weight { get { return 1.5m; } }
+}
+public class Program
+{
+    public static void Main()
+    {
+        Sized s = new Fixed();
+        Console.WriteLine(s.Length + ""/"" + s.Weight);
+
+        var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+        Console.WriteLine(ms.Length);
+    }
+}");
+        }
+
+        /// <summary>
+        /// The rest of the family the abstract auto-property above belongs to: every shape an
+        /// inheritance hierarchy can put an object-numeric slot in, each a different slot-emission
+        /// path — a virtual auto-property overridden by a field-backed one (base and derived hold
+        /// SEPARATE slots), a base constructor reading a virtual member DURING construction, an
+        /// interface implementation (implicit and explicit), a `new`-shadowed property, a closed
+        /// generic base, statics on an abstract type, records (class and struct), the `field`
+        /// keyword and an indexer. `default(T)` of a struct carrying such slots goes through the
+        /// struct's own getDefaultValue, which is a third path again.
+        /// </summary>
+        [TestMethod]
+        public async Task ObjectNumericDefaultsAreCorrectThroughEveryInheritanceShape()
+        {
+            await RunTest(@"
+using System;
+using System.Collections.Generic;
+
+public abstract class Base
+{
+    public long BaseSlot { get; set; }
+    public decimal BaseDec;
+    public virtual long Virt { get; set; }
+    public abstract long Abs { get; }
+    protected Base() { Trace = Virt.ToString() + ""/"" + BaseSlot.ToString(); }
+    public string Trace;
+}
+public class Derived : Base
+{
+    public override long Virt { get; set; }
+    public override long Abs { get { return 42L; } }
+    public long DerivedSlot { get; set; }
+    public Derived() { DerivedSlot = 3L; }
+}
+
+public class Statics { public static long SLong; public static decimal SDec { get; set; } }
+public abstract class AbsStatics { public static long AS { get; set; } }
+public class DerStatics : AbsStatics { }
+
+public interface IStored { long Stored { get; set; } }
+public class Impl : IStored { public long Stored { get; set; } }
+public class ExplicitImpl : IStored { long IStored.Stored { get; set; } }
+
+public class ShadowBase { public long S { get; set; } }
+public class ShadowDerived : ShadowBase { public new long S { get; set; } }
+
+public abstract class GenBase<T> { public abstract T G { get; } public T Slot { get; set; } }
+public class GenLong : GenBase<long> { public override long G { get { return 2L; } } }
+
+public record Rec(long Id, decimal Amount) { public long Extra { get; init; } }
+public record struct RecS(long Id) { public decimal Amount { get; init; } }
+public struct Holder { public long L; public decimal M; public int I; public long P { get; set; } }
+
+public class WithField { public long F { get { return field; } set { field = value; } } }
+public class Indexed
+{
+    private readonly Dictionary<int, long> _m = new Dictionary<int, long>();
+    public long this[int i] { get { long v; return _m.TryGetValue(i, out v) ? v : 0L; } set { _m[i] = value; } }
+}
+
+public class Program
+{
+    static string T(object o) { return o.GetType().FullName; }
+    public static void Main()
+    {
+        var d = new Derived();
+        Console.WriteLine(""trace="" + d.Trace);
+        Console.WriteLine(T(d.BaseSlot) + ""|"" + T(d.BaseDec) + ""|"" + T(d.Virt) + ""|"" + T(d.Abs) + ""|"" + T(d.DerivedSlot));
+        Console.WriteLine(d.BaseSlot + ""/"" + d.BaseDec + ""/"" + d.Virt + ""/"" + d.Abs + ""/"" + d.DerivedSlot);
+
+        // A field-backed override has storage of its own; the base slot must not be clobbered.
+        var o = new Derived(); o.Virt = 8L;
+        Console.WriteLine(((Base)o).Virt + ""|"" + o.Virt);
+
+        Console.WriteLine(T(Statics.SLong) + ""|"" + T(Statics.SDec) + ""|"" + T(DerStatics.AS));
+        Console.WriteLine(Statics.SLong + ""/"" + Statics.SDec + ""/"" + DerStatics.AS);
+
+        Console.WriteLine(T(new Impl().Stored) + ""|"" + T(((IStored)new ExplicitImpl()).Stored));
+        var sd = new ShadowDerived();
+        Console.WriteLine(T(sd.S) + ""|"" + T(((ShadowBase)sd).S));
+        var gl = new GenLong();
+        Console.WriteLine(T(gl.G) + ""|"" + T(gl.Slot));
+
+        var r = new Rec(0L, 0m);
+        Console.WriteLine(T(r.Id) + ""|"" + T(r.Amount) + ""|"" + T(r.Extra));
+        var rs = default(RecS);
+        Console.WriteLine(T(rs.Id) + ""|"" + T(rs.Amount) + ""|"" + rs.Id + ""|"" + rs.Amount);
+
+        // default(T) of a struct goes through the struct's own getDefaultValue.
+        var h = default(Holder);
+        Console.WriteLine(T(h.L) + ""|"" + T(h.M) + ""|"" + T(h.I) + ""|"" + T(h.P));
+        Console.WriteLine((h.L + 1L) + ""/"" + (h.M + 1.5m) + ""/"" + h.L.Equals(0L) + ""/"" + h.L.CompareTo(0L));
+        var harr = new Holder[2];
+        Console.WriteLine(T(harr[0].L) + ""|"" + harr[0].L);
+        Holder a = default; Holder b = a; b.L = 9L;
+        Console.WriteLine(a.L + ""/"" + b.L);
+
+        Console.WriteLine(T(new WithField().F) + ""|"" + T(new Indexed()[7]));
+        Console.WriteLine(default(long) + ""|"" + T(default(long)) + ""|"" + default(decimal) + ""|"" + T(default(decimal)));
+    }
+}");
+        }
     }
 }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -201,7 +201,7 @@ public sealed partial class Emitter
             if (m is IFieldSymbol f && !f.IsConst && f.AssociatedSymbol is null
                 && FieldInitializerSyntax(f) is null && NeedsStructDefaultInit(f.Type))
                 yield return (TransposeNaming.MemberJsName(f), f.Type);
-            else if (m is IPropertySymbol p && IsAutoProperty(p)
+            else if (m is IPropertySymbol p && IsAutoProperty(p) && !p.IsAbstract && !p.IsIndexer
                 && AutoPropertyInitializerSyntax(p) is null && NeedsStructDefaultInit(p.Type))
                 yield return (TransposeNaming.MemberJsName(p), p.Type);
         }
@@ -486,10 +486,17 @@ public sealed partial class Emitter
         foreach (var m in type.GetMembers())
         {
             if (m.IsStatic) continue;
+            // This selection must stay in lockstep with InstanceFieldSlots: a member with no slot
+            // has nothing to initialize, and assigning to it anyway writes through whatever the
+            // runtime DID install at that name. An ABSTRACT auto-property is the case that bit —
+            // `public abstract long Length { get; }` (System.IO.Stream) becomes a real getter, so
+            // `this.Length = …` throws "Cannot set property Length of #<ctor> which has only a
+            // getter". An indexer, and a field with no referenceable name, are the same shape.
             ITypeSymbol? slotType = m switch
             {
-                IFieldSymbol f when !f.IsConst && f.AssociatedSymbol is null => f.Type,
-                IPropertySymbol p when IsAutoProperty(p) || IsFieldBackedProperty(p) => p.Type,
+                IFieldSymbol f when !f.IsConst && f.AssociatedSymbol is null && f.CanBeReferencedByName => f.Type,
+                IPropertySymbol p when (IsAutoProperty(p) && !p.IsAbstract && !p.IsIndexer)
+                                       || IsFieldBackedProperty(p) => p.Type,
                 _ => null,
             };
             if (slotType is null) continue;
@@ -525,13 +532,15 @@ public sealed partial class Emitter
         }
     }
 
-    /// <summary>A slot whose C# <c>default(T)</c> is a zeroed struct value rather than null:
-    /// DateTime, Guid, a user struct, ValueTuple, etc. Excludes primitives (already a literal slot
-    /// default), enums (numeric slot default), Nullable&lt;T&gt; (null is correct), and type
-    /// parameters (their default defers to the runtime at construction).</summary>
+    /// <summary>A slot whose C# <c>default(T)</c> is a runtime OBJECT rather than null or a JS
+    /// number: DateTime, Guid, a user struct, ValueTuple — and long/ulong/decimal, whose zero is a
+    /// System.Int64/UInt64/Decimal instance. Excludes the primitives that really are a JS number or
+    /// boolean (already a literal slot default), enums (numeric slot default), Nullable&lt;T&gt;
+    /// (null is correct), and type parameters (their default defers to the runtime at
+    /// construction).</summary>
     private static bool NeedsStructDefaultInit(ITypeSymbol type)
         => type.TypeKind == TypeKind.Struct
-           && !IsPrimitiveNumericOrBool(type)
+           && (!IsPrimitiveNumericOrBool(type) || IsRuntimeObjectNumeric(type))
            && type is not INamedTypeSymbol { ConstructedFrom.SpecialType: SpecialType.System_Nullable_T };
 
     // ---- methods -----------------------------------------------------------

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -793,7 +793,8 @@ public sealed partial class Emitter
     {
         // A struct-typed slot other than a primitive numeric/bool (DateTime, Guid, Nullable<T>, a
         // user struct) defaults to null in the slot; the zeroed struct is assigned in $initialize.
-        if (type.TypeKind == TypeKind.Struct && !IsPrimitiveNumericOrBool(type))
+        // long/ulong/decimal go the same way: they are JS *objects* at runtime, not numbers.
+        if (type.TypeKind == TypeKind.Struct && (!IsPrimitiveNumericOrBool(type) || IsRuntimeObjectNumeric(type)))
             return "null";
         return DefaultValueLiteral(type);
     }
@@ -844,13 +845,16 @@ public sealed partial class Emitter
             case SpecialType.System_UInt16:
             case SpecialType.System_Int32:
             case SpecialType.System_UInt32:
-            case SpecialType.System_Int64:
-            case SpecialType.System_UInt64:
             case SpecialType.System_Single:
             case SpecialType.System_Double:
-            case SpecialType.System_Decimal:
                 return "0";
         }
+        // long, ulong and decimal are deliberately NOT in that list: tps.js models them as runtime
+        // OBJECTS (System.Int64/UInt64/Decimal), so their default is that type's zero instance, not
+        // the literal 0 — which is a plain JS number and therefore a System.Int32 to everything that
+        // asks. They fall through to the struct path below, i.e. Transpose.getDefaultValue(…), which
+        // keeps a field slot the same shape as every other struct (null in the slot, the real zero
+        // assigned in the constructor) and so stays order-independent during the BCL's self-build.
         // default(T?) is null whatever T is — the null state IS the default, and the runtime's
         // Nullable$1(T).getDefaultValue() returns null for every T, so this is the same value by a
         // shorter route. Routing it through getDefaultValue(Nullable$1(T)) names T for a value that


### PR DESCRIPTION
tps.js models long, ulong and decimal as runtime OBJECTS (System.Int64,
System.UInt64, System.Decimal), not as JavaScript numbers — every other
part of the compiler already agrees: an assigned literal is wrapped
(`d.V = System.Int64("0")`), a const goes through Long64Literal, and
Transpose.getDefaultValue(System.Int64) answers System.Int64.Zero.

DefaultValueLiteral did not: it lumped the three in with int/double and
emitted the literal `0`, so an UNASSIGNED `long` field, auto-property,
array element or `default` local held a plain JS number. That number
reports System.Int32 from GetType() and carries none of the Int64
methods, which is how

    class Probe { public long V { get; set; } }
    JsonConvert.SerializeObject(new Probe());       // TypeError: obj.toJSON is not a function
    JsonConvert.SerializeObject(new Probe { V = 0 }); // {"V":0} — fine

failed: the serializer switches on the DECLARED type and then calls the
runtime object's toJSON(). System.Text.Json did not crash but silently
took the plain-number path, so the declared type stopped deciding the
wire format.

The three now fall through to the struct path — null in the field slot
(order-independent during the BCL's self-build), the real zero assigned
in the constructor, exactly as DateTime and Guid already do.

That surfaced a latent bug in the constructor default-init: it selected
members InstanceFieldSlots never gave a slot. An abstract auto-property
is one — `public abstract long Length { get; }` becomes a real getter, so
System.IO.Stream died on "Cannot set property Length of #<ctor> which has
only a getter". The two selections are now in lockstep (abstract
auto-properties, indexers and fields with no referenceable name are
excluded from both).

Both JSON packages also rebuild the declared type from a bare number
before writing it, so a value arriving from JavaScript interop — or from
an assembly an older compiler built — still takes the declared wire
format instead of crashing or silently changing shape.

Verified against native .NET across every shape an inheritance hierarchy
puts such a slot in: abstract get-only implemented by an override, a
virtual auto-property overridden by a field-backed one (separate slots),
a base constructor reading a virtual member during construction,
implicit and explicit interface implementations, `new`-shadowing, a
closed generic base, statics on an abstract type, records (class and
struct), a struct's own getDefaultValue, the `field` keyword and
indexers. Covered by EmitRegressionTests and by a JSON round-trip test in
each package.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017sgo5CNAZDt4ee8Zsaa6P7