### PR TITLE
Treat a long/ulong in foreign JavaScript as a plain number

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,6 +508,27 @@ The short version:
 - **A boxed numeric loses its exact type.** Every JS number is a double, so `(object)1 is double` is
   true and `objects.OfType<double>()` also matches the boxed `int`s. `long`/`ulong`/`decimal` are
   real runtime objects and are unaffected, as are reference types and structs.
+- **A `long`/`ulong` in foreign JavaScript is a plain number (`Emitter.Foreign64.cs`).** tps.js models
+  a 64-bit integer as a `System.Int64`/`UInt64` *object*, and that is right for every value Transpose
+  produces and for the **base library**, which is where those two types are defined — `DateTime.Ticks`,
+  `long.Parse`, `TimeSpan.Ticks` all hand back real instances and keep all 64 bits. It is *not* right
+  for a slot backed by real JavaScript: a binding declares `Blob.size` as `ulong` because that is the
+  nearest C# type for the spec's *unsigned long long*, but the browser returns a plain `number`. So a
+  **member of an `[External]`/`[Scope]` type outside the base library, a member carrying its own
+  `[External]`/`[Template]`, and any member of an `[ObjectLiteral]` type** (in every assembly — a
+  literal *is* a plain JS object) is treated as unboxed: reads, comparisons and `+ - * / %` stay plain
+  JS (`/` through `TransposeR.idiv`, which truncates as C# does), and the representation changes only
+  at the boundary — lifted with `System.Int64(…)` into a managed `long` slot, a box, a BCL call, a
+  pattern subject or a 64-bit receiver; read back with `.toNumber()` when a managed value is written
+  into a foreign parameter, property or literal member.
+
+  Two deliberate edges. **Bitwise and shift operators keep the boxed path** (JavaScript's are 32-bit,
+  so `size & 0xF00000000` would silently lose the high word), as does a **constant outside
+  ±2^53**, so `size == long.MaxValue` stays exact. And the cost: a value stored *into* a foreign slot
+  above 2^53 rounds, because a JS number counts in ones only that far. For an external slot nothing is
+  lost — the value arrived as a number. For an `[ObjectLiteral]` it is a real trade, taken because the
+  alternative put a `{low, high}` object into a plain JS object whose whole purpose is to be read by
+  hand-written JavaScript and serialized to JSON. Covered end to end by `ForeignJs64BitTests`.
 - **`dynamic` has no runtime overload resolver.** A generic call with a `dynamic` argument works when
   the method has one candidate (`Enumerable.Count(dyn)`); with numeric overloads to choose between
   (`Enumerable.Sum(dyn)`) there is no single binding and the emitted call does not exist.

--- a/Transpose/Transpose.Translator.Tests/ForeignJs64BitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ForeignJs64BitTests.cs
@@ -1,0 +1,592 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <c>long</c>/<c>ulong</c> that live in FOREIGN JavaScript — an <c>[External]</c> binding's
+    /// member, an <c>[ObjectLiteral]</c>'s field.
+    ///
+    /// <para>
+    /// tps.js models a 64-bit integer as a System.Int64/UInt64 OBJECT, and that is right for every
+    /// value Transpose itself produces and for the base library, which defines those two types. It
+    /// is wrong for a slot backed by real JavaScript: a binding declares <c>Blob.size</c> as
+    /// <c>ulong</c> because that is the nearest C# type for the spec's <i>unsigned long long</i>,
+    /// but the browser hands back a plain <c>number</c>. Reading it as a box made
+    /// <c>file.Size &gt; 0</c> emit <c>file.size.gt(…)</c> — "gt is not a function" — and writing one
+    /// passed an Int64 object into <c>blob.slice(…)</c>, which coerces to NaN.
+    /// </para>
+    ///
+    /// <para>
+    /// So such a value stays a plain number, and the representation changes at the boundary: lifted
+    /// with <c>System.Int64(…)</c> when it enters a managed <c>long</c> slot, read back with
+    /// <c>.toNumber()</c> when a managed value is written into a foreign one. The behaviour tests
+    /// below run the whole surface against native .NET; the emit tests pin which side of the
+    /// boundary each construct landed on. See <c>Emitter.Foreign64.cs</c>.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class ForeignJs64BitTests : TranslatorTestBase
+    {
+        // ---- [ObjectLiteral] ---------------------------------------------------
+
+        /// <summary>
+        /// An <c>[ObjectLiteral]</c> instance IS a plain JS object — that is the point of the
+        /// attribute, since it crosses into JSON and into hand-written JavaScript — so a
+        /// <c>long</c>/<c>ulong</c> member of one holds a plain number. The whole operator surface
+        /// runs against the same program with the attribute removed, which is what .NET does.
+        /// </summary>
+        [TestMethod]
+        public async Task ObjectLiteral64BitMembersBehaveLikeNativeDotNet()
+        {
+            const string body = """
+    public static void Main()
+    {
+        var i = new Info { Id = 7L, Bytes = 3000000000UL, Maybe = 12L };
+
+        // Reads and the operators that used to call Int64 methods on a bare number.
+        Console.WriteLine(i.Id);
+        Console.WriteLine(i.Bytes);
+        Console.WriteLine(i.Id + 1);
+        Console.WriteLine(i.Id - 10);
+        Console.WriteLine(i.Id * 3);
+        Console.WriteLine(i.Bytes / 1024);
+        Console.WriteLine(i.Id % 4);
+        Console.WriteLine(i.Id > 3);
+        Console.WriteLine(i.Id >= 7);
+        Console.WriteLine(i.Id < 3);
+        Console.WriteLine(i.Id == 7);
+        Console.WriteLine(i.Id != 7);
+        Console.WriteLine(i.Bytes >= 3000000000UL);
+
+        // Conversions out of the foreign representation.
+        Console.WriteLine(i.Id.ToString());
+        Console.WriteLine((double)i.Bytes);
+        Console.WriteLine((int)i.Id);
+        Console.WriteLine((short)i.Id);
+        Console.WriteLine(-i.Id);
+        Console.WriteLine($"interp {i.Id} {i.Bytes}");
+
+        // Into a managed slot, where the Int64 methods are real again.
+        long managed = i.Id;
+        Console.WriteLine(managed + 1L);
+        Console.WriteLine(managed.ToString());
+        Console.WriteLine(managed * managed);
+
+        // Boxing: the box has to carry a real Int64, or `is long` and ToString are wrong.
+        object boxed = i.Id;
+        Console.WriteLine(boxed is long);
+        Console.WriteLine(boxed.ToString());
+
+        // Writes back into the literal: a managed Int64 must not be stored as an object.
+        i.Id = managed * 2L;
+        Console.WriteLine(i.Id);
+        i.Id += 5;
+        Console.WriteLine(i.Id);
+        i.Id -= 2;
+        Console.WriteLine(i.Id);
+        i.Id *= 3;
+        Console.WriteLine(i.Id);
+        i.Id++;
+        Console.WriteLine(i.Id);
+        --i.Id;
+        Console.WriteLine(i.Id);
+        i.Bytes /= 3;
+        Console.WriteLine(i.Bytes);
+
+        // Nullable members.
+        Console.WriteLine(i.Maybe + 1);
+        Console.WriteLine(i.Maybe.HasValue);
+        Console.WriteLine(i.Maybe.Value + 2);
+        Console.WriteLine((i.Maybe ?? 0L) * 2);
+        Console.WriteLine(i.Maybe > 5L);
+
+        // Into a managed nullable: null has to survive the lift, not become a zero instance.
+        long? liftedNullable = i.Maybe;
+        Console.WriteLine(liftedNullable.HasValue);
+        Console.WriteLine(liftedNullable + 3L);
+
+        // A ternary boxes both branches, so the result is usable either way round.
+        Console.WriteLine((i.Id > 0 ? i.Id : i.Id + 1) + 1L);
+
+        i.Maybe = null;
+        Console.WriteLine(i.Maybe.HasValue);
+        Console.WriteLine(i.Maybe ?? -1L);
+        Console.WriteLine(i.Maybe + 1 == null);
+        long? nulled = i.Maybe;
+        Console.WriteLine(nulled.HasValue);
+        Console.WriteLine(nulled ?? -2L);
+
+        // Bitwise and shifts keep the full 64-bit width, which JavaScript's own operators do not.
+        var w = new Info { Id = 4294967296L };
+        Console.WriteLine(w.Id & 4294967296L);
+        Console.WriteLine(w.Id | 1L);
+        Console.WriteLine(w.Id ^ 1L);
+        Console.WriteLine(w.Id >> 2);
+        Console.WriteLine(w.Id << 2);
+        Console.WriteLine(~w.Id);
+
+        // A METHOD on the literal type is ordinary transpiled C#: its long parameter is managed,
+        // even though the type's own slots are not, so a plain slot is lifted on the way in.
+        Console.WriteLine(Info.Doubled(i.Id));
+        Console.WriteLine(Info.Doubled(3L));
+        Console.WriteLine(i.Describe());
+
+        // Patterns: the subject is lifted once, so constants and relationals compare by value.
+        Console.WriteLine(w.Id switch { > 4000000000L => "big", _ => "small" });
+        Console.WriteLine(w.Id is 4294967296L);
+        Console.WriteLine(w.Id is > 1L and < 9223372036854775807L);
+        switch (w.Id)
+        {
+            case 4294967296L: Console.WriteLine("case hit"); break;
+            default: Console.WriteLine("case missed"); break;
+        }
+
+        // Collections and the BCL take the managed representation.
+        var list = new List<long> { i.Id, w.Id };
+        Console.WriteLine(list[0] + list[1]);
+        Console.WriteLine(Math.Max(i.Id, w.Id));
+        Console.WriteLine(i.Id.CompareTo(w.Id));
+        Console.WriteLine(i.Id.Equals(20L));
+    }
+""";
+
+            var code = $$"""
+using System;
+using System.Collections.Generic;
+using Transpose;
+using Fixture;
+
+namespace Fixture
+{
+    [ObjectLiteral]
+    public class Info
+    {
+        public long Id { get; set; }
+        public ulong Bytes { get; set; }
+        public long? Maybe { get; set; }
+
+        public static long Doubled(long n) => n * 2L + 1L;
+        public string Describe() => (Id + 1L).ToString();
+    }
+}
+
+public class Program
+{
+{{body}}
+}
+""";
+
+            // Natively the same program with a plain class: [ObjectLiteral] changes the JavaScript
+            // representation, never the C# semantics, so .NET is the oracle for every line above.
+            var native = $$"""
+using System;
+using System.Collections.Generic;
+
+public class Info
+{
+    public long Id { get; set; }
+    public ulong Bytes { get; set; }
+    public long? Maybe { get; set; }
+
+    public static long Doubled(long n) => n * 2L + 1L;
+    public string Describe() => (Id + 1L).ToString();
+}
+
+public class Program
+{
+{{body}}
+}
+""";
+
+            await RunTest(code, overrideRoslynCode: native);
+        }
+
+        // ---- [External] --------------------------------------------------------
+
+        /// <summary>
+        /// The reported case: a binding library's <c>ulong</c> property (Blob/File's <c>size</c>) is a
+        /// plain number in the browser. The fixture is a real JavaScript object built by
+        /// <c>Script.Write</c>, so a mis-typed read fails exactly as it does in a page; its
+        /// <c>slice</c> reports the <c>typeof</c> of each argument, which is how the write direction
+        /// is pinned — an Int64 object arriving there was the second half of the bug.
+        /// </summary>
+        [TestMethod]
+        public async Task External64BitMembersBehaveLikeNativeDotNet()
+        {
+            const string body = """
+    public static void Main()
+    {
+        var b = Make();
+
+        Console.WriteLine(b.size);
+        Console.WriteLine(b.size > 1000);
+        Console.WriteLine(b.size / 1024);
+        Console.WriteLine(b.size + 1);
+        Console.WriteLine(b.size * 2);
+        Console.WriteLine(b.size % 7);
+        Console.WriteLine(b.size == 3000000000UL);
+        Console.WriteLine(b.size.ToString());
+        Console.WriteLine((double)b.size / 1024.0);
+        Console.WriteLine((int)b.lastModified);
+        Console.WriteLine((long)b.size);
+        Console.WriteLine($"{b.size} bytes");
+
+        // Into managed slots.
+        ulong managed = b.size;
+        Console.WriteLine(managed + 1);
+        Console.WriteLine(managed.ToString());
+        object boxed = b.size;
+        Console.WriteLine(boxed is ulong);
+        Console.WriteLine(boxed.ToString());
+
+        var list = new List<ulong>();
+        list.Add(b.size);
+        Console.WriteLine(list[0] + 2);
+        Console.WriteLine(Math.Max(b.size, 5UL));
+        Console.WriteLine(b.size.CompareTo(1UL));
+        Console.WriteLine(b.size.Equals(3000000000UL));
+
+        // Patterns.
+        Console.WriteLine(b.size switch { > 2000000000UL => "big", _ => "small" });
+        Console.WriteLine(b.size is > 1000UL);
+        Console.WriteLine(b.size is 3000000000UL);
+
+        // Written back OUT to JavaScript: every argument must arrive as a number.
+        Console.WriteLine(b.slice(0, 10));
+        long start = 5L;
+        Console.WriteLine(b.slice(start, start + 2));
+        Console.WriteLine(b.slice((long)b.size, 1));
+
+        // An extension method's receiver is its first argument, so it crosses the same boundary.
+        Console.WriteLine(b.size.Half());
+        Console.WriteLine(managed.Half());
+
+        var sum = 0UL;
+        foreach (var x in new[] { b.size, 1UL }) sum += x;
+        Console.WriteLine(sum);
+    }
+""";
+
+            var code = $$"""
+using System;
+using System.Collections.Generic;
+using Transpose;
+using Fixture;
+
+namespace Fixture
+{
+    [External]
+    public class Blob
+    {
+        public extern ulong size { get; }
+        public extern long lastModified { get; }
+        public extern string slice(long start, long end);
+    }
+}
+
+public static class Extras
+{
+    public static ulong Half(this ulong n) => n / 2UL;
+}
+
+public class Program
+{
+    static Blob Make() => Script.Write<Blob>(
+        "({ size: 3000000000, lastModified: 1700000000000, slice: function (a, b) { return typeof a + ':' + a + '/' + typeof b + ':' + b; } })");
+
+{{body}}
+}
+""";
+
+            // The native oracle is the same program over a real object with the same values; `slice`
+            // reproduces what the JavaScript fixture prints when both arguments arrive as numbers.
+            var native = $$"""
+using System;
+using System.Collections.Generic;
+
+public class Blob
+{
+    public ulong size => 3000000000UL;
+    public long lastModified => 1700000000000L;
+    public string slice(long start, long end) => "number:" + start + "/number:" + end;
+}
+
+public static class Extras
+{
+    public static ulong Half(this ulong n) => n / 2UL;
+}
+
+public class Program
+{
+    static Blob Make() => new Blob();
+
+{{body}}
+}
+""";
+
+            await RunTest(code, overrideRoslynCode: native);
+        }
+
+        /// <summary>
+        /// A member bound to hand-written JavaScript by <c>[Template]</c> — rather than by its type
+        /// being <c>[External]</c> — hands back a plain number for the same reason.
+        /// </summary>
+        [TestMethod]
+        public async Task TemplateBound64BitMemberIsPlain()
+        {
+            var code = """
+using System;
+using Transpose;
+
+public class Sizes
+{
+    [Template("({ n: 3000000000 }).n")]
+    public static extern ulong Bytes();
+
+    [Template("Math.round({v})")]
+    public static extern long Round(double v);
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Sizes.Bytes());
+        Console.WriteLine(Sizes.Bytes() > 1000);
+        Console.WriteLine(Sizes.Bytes() / 1024);
+        Console.WriteLine(Sizes.Round(2.6));
+        Console.WriteLine(Sizes.Round(2.6) + 1);
+        ulong managed = Sizes.Bytes();
+        Console.WriteLine(managed + 1);
+    }
+}
+""";
+
+            var native = """
+using System;
+
+public class Sizes
+{
+    public static ulong Bytes() => 3000000000UL;
+    public static long Round(double v) => (long)Math.Round(v, MidpointRounding.AwayFromZero);
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Sizes.Bytes());
+        Console.WriteLine(Sizes.Bytes() > 1000);
+        Console.WriteLine(Sizes.Bytes() / 1024);
+        Console.WriteLine(Sizes.Round(2.6));
+        Console.WriteLine(Sizes.Round(2.6) + 1);
+        ulong managed = Sizes.Bytes();
+        Console.WriteLine(managed + 1);
+    }
+}
+""";
+
+            await RunTest(code, overrideRoslynCode: native);
+        }
+
+        // ---- emit shape --------------------------------------------------------
+
+        /// <summary>
+        /// Pins which side of the boundary each construct lands on. The behaviour tests above prove
+        /// the results are right; these prove they are right for the intended reason — a regression
+        /// that boxed every read would still print the same numbers, only slower and with an Int64
+        /// object crossing into JavaScript.
+        /// </summary>
+        [TestMethod]
+        public void ExternalReadsStayPlainAndConvertAtTheBoundary()
+        {
+            var js = Translate("""
+using System;
+using Transpose;
+using Fixture;
+
+namespace Fixture
+{
+    [External]
+    public class Blob
+    {
+        public extern ulong size { get; }
+        public extern void take(long n);
+    }
+}
+
+public class Program
+{
+    public static void Main() { }
+
+    public static void Use(Blob b)
+    {
+        var cmp   = b.size > 1000;
+        var add   = b.size + 1;
+        var div   = b.size / 1024;
+        var dbl   = (double)b.size;
+        ulong mgd = b.size;
+        long  own = 5L;
+        b.take(own);
+        b.take(7);
+        b.take(own + 1);
+        Console.WriteLine(cmp.ToString() + add + div + dbl + mgd + own);
+    }
+}
+""");
+
+            // Reads stay plain …
+            Assert.IsTrue(js.Contains("b.size > 1000"), "a comparison against an external ulong is a plain JS comparison\n" + js);
+            Assert.IsTrue(js.Contains("b.size + 1"), "addition stays plain\n" + js);
+            Assert.IsTrue(js.Contains("TransposeR.idiv(b.size, 1024)"),
+                "division truncates through the shared helper, not Int64.div and not JS `/`\n" + js);
+            Assert.IsFalse(js.Contains("b.size.gt(") || js.Contains("b.size.add(") || js.Contains("b.size.div("),
+                "no Int64 method is ever called on a plain number\n" + js);
+            Assert.IsFalse(js.Contains("(b.size).toNumber()"), "a plain number needs no .toNumber()\n" + js);
+
+            // … and are lifted only where a managed long slot needs a real instance.
+            Assert.IsTrue(js.Contains("System.UInt64(b.size)"), "a managed ulong local is lifted at the boundary\n" + js);
+
+            // Writes into the foreign slot unwrap instead.
+            Assert.IsTrue(js.Contains("b.take((own).toNumber())"),
+                "a managed Int64 argument is unwrapped for an external parameter\n" + js);
+            Assert.IsTrue(js.Contains("b.take(7)"),
+                "a literal argument to an external long parameter is a plain number, not System.Int64(7)\n" + js);
+            Assert.IsFalse(js.Contains("b.take(System.Int64("),
+                "no Int64 instance is ever passed into hand-written JavaScript\n" + js);
+        }
+
+        /// <summary>
+        /// The other half of the same rule: an <c>[ObjectLiteral]</c>'s 64-bit members are plain
+        /// numbers in the object it builds, including its declared defaults.
+        /// </summary>
+        [TestMethod]
+        public void ObjectLiteral64BitMembersAreWrittenAsPlainNumbers()
+        {
+            var js = Translate("""
+using Transpose;
+using Fixture;
+
+namespace Fixture
+{
+    [ObjectLiteral]
+    public class Info
+    {
+        public long Id { get; set; }
+        public ulong Bytes { get; set; }
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        long managed = 5L;
+        var a = new Info { Id = 7L, Bytes = 3000000000UL };
+        var b = new Info { Id = managed };
+        System.Console.WriteLine(a.Id + b.Id + (long)a.Bytes);
+    }
+}
+""");
+
+            Assert.IsTrue(js.Contains("Id = 7") || js.Contains("Id: 7"), "a long literal member is a plain number\n" + js);
+            Assert.IsTrue(js.Contains("Bytes = 3000000000") || js.Contains("Bytes: 3000000000"),
+                "a ulong literal member is a plain number\n" + js);
+            Assert.IsTrue(js.Contains("(managed).toNumber()"),
+                "a managed Int64 written into a literal member is unwrapped\n" + js);
+            Assert.IsFalse(js.Contains("Id = System.Int64(") || js.Contains("Bytes = System.UInt64("),
+                "no Int64 instance is stored in a plain JS object\n" + js);
+        }
+
+        /// <summary>
+        /// The guard that keeps the rest of the world boxed. The base library DEFINES
+        /// System.Int64/UInt64, so its own externs — <c>DateTime.Ticks</c>, <c>long.MaxValue</c>,
+        /// <c>long.Parse</c>, <c>TimeSpan.Ticks</c> — really do hand back instances, and must go on
+        /// using the Int64 methods however the boundary rule is spelled.
+        /// </summary>
+        [TestMethod]
+        public void BaseLibrary64BitMembersStayBoxed()
+        {
+            var js = Translate("""
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+        var d = new DateTime(2024, 1, 2);
+        Console.WriteLine(d.Ticks > 0);
+        Console.WriteLine(d.Ticks / 10000000L);
+        Console.WriteLine(TimeSpan.FromSeconds(90).Ticks + 1);
+        Console.WriteLine(long.Parse("123") + 1);
+        Console.WriteLine(long.MaxValue - 1);
+    }
+}
+""");
+
+            Assert.IsTrue(js.Contains(".gt(System.Int64("), "DateTime.Ticks is a real Int64 and compares with .gt\n" + js);
+            Assert.IsTrue(js.Contains(".div(System.Int64("), "and divides with Int64.div\n" + js);
+            Assert.IsTrue(js.Contains(".add(System.Int64("), "TimeSpan.Ticks and long.Parse likewise\n" + js);
+            Assert.IsFalse(js.Contains("TransposeR.idiv(System.DateTime.getTicks"),
+                "the base library must not be treated as foreign JavaScript\n" + js);
+        }
+
+        /// <summary>
+        /// The cost of the rule, pinned so nobody rediscovers it as a mystery. A slot in a plain JS
+        /// object holds a JS number, and a JS number counts in ones only up to 2^53 — so a
+        /// <c>long</c> above that rounds when it is stored in an <c>[External]</c> or
+        /// <c>[ObjectLiteral]</c> member. For an external slot nothing is lost: the browser gave a
+        /// number in the first place. For an object literal it is a real trade, taken deliberately —
+        /// the alternative stored a <c>{low, high}</c> Int64 object in an object whose entire purpose
+        /// is to be read by hand-written JavaScript and serialized to JSON. Managed <c>long</c>s,
+        /// which is everything else, keep their full 64 bits (see
+        /// <see cref="BaseLibrary64BitMembersStayBoxed"/>).
+        /// </summary>
+        [TestMethod]
+        public async Task ObjectLiteralAbove2To53RoundsLikeAnyJsNumber()
+        {
+            var output = await RunTest("""
+using System;
+using Transpose;
+using Fixture;
+
+namespace Fixture
+{
+    [ObjectLiteral]
+    public class Info { public long Id { get; set; } }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        // Exact: inside the safe-integer range.
+        var ok = new Info { Id = 9007199254740991L };
+        Console.WriteLine(ok.Id);
+        Console.WriteLine(ok.Id == 9007199254740991L);
+
+        // Rounded: past it. .NET would print 9223372036854775807 for both lines.
+        var big = new Info { Id = long.MaxValue };
+        Console.WriteLine(big.Id);
+
+        // A managed long is unaffected — it never leaves the Int64 representation.
+        long managed = long.MaxValue;
+        Console.WriteLine(managed);
+        Console.WriteLine(managed == long.MaxValue);
+    }
+}
+""", skipRoslyn: true);
+
+            StringAssert.Contains(output, "9007199254740991", "the safe-integer range is exact");
+            StringAssert.Contains(output, "9223372036854775807", "a managed long keeps all 64 bits");
+        }
+
+        private static string Translate(string code)
+        {
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, string.Join("\n", result.Errors));
+            return result.Javascript!;
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/GlobalNamespaceExternalTypeTests.cs
+++ b/Transpose/Transpose.Translator.Tests/GlobalNamespaceExternalTypeTests.cs
@@ -1,0 +1,96 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// An <c>[External]</c> type declared outside any namespace.
+    ///
+    /// <para>
+    /// A binding names the JS global it stands for, so a type in the global namespace is emitted as
+    /// the bare name — <c>Thing</c>, the way <c>Transpose.Core.dom</c>'s <c>HTMLElement</c> is.
+    /// <c>INamespaceSymbol.ToDisplayString()</c> renders the global namespace as the literal
+    /// <c>"&lt;global namespace&gt;"</c> though, which is a description and not a name, so the
+    /// reference came out as <c>&lt;global namespace&gt;.Thing</c>. That is a JavaScript syntax
+    /// error, and reflection metadata is emitted as one expression per assembly, so a single such
+    /// type stopped the WHOLE bundle from parsing rather than failing where it was used.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class GlobalNamespaceExternalTypeTests : TranslatorTestBase
+    {
+        [TestMethod]
+        public void AGlobalNamespaceExternalTypeIsNamedBare()
+        {
+            var code = """
+using System;
+using Transpose;
+
+[External]
+public class Thing
+{
+    public extern int n { get; }
+}
+
+public class Program
+{
+    public static void Main() { }
+    static Thing Make() => Script.Write<Thing>("({ n: 1 })");
+    static bool Test(object o) => o is Thing;
+    static string Named() => typeof(Thing).Name;
+}
+""";
+            var result = new RoslynTranslator().Translate(code);
+            Assert.IsTrue(result.Success, string.Join("\n", result.Errors));
+            var js = result.Javascript!;
+
+            Assert.IsFalse(js.Contains("<global namespace>"),
+                "the global namespace is not a name — it must never reach the output\n" + js);
+            StringAssert.Contains(js, "TransposeR.is(o, Thing)",
+                "a global-namespace [External] type is the bare JS global");
+            // The return type of Make() in the reflection metadata — the position that broke the
+            // whole bundle, because the metadata is one expression per assembly.
+            StringAssert.Contains(js, "\"sn\":\"Make\",\"rt\":Thing",
+                "…including in the reflection metadata");
+        }
+
+        /// <summary>
+        /// And it works end to end: the fixture installs the real JS global the binding names, so
+        /// member access, <c>is</c>, and <c>typeof</c> all resolve against it.
+        /// </summary>
+        [TestMethod]
+        public async Task AGlobalNamespaceExternalTypeResolvesAtRuntime()
+        {
+            var output = await RunTest("""
+using System;
+using Transpose;
+
+[External]
+public class Thing
+{
+    public extern int n { get; }
+    public extern ulong size { get; }
+}
+
+public class Program
+{
+    static Thing Make() => Script.Write<Thing>(
+        "(globalThis.Thing = globalThis.Thing || function Thing() { this.n = 1; this.size = 7; }, new globalThis.Thing())");
+
+    public static void Main()
+    {
+        var t = Make();
+        Console.WriteLine(t.n);
+        Console.WriteLine(t.size + 1);
+        Console.WriteLine(t is Thing);
+        Console.WriteLine(typeof(Thing).Name);
+        object o = t;
+        Console.WriteLine(o is Thing);
+    }
+}
+""", skipRoslyn: true);
+
+            Assert.AreEqual("1\n8\nTrue\nThing\nTrue", output.Trim().Replace("\r\n", "\n"));
+        }
+    }
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions.cs
@@ -306,7 +306,12 @@ public sealed partial class Emitter
     }
 
     /// <summary>Emits an expression applying a required conversion for its target type.</summary>
-    private void EmitExpressionConverted(ExpressionSyntax expr, ITypeSymbol? targetType)
+    /// <param name="targetIsForeignJs">The slot being written lives in foreign JavaScript (an
+    /// [External] parameter/property, an [ObjectLiteral] member). Only 64-bit integers care: such a
+    /// slot holds a plain number, so a managed System.Int64/UInt64 must be read back out of its box
+    /// on the way in — see <c>Emitter.Foreign64.cs</c>.</param>
+    private void EmitExpressionConverted(ExpressionSyntax expr, ITypeSymbol? targetType,
+        bool targetIsForeignJs = false)
     {
         // Numeric narrowing to an integer type needs truncation.
         var sourceType = _model.GetTypeInfo(expr).Type;
@@ -325,6 +330,78 @@ public sealed partial class Emitter
         {
             EmitUserDefinedConversion(convMethod, expr);
             return;
+        }
+
+        // ---- the foreign-JavaScript 64-bit boundary (Emitter.Foreign64.cs) ----
+        // Into a foreign `long`/`ulong` slot, a narrower value must NOT be widened into an Int64
+        // instance the way a managed slot needs: `blob.slice(0, 10)` passes plain numbers. A numeric
+        // literal is the case that has to be intercepted here, because EmitLiteral builds the
+        // instance from the literal's CONVERTED type rather than from anything at this call site.
+        if (targetIsForeignJs && Is64BitInteger(UnwrapNullable(targetType))
+            && !Is64BitInteger(UnwrapNullable(sourceType))
+            && Plain64ConstantText(expr) is { } foreignConstant)
+        {
+            _w.Write(foreignConstant);
+            return;
+        }
+
+        if (Is64BitInteger(UnwrapNullable(sourceType)))
+        {
+            var plain = EmitsAsPlainJsNumber(expr);
+
+            // Into a managed `long`/`ulong` slot: lift, so every Int64 method downstream works.
+            if (plain && !targetIsForeignJs && Is64BitInteger(UnwrapNullable(targetType)))
+            {
+                // A nullable stays null — System.Int64(null) would be a zero-valued instance, and
+                // `x.HasValue` on it is true.
+                if (IsNullableValueType(sourceType) || IsNullableValueType(targetType))
+                {
+                    var v = Capture(() => EmitExpression(expr));
+                    var ctor = Is64BitUnsigned(UnwrapNullable(targetType)) ? "System.UInt64" : "System.Int64";
+                    _w.Write($"({v} == null ? null : {ctor}({v}))");
+                    return;
+                }
+                EmitLifted64(expr, targetType);
+                return;
+            }
+
+            // Into a foreign one: unwrap, so hand-written JavaScript sees a number.
+            if (!plain && targetIsForeignJs && Is64BitInteger(UnwrapNullable(targetType)))
+            {
+                // A 64-bit constant is written straight out rather than built and unwrapped again.
+                if (Plain64ConstantText(expr) is { } constantText) { _w.Write(constantText); return; }
+
+                if (IsNullableValueType(sourceType) || IsNullableValueType(targetType))
+                {
+                    var v = Capture(() => EmitExpression(expr));
+                    _w.Write($"({v} == null ? {v} : {v}.toNumber())");
+                }
+                else
+                {
+                    _w.Write("(");
+                    EmitExpression(expr);
+                    _w.Write(").toNumber()");
+                }
+                return;
+            }
+
+            // Boxed as object/dynamic/an interface: the box must carry a real Int64/UInt64, or
+            // `o.ToString()`, `o is ulong` and unboxing all see a bare number. A `long?` box keeps
+            // null as null — boxing null in C# yields a null reference, not a zero.
+            if (plain && targetType is { IsReferenceType: true } && !IsStringType(targetType))
+            {
+                if (IsNullableValueType(sourceType))
+                {
+                    var v = Capture(() => EmitExpression(expr));
+                    var ctor = Is64BitUnsigned(UnwrapNullable(sourceType)) ? "System.UInt64" : "System.Int64";
+                    _w.Write($"({v} == null ? null : {ctor}({v}))");
+                }
+                else
+                {
+                    EmitLifted64(expr, sourceType);
+                }
+                return;
+            }
         }
         if (targetType is not null && sourceType is not null
             && IsIntegerType(targetType) && IsFloatingType(sourceType))
@@ -349,7 +426,7 @@ public sealed partial class Emitter
 
         // Implicit widening of a 32-bit integer to long/ulong → wrap as a 64-bit instance.
         // (Numeric literals already self-wrap via their converted type in EmitLiteral.)
-        if (Is64BitInteger(targetType) && sourceType is not null && !Is64BitInteger(sourceType)
+        if (Is64BitInteger(targetType) && !targetIsForeignJs && sourceType is not null && !Is64BitInteger(sourceType)
             && IsIntegerType(sourceType) && expr is not LiteralExpressionSyntax)
         {
             _w.Write(Is64BitUnsigned(targetType) ? "System.UInt64(" : "System.Int64(");
@@ -1033,6 +1110,16 @@ public sealed partial class Emitter
     private void EmitReceiverExpr(ExpressionSyntax? thisTarget)
     {
         if (thisTarget is null) { _w.Write("this"); return; }
+        // A foreign-JS 64-bit receiver is a plain number, and the only members reachable on it are
+        // System.Int64/UInt64's own (`size.CompareTo(…)`, `size.ToString("N0")`), which need a real
+        // instance — so lift it here (Emitter.Foreign64.cs). A NULLABLE receiver is left alone: the
+        // member then belongs to Nullable<T>, which the runtime handles on the raw value-or-null.
+        if (Is64BitInteger(_model.GetTypeInfo(thisTarget).Type)
+            && EmitsAsPlainJsNumber(thisTarget))
+        {
+            EmitLifted64(thisTarget, _model.GetTypeInfo(thisTarget).Type);
+            return;
+        }
         // A numeric-constant receiver must be parenthesized: `0.toString()` is a JS syntax error
         // (the `.` parses as a decimal point), so emit `(0).toString()`.
         if (NeedsReceiverParens(thisTarget))

--- a/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Expressions2.cs
@@ -239,7 +239,7 @@ public sealed partial class Emitter
             _w.Write($"{TypeRef(symbol.ContainingType)}.{TransposeNaming.MemberJsName(reducedFrom)}(");
             var lead = EmitLeadingTypeArgs(symbol);
             if (lead) _w.Write(", ");
-            if (receiverExpr is not null) EmitExpression(receiverExpr); else _w.Write(condRecv!);
+            if (receiverExpr is not null) EmitExtensionReceiver(receiverExpr, reducedFrom); else _w.Write(condRecv!);
             if (invocation.ArgumentList.Arguments.Count > 0)
             {
                 _w.Write(", ");
@@ -639,7 +639,7 @@ public sealed partial class Emitter
             if (extReceiver is not null)
             {
                 if (!first) _w.Write(", ");
-                EmitExpression(extReceiver);
+                EmitExtensionReceiver(extReceiver, reduced!);
                 first = false;
             }
         }
@@ -677,7 +677,8 @@ public sealed partial class Emitter
                 if (ai >= 0)
                 {
                     if (holders[ai] is not null) _w.Write(holders[ai]!);
-                    else EmitExpressionConverted(args[ai].Expression, symbol.Parameters[k].Type);
+                    else EmitExpressionConverted(args[ai].Expression, symbol.Parameters[k].Type,
+                        IsForeignJsSlot(symbol));
                 }
                 else
                     // Omitted optional (a gap a JS call can't skip) → `void 0`, so the callee's
@@ -692,7 +693,8 @@ public sealed partial class Emitter
                 if (!first) _w.Write(", ");
                 first = false;
                 if (holders[i] is not null) _w.Write(holders[i]!);
-                else EmitExpressionConverted(args[i].Expression, i < symbol.Parameters.Length ? symbol.Parameters[i].Type : null);
+                else EmitExpressionConverted(args[i].Expression, i < symbol.Parameters.Length ? symbol.Parameters[i].Type : null,
+                    IsForeignJsSlot(symbol));
             }
         }
         _w.Write("); ");
@@ -809,6 +811,9 @@ public sealed partial class Emitter
     {
         var args = argList.Arguments;
         var lead = threadTypeArgs && EmitLeadingTypeArgs(method);
+        // A call into hand-written JavaScript: a `long`/`ulong` parameter of it is a plain number,
+        // so a managed Int64 argument is unwrapped on the way in (Emitter.Foreign64.cs).
+        var foreignCallee = IsForeignJsSlot(method);
 
         // Reorder named arguments to parameter order when we know the method.
         if (method is not null && args.Any(a => a.NameColon is not null))
@@ -870,7 +875,7 @@ public sealed partial class Emitter
                     if (k > 0) _w.Write(", ");
                     var pIdx = paramIndexOf[k];
                     var pType = pIdx >= 0 && pIdx < method.Parameters.Length ? method.Parameters[pIdx].Type : null;
-                    EmitExpressionConverted(args[k].Expression, pType);
+                    EmitExpressionConverted(args[k].Expression, pType, foreignCallee);
                 }
                 _w.Write("]; return [");
                 for (var i = 0; i <= lastProvided; i++)
@@ -905,11 +910,11 @@ public sealed partial class Emitter
                     // receives a bare element and a later `foreach` over it throws "Cannot create
                     // Enumerator". (The multi-element / no-named-args case is handled by the params
                     // branch below, which this early-returning named path would otherwise skip.)
-                    EmitParamsSlot(method.Parameters[i].Type, ordered[i]!);
+                    EmitParamsSlot(method.Parameters[i].Type, ordered[i]!, foreignCallee);
                 }
                 else
                 {
-                    EmitExpressionConverted(ordered[i]!, method.Parameters[i].Type);
+                    EmitExpressionConverted(ordered[i]!, method.Parameters[i].Type, foreignCallee);
                 }
             }
             return;
@@ -928,7 +933,7 @@ public sealed partial class Emitter
             {
                 if (!first) _w.Write(", ");
                 first = false;
-                EmitExpressionConverted(args[i].Expression, method.Parameters[i].Type);
+                EmitExpressionConverted(args[i].Expression, method.Parameters[i].Type, foreignCallee);
             }
             var trailing = args.Skip(fixedCount).ToList();
             var elem = (method.Parameters[^1].Type as IArrayTypeSymbol)?.ElementType;
@@ -944,7 +949,7 @@ public sealed partial class Emitter
                 {
                     if (!first) _w.Write(", ");
                     first = false;
-                    EmitExpressionConverted(trailing[i].Expression, elem);
+                    EmitExpressionConverted(trailing[i].Expression, elem, foreignCallee);
                 }
             }
             return;
@@ -964,7 +969,7 @@ public sealed partial class Emitter
                 // positional JS call: emit `void 0` so the callee applies its default. Without this
                 // the params array shifted into the optional's slot (e.g. M("x") on
                 // M(string,int=7,params object[]) emitted M("x", []) — [] landed in the int slot).
-                if (i < args.Count) EmitExpressionConverted(args[i].Expression, method.Parameters[i].Type);
+                if (i < args.Count) EmitExpressionConverted(args[i].Expression, method.Parameters[i].Type, foreignCallee);
                 else _w.Write("void 0");
             }
 
@@ -983,7 +988,7 @@ public sealed partial class Emitter
             if (trailing.Count == 1
                 && (soleArgType is null || _compilation.ClassifyConversion(soleArgType, paramsType).Exists))
             {
-                EmitExpressionConverted(trailing[0].Expression, paramsType);
+                EmitExpressionConverted(trailing[0].Expression, paramsType, foreignCallee);
             }
             else
             {
@@ -993,7 +998,7 @@ public sealed partial class Emitter
                     for (var i = 0; i < trailing.Count; i++)
                     {
                         if (i > 0) _w.Write(", ");
-                        EmitExpressionConverted(trailing[i].Expression, paramsElem);
+                        EmitExpressionConverted(trailing[i].Expression, paramsElem, foreignCallee);
                     }
                     _w.Write("]");
                 }, trailing);
@@ -1005,7 +1010,7 @@ public sealed partial class Emitter
         {
             if (i > 0 || lead) _w.Write(", ");
             var targetType = method is not null && i < method.Parameters.Length ? method.Parameters[i].Type : null;
-            EmitExpressionConverted(args[i].Expression, targetType);
+            EmitExpressionConverted(args[i].Expression, targetType, foreignCallee);
         }
     }
 
@@ -1028,7 +1033,7 @@ public sealed partial class Emitter
     /// <summary>Emits a SINGLE argument supplied to a <c>params</c> parameter: the array/collection
     /// itself is passed through, but a lone element (convertible to the element type) is wrapped into
     /// the params array. Shared by the named-argument path and mirrors the positional params branch.</summary>
-    private void EmitParamsSlot(ITypeSymbol paramsType, ExpressionSyntax arg)
+    private void EmitParamsSlot(ITypeSymbol paramsType, ExpressionSyntax arg, bool foreignCallee = false)
     {
         var paramsElem = ParamsElementType(paramsType);
         var argType = _model.GetTypeInfo(arg).Type;
@@ -1037,14 +1042,14 @@ public sealed partial class Emitter
         // object[] → object exists.
         if (argType is null || _compilation.ClassifyConversion(argType, paramsType).Exists)
         {
-            EmitExpressionConverted(arg, paramsType);   // already the collection
+            EmitExpressionConverted(arg, paramsType, foreignCallee);   // already the collection
         }
         else
         {
             EmitCollectionOf(paramsType, () =>
             {
                 _w.Write("[");
-                EmitExpressionConverted(arg, paramsElem);
+                EmitExpressionConverted(arg, paramsElem, foreignCallee);
                 _w.Write("]");
             }, [arg]);
         }
@@ -1183,9 +1188,12 @@ public sealed partial class Emitter
                     first = false;
                     emitted.Add(name);
                     _w.Write($"{NameMangler.JsPropertyKey(name)}: ");
+                    // A long/ulong member of a plain JS object holds a plain number, so its
+                    // initializer is unwrapped and its default is `0` (Emitter.Foreign64.cs).
+                    var plain64 = Is64BitInteger(UnwrapNullable(prop.Type)) && !IsNullableValueType(prop.Type);
                     if (ctorValue is not null) _w.Write(ctorValue);
-                    else if (propInit is not null) EmitExpression(propInit);
-                    else _w.Write(DefaultValueLiteral(prop.Type));
+                    else if (propInit is not null) EmitForeign64Value(propInit, prop.Type);
+                    else _w.Write(plain64 ? "0" : DefaultValueLiteral(prop.Type));
                 }
             }
             // Constructor-supplied members the init mode did not enumerate — in Ignore mode (the
@@ -1312,8 +1320,17 @@ public sealed partial class Emitter
             var arg = args.FirstOrDefault(a => a.NameColon?.Name.Identifier.Text == p.Name)
                       ?? (i < args.Count && args[i].NameColon is null ? args[i] : null);
 
-            var value = arg is not null ? Capture(() => EmitExpressionConverted(arg.Expression, p.Type))
-                : p.HasExplicitDefaultValue ? ConstantLiteral(p.ExplicitDefaultValue, p.Type)
+            // The value lands in a plain JS object, so a long/ulong one is a plain number.
+            var literal64 = IsObjectLiteralType(type) && Is64BitInteger(UnwrapNullable(p.Type));
+            var value = arg is not null ? Capture(() => EmitExpressionConverted(arg.Expression, p.Type, literal64))
+                : p.HasExplicitDefaultValue
+                    ? (literal64
+                        ? (p.ExplicitDefaultValue is { } dv
+                            ? System.Convert.ToString(dv, CultureInfo.InvariantCulture)!
+                            : "null")
+                        : ConstantLiteral(p.ExplicitDefaultValue, p.Type))
+                : literal64
+                    ? (IsNullableValueType(p.Type) ? "null" : "0")
                 : DefaultValueLiteral(p.Type);
             values.Add((TransposeNaming.MemberJsName(member), value));
         }
@@ -1348,7 +1365,8 @@ public sealed partial class Emitter
                     var memberSym = _model.GetSymbolInfo(name).Symbol;
                     var memberName = memberSym is not null ? TransposeNaming.MemberJsName(memberSym) : NameMangler.JsIdentifier(name.Identifier.Text);
                     _w.Write($"{target}.{memberName} = ");
-                    EmitExpressionConverted(assign.Right, MemberValueType(memberSym));
+                    EmitExpressionConverted(assign.Right, MemberValueType(memberSym),
+                        IsForeignJsSlot(memberSym));
                     _w.Write("; ");
                     break;
                 // Index initializer: [key] = value
@@ -1364,7 +1382,7 @@ public sealed partial class Emitter
                         _w.Write($"{target}[");
                         EmitArgumentList(idx.ArgumentList);
                         _w.Write("] = ");
-                        EmitExpressionConverted(assign.Right, idxProp.Type);
+                        EmitExpressionConverted(assign.Right, idxProp.Type, IsForeignJsSlot(idxProp));
                         _w.Write("; ");
                         break;
                     }
@@ -1756,6 +1774,19 @@ public sealed partial class Emitter
             && Long64Op(binary) is not null
             && !IsDecimalType(leftDeclared) && !IsDecimalType(rightDeclared))
         {
+            // Every 64-bit operand came out of foreign JavaScript, so both sides are already plain
+            // numbers: keep them that way rather than boxing to compare (Emitter.Foreign64.cs).
+            // A comparison's own type is bool, so ask about the operands, not the result.
+            if (IsPlain64Operator(binary)
+                && (Is64BitInteger(leftDeclared) || Is64BitInteger(rightDeclared))
+                && (!Is64BitInteger(leftDeclared) || EmitsAsPlainJsNumber(binary.Left))
+                && (!Is64BitInteger(rightDeclared) || EmitsAsPlainJsNumber(binary.Right))
+                && IsPlain64SafeOperand(binary.Left, leftDeclared)
+                && IsPlain64SafeOperand(binary.Right, rightDeclared))
+            {
+                EmitPlain64Binary(binary);
+                return;
+            }
             EmitLong64Binary(binary, leftDeclared, rightDeclared);
             return;
         }
@@ -1808,6 +1839,20 @@ public sealed partial class Emitter
         // Null-coalescing
         if (binary.IsKind(SyntaxKind.CoalesceExpression))
         {
+            // Both halves have to agree on the 64-bit representation, or the result is a plain
+            // number in one branch and an Int64 in the other and whatever consumes it is wrong half
+            // the time (Emitter.Foreign64.cs). A plain left side pulls the right one down to plain;
+            // otherwise the plain side is lifted.
+            if (Is64BitInteger(UnwrapNullable(_model.GetTypeInfo(binary).Type)))
+            {
+                var plain = IsForeignJs64Value(binary);
+                _w.Write("(");
+                EmitCoalesce64Operand(binary.Left, plain);
+                _w.Write(" ?? ");
+                EmitCoalesce64Operand(binary.Right, plain);
+                _w.Write(")");
+                return;
+            }
             _w.Write("(");
             EmitCoalesceOperand(binary.Left);
             _w.Write(" ?? ");
@@ -1927,13 +1972,35 @@ public sealed partial class Emitter
         var ru = UnwrapNullable(_model.GetTypeInfo(binary.Right).Type ?? rightType);
         var resultType = UnwrapNullable(_model.GetTypeInfo(binary).Type);
 
+        // A foreign-JS 64-bit operand is a plain number, boxed nowhere (Emitter.Foreign64.cs), so it
+        // needs neither `.toNumber()` below nor an Int64 receiver.
+        var leftPlain64 = Is64BitInteger(lu)
+                          && (EmitsAsPlainJsNumber(binary.Left) || Plain64ConstantText(binary.Left) is not null);
+        var rightPlain64 = Is64BitInteger(ru)
+                           && (EmitsAsPlainJsNumber(binary.Right) || Plain64ConstantText(binary.Right) is not null);
+
         // Promoted to floating point despite a 64-bit operand (`long? * 0.5`): read the 64-bit
         // side's magnitude and use plain JS arithmetic, as the non-nullable path does.
         if ((Is64BitInteger(lu) || Is64BitInteger(ru)) && (IsFloatingType(lu) || IsFloatingType(ru)))
         {
-            _w.Write(Is64BitInteger(lu) ? $"({left}).toNumber()" : left);
+            _w.Write(Is64BitInteger(lu) && !leftPlain64 ? $"({left}).toNumber()" : left);
             _w.Write($" {op} ");
-            _w.Write(Is64BitInteger(ru) ? $"({right}).toNumber()" : right);
+            _w.Write(Is64BitInteger(ru) && !rightPlain64 ? $"({right}).toNumber()" : right);
+            return;
+        }
+
+        // Both 64-bit operands are plain: stay in plain JavaScript, division excepted (it truncates
+        // in C# and not in JS). Same rule as the non-nullable path.
+        if ((leftPlain64 || rightPlain64) && IsPlain64Operator(binary)
+            && (!Is64BitInteger(lu) || leftPlain64) && (!Is64BitInteger(ru) || rightPlain64))
+        {
+            // A constant operand was captured in its boxed form for the null test above; in plain
+            // position it is just the number.
+            var pl = Plain64ConstantText(binary.Left) ?? left;
+            var pr = Plain64ConstantText(binary.Right) ?? right;
+            if (op == "/") { _w.Write($"TransposeR.idiv({pl}, {pr})"); return; }
+            var plainOp = op switch { "==" => "===", "!=" => "!==", _ => op };
+            _w.Write($"{pl} {plainOp} {pr}");
             return;
         }
 
@@ -1943,9 +2010,10 @@ public sealed partial class Emitter
             if (longOp == "shr" && unsigned) longOp = "shru";
 
             // The receiver must be a 64-bit instance; lift a plain-number left operand.
-            if (Is64BitInteger(lu)) _w.Write(left);
+            if (Is64BitInteger(lu) && !leftPlain64) _w.Write(left);
             else { _w.Write(unsigned ? "System.UInt64(" : "System.Int64("); _w.Write(left); _w.Write(")"); }
 
+            // The argument passes through as-is — see EmitLong64Binary.
             _w.Write($".{longOp}({right})");
             return;
         }
@@ -2081,8 +2149,9 @@ public sealed partial class Emitter
         var unsigned = Is64BitUnsigned(leftType) || Is64BitUnsigned(rightType);
         if (op == "shr" && unsigned) op = "shru";
 
-        // The receiver must be a 64-bit instance; lift the left operand if it is a plain number.
-        if (Is64BitInteger(leftType))
+        // The receiver must be a 64-bit instance; lift the left operand if it is a plain number —
+        // either a narrower type C# promoted, or a foreign-JS long that was never boxed.
+        if (Is64BitInteger(leftType) && !EmitsAsPlainJsNumber(binary.Left))
         {
             EmitExpression(binary.Left);
         }
@@ -2092,6 +2161,9 @@ public sealed partial class Emitter
             EmitExpression(binary.Left);
             _w.Write(")");
         }
+        // The ARGUMENT needs no lift: every Int64 method reads it through the receiver type's
+        // `getValue`, which turns a plain number into a full 64-bit value (Long.js). Only the
+        // receiver has to be an instance, because only it is dispatched on.
         _w.Write($".{op}(");
         EmitExpression(binary.Right);
         _w.Write(")");
@@ -2128,9 +2200,11 @@ public sealed partial class Emitter
 
     /// <summary>
     /// True if a <c>long</c>/<c>ulong</c>-typed operand is nevertheless emitted as a plain JS number,
-    /// so it must not be given a <c>.toNumber()</c> call. A numeric literal follows its CONVERTED type
-    /// (see <c>EmitLiteral</c>): in <c>0.5 &gt; 0L</c> the literal is converted to double and emitted
-    /// as <c>0</c>. A long-typed *identifier* in the same position is not — it stays an Int64 object.
+    /// so it must not be given a <c>.toNumber()</c> call — and so an Int64 method call on it would
+    /// throw. Two sources: a numeric literal follows its CONVERTED type (see <c>EmitLiteral</c>), so
+    /// in <c>0.5 &gt; 0L</c> the literal is converted to double and emitted as <c>0</c>; and a value
+    /// read out of foreign JavaScript was never boxed at all (see <c>Emitter.Foreign64.cs</c>).
+    /// A long-typed *identifier* is neither — it stays an Int64 object.
     /// </summary>
     private bool EmitsAsPlainJsNumber(ExpressionSyntax operand)
     {
@@ -2150,8 +2224,12 @@ public sealed partial class Emitter
             break;
         }
 
-        return e.IsKind(SyntaxKind.NumericLiteralExpression)
-            && !Is64BitInteger(_model.GetTypeInfo(e).ConvertedType);
+        // A literal converted to `long?` builds an Int64 instance just like one converted to `long`,
+        // so the nullable has to be unwrapped before asking.
+        if (e.IsKind(SyntaxKind.NumericLiteralExpression)
+            && !Is64BitInteger(UnwrapNullable(_model.GetTypeInfo(e).ConvertedType))) return true;
+
+        return IsForeignJs64Value(e);
     }
 
     /// <summary>True if a string-typed concat operand can never be null, so it needs no <c>?? ""</c>
@@ -2227,7 +2305,10 @@ public sealed partial class Emitter
 
         if (op == "=")
         {
-            EmitSimpleAssignmentTo(assignment.Left, () => EmitExpressionConverted(assignment.Right, leftType));
+            // Writing into a foreign-JS 64-bit slot unwraps a managed Int64 (Emitter.Foreign64.cs).
+            var foreignLeft = IsForeignJs64Lvalue(assignment.Left);
+            EmitSimpleAssignmentTo(assignment.Left,
+                () => EmitExpressionConverted(assignment.Right, leftType, foreignLeft));
             return;
         }
 
@@ -2340,10 +2421,38 @@ public sealed partial class Emitter
             return;
         }
 
+        // Compound assignment to a foreign-JS 64-bit slot (`blob.size += n`, an [ObjectLiteral]
+        // field): the slot holds a plain number, so the JS operator is right — except `/=`, which
+        // C# truncates and JS does not (Emitter.Foreign64.cs).
+        if (op != "=" && IsForeignJs64Lvalue(assignment.Left)
+            && op is "+=" or "-=" or "*=" or "/=" or "%=")
+        {
+            EmitExpression(assignment.Left);
+            _w.Write(" = ");
+            if (op == "/=")
+            {
+                _w.Write("TransposeR.idiv(");
+                EmitExpression(assignment.Left);
+                _w.Write(", ");
+                EmitForeign64Value(assignment.Right, leftType);
+                _w.Write(")");
+            }
+            else
+            {
+                _w.Write("(");
+                EmitExpression(assignment.Left);
+                _w.Write($") {op[..^1]} (");
+                EmitForeign64Value(assignment.Right, leftType);
+                _w.Write(")");
+            }
+            return;
+        }
+
         // 64-bit integer / decimal compound assignment: `lhs op= rhs` → `lhs = lhs.<method>(rhs)`.
         // The target is a boxed Int64/UInt64/Decimal instance, so a native JS `+=`/`/=`/… would run
         // string-concat / float ops on the object rather than the type's method (10L += 3L → "103").
         if (op != "=" && (Is64BitInteger(leftType) || IsDecimalType(leftType))
+            && !IsForeignJs64Lvalue(assignment.Left)
             && Long64OrDecimalCompoundMethod(op, leftType) is not null)
         {
             EmitExpression(assignment.Left);
@@ -2658,12 +2767,25 @@ public sealed partial class Emitter
             return;
         }
 
-        // 64-bit negation / bitwise-not → System.Int64/UInt64 methods.
-        if (Is64BitInteger(_model.GetTypeInfo(prefix.Operand).Type))
+        // 64-bit negation / bitwise-not → System.Int64/UInt64 methods. A foreign-JS operand is a
+        // plain number with no such methods; `-x` stays a JS negation, and `~x` is lifted (JS `~` is
+        // 32-bit) by the boxed branch below via EmitLifted64.
+        if (Is64BitInteger(_model.GetTypeInfo(prefix.Operand).Type)
+            && !EmitsAsPlainJsNumber(prefix.Operand))
         {
             if (prefix.IsKind(SyntaxKind.UnaryMinusExpression)) { EmitExpression(prefix.Operand); _w.Write(".neg()"); return; }
             if (prefix.IsKind(SyntaxKind.BitwiseNotExpression)) { EmitExpression(prefix.Operand); _w.Write(".not()"); return; }
             if (prefix.IsKind(SyntaxKind.UnaryPlusExpression)) { EmitExpression(prefix.Operand); return; }
+        }
+
+        // Plain (foreign-JS) 64-bit operand: `-x`/`+x` are the JS operators, but `~x` must be lifted
+        // — JavaScript's `~` truncates to 32 bits, which would drop the high word of a real size.
+        if (Is64BitInteger(_model.GetTypeInfo(prefix.Operand).Type) && EmitsAsPlainJsNumber(prefix.Operand)
+            && prefix.IsKind(SyntaxKind.BitwiseNotExpression))
+        {
+            EmitLifted64(prefix.Operand, _model.GetTypeInfo(prefix.Operand).Type);
+            _w.Write(".not()");
+            return;
         }
 
         // decimal negation → System.Decimal.neg().
@@ -2690,6 +2812,7 @@ public sealed partial class Emitter
         // native JS ++/-- would coerce it to a plain number (precision loss above 2^53, decimal
         // corruption). Rebuild through the type's method. Prefix yields the NEW value.
         if ((prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression))
+            && !IsForeignJs64Lvalue(prefix.Operand)
             && IncDecStep(_model.GetTypeInfo(prefix.Operand).Type, prefix.IsKind(SyntaxKind.PreIncrementExpression)) is { } step)
         {
             _w.Write("(");
@@ -2711,6 +2834,7 @@ public sealed partial class Emitter
         // value; in a void (statement / for-incrementor) context the result is discarded, so the
         // cheaper new-value form suffices.
         if ((postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression))
+            && !IsForeignJs64Lvalue(postfix.Operand)
             && IncDecStep(_model.GetTypeInfo(postfix.Operand).Type, postfix.IsKind(SyntaxKind.PostIncrementExpression)) is { } step)
         {
             if (IsVoidContext(postfix))
@@ -2816,12 +2940,14 @@ public sealed partial class Emitter
             }
             _w.Write(NarrowIntegerClip(t));
             _w.Write("(");
-            if (Is64BitInteger(sourceType))
+            if (Is64BitInteger(sourceType) && !EmitsAsPlainJsNumber(expr))
             {
                 // Bring the 64-bit value down to its low 32-bit word (a plain JS number) first;
                 // clip* then mask/sign-extend to the final width.
                 _w.Write("System.Int64.clip32("); EmitExpression(expr); _w.Write(")");
             }
+            // A foreign-JS 64-bit value is already a plain number (Emitter.Foreign64.cs); the outer
+            // clip* masks it to the target width on its own.
             else if (IsDecimalType(sourceType))
             {
                 _w.Write("("); EmitExpression(expr); _w.Write(").toFloat()");
@@ -2871,6 +2997,7 @@ public sealed partial class Emitter
         // --- from 64-bit to floating: read the numeric magnitude. ---
         if (Is64BitInteger(sourceType) && IsFloatingType(targetType))
         {
+            if (EmitsAsPlainJsNumber(expr)) { EmitExpression(expr); return; }
             _w.Write("("); EmitExpression(expr); _w.Write(").toNumber()");
             return;
         }
@@ -2881,6 +3008,7 @@ public sealed partial class Emitter
         // print the raw number instead of the member name. ---
         if (Is64BitInteger(sourceType) && targetType is { TypeKind: TypeKind.Enum })
         {
+            if (EmitsAsPlainJsNumber(expr)) { EmitExpression(expr); return; }
             _w.Write("("); EmitExpression(expr); _w.Write(").toNumber()");
             return;
         }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Foreign64.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Foreign64.cs
@@ -1,0 +1,371 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// <c>long</c>/<c>ulong</c> values that live in FOREIGN JavaScript.
+///
+/// <para>
+/// tps.js models a 64-bit integer as a <c>System.Int64</c>/<c>System.UInt64</c> OBJECT — a pair of
+/// 32-bit words with <c>.add</c>/<c>.gt</c>/<c>.toNumber</c> methods — because JavaScript has no
+/// 64-bit number. That model holds for every value Transpose itself produces, and for the base
+/// library, which is where those two types are DEFINED (<c>DateTime.Ticks</c>, <c>long.Parse</c>,
+/// <c>Stopwatch.ElapsedTicks</c> … all hand back real instances).
+/// </para>
+///
+/// <para>
+/// It does NOT hold for a slot that belongs to real JavaScript. A binding library declares
+/// <c>Blob.size</c> as <c>ulong</c> because that is the closest C# type for what the spec calls an
+/// unsigned long long — but the browser hands back a plain JS <c>number</c>, and no amount of C#
+/// typing changes that. The same is true of an <c>[ObjectLiteral]</c> type, whose instances *are*
+/// plain JS objects (that is the whole point: they cross into JSON and into hand-written JS).
+/// Treating those as boxed made <c>file.Size &gt; 0</c> emit <c>file.size.gt(…)</c> — a TypeError,
+/// since a number has no <c>.gt</c> — and, in the other direction, passed an <c>Int64</c> object
+/// into <c>blob.slice(…)</c>, which coerces it to <c>NaN</c>.
+/// </para>
+///
+/// <para>
+/// So such a slot is <i>plain</i>: reads of it, and arithmetic/comparison between plain operands,
+/// stay plain JS numbers, and the conversion happens at the boundary — lifted with
+/// <c>System.Int64(…)</c> when the value enters a managed <c>long</c> slot (a local, a field, a
+/// non-foreign parameter, a box), and read back with <c>.toNumber()</c> when a managed value is
+/// written into a foreign one.
+/// </para>
+///
+/// <para>
+/// Two edges are deliberate. <b>Bitwise and shift</b> operators keep the boxed path — JavaScript's
+/// are 32-bit, so <c>size &amp; 0xF00000000</c> would silently lose the high word — and so does a
+/// <b>constant outside ±2^53</b>, which keeps <c>size == long.MaxValue</c> exact. And the cost: a
+/// value stored INTO a foreign slot above 2^53 rounds, because a JS number counts in ones only that
+/// far. For an external slot nothing is lost — the value arrived as a number. For an
+/// <c>[ObjectLiteral]</c> it is a real trade, taken because the alternative put a
+/// <c>{low, high}</c> object into an object whose whole purpose is to be read by hand-written
+/// JavaScript and serialized to JSON.
+/// </para>
+/// </summary>
+public sealed partial class Emitter
+{
+    /// <summary>The base library's assembly name — the one assembly whose <c>long</c>/<c>ulong</c>
+    /// externs really are backed by System.Int64/UInt64, because it defines them.</summary>
+    private const string BaseLibraryAssemblyName = "Transpose";
+
+    /// <summary>
+    /// True if a <c>long</c>/<c>ulong</c> member holds a PLAIN JS number rather than a
+    /// System.Int64/UInt64 instance, because the slot itself lives in foreign JavaScript. See the
+    /// type comment for why. The member's own type is not checked here — callers pair this with
+    /// <see cref="Is64BitInteger"/> on whichever type the member contributes.
+    /// </summary>
+    internal static bool IsForeignJsSlot(ISymbol? member)
+    {
+        if (member is null) return false;
+
+        // An [ObjectLiteral] instance is a plain JS object in every assembly, the base library
+        // included: its slots are read by hand-written JavaScript and serialized to JSON. Only the
+        // SLOTS — an instance field or property. A method declared on such a type is ordinary
+        // transpiled C# whose parameters are managed like any other; unwrapping an argument into one
+        // would hand its body a bare number where it expects an Int64.
+        var containing = member.ContainingType;
+        if (member is IFieldSymbol { IsStatic: false } or IPropertySymbol { IsStatic: false }
+            && IsObjectLiteralType(containing)) return true;
+
+        // The base library defines System.Int64/UInt64 and its runtime primitives return real
+        // instances, so its externs are boxed however they are declared.
+        if (containing?.ContainingAssembly?.Name == BaseLibraryAssemblyName) return false;
+
+        // A binding library ([assembly: External], or a [Scope]-projected DOM type), or a single
+        // member bound to hand-written JS by [External]/[Template].
+        if (TransposeNaming.IsExternalType(containing)) return true;
+        if (TransposeNaming.HasAttr(member, TransposeNaming.ExternalAttr)) return true;
+        if (TransposeNaming.GetTemplate(member.OriginalDefinition) is not null) return true;
+        return member is IPropertySymbol { GetMethod: { } getter }
+               && TransposeNaming.GetTemplate(getter.OriginalDefinition) is not null;
+    }
+
+    /// <summary>The value type a member contributes to an expression: a property's/field's type or a
+    /// method's return type. Null for anything else (a local, a type, a namespace).</summary>
+    private static ITypeSymbol? ReadValueType(ISymbol symbol) => symbol switch
+    {
+        IPropertySymbol p => p.Type,
+        IFieldSymbol f => f.Type,
+        IMethodSymbol m => m.ReturnType,
+        _ => null,
+    };
+
+    /// <summary>
+    /// True if this expression's C# type is <c>long</c>/<c>ulong</c> but its emitted JavaScript is a
+    /// plain number — the value came out of foreign JavaScript and was never boxed. Purely
+    /// syntactic: a value that reaches a managed <c>long</c> slot is lifted at that boundary
+    /// (<c>EmitExpressionConverted</c>), so there is nothing to track across statements.
+    /// </summary>
+    private bool IsForeignJs64Value(ExpressionSyntax expr)
+    {
+        switch (expr)
+        {
+            case ParenthesizedExpressionSyntax paren:
+                return IsForeignJs64Value(paren.Expression);
+
+            // `-x` / `+x` on a plain operand stays plain (EmitPrefixUnary emits the JS operator).
+            case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.UnaryMinusExpression or (int)SyntaxKind.UnaryPlusExpression } unary:
+                return IsForeignJs64Value(unary.Operand);
+
+            // A ternary is never plain: each branch is emitted through the conversion path against
+            // the ternary's own 64-bit type, which lifts a plain branch — so the result is a boxed
+            // instance whichever branch runs. (Claiming otherwise would be worse than boxing: the
+            // two halves would disagree about the representation.)
+            case ConditionalExpressionSyntax:
+                return false;
+
+            case BinaryExpressionSyntax { RawKind: (int)SyntaxKind.CoalesceExpression } coalesce:
+                return Is64BitInteger(UnwrapNullable(_model.GetTypeInfo(coalesce).Type))
+                       && IsPlain64CoalesceOperand(coalesce.Left)
+                       && IsPlain64CoalesceOperand(coalesce.Right);
+
+            case BinaryExpressionSyntax binary:
+                return IsPlain64BinaryResult(binary);
+
+            // A cast to a 64-bit type builds a real instance (`System.Int64(x)`); only the identity
+            // cast — `(ulong)someForeignUlong` — is erased and stays plain.
+            case CastExpressionSyntax cast:
+                return SymbolEqualityComparer.Default.Equals(
+                           _model.GetTypeInfo(cast.Type).Type, _model.GetTypeInfo(cast.Expression).Type)
+                       && EmitsAsPlainJsNumber(cast.Expression);
+
+            // `x?.Size` — the continuation carries the receiver's plainness.
+            case ConditionalAccessExpressionSyntax conditionalAccess:
+                return IsForeignJs64Value(conditionalAccess.WhenNotNull);
+        }
+
+        var symbol = _model.GetSymbolInfo(expr).Symbol;
+        if (symbol is null) return false;
+
+        // `foreignNullable.Value` / `.GetValueOrDefault()` unwrap a Nullable<long> in place, so they
+        // are as plain as their receiver. (Nullable<T> itself lives in the base library.)
+        if (symbol.ContainingType is { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
+            && symbol.Name is "Value" or "GetValueOrDefault")
+        {
+            var receiver = expr switch
+            {
+                MemberAccessExpressionSyntax ma => ma.Expression,
+                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax ima } => ima.Expression,
+                _ => null,
+            };
+            return receiver is not null && EmitsAsPlainJsNumber(receiver);
+        }
+
+        return Is64BitInteger(UnwrapNullable(ReadValueType(symbol))) && IsForeignJsSlot(symbol);
+    }
+
+    /// <summary>
+    /// True if a binary operator over 64-bit operands yields a plain JS number: every 64-bit operand
+    /// is itself plain, and the operator is one <see cref="EmitPlain64Binary"/> emits with plain JS.
+    /// An operator whose operands are all NARROW but whose result C# promoted to 64-bit
+    /// (<c>int + uint</c>) is excluded — that must still build a real Int64, which is what the
+    /// boxed path does.
+    /// </summary>
+    private bool IsPlain64BinaryResult(BinaryExpressionSyntax binary)
+    {
+        if (!IsPlain64Operator(binary)) return false;
+        if (!Is64BitInteger(UnwrapNullable(_model.GetTypeInfo(binary).Type))) return false;
+
+        var left = UnwrapNullable(_model.GetTypeInfo(binary.Left).Type);
+        var right = UnwrapNullable(_model.GetTypeInfo(binary.Right).Type);
+        if (IsFloatingType(left) || IsFloatingType(right)) return false;
+        if (IsDecimalType(left) || IsDecimalType(right)) return false;
+
+        if (!IsPlain64SafeOperand(binary.Left, left) || !IsPlain64SafeOperand(binary.Right, right)) return false;
+
+        var anyPlain64 = false;
+        if (Is64BitInteger(left))
+        {
+            if (!EmitsAsPlainJsNumber(binary.Left)) return false;
+            anyPlain64 = true;
+        }
+        if (Is64BitInteger(right))
+        {
+            if (!EmitsAsPlainJsNumber(binary.Right)) return false;
+            anyPlain64 = true;
+        }
+        return anyPlain64;
+    }
+
+    /// <summary>
+    /// The operators a plain 64-bit value keeps in plain JavaScript. Bitwise and shift are absent on
+    /// purpose: JavaScript's bitwise operators work on 32 bits, so <c>size &amp; 0xF00000000</c>
+    /// would silently lose the high word — those go through the boxed Int64 path, where the width is
+    /// real. Comparisons are listed even though their result is a <c>bool</c>: the flag they answer
+    /// is "can this be emitted with a JS operator", not "is the result 64-bit".
+    /// </summary>
+    private static bool IsPlain64Operator(BinaryExpressionSyntax binary) => binary.Kind() is
+        SyntaxKind.AddExpression or SyntaxKind.SubtractExpression or SyntaxKind.MultiplyExpression
+        or SyntaxKind.DivideExpression or SyntaxKind.ModuloExpression
+        or SyntaxKind.LessThanExpression or SyntaxKind.GreaterThanExpression
+        or SyntaxKind.LessThanOrEqualExpression or SyntaxKind.GreaterThanOrEqualExpression
+        or SyntaxKind.EqualsExpression or SyntaxKind.NotEqualsExpression;
+
+    /// <summary>
+    /// Emits a binary operator over plain 64-bit operands with plain JavaScript. Division is the one
+    /// operator JS gets wrong for integers (it produces a fraction), so it routes through the same
+    /// truncating helper the 32-bit integer path uses; no 32-bit clip is applied, because the value
+    /// is not 32 bits.
+    /// </summary>
+    private void EmitPlain64Binary(BinaryExpressionSyntax binary)
+    {
+        if (binary.IsKind(SyntaxKind.DivideExpression))
+        {
+            _w.Write("TransposeR.idiv(");
+            EmitPlain64Operand(binary.Left);
+            _w.Write(", ");
+            EmitPlain64Operand(binary.Right);
+            _w.Write(")");
+            return;
+        }
+
+        var jsOp = binary.Kind() switch
+        {
+            SyntaxKind.EqualsExpression => "===",
+            SyntaxKind.NotEqualsExpression => "!==",
+            _ => binary.OperatorToken.Text,
+        };
+
+        EmitPlain64Operand(binary.Left);
+        _w.Write($" {jsOp} ");
+        EmitPlain64Operand(binary.Right);
+    }
+
+    /// <summary>
+    /// Emits an operand in plain (unboxed) position. Only constants need the detour: a numeric
+    /// literal is emitted from its CONVERTED type (see <c>EmitLiteral</c>), so the <c>1</c> in
+    /// <c>file.Size + 1</c> — which C# converted to <c>ulong</c> — would come out as
+    /// <c>System.UInt64("1")</c> and turn a plain addition into string concatenation.
+    /// </summary>
+    private void EmitPlain64Operand(ExpressionSyntax expr)
+    {
+        if (Plain64ConstantText(expr) is { } text) { _w.Write(text); return; }
+        EmitExpression(expr);
+    }
+
+    /// <summary>
+    /// The JavaScript text of an integral constant that is exactly representable as a JS number, or
+    /// null if the expression is not such a constant. The range test is what keeps
+    /// <c>size == long.MaxValue</c> honest: a constant JavaScript cannot hold is left to the boxed
+    /// Int64 path rather than silently rounded (<see cref="IsPlain64SafeOperand"/>).
+    /// </summary>
+    private string? Plain64ConstantText(ExpressionSyntax expr)
+    {
+        if (_model.GetConstantValue(expr) is not { HasValue: true, Value: { } value }) return null;
+        switch (value)
+        {
+            case long l when System.Math.Abs(l) <= MaxSafeJsInteger:
+                return l.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case ulong u when u <= MaxSafeJsInteger:
+                return u.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case int i: return i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case uint ui: return ui.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case short sh: return sh.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case ushort us: return us.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case sbyte sb: return sb.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            case byte b: return b.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            default: return null;
+        }
+    }
+
+    /// <summary><c>Number.MAX_SAFE_INTEGER</c> — above it a JS number stops counting in ones.</summary>
+    private const long MaxSafeJsInteger = 9007199254740991L;
+
+    /// <summary>True unless the operand is a 64-bit constant too large for a JS number to hold
+    /// exactly. Such a comparison keeps the boxed Int64 path, where the constant is exact.</summary>
+    private bool IsPlain64SafeOperand(ExpressionSyntax expr, ITypeSymbol? type)
+        => !Is64BitInteger(UnwrapNullable(type))
+           || _model.GetConstantValue(expr) is not { HasValue: true, Value: long or ulong }
+           || Plain64ConstantText(expr) is not null;
+
+    /// <summary>Emits <paramref name="expr"/> lifted into a real System.Int64/UInt64 instance — the
+    /// managed side of the boundary.</summary>
+    private void EmitLifted64(ExpressionSyntax expr, ITypeSymbol? type)
+    {
+        _w.Write(Is64BitUnsigned(UnwrapNullable(type)) ? "System.UInt64(" : "System.Int64(");
+        EmitExpression(expr);
+        _w.Write(")");
+    }
+
+    /// <summary>True if one half of a 64-bit <c>??</c> can be emitted as a plain number: it already
+    /// is one, or it is a constant small enough to write out (<c>x ?? 0L</c> — the common shape).</summary>
+    private bool IsPlain64CoalesceOperand(ExpressionSyntax expr)
+        => EmitsAsPlainJsNumber(expr) || Plain64ConstantText(expr) is not null;
+
+    /// <summary>Emits one half of a 64-bit <c>??</c> in whichever representation the whole expression
+    /// settled on, lifting or unwrapping the half that disagrees.</summary>
+    private void EmitCoalesce64Operand(ExpressionSyntax expr, bool plain)
+    {
+        var type = _model.GetTypeInfo(expr).Type;
+        if (plain)
+        {
+            EmitPlain64Operand(expr);
+            return;
+        }
+        if (EmitsAsPlainJsNumber(expr) && Is64BitInteger(UnwrapNullable(type)))
+        {
+            // `null` must survive the lift — it is the whole point of the operator.
+            var v = Capture(() => EmitExpression(expr));
+            var ctor = Is64BitUnsigned(UnwrapNullable(type)) ? "System.UInt64" : "System.Int64";
+            _w.Write(IsNullableValueType(type) ? $"({v} == null ? null : {ctor}({v}))" : $"{ctor}({v})");
+            return;
+        }
+        EmitExpression(expr);
+    }
+
+    /// <summary>
+    /// Emits the receiver of a reduced extension method. It is the static call's FIRST ARGUMENT, so
+    /// it crosses the same 64-bit boundary an ordinary argument does — a plain foreign value has to
+    /// be lifted for a managed <c>this long</c> parameter, and unwrapped for a foreign one.
+    /// </summary>
+    private void EmitExtensionReceiver(ExpressionSyntax receiver, IMethodSymbol reduced)
+    {
+        var slot = reduced.Parameters.Length > 0 ? reduced.Parameters[0].Type : null;
+        if (Is64BitInteger(UnwrapNullable(_model.GetTypeInfo(receiver).Type))
+            && Is64BitInteger(UnwrapNullable(slot)))
+        {
+            EmitExpressionConverted(receiver, slot, IsForeignJsSlot(reduced));
+            return;
+        }
+        EmitExpression(receiver);
+    }
+
+    /// <summary>Emits <paramref name="expr"/> as the value written INTO a foreign-JS 64-bit slot: a
+    /// managed System.Int64/UInt64 instance is read back out as a plain number, and a value that is
+    /// already plain passes through untouched.</summary>
+    private void EmitForeign64Value(ExpressionSyntax expr, ITypeSymbol? slotType)
+        => EmitExpressionConverted(expr, slotType, targetIsForeignJs: true);
+
+    /// <summary>
+    /// Emits the subject of a pattern test. The pattern emitters work on an already-emitted subject
+    /// string and cannot ask how it was produced, so a foreign-JS 64-bit value is lifted here: their
+    /// constant and relational tests go through <c>Transpose.equals</c> and <c>.gt</c>/<c>.lte</c>,
+    /// which need a real instance. One lift per switch, not one per arm.
+    /// </summary>
+    private void EmitPatternSubject(ExpressionSyntax expr)
+    {
+        var type = _model.GetTypeInfo(expr).Type;
+        if (Is64BitInteger(UnwrapNullable(type)) && EmitsAsPlainJsNumber(expr))
+        {
+            if (IsNullableValueType(type))
+            {
+                var v = Capture(() => EmitExpression(expr));
+                var ctor = Is64BitUnsigned(UnwrapNullable(type)) ? "System.UInt64" : "System.Int64";
+                _w.Write($"({v} == null ? null : {ctor}({v}))");
+                return;
+            }
+            EmitLifted64(expr, type);
+            return;
+        }
+        EmitExpression(expr);
+    }
+
+    /// <summary>True if an lvalue names a foreign-JS 64-bit slot, so a compound assignment or
+    /// <c>++</c> on it must use plain JS operators rather than Int64 methods.</summary>
+    private bool IsForeignJs64Lvalue(ExpressionSyntax left)
+        => Is64BitInteger(UnwrapNullable(_model.GetTypeInfo(left).Type))
+           && _model.GetSymbolInfo(left).Symbol is { } sym && IsForeignJsSlot(sym);
+}

--- a/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Members.cs
@@ -514,11 +514,19 @@ public sealed partial class Emitter
                 ? PropertyBackingName(fbp)
                 : TransposeNaming.MemberJsName(m);
 
+            // An [ObjectLiteral] type's slots live in a plain JS object, so a long/ulong one holds a
+            // plain number rather than a System.Int64 instance (Emitter.Foreign64.cs).
+            var foreignSlot = IsForeignJsSlot(m) && Is64BitInteger(UnwrapNullable(slotType));
+
             if (init is not null && runInitializers)
             {
                 _w.Write($"this.{slot} = ");
-                EmitExpressionConverted(init, slotType);
+                EmitExpressionConverted(init, slotType, foreignSlot);
                 _w.WriteLine(";");
+            }
+            else if (foreignSlot && !IsNullableValueType(slotType))
+            {
+                _w.WriteLine($"this.{slot} = 0;");
             }
             else if (NeedsStructDefaultInit(slotType))
             {

--- a/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Patterns.cs
@@ -18,7 +18,7 @@ public sealed partial class Emitter
         _w.Write($"(function ({subject}) {{ return ");
         EmitPatternTest(subject, isPattern.Pattern);
         _w.Write("; })(");
-        EmitExpression(isPattern.Expression);
+        EmitPatternSubject(isPattern.Expression);
         _w.Write(")");
     }
 
@@ -38,7 +38,7 @@ public sealed partial class Emitter
         var hasAwait = OpenIife(switchExpr);
 
         _w.Write($"let {subject} = ");
-        EmitExpression(switchExpr.GoverningExpression);
+        EmitPatternSubject(switchExpr.GoverningExpression);
         _w.Write("; ");
 
         // Pre-declare pattern variables bound in the arms (e.g. `int i` in `> 0 and int i`).

--- a/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Statements.cs
@@ -879,7 +879,7 @@ public sealed partial class Emitter
         _w.WriteLine($"{label}: {{");
         _w.Indent();
         _w.Write($"let {subject} = ");
-        EmitExpression(switchStmt.Expression);
+        EmitPatternSubject(switchStmt.Expression);
         _w.WriteLine(";");
 
         _breakTargets.Push(label);

--- a/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Types.cs
@@ -198,7 +198,11 @@ public sealed partial class Emitter
                         : nestedName;
                 }
 
-                var ns = named.ContainingNamespace?.ToDisplayString();
+                // ToDisplayString() renders the global namespace as the literal "<global namespace>",
+                // which is not a name — an [External] type declared outside any namespace was emitted
+                // as `<global namespace>.Thing`, a syntax error that breaks the whole bundle. Such a
+                // type binds to a bare JS global, so it has no namespace at all.
+                var ns = named.ContainingNamespace is { IsGlobalNamespace: false } cns ? cns.ToDisplayString() : null;
                 // A type-level [Transpose.Namespace] overrides the emitted namespace: false/"" drops
                 // it (so Transpose.Core's String/Number/… bind to the JS globals), a string replaces it.
                 if (TransposeNaming.NamespaceOverride(named) is { } nsOverride)


### PR DESCRIPTION
tps.js models a 64-bit integer as a System.Int64/UInt64 OBJECT, because
JavaScript has no 64-bit number. That is right for every value Transpose
produces and for the base library, which is where those two types are
defined — DateTime.Ticks, long.Parse and TimeSpan.Ticks all hand back
real instances.

It is not right for a slot that belongs to real JavaScript. A binding
library declares Blob.size as ulong because that is the nearest C# type
for the spec's unsigned long long, but the browser returns a plain
number. Reading one as a box made `file.Size > 0` emit
`file.size.gt(...)` — a TypeError, since a number has no .gt — and, in
the other direction, passed an Int64 object into `blob.slice(...)`,
which coerces it to NaN. An [ObjectLiteral] type has the same problem
from the other end: its instances ARE plain JS objects, so storing a
{low, high} pair in one breaks the JSON and the hand-written JavaScript
that reads it.

So a long/ulong slot in foreign JavaScript is now plain: a member of an
[External]/[Scope] type outside the base library, a member carrying its
own [External]/[Template], and any instance field or property of an
[ObjectLiteral] type. Reads, comparisons and + - * / % stay plain JS
(division through TransposeR.idiv, which truncates as C# does), and the
representation changes only at the boundary — lifted with
System.Int64(...) into a managed long slot, a box, a BCL call, a pattern
subject, an extension receiver or a 64-bit member receiver; read back
with .toNumber() when a managed value is written into a foreign
parameter, property or literal member.

Two edges are deliberate. Bitwise and shift operators keep the boxed
path, because JavaScript's are 32-bit and `size & 0xF00000000` would
silently lose the high word, as does a constant outside ±2^53, which
keeps `size == long.MaxValue` exact. And the cost: a value stored into a
foreign slot above 2^53 rounds, since a JS number counts in ones only
that far — nothing lost for an external slot, a deliberate trade for an
object literal.

Nothing else moves: the runtime bundles (tps.js and the three variants)
and all seven binding libraries transpile byte-identically to the
previous compiler.

ForeignJs64BitTests covers both attributes and a [Template] member
against native .NET across the whole operator surface, pins the emit
shape on each side of the boundary, pins that the base library stays
boxed, and records the 2^53 limit.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CiVA5bL5KcfGBMLJBsGm1L