### PR TITLE
Name module chunk files after the hash of their content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,7 +573,7 @@ The short version:
   built against the package was missing 243 icons/illustrations, both variable-font families and the
   favicon.
 - **Lazily-loaded modules (done).** `outputBy: "Module"` in a project's `tps.json` makes a site build
-  emit one ES module per chunk (`chunks/cN.mjs`) plus an entry module, and index.html carries a single
+  emit one ES module per chunk (`chunks/c<hash>.mjs`) plus an entry module, and index.html carries a single
   `<script type="module">`. A **chunk is a strongly-connected component of the reference graph**
   `TypeRef` records while emitting each type — the smallest sound unit, because `Transpose.define`
   resolves `inherits` eagerly, so a per-class split cannot order a reference cycle. Components come
@@ -588,6 +588,20 @@ The short version:
   what it measures (Tesserae's sample gallery: the app's initial payload 1,109 KB → 164 KB raw, all
   140 samples rendering identically).
 
+  **A chunk is named after the hash of its own text** (`c<hash>.mjs` — the first 16 hex digits of the
+  SHA-256 of the file, `ChunkLeafName`), so a rebuild renames exactly the chunks whose JavaScript
+  changed: a chunk can be served immutably and a returning browser or CDN re-fetches only what really
+  differs, with nothing to bust by hand. Two invariants that already held make it work — a chunk's
+  text never mentions its *own* name (an import specifier is relative to the chunk *directory*, which
+  is fixed before any hashing), and every import points at an earlier chunk, so hashing in index
+  order always has a chunk's dependencies' final names in hand. Renaming a chunk therefore renames
+  the chunks that import it, which is required rather than incidental: an unchanged importer would
+  import a file that is no longer there. The hash is of the emitted text, not of the minified form a
+  Release site serves — minification is later and deterministic, so it still identifies the served
+  bytes — and the stale-output prune deletes a renamed chunk's predecessor with no extra machinery,
+  because the site manifest already records what the previous build wrote. See **`TODO.modules.md`**
+  §7i.
+
   Three things are load-bearing and were found by running it, not by reasoning: the entry module
   emits its **reflection metadata before the manifest** (`Modules.register` ends with a
   `Transpose.init()`, and `init` runs `Main` — anything after it would not exist yet); the stub
@@ -601,7 +615,7 @@ The short version:
   handlers) and publishes a chunk map — emitted type name → chunk file — embedded as
   `Transpose.Modules.json` (embedded but *not* listed in `Transpose.Resources.json`, like the
   `BuildStamp`, so nothing extracts it into a site). A consuming build merges its references' maps
-  (`ModuleMap.Read`) and emits `import '../<lib>/cN.mjs'` from whichever of its own chunks reaches
+  (`ModuleMap.Read`) and emits `import '../<lib>/c<hash>.mjs'` from whichever of its own chunks reaches
   into a library type — without that the reference would land on the library's stub, which cannot be
   resolved synchronously. Covered by `ModulePackageTests`.
 

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -245,8 +245,11 @@ imports.
 tps/
   app.js            entry module: imports the eager chunks, the reflection metadata for every type,
                     the manifest of what was deferred, Transpose.init()
-  chunks/c0.mjs …   one file per chunk: side-effect imports of the chunks it references, then the
-                    Transpose.define of each of its types
+  chunks/c<hash>.mjs
+                    one file per chunk: side-effect imports of the chunks it references, then the
+                    Transpose.define of each of its types. The name is the first 16 hex digits of the
+                    SHA-256 of the file's own text (§7i), so a rebuild renames exactly the chunks
+                    whose JavaScript changed and every chunk can be served immutably.
 ```
 
 **Translator** (`Emitter.Modules.cs`, ~300 lines):
@@ -317,7 +320,7 @@ assembly boundary:
 - **It publishes a chunk map** — emitted type name → chunk file — embedded as `Transpose.Modules.json`
   (embedded but *not* listed in `Transpose.Resources.json`, like the `BuildStamp`, so no consumer
   extracts it into a site). A consuming build reads the maps of all its references (`ModuleMap.Read`)
-  and, wherever its own code reaches into a library type, emits `import '../<lib>/cN.mjs'` from the
+  and, wherever its own code reaches into a library type, emits `import '../<lib>/c<hash>.mjs'` from the
   chunk that uses it. Without that the reference would land on the library's stub, and a stub cannot
   be resolved synchronously.
 
@@ -616,6 +619,40 @@ Measured on a consumer built against each, deserializing an `Order` whose graph 
 
 `Serialize`/`SerializeObject` are deliberately left alone: serialization reads an instance it was
 handed and never constructs the type, so marking it would only inflate what a screen fetches.
+
+### 7i. Content-addressed chunk names
+
+A chunk file is named `c<hash>.mjs`, where the hash is the first 16 hex digits of the SHA-256 of the
+file's own text (`ChunkLeafName`, `Emitter.Modules.cs`). The name is therefore a fingerprint of the
+content, which is the whole point: a rebuild renames exactly the chunks whose JavaScript changed, so
+chunks can be served with a far-future `Cache-Control: immutable` and a returning browser (or a CDN)
+re-fetches only what actually differs, with no deployment step to bust a cache by hand. Numbered
+names could not do that — `c17.mjs` means something different after every edit that shifts the
+chunking, and the same URL holding different bytes is the one thing an HTTP cache cannot see.
+
+Two invariants make it possible, and both already held:
+
+- **A chunk's text never mentions its own name.** Every import specifier is computed relative to the
+  chunk *directory*, which is fixed before anything is hashed, so hashing the finished text cannot
+  invalidate the text.
+- **Every import points at an earlier chunk** — the invariant `Chunk()` establishes (Tarjan emits a
+  component only after everything it points at) and `Coalesce()` re-checks. So walking the chunks in
+  index order always has the final names of a chunk's dependencies in hand by the time it is hashed.
+
+The consequence is a cascade, and a wanted one: renaming a chunk changes the text of every chunk that
+imports it, so those are renamed too. They have to be — an unchanged importer would go on importing a
+file that is no longer there. An edit's blast radius is the edited chunk plus its dependents, which is
+also exactly the set whose bytes are no longer valid.
+
+The hash covers the text the emitter produced, not the minified form a Release site serves:
+minification runs later (`OutputBuilder.MinifyModule`) and is deterministic, so the emitted text still
+identifies the served bytes exactly. Names stay deterministic, so two builds of the same sources are
+still byte-identical. And the stale-output prune needs nothing new — the site manifest already records
+what the previous build wrote, so a renamed chunk's predecessor is deleted like any other stale file.
+
+Collisions are guarded but not expected: 64 bits is far past the birthday risk for the number of
+chunks an assembly emits, and two chunks cannot legitimately share text at all (a type is emitted into
+exactly one chunk and its define name is part of that text). A collision would take a `-2` suffix.
 
 ### Not done
 

--- a/Transpose/Transpose.Translator.Tests/ModuleChunkCoalescingTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleChunkCoalescingTests.cs
@@ -27,9 +27,17 @@ namespace Transpose.Translator.Tests
             ModuleEmitTests.Emit(source, minChunkBytes: min, maxChunkBytes: max);
 
         private static IEnumerable<string> ImportsOf(string js) =>
-            Regex.Matches(js, @"^import '\./(c\d+\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
+            Regex.Matches(js, @"^import '\./(c[0-9a-f]+(?:-\d+)?\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
 
-        private static int IndexOfChunk(string relPath) => int.Parse(Regex.Match(relPath, @"c(\d+)\.mjs").Groups[1].Value);
+        /// <summary>Where a chunk sits in the emission order. A chunk file is named after the hash of
+        /// its content, so the order is its position in <c>Chunks</c> — there is no index to read off
+        /// the name.</summary>
+        private static Func<string, int> PositionIn(Emitter.ModuleOutput m)
+        {
+            var byName = m.Chunks.Select((c, i) => (name: System.IO.Path.GetFileName(c.relPath), i))
+                                 .ToDictionary(x => x.name, x => x.i);
+            return relPath => byName[System.IO.Path.GetFileName(relPath)];
+        }
 
         /// <summary>Ten independent types, each with a body big enough to be worth measuring.</summary>
         private static string Widgets(int count, int bodyLines, string prefix = "W")
@@ -97,12 +105,13 @@ public class Program { public static void Main() { System.Console.WriteLine(new 
         }
 
         [TestMethod]
-        public void EveryImportStillPointsAtALowerNumberedChunk()
+        public void EveryImportStillPointsAtAnEarlierChunk()
         {
             // The merged graph has to stay a DAG, and the emitter's invariant is stronger than that:
-            // a chunk only ever imports lower-numbered chunks. That is what makes the file names
-            // deterministic, and — because Transpose.define resolves `inherits` eagerly — what makes
-            // the evaluation order sound. A merge is the one operation that could break it.
+            // a chunk only ever imports chunks emitted before it. That is what lets a chunk be named
+            // after the hash of its own text (its dependencies' names are already final), and —
+            // because Transpose.define resolves `inherits` eagerly — what makes the evaluation order
+            // sound. A merge is the one operation that could break it.
             var body = new StringBuilder(Widgets(24, 10));
             for (var i = 0; i < 8; i++)
                 body.Append($"public class Mid{i} {{ public int Go(int n) {{ return new W{i}().Run(n) + new W{i + 8}().Run(n) + new W{i + 16}().Run(n); }} }}\n");
@@ -110,12 +119,13 @@ public class Program { public static void Main() { System.Console.WriteLine(new 
 
             var m = Emit(body.ToString(), min: 6 * 1024, max: 12 * 1024);
 
+            var position = PositionIn(m);
             foreach (var (relPath, js) in m.Chunks)
             {
-                var self = IndexOfChunk(relPath);
+                var self = position(relPath);
                 foreach (var imported in ImportsOf(js))
-                    Assert.IsTrue(IndexOfChunk(imported) < self,
-                        $"{relPath} imports {imported}, which is not a lower-numbered chunk");
+                    Assert.IsTrue(position(imported) < self,
+                        $"{relPath} imports {imported}, which is not an earlier chunk");
             }
         }
 

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -48,7 +48,7 @@ namespace Transpose.Translator.Tests
             m.Chunks.First(c => Regex.IsMatch(c.js, @"Transpose\.definei?\(""" + Regex.Escape(typeName) + @"""")).relPath;
 
         private static IEnumerable<string> ImportsOf(string js) =>
-            Regex.Matches(js, @"^import '\./(c\d+\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
+            Regex.Matches(js, @"^import '\./(c[0-9a-f]+(?:-\d+)?\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
 
         [TestMethod]
         public void MutuallyReferencingTypesShareOneChunk()
@@ -472,7 +472,7 @@ public class Program { public static void Main() { Console.WriteLine(new UsesBot
         }
 
         [TestMethod]
-        public void TheChunkGraphIsADagInFileOrder()
+        public void TheChunkGraphIsADagInEmissionOrder()
         {
             var m = Emit(@"
 using System;
@@ -482,17 +482,85 @@ public class Circle : IShape { public double R; public double Area() { return R 
 public class Pair { public Square A = new Square(); public Circle B = new Circle(); }
 public class Program { public static void Main() { Console.WriteLine(new Pair().A.Area()); } }
 ");
-            // Chunks are numbered in topological order, so every import points at a LOWER index.
-            // That is what makes the side-effect imports sound and the file names deterministic.
+            // Chunks are EMITTED in topological order, so every import points at a chunk emitted
+            // EARLIER. That is what makes the side-effect imports sound — and, since a chunk is named
+            // after the hash of its own text, it is also what lets a chunk's dependencies already
+            // have their final names when it is hashed. The order is the position in Chunks, not
+            // anything readable off the (content-addressed) file name.
+            var position = m.Chunks.Select((c, i) => (c.relPath, i))
+                                   .ToDictionary(x => System.IO.Path.GetFileName(x.relPath), x => x.i);
             foreach (var (relPath, js) in m.Chunks)
             {
-                var self = int.Parse(Regex.Match(relPath, @"c(\d+)\.mjs").Groups[1].Value);
+                var self = position[System.IO.Path.GetFileName(relPath)];
                 foreach (var dep in ImportsOf(js))
-                {
-                    var to = int.Parse(Regex.Match(dep, @"c(\d+)\.mjs").Groups[1].Value);
-                    Assert.IsTrue(to < self, $"{relPath} imports {dep}, which is not earlier in the order");
-                }
+                    Assert.IsTrue(position[dep] < self,
+                        $"{relPath} imports {dep}, which is not earlier in the order");
             }
+        }
+
+        [TestMethod]
+        public void AChunkIsNamedAfterTheHashOfItsContent()
+        {
+            var m = Emit(@"
+using System;
+public class Leaf { public int N; }
+public class Trunk { public Leaf L = new Leaf(); }
+public class Program { public static void Main() { Console.WriteLine(new Trunk().L.N); } }
+");
+            foreach (var (relPath, js) in m.Chunks)
+            {
+                var expected = "c" + Convert.ToHexStringLower(
+                    System.Security.Cryptography.SHA256.HashData(
+                        System.Text.Encoding.UTF8.GetBytes(js)).AsSpan(0, 8)) + ".mjs";
+                Assert.AreEqual(expected, System.IO.Path.GetFileName(relPath),
+                    "a chunk file is named after the hash of its own JavaScript — that is what makes a "
+                    + "rebuild rename exactly the files whose content changed");
+            }
+        }
+
+        [TestMethod]
+        public void EditingOneTypeRenamesOnlyItsOwnChunkAndItsDependents()
+        {
+            const string before = @"
+using System;
+public class Untouched { public int Stable() { return 1; } }
+public class Edited { public int Value() { return 41; } }
+public class Program { public static void Main() { Console.WriteLine(new Untouched().Stable() + new Edited().Value()); } }
+";
+            var m1 = Emit(before);
+            var m2 = Emit(before.Replace("return 41;", "return 42;"));
+
+            // The point of hashing: the chunk whose JavaScript changed gets a new URL, so a browser
+            // or CDN holding the old one re-fetches it, and every chunk that did NOT change keeps its
+            // name and is never re-fetched.
+            Assert.AreNotEqual(ChunkOf(m1, "Edited"), ChunkOf(m2, "Edited"),
+                "the edited type's chunk must be renamed, or a cached copy would be served forever");
+            Assert.AreEqual(ChunkOf(m1, "Untouched"), ChunkOf(m2, "Untouched"),
+                "an untouched chunk must keep its name, or every rebuild would invalidate the whole site");
+        }
+
+        [TestMethod]
+        public void ARenamedDependencyRenamesTheChunksThatImportIt()
+        {
+            const string before = @"
+using System;
+public class Dep { public int Value() { return 41; } }
+public class User { public Dep D = new Dep(); }
+public class Program { public static void Main() { Console.WriteLine(new User().D.Value()); } }
+";
+            var m1 = Emit(before);
+            var m2 = Emit(before.Replace("return 41;", "return 42;"));
+
+            // A chunk's text contains the names of the chunks it imports, so a renamed dependency is a
+            // changed importer — which it has to be: the old importer would import a file that is no
+            // longer there.
+            Assert.AreNotEqual(ChunkOf(m1, "Dep"), ChunkOf(m2, "Dep"));
+            Assert.AreNotEqual(ChunkOf(m1, "User"), ChunkOf(m2, "User"),
+                "a chunk importing a renamed chunk must itself be renamed");
+            StringAssert.Contains(
+                m2.Chunks.First(c => c.relPath == ChunkOf(m2, "User")).js,
+                System.IO.Path.GetFileName(ChunkOf(m2, "Dep")),
+                "and it must import the NEW name");
         }
 
         [TestMethod]

--- a/Transpose/Transpose.Translator.Tests/ModuleReflectionDepsTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleReflectionDepsTests.cs
@@ -42,7 +42,7 @@ public static class Wire
 ";
 
         private static IEnumerable<string> ImportsOf(string js) =>
-            Regex.Matches(js, @"^import '\./(c\d+\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
+            Regex.Matches(js, @"^import '\./(c[0-9a-f]+(?:-\d+)?\.mjs)';$", RegexOptions.Multiline).Select(x => x.Groups[1].Value);
 
         /// <summary>Everything the chunk holding <paramref name="typeName"/> pulls in, transitively.</summary>
         private static HashSet<string> ChunkClosure(Emitter.ModuleOutput m, string typeName)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -208,7 +209,28 @@ public sealed partial class Emitter
         }
 
         var dir = string.IsNullOrEmpty(chunkDirectory) ? "" : chunkDirectory.TrimEnd('/') + "/";
-        string ChunkFile(int i) => $"{dir}c{i}.mjs";
+
+        // A chunk is named after the hash of its own text (see ChunkLeafName), so a rebuild renames
+        // exactly the files whose JavaScript changed: a chunk can be served immutably, and a browser
+        // or CDN re-fetches only what actually differs instead of revalidating every file behind a
+        // name that never moves. Two properties make that possible, and both are already invariants
+        // of the chunker rather than anything added for it:
+        //
+        //  - a chunk's text never mentions its OWN name. Every import specifier is relative to the
+        //    chunk *directory*, which is fixed before any hashing (ChunkImport below), so hashing the
+        //    finished text cannot invalidate the text;
+        //  - every import points at a LOWER index — the invariant Chunk() establishes and Coalesce()
+        //    re-checks — so walking the chunks in index order always has the final names of a chunk's
+        //    dependencies in hand by the time that chunk is hashed.
+        //
+        // The names are still deterministic, so two builds of the same sources remain byte-identical.
+        var chunkNames = new string[chunks.Members.Count];
+        var usedChunkNames = new HashSet<string>(StringComparer.Ordinal);
+        string ChunkFile(int i) => chunkNames[i];
+        // The specifier from a chunk to another file. It depends only on the importing chunk's
+        // directory, never on its own (not yet known) file name — which is what lets the name be a
+        // hash of the text these imports are part of.
+        string ChunkImport(string to) => RelativeImport(dir + "c.mjs", to);
 
         var output = new List<(string, string)>();
         for (var i = 0; i < chunks.Members.Count; i++)
@@ -217,7 +239,7 @@ public sealed partial class Emitter
             // Import order is the chunk index, which is the topological order Chunk() assigned, so
             // two builds of the same sources produce byte-identical files.
             foreach (var d in chunks.Deps[i].OrderBy(x => x))
-                w.Append("import '").Append(RelativeImport(ChunkFile(i), ChunkFile(d))).Append("';\n");
+                w.Append("import '").Append(ChunkImport(ChunkFile(d))).Append("';\n");
             // Cross-assembly: a referenced module-mode assembly's chunk holding a type this one uses.
             // Without it the reference would resolve to that assembly's stub, and a stub cannot be
             // resolved synchronously.
@@ -229,7 +251,7 @@ public sealed partial class Emitter
                         foreach (var n in names)
                             if (externalChunks.TryGetValue(n, out var file)) wanted.Add(file);
                 foreach (var file in wanted)
-                    w.Append("import '").Append(RelativeImport(ChunkFile(i), file)).Append("';\n");
+                    w.Append("import '").Append(ChunkImport(file)).Append("';\n");
             }
             // A bare Transpose.define outside the Transpose.assembly(...) wrapper has no ambient
             // assembly, so each chunk names its own before defining anything.
@@ -239,7 +261,9 @@ public sealed partial class Emitter
                 w.Append(Dedent(bodies[t]));
                 w.Append('\n');
             }
-            output.Add((ChunkFile(i), w.ToString()));
+            var js = w.ToString();
+            chunkNames[i] = dir + ChunkLeafName(js, usedChunkNames);
+            output.Add((chunkNames[i], js));
         }
 
         var lazyTypes = new List<INamedTypeSymbol>();
@@ -256,6 +280,28 @@ public sealed partial class Emitter
         foreach (var t in types) result.TypeToChunk[MetaTypeDefName(t)] = ChunkFile(chunks.IndexOf[t]);
         foreach (var kv in skipDeps) result.SkipClusterDeps[kv.Key] = kv.Value;
         return result;
+    }
+
+    /// <summary>
+    /// A chunk's file name: <c>c</c> followed by the first 16 hex digits of the SHA-256 of its
+    /// JavaScript. The name is therefore a fingerprint of the content, which is what makes cache
+    /// invalidation automatic — an unchanged chunk keeps its URL across a rebuild and a changed one
+    /// gets a new one, so chunks can be served with a far-future <c>Cache-Control</c> and no
+    /// deployment ever has to bust a cache by hand. 64 bits is far past collision risk for the
+    /// number of chunks an assembly emits; the loop below is a guard, not an expectation, since two
+    /// chunks cannot legitimately share text (a type is emitted into exactly one chunk and its
+    /// define name is part of that text).
+    ///
+    /// The hash is of the text the emitter produced, not of the minified form a Release site serves:
+    /// minification runs later, in OutputBuilder, and is deterministic, so the emitted text still
+    /// identifies the served bytes exactly.
+    /// </summary>
+    private static string ChunkLeafName(string js, HashSet<string> used)
+    {
+        var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(js)).AsSpan(0, 8));
+        var name = "c" + hash + ".mjs";
+        for (var n = 2; !used.Add(name); n++) name = "c" + hash + "-" + n + ".mjs";
+        return name;
     }
 
     private sealed record ChunkGraph(


### PR DESCRIPTION
A chunk file was `chunks/<Assembly>/c<index>.mjs`, where the index was its
position in the chunker's topological order. That name means something
different after every edit that shifts the chunking, so the same URL serves
different bytes across deployments and a chunk can never be cached beyond a
revalidation — the one thing an HTTP cache cannot see through.

Name it `c<hash>.mjs` instead, the first 16 hex digits of the SHA-256 of the
file's own text. The name is now a fingerprint of the content, so a rebuild
renames exactly the chunks whose JavaScript changed: chunks can be served
immutably, and a returning browser or CDN re-fetches only what actually
differs, with no cache to bust by hand.

Two invariants make it work, and both already held:

  - a chunk's text never mentions its own name. Every import specifier is
    relative to the chunk *directory*, which is fixed before anything is
    hashed, so hashing the finished text cannot invalidate the text;
  - every import points at an earlier chunk — the invariant Chunk()
    establishes and Coalesce() re-checks — so walking the chunks in index
    order always has the final names of a chunk's dependencies in hand by the
    time that chunk is hashed.

Renaming a chunk therefore renames the chunks that import it. That is
required rather than incidental: an unchanged importer would go on importing
a file that is no longer there. The blast radius of an edit is the edited
chunk plus its dependents, which is also exactly the set whose bytes are no
longer valid.

The hash covers the emitted text, not the minified form a Release site
serves: minification runs later, in OutputBuilder, and is deterministic, so
the emitted text still identifies the served bytes exactly. Names stay
deterministic, so two builds of the same sources remain byte-identical. The
stale-output prune needs nothing new — the site manifest already records what
the previous build wrote, so a renamed chunk's predecessor is deleted like any
other stale file.

Verified end to end: a module-mode site rebuilt after editing one type renames
that type's chunk only, keeps the other three, and prunes the old file; a
consumer of a module-mode package imports the library's hashed chunk name
across assemblies. Three tests pin the behaviour (the name is the hash, an
untouched chunk keeps its name across a rebuild, a renamed dependency renames
its importers), and the two tests that read a chunk's position off its file
name now read it off the emission order instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wu1EFZX9uXBJKBRq1PFC89