### PR TITLE
Stop emitting (and folding) `0 == null` in lifted nullable comparisons

### DIFF
--- a/Transpose/Transpose.Compiler.Core/JsMinifier.cs
+++ b/Transpose/Transpose.Compiler.Core/JsMinifier.cs
@@ -1,4 +1,4 @@
-using NUglify;
+﻿using NUglify;
 using NUglify.JavaScript;
 
 namespace Transpose.Compiler;
@@ -62,8 +62,25 @@ internal static class JsMinifier
     private const long KillBlockScopeUnsafeInversions =
         (long)(TreeModifications.InvertIfReturn | TreeModifications.InvertIfContinue);
 
+    // NUglify evaluates a loose `<literal> == null` by coercing `null` to 0 and comparing, so it
+    // folds every FALSY literal to the wrong answer:
+    //
+    //   0 == null  -> true      '' == null    -> true      false == null -> true
+    //   0 != null  -> false     '' != null    -> false     false != null -> false
+    //
+    // (`1 == null` and the strict `0 === null` are folded correctly, which is why this went unnoticed:
+    // it only misfires on a falsy constant, and only under `==`/`!=`.)
+    //
+    // We used to emit `0 == null` ourselves - a lifted `x?.Count > 0` null-tested both operands, the
+    // literal included - and the fold turned that guard into `x == null || true`, so the comparison
+    // answered false for every non-null x. The emitter no longer null-tests an operand that cannot be
+    // null, but the fold is still unsound for any `== null` that reaches the minifier from hand-written
+    // runtime JS, a Script.Write template or a third-party bundle, so it is switched off here too.
+    // Cost measured on the Curiosity front end: 37 bytes on a 3.5 MB bundle (+0.001%).
+    private const long KillUnsoundNullComparisonFold = (long)TreeModifications.EvaluateNumericExpressions;
+
     // Everything the settings profiles below switch off.
-    private const long KillSwitches = KillIfConditionCollapse | KillBlockScopeUnsafeInversions;
+    private const long KillSwitches = KillIfConditionCollapse | KillBlockScopeUnsafeInversions | KillUnsoundNullComparisonFold;
 
     // Safe profile: never rename locals, terminate statements with semicolons, escape non-ASCII.
     private static CodeSettings Safe() => new()

--- a/Transpose/Transpose.Translator.Tests/JsMinifierTests.cs
+++ b/Transpose/Transpose.Translator.Tests/JsMinifierTests.cs
@@ -1,4 +1,5 @@
-﻿using Transpose.Compiler;
+﻿using System.Threading.Tasks;
+using Transpose.Compiler;
 
 namespace Transpose.Translator.Tests;
 
@@ -27,6 +28,36 @@ public sealed class JsMinifierTests
         // The unparenthesised mix is the exact syntax error we are guarding against.
         Assert.IsFalse(min.Contains("&&c??") || min.Contains("||c??") || min.Contains("??d&&"),
             $"minifier produced an invalid `??`/`&&`/`||` mix: {min}");
+    }
+
+    // NUglify evaluates a loose `<literal> == null` by coercing `null` to 0, so every FALSY literal
+    // folds to the wrong answer (`0 == null` -> true, `0 != null` -> false, same for `''` and
+    // `false`). We emitted `0 == null` for a lifted `x?.Count > 0` and the fold turned the guard into
+    // `x == null || true`. EvaluateNumericExpressions is killed for this; these rows fail if it comes
+    // back. `1 == null` and the strict `0 === null` were always folded correctly.
+    //
+    // The minified expression is RUN rather than pattern-matched: what matters is that it still means
+    // what JavaScript says it means, whether the minifier folded it or left it alone.
+    [DataTestMethod]
+    [DataRow("0 == null",     "false")]
+    [DataRow("'' == null",    "false")]
+    [DataRow("false == null", "false")]
+    [DataRow("null == 0",     "false")]
+    [DataRow("0 != null",     "true")]
+    [DataRow("'' != null",    "true")]
+    [DataRow("false != null", "true")]
+    [DataRow("null != 0",     "true")]
+    [DataRow("1 == null",     "false")]
+    [DataRow("0 === null",    "false")]
+    [DataRow("0 !== null",    "true")]
+    public async Task LooseNullComparisonAgainstAFalsyLiteralIsNotMisfolded(string expression, string expected)
+    {
+        var min = JsMinifier.Minify($"function f(){{ return ({expression}); }} console.log(f());", "app.js");
+
+        var actual = (await NodeJsRunner.RunAsync(min)).Trim();
+
+        Assert.AreEqual(expected, actual,
+            $"`{expression}` is {expected} in JavaScript, but minified to: {min}");
     }
 
     [TestMethod]

--- a/Transpose/Transpose.Translator.Tests/LiftedNullableComparisonTests.cs
+++ b/Transpose/Transpose.Translator.Tests/LiftedNullableComparisonTests.cs
@@ -1,0 +1,132 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// A lifted <c>Nullable&lt;T&gt;</c> operator used to null-test BOTH operands, because C# converts
+/// both sides to <c>Nullable&lt;T&gt;</c> and the emitter read the converted type. For the very common
+/// <c>x?.Count &gt; 0</c> that meant emitting <c>0 == null</c> - dead at runtime, and NUglify folds a
+/// loose <c>&lt;falsy literal&gt; == null</c> to TRUE (it coerces <c>null</c> to 0 before comparing).
+/// The guard became <c>x == null || true</c>, so the comparison answered false for every x, in
+/// minified builds only.
+///
+/// Two things are guarded here: the emitter no longer writes a null test for an operand that cannot
+/// be null, and the minified output is executed - the formatted output was always correct, which is
+/// exactly why the Node suite never saw this.
+/// </summary>
+[TestClass]
+public class LiftedNullableComparisonTests : TranslatorTestBase
+{
+    private static string Js(string source) => new RoslynTranslator().Translate(source).Javascript ?? "";
+
+    // ---- emission -----------------------------------------------------------
+
+    [TestMethod]
+    public void AConstantOperandIsNotNullTested()
+    {
+        var js = Js(@"
+using System.Collections.Generic;
+public class P
+{
+    public static bool M(List<int> items) { return items?.Count > 0; }
+}");
+
+        Assert.IsFalse(js.Contains("|| 0 == null"),
+            $"a literal can never be null, so the lifted operator must not test it:\n{js}");
+        StringAssert.Contains(js, "== null ? false :",
+            $"the nullable operand still has to be null-tested:\n{js}");
+    }
+
+    [TestMethod]
+    public void BothOperandsAreStillTestedWhenBothCanBeNull()
+    {
+        var js = Js("public class P { public static bool M(int? a, int? b) { return a > b; } }");
+
+        StringAssert.Contains(js, "== null || ",
+            $"two nullable operands both need their null test:\n{js}");
+    }
+
+    [TestMethod]
+    public void ANonNullableOperandIsNotNullTested()
+    {
+        // Only the right-hand side is nullable here; the left is a plain int local.
+        var js = Js("public class P { public static bool M(int a, int? b) { return a > b; } }");
+
+        Assert.IsFalse(js.Contains("== null || "),
+            $"only one operand can be null, so only one null test belongs:\n{js}");
+    }
+
+    // ---- semantics, formatted AND minified ----------------------------------
+
+    private const string LiftedComparisons = @"
+using System;
+using System.Collections.Generic;
+public class Program
+{
+    static bool HasAny(List<int> items) { return items?.Count > 0; }
+    public static void Main()
+    {
+        Console.WriteLine(HasAny(null));
+        Console.WriteLine(HasAny(new List<int>()));
+        Console.WriteLine(HasAny(new List<int> { 1 }));
+
+        int? n = null;      Console.WriteLine(n > 0);
+        int? z = 0;         Console.WriteLine(z > 0);
+        int? p = 5;         Console.WriteLine(p > 0);
+        Console.WriteLine(p >= 5);
+        Console.WriteLine(n < 0);
+        Console.WriteLine(n <= 0);
+
+        int? a = null, b = 3;
+        Console.WriteLine(a > b);
+        Console.WriteLine(b > a);
+        Console.WriteLine((a + b) is null);
+        Console.WriteLine(b + 1);
+        Console.WriteLine(n + 1 is null);
+
+        double? d = 0.0;    Console.WriteLine(d > 0);
+        long? l = 0L;       Console.WriteLine(l > 0);
+        Console.WriteLine(""<<DONE>>"");
+    }
+}";
+
+    [TestMethod]
+    public async Task LiftedComparisonsMatchDotNet()
+    {
+        await RunTest(LiftedComparisons, waitForOutput: "<<DONE>>");
+    }
+
+    [TestMethod]
+    public async Task LiftedComparisonsMatchDotNetAfterMinification()
+    {
+        // The bug this file is named for existed only after minification. Run the same program
+        // through JsMinifier and compare against the same native output.
+        var result = new RoslynTranslator().Translate(
+            new[] { ("App.cs", LiftedComparisons) },
+            CompilationBuilder.DefaultAssemblyName,
+            extraReferencePaths: null,
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" });
+
+        Assert.IsTrue(result.Success,
+            "translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));
+
+        var full     = RoslynTranslator.LoadRuntime() + "\n" + result.Javascript!;
+        var minified = JsMinifier.Minify(full, "app.js");
+
+        Assert.IsFalse(minified.Contains("||!0?"),
+            "the minifier folded a `<falsy literal> == null` to true - the guard is now dead");
+
+        var expected = RoslynNativeRunner.CompileAndRun(LiftedComparisons);
+        var actual   = await NodeJsRunner.RunAsync(minified);
+
+        Assert.AreEqual(Lines(expected), Lines(actual),
+            "minified output disagrees with .NET while the formatted output agrees");
+    }
+
+    private static string Lines(string output) => string.Join("\n", output.Trim()
+        .Split(new[] { "\r\n", "\r", "\n" }, System.StringSplitOptions.None)
+        .Select(s => s.TrimEnd()));
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -1703,7 +1703,23 @@ public sealed partial class Emitter
         {
             var l = Capture(() => EmitExpression(binary.Left));
             var r = Capture(() => EmitExpression(binary.Right));
-            _w.Write($"({l} == null || {r} == null ? {(relational ? "false" : "null")} : ");
+
+            // Only the operands that can actually BE null are tested. C# converts both sides of a
+            // lifted operator to Nullable<T>, so `x?.Count > 0` used to emit `0 == null` for the
+            // literal as well - dead at runtime, and NUglify folds it to TRUE (it reads `null` as 0),
+            // which collapsed the whole guard to `x == null || true` and made every such comparison
+            // answer false in a minified build. See CanBeNullOperand.
+            var nullTests = new List<string>(2);
+            if (CanBeNullOperand(binary.Left)) nullTests.Add($"{l} == null");
+            if (CanBeNullOperand(binary.Right)) nullTests.Add($"{r} == null");
+
+            if (nullTests.Count == 0)
+            {
+                EmitLiftedInnerOperation(binary, l, r, op, leftType, rightType);
+                return;
+            }
+
+            _w.Write($"({string.Join(" || ", nullTests)} ? {(relational ? "false" : "null")} : ");
             EmitLiftedInnerOperation(binary, l, r, op, leftType, rightType);
             _w.Write(")");
             return;
@@ -1904,6 +1920,23 @@ public sealed partial class Emitter
 
     private static bool IsNullableValueType(ITypeSymbol? t)
         => t is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };
+
+    /// <summary>
+    /// Whether an operand of a lifted <c>Nullable&lt;T&gt;</c> operator can hold null at runtime.
+    /// The operand's CONVERTED type is always <c>Nullable&lt;T&gt;</c> - that is what lifting means -
+    /// so it cannot tell `x?.Count` from the `0` it is compared against; the DECLARED type can, and a
+    /// non-nullable value type is never null. Anything else (a reference type, an unconstrained type
+    /// parameter, an expression with no type at all) stays conservative and keeps its null test.
+    /// </summary>
+    private bool CanBeNullOperand(ExpressionSyntax expr)
+    {
+        var declared = _model.GetTypeInfo(expr).Type;
+
+        if (declared is null) return true;
+        if (IsNullableValueType(declared)) return true;
+
+        return !declared.IsValueType;
+    }
 
     /// <summary><c>T</c> for a <c>Nullable&lt;T&gt;</c>, otherwise the type unchanged.</summary>
     private static ITypeSymbol? UnwrapNullable(ITypeSymbol? t)


### PR DESCRIPTION
A lifted Nullable<T> operator null-tested BOTH operands. C# converts both sides of a lifted operator to Nullable<T>, and the emitter read the CONVERTED type, so `x?.Count > 0` emitted

  (x == null || 0 == null ? false : x > 0)

The `0 == null` is dead at runtime - and NUglify folds it wrong. It evaluates a loose `<literal> == null` by coercing null to 0 and comparing, so every FALSY literal gets the opposite answer:

  0 == null -> true    '' == null -> true    false == null -> true
  0 != null -> false   '' != null -> false   false != null -> false

(`1 == null` and the strict `0 === null` fold correctly, which is why this went unnoticed.) The guard therefore minified to `x == null || true`, and every `x?.Count > 0` in a Release build answered false regardless of x. Reported from Curiosity, where a faceted `#/search?vf=...` URL rendered the home welcome box because HomeView.HasSearchPayload is eight such checks.

Two changes:

- Emitter: a null test is emitted only for an operand that can actually be null, decided on the DECLARED type (a non-nullable value type never is) - the same declared-vs-converted distinction EmitLiftedInnerOperation and the 64-bit path already make. `x?.Count > 0` now emits `(x == null ? false : x > 0)`.
- JsMinifier: EvaluateNumericExpressions is killed, because the fold stays unsound for any `== null` reaching the minifier from hand-written runtime JS, a Script.Write template or a third-party bundle. Measured cost on the Curiosity front end: 37 bytes on a 3.5 MB bundle (+0.001%).

Tests: LiftedNullableComparisonTests covers the emission and runs the lifted comparisons against .NET both formatted and MINIFIED - the minified path is the gap that let this through, since the formatted output was always correct. JsMinifierTests gains a row per falsy-literal comparison, executed under Node rather than pattern-matched. All 11 fail on the unfixed compiler; the full suite (1015 tests) passes with it.

Verified end to end: rebuilding Curiosity's Release front end with this compiler, from the UNPATCHED HomeView source, emits `(x == null ? !1 : x > 0)` and the faceted search URL renders the search results again.


Claude-Session: https://claude.ai/code/session_01AM86Udf7r28j27ZdPnjAV3