### PR TITLE
Fix three emission bugs surfaced by real binding callbacks

### DIFF
--- a/BCL/Transpose.Core/Primitive/String.cs
+++ b/BCL/Transpose.Core/Primitive/String.cs
@@ -253,7 +253,12 @@ namespace Transpose.Core
             double localeCompare(string that, string[] locales, es5.Intl.CollatorOptions options);
         }
 
+        // The JS engine invokes a replacer positionally — (match, group1…groupN, offset, source) —
+        // so the variadic tail is a native rest argument, not a packed array: [ExpandParams] makes
+        // a lambda bound to this delegate declare a rest parameter (and a C#-side invocation
+        // spread), so `args` actually materializes.
         [Generated]
+        [ExpandParams]
         public delegate string replaceFn(string substring, params object[] args);
     }
 }

--- a/Transpose/Transpose.Translator.Tests/CoalescePrecedenceTests.cs
+++ b/Transpose/Transpose.Translator.Tests/CoalescePrecedenceTests.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// C#'s <c>??</c> binds looser than <c>&amp;&amp;</c> / <c>||</c>, but JavaScript refuses
+    /// <c>??</c> mixed bare with either (an early SyntaxError) — so <c>a ?? b &amp;&amp; c</c> is
+    /// valid C# whose naive emission does not even parse (the whole bundle dies at load). The
+    /// emitter parenthesizes the <c>??</c> operands, which also shields operands whose emission is
+    /// opaque text (Script.Write, [Template] members).
+    /// </summary>
+    [TestClass]
+    public class CoalescePrecedenceTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task CoalesceWithLogicalOperandParses()
+        {
+            var code = """
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        bool? maybe = null;
+        bool y = true;
+        bool z = false;
+
+        Console.WriteLine(maybe ?? y && z);
+        Console.WriteLine(maybe ?? y || z);
+
+        maybe = true;
+        Console.WriteLine(maybe ?? y && z);
+
+        bool? a = null;
+        bool? b = null;
+        Console.WriteLine(a ?? b ?? y || z);
+
+        string s = null;
+        Console.WriteLine(s ?? (y ? "left" : "right"));
+    }
+}
+""";
+            await RunTest(code);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ExpandParamsDelegateTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ExpandParamsDelegateTests.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// [ExpandParams] targets delegates as well as methods: it declares the native variadic calling
+    /// convention for a JS callback such as <c>String.replaceFn</c>, where the engine passes the
+    /// tail positionally — (match, group1…groupN, offset, source). A lambda bound to such a
+    /// delegate therefore emits its trailing <c>params</c> parameter as a JS rest parameter (the
+    /// positional tail packs back into the array the C# body expects), and a C#-side invocation of
+    /// the delegate spreads its packed array so both directions agree. Without this, the params
+    /// array never materialized and the callback read <c>undefined</c>.
+    /// </summary>
+    [TestClass]
+    public class ExpandParamsDelegateTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public async Task LambdaOnExpandParamsDelegateReceivesPositionalTail()
+        {
+            var code = """
+using System;
+using Transpose;
+
+[ExpandParams]
+public delegate string ReplacerFn(string substring, params object[] args);
+
+public class Program
+{
+    public static void Main()
+    {
+        Script.Write("globalThis.callPositionally = (fn) => fn('match', 7, 'source')");
+
+        ReplacerFn replacer = (substring, args) => substring + "|" + args[0] + "|" + args[1] + "|" + args.Length;
+
+        // The JS engine's positional invocation packs the tail into the params array...
+        Console.WriteLine(Script.Write<string>("globalThis.callPositionally({0})", replacer));
+
+        // ...and a C#-side invocation spreads its packed array, so the body sees the same shape.
+        Console.WriteLine(replacer("x", new object[] { 1, 2 }));
+        Console.WriteLine(replacer("y", 3, 4));
+    }
+}
+""";
+            var output = await RunTest(code, skipRoslyn: true);
+            StringAssert.Contains(output, "match|7|source|2");
+            StringAssert.Contains(output, "x|1|2|2");
+            StringAssert.Contains(output, "y|3|4|2");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ExternalMemberCasingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ExternalMemberCasingTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// An [External] type's members default to camelCase so .NET PascalCase lands on the native JS
+    /// name (Length → length). A member with no lowercase letter anywhere is not PascalCase but a
+    /// platform constant — NodeFilter.SHOW_TEXT, Node.ELEMENT_NODE, document.URL, the WebGL GL_*
+    /// constants — whose JS name is the all-caps name itself: lowercasing its first letter
+    /// fabricated identifiers (sHOW_TEXT, uRL) that exist nowhere, so every such binding constant
+    /// read undefined at run time.
+    /// </summary>
+    [TestClass]
+    public class ExternalMemberCasingTests
+    {
+        [TestMethod]
+        public void AllCapsExternalMembersKeepTheirName()
+        {
+            var code = @"
+using Transpose;
+
+[External]
+[Name(""NodeFilterFixture"")]
+public static class NodeFilterFixture
+{
+    public static extern uint   SHOW_TEXT { get; }
+    public static extern ushort FILTER_ACCEPT { get; }
+    public static extern string URL { get; }
+    public static extern int    Duration { get; }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(NodeFilterFixture.SHOW_TEXT + NodeFilterFixture.FILTER_ACCEPT + NodeFilterFixture.URL + NodeFilterFixture.Duration);
+    }
+}";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, string.Join("\n", result.Errors));
+
+            var js = result.Javascript!;
+            Assert.IsTrue(js.Contains("NodeFilterFixture.SHOW_TEXT"), "an ALL_CAPS constant must keep its name\n" + js);
+            Assert.IsTrue(js.Contains("NodeFilterFixture.FILTER_ACCEPT"), "an ALL_CAPS constant must keep its name\n" + js);
+            Assert.IsTrue(js.Contains("NodeFilterFixture.URL"), "an all-caps acronym member (document.URL) must keep its name\n" + js);
+            Assert.IsTrue(js.Contains("NodeFilterFixture.duration"), "a PascalCase member still camelCases onto the native name\n" + js);
+            Assert.IsFalse(js.Contains("sHOW_TEXT") || js.Contains("fILTER_ACCEPT") || js.Contains("uRL"),
+                "no first-letter-lowercased all-caps names\n" + js);
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -204,13 +204,15 @@ public sealed partial class Emitter
                 break;
             case ParenthesizedLambdaExpressionSyntax lambda:
                 EmitLambda(lambda.ParameterList.Parameters.Select(p => p.Identifier.Text), lambda.Body,
-                    lambda.Modifiers.Any(SyntaxKind.AsyncKeyword), lambda.ParameterList.Parameters);
+                    lambda.Modifiers.Any(SyntaxKind.AsyncKeyword), lambda.ParameterList.Parameters,
+                    restLastParam: ConvertsToExpandParamsDelegate(lambda));
                 break;
             case SimpleLambdaExpressionSyntax simpleLambda:
                 EmitLambda(new[] { simpleLambda.Parameter.Identifier.Text }, simpleLambda.Body, simpleLambda.Modifiers.Any(SyntaxKind.AsyncKeyword));
                 break;
             case AnonymousMethodExpressionSyntax anon:
-                EmitLambda(anon.ParameterList?.Parameters.Select(p => p.Identifier.Text) ?? Enumerable.Empty<string>(), anon.Body, anon.Modifiers.Any(SyntaxKind.AsyncKeyword));
+                EmitLambda(anon.ParameterList?.Parameters.Select(p => p.Identifier.Text) ?? Enumerable.Empty<string>(), anon.Body, anon.Modifiers.Any(SyntaxKind.AsyncKeyword),
+                    restLastParam: ConvertsToExpandParamsDelegate(anon));
                 break;
             case DefaultExpressionSyntax def:
                 _w.Write(DefaultValueLiteral(_model.GetTypeInfo(def).Type ?? _model.GetTypeInfo(def).ConvertedType!));

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -323,6 +323,26 @@ public sealed partial class Emitter
     }
 
     /// <summary>
+    /// Emits a <c>??</c> operand, parenthesized unless it is trivially atomic. JavaScript refuses
+    /// <c>??</c> mixed bare with <c>&amp;&amp;</c> or <c>||</c> (an early SyntaxError), while C#'s
+    /// <c>??</c> binds looser than both — so <c>a ?? b &amp;&amp; c</c> is valid C# whose naive
+    /// emission does not parse. And an operand can emit arbitrary expression text (Script.Write,
+    /// [Template] members), so anything that is not a plainly atomic node is wrapped.
+    /// </summary>
+    private void EmitCoalesceOperand(ExpressionSyntax operand)
+    {
+        var atomic = operand is IdentifierNameSyntax
+            or LiteralExpressionSyntax
+            or ParenthesizedExpressionSyntax
+            or ThisExpressionSyntax
+            or BaseExpressionSyntax;
+
+        if (!atomic) _w.Write("(");
+        EmitExpression(operand);
+        if (!atomic) _w.Write(")");
+    }
+
+    /// <summary>
     /// True when <paramref name="expr"/> emits as an inline function expression (an arrow function),
     /// i.e. a lambda / anonymous method, or a delegate-creation / cast wrapping one. Such an emission
     /// is not a primary JS expression and must be parenthesized before it can sit in call or
@@ -995,10 +1015,15 @@ public sealed partial class Emitter
     /// arguments in the runtime, so they are excluded.
     /// </summary>
     /// <summary>A method whose <c>params</c> array must be expanded (spread) at the call site,
-    /// per Transpose's <c>[ExpandParams]</c> — the native variadic DOM/JS functions.</summary>
+    /// per Transpose's <c>[ExpandParams]</c> — the native variadic DOM/JS functions. The attribute
+    /// also targets delegates (a variadic JS callback such as <c>String.replaceFn</c>), where it
+    /// sits on the delegate type and governs its Invoke.</summary>
     private static bool HasExpandParams(IMethodSymbol method)
         => method.OriginalDefinition.GetAttributes()
-            .Any(a => TransposeNaming.AttrIs(a, "Transpose.ExpandParamsAttribute"));
+            .Any(a => TransposeNaming.AttrIs(a, "Transpose.ExpandParamsAttribute"))
+           || (method is { MethodKind: MethodKind.DelegateInvoke, ContainingType: { } delegateType }
+               && delegateType.OriginalDefinition.GetAttributes()
+                   .Any(a => TransposeNaming.AttrIs(a, "Transpose.ExpandParamsAttribute")));
 
     /// <summary>Emits a SINGLE argument supplied to a <c>params</c> parameter: the array/collection
     /// itself is passed through, but a lone element (convertible to the element type) is wrapped into
@@ -1784,9 +1809,9 @@ public sealed partial class Emitter
         if (binary.IsKind(SyntaxKind.CoalesceExpression))
         {
             _w.Write("(");
-            EmitExpression(binary.Left);
+            EmitCoalesceOperand(binary.Left);
             _w.Write(" ?? ");
-            EmitExpression(binary.Right);
+            EmitCoalesceOperand(binary.Right);
             _w.Write(")");
             return;
         }
@@ -3415,8 +3440,23 @@ public sealed partial class Emitter
 
     // ---- lambda ------------------------------------------------------------
 
+    /// <summary>
+    /// True when a lambda / anonymous method converts to a delegate whose trailing <c>params</c>
+    /// parameter has the <c>[ExpandParams]</c> (native variadic) calling convention — the attribute
+    /// on the delegate type, per its Delegate target. Such a lambda's last parameter is emitted as
+    /// a JS rest parameter, so a positional caller (the JS engine invoking a binding callback such
+    /// as <c>String.replaceFn</c>) packs the tail into the array the C# body expects; a C#-side
+    /// invocation of the delegate spreads correspondingly through the <c>HasExpandParams</c>
+    /// call-site branch, so both directions see the same packed array.
+    /// </summary>
+    private bool ConvertsToExpandParamsDelegate(ExpressionSyntax lambda)
+        => _model.GetTypeInfo(lambda).ConvertedType is INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: { } invoke }
+           && invoke.Parameters.Length > 0
+           && invoke.Parameters[^1].IsParams
+           && HasExpandParams(invoke);
+
     private void EmitLambda(IEnumerable<string> parameters, CSharpSyntaxNode body, bool isAsync,
-        SeparatedSyntaxList<ParameterSyntax>? paramSyntax = null)
+        SeparatedSyntaxList<ParameterSyntax>? paramSyntax = null, bool restLastParam = false)
     {
         // Emit an arrow function so `this` is captured lexically, matching C# lambda semantics
         // (a plain `function` would rebind `this` and break `this`-referencing closures).
@@ -3431,8 +3471,13 @@ public sealed partial class Emitter
         var paramList = parameters as IReadOnlyCollection<string> ?? parameters.ToList();
         var isRealDiscard = paramList.Count(p => p == "_") > 1;
         var discardN = 0;
-        _w.Write(string.Join(", ", paramList.Select(p =>
-            p == "_" && isRealDiscard ? "$d" + discardN++ : NameMangler.JsIdentifier(p))));
+        var names = paramList.Select(p =>
+            p == "_" && isRealDiscard ? "$d" + discardN++ : NameMangler.JsIdentifier(p)).ToList();
+        // A lambda targeting an [ExpandParams] delegate receives its variadic tail positionally
+        // (the JS engine calls the callback with individual arguments), so its params parameter
+        // is a rest parameter that packs them back into the array the body expects.
+        if (restLastParam && names.Count > 0) names[^1] = "..." + names[^1];
+        _w.Write(string.Join(", ", names));
         _w.Write(") => ");
 
         // Optional lambda parameters (C# 12): default when undefined.

--- a/Transpose/Transpose.Translator/Support/TransposeNaming.cs
+++ b/Transpose/Transpose.Translator/Support/TransposeNaming.cs
@@ -1176,6 +1176,12 @@ internal static class TransposeNaming
         if (string.IsNullOrEmpty(name)) return name;
         return notation switch
         {
+            // CamelCase maps .NET PascalCase onto JS camelCase (Length -> length). A name with no
+            // lowercase letter anywhere is not PascalCase but a constant — NodeFilter.SHOW_TEXT,
+            // Node.ELEMENT_NODE, document.URL, the WebGL GL_* constants — whose JS name is the
+            // all-caps name itself; lowercasing its first letter fabricates an identifier
+            // (sHOW_TEXT) that exists nowhere.
+            Notation.CamelCase when !name.Any(char.IsLower) => name,
             Notation.CamelCase => char.ToLowerInvariant(name[0]) + name.Substring(1),
             Notation.PascalCase => char.ToUpperInvariant(name[0]) + name.Substring(1),
             Notation.LowerCase => name.ToLowerInvariant(),


### PR DESCRIPTION
Null-coalescing operands are parenthesized: JavaScript refuses ?? mixed bare with && or || (an early SyntaxError), while C#'s ?? binds looser than both - so `a ?? b && c` is valid C# whose emission did not parse, killing the entire bundle at load. Operands that are not trivially atomic get parens, which also shields opaque emissions (Script.Write, [Template] members) on either side of a ??.

The [External] camelCase default no longer mangles ALL_CAPS members: it exists to map .NET PascalCase onto native JS names (Length -> length), but a name with no lowercase letter anywhere is a platform constant - NodeFilter.SHOW_TEXT, Node.ELEMENT_NODE, XMLHttpRequest.DONE, document.URL, the WebGL GL_* constants - whose JS name is the all-caps name itself. Lowercasing its first letter fabricated identifiers (sHOW_TEXT) that exist nowhere, so every such binding constant read undefined at run time; a NodeIterator created with whatToShow: undefined then silently visits nothing, which is how this surfaced (Tesserae's MarkHighlighter). Enum casing modes are untouched.

[ExpandParams] now works on delegates, which its AttributeUsage always declared: it marks the native variadic calling convention of a JS callback such as String.replaceFn, where the engine passes the tail positionally - (match, group1..groupN, offset, source). A lambda bound to such a delegate emits its trailing params parameter as a JS rest parameter so the positional tail packs back into the array the C# body expects, and a C#-side invocation of the delegate spreads through the existing HasExpandParams call-site branch, so both directions see the same shape. Previously the params array never materialized and the callback read undefined. String.replaceFn in Transpose.Core is tagged accordingly.

Each fix carries a test: CoalescePrecedenceTests runs the mixed-operator forms on Node, ExternalMemberCasingTests pins the preserved and the still-camelCased names, and ExpandParamsDelegateTests drives a replacer through a JS positional call, a packed-array C# call and an expanded C# call.


Claude-Session: https://claude.ai/code/session_01Wmu2FB2Wenuj4vSsDegNqN