### PR TITLE
Let a project keep a referenced library out of index.html

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,21 @@ The short version:
   contributes only its load flag; `"loadCompiledOutput": false` is the direct way to say "copy my
   bundle but do not script it" (Curiosity's Admin package, which the app fetches itself).
 
+  **`dontLoadReferences` is the same decision made by the consumer.** `loadCompiledOutput` lets a
+  *library* say "copy my bundle but do not script it"; a list of assembly names in the *application's*
+  tps.json says the same about a library that did not — the case a published package cannot decide for
+  itself, because only one of its consumers wants it lazily. Each entry is matched case-insensitively
+  (with `*`/`?` wildcards, and a `.dll` suffix tolerated) against a referenced assembly's name;
+  everything that assembly contributes is still extracted into the site — its bundle, its authored
+  scripts, its stylesheets — and none of it is referenced from index.html, the same reach the resource
+  `load` flag has. Loading it is then the application's job (`Transpose.Require`, `Transpose.Modules`),
+  and reaching the deferred code before that fails at run time exactly as it would for any library the
+  page never loaded. An entry matching no reference is a warning (`TPS0106`), because its failure mode
+  is otherwise silent: the library goes on loading as if the setting were not there. Measured on an app
+  referencing `Tesserae.Plotly`: 10.5 MB (`Tesserae.Plotly.js` + `plotly.js`) off the initial payload,
+  with the chart screen fetching both — through `Require`'s `.js`/`.min.js` fallback, which is what
+  makes one spelling work in a Debug and a Release site alike — the first time it opens.
+
   Minification is NUglify-based (`JsMinifier`), pinned to `NUglify 1.21.15`; the legacy compiler used
   1.20.7, but that version mis-parenthesised a `??` operand of `&&`/`||` and emitted invalid JS, fixed
   in NUglify 1.21.14 — not the newer 1.22.0, which regressed by inserting a stray empty statement when

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -140,6 +140,25 @@ stylesheets — and it survives packaging: the flag is recorded in the resource
 manifest embedded in the package DLL, so a project referencing the library
 extracts the file without auto-loading it either.
 
+### References you load yourself
+
+The same idea, one level up: `dontLoadReferences` lists referenced **assemblies**
+whose JavaScript your site copies but never scripts, so an application can defer
+a library that did not ask to be deferred. h5 had no equivalent — a referenced
+library was always scripted — so a heavy binding only one screen used was paid
+for on every page load.
+
+```jsonc
+{
+    "dontLoadReferences": [ "Tesserae.Plotly" ]
+}
+```
+
+Everything the assembly ships is still extracted into the site; your code loads
+it when it needs it (`await Transpose.Require.RequireAsync("plotly.js",
+"Tesserae.Plotly.js")`). Entries match an assembly name, case-insensitively,
+with `*`/`?` wildcards; one that matches nothing is reported as `TPS0106`.
+
 ### Cleaning the output folder
 
 h5's `cleanOutputFolderBeforeBuild` / `cleanOutputFolderBeforeBuildPattern`

--- a/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
@@ -62,6 +62,7 @@ internal static class MsBuildDiagnostic
     public const string CodeCacheNotWritten         = "TPS0103";
     public const string CodeWatchServerFailed       = "TPS0104";
     public const string CodeTypeSizesJsonNotWritten = "TPS0105";
+    public const string CodeDontLoadReferenceUnmatched = "TPS0106";
 
     /// <summary>Formats a Roslyn diagnostic, pointing at its source location when it has one.</summary>
     public static string Format(Diagnostic d)

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -91,8 +91,18 @@ internal static class OutputBuilder
     /// <summary>The outcome of assembling a site: the directory it was written to, and every stale
     /// file that <c>cleanOutputFolder</c> pruned (files from a previous build this one did not
     /// re-produce). <see cref="RemovedStaleFiles"/> is empty when cleaning is disabled or nothing was
-    /// stale.</summary>
-    public readonly record struct SiteBuildResult(string OutputDir, IReadOnlyList<string> RemovedStaleFiles);
+    /// stale.
+    ///
+    /// <see cref="UnscriptedReferences"/> names the referenced assemblies <c>dontLoadReferences</c>
+    /// kept out of index.html (extracted, but not scripted), and <see cref="UnmatchedDontLoadReferences"/>
+    /// the entries of that list which matched no reference at all — a typo or a dependency that has
+    /// since been dropped, which would otherwise do nothing silently. Both are reported by the caller;
+    /// the site build itself writes no diagnostics.</summary>
+    public readonly record struct SiteBuildResult(
+        string OutputDir,
+        IReadOnlyList<string> RemovedStaleFiles,
+        IReadOnlyList<string> UnscriptedReferences,
+        IReadOnlyList<string> UnmatchedDontLoadReferences);
 
     /// <summary>
     /// One stylesheet a site build produces <em>from files on disk</em> — a <c>tps.json</c> resource
@@ -169,7 +179,7 @@ internal static class OutputBuilder
         // keeps exactly one of those sets — the one its own profile calls for. A package that offers
         // no module variant falls back to its minified/formatted bundle even in a chunked site, which
         // is how a plain library (Transpose.Newtonsoft.Json, a vendored binding) keeps working.
-        void RouteTaggedPackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
+        void RouteTaggedPackageJs(IReadOnlyList<EmbeddedJs> jsFiles, bool scripted)
         {
             var takeModules = siteIsChunked && jsFiles.Any(f => f.Variant == JsVariant.ModuleEntry);
 
@@ -189,7 +199,7 @@ internal static class OutputBuilder
                 }
 
                 WriteText(f.Rel, f.Text);
-                if (!f.Load) continue;
+                if (!f.Load || !scripted) continue;
                 jsOuts.Add(new JsOut
                 {
                     Path = f.Rel,
@@ -218,7 +228,10 @@ internal static class OutputBuilder
         // every consumer that fetches the file by path — a module loader, a `new Worker(...)`, an
         // import map — none of which this compiler rewrites. It matches what the same resource group
         // does when it is built from disk rather than extracted from a package (ProcessResourceGroup).
-        void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles)
+        // `scripted` is the consumer-side `dontLoadReferences` verdict for the assembly these files
+        // came from: false writes every one of them into the site exactly as usual and injects none of
+        // them into index.html, so the application can fetch the library itself when it first needs it.
+        void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles, bool scripted = true)
         {
             // A package says which of ITS OWN compiled files are interchangeable and what each one is
             // for, so those are chosen by a filter rather than a guess. Its authored resources carry no
@@ -228,7 +241,7 @@ internal static class OutputBuilder
             var tagged = jsFiles.Where(f => f.Variant is not null).ToList();
             if (tagged.Count > 0)
             {
-                RouteTaggedPackageJs(tagged);
+                RouteTaggedPackageJs(tagged, scripted);
                 jsFiles = jsFiles.Where(f => f.Variant is null).ToList();
                 if (jsFiles.Count == 0) return;
             }
@@ -251,7 +264,7 @@ internal static class OutputBuilder
                     // A standalone .min.js is still a Release-only script as far as index.html goes,
                     // matching how the same group routes from disk. A .dontload resource is on disk
                     // (above) but never injected into either HTML.
-                    if (f.Load) jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = IsMinifiedName(f.FileName), IsModule = f.Module });
+                    if (f.Load && scripted) jsOuts.Add(new JsOut { Path = f.Rel, IsMinified = IsMinifiedName(f.FileName), IsModule = f.Module });
                     continue;
                 }
 
@@ -269,7 +282,7 @@ internal static class OutputBuilder
                 var pre = byName[counterpart];   // pre-built .min.js from the package
                 WriteText(pre.Rel, pre.Text);
                 if (wantMinified) o.MinifiedPath = pre.Rel;
-                if (f.Load) jsOuts.Add(o);
+                if (f.Load && scripted) jsOuts.Add(o);
             }
         }
 
@@ -283,11 +296,22 @@ internal static class OutputBuilder
         //    post-order walk of the assembly reference graph (dependencies first), matching how the
         //    legacy compiler loaded assemblies. The TransposeR shim loads immediately after the
         //    Transpose runtime (tps.js) and before any generated code that calls into it.
+        // tps.json `dontLoadReferences`: assemblies whose JavaScript this site copies but never
+        // scripts. The application loads them itself (Transpose.Require / Transpose.Modules) the first
+        // time it needs them, so a heavy binding only one screen uses costs nothing on start-up.
+        var dontLoad = new DontLoadReferenceMatcher(config.DontLoadReferences);
+
         foreach (var dll in TopologicalOrder(project.ReferencePaths))
         {
+            // A suppressed reference contributes its files and none of its index.html entries — its
+            // stylesheets no more than its scripts, exactly the reach the resource `load` flag has.
+            // The CSS links are collected by the extractors, so hand them a list that is thrown away.
+            var scripted = !dontLoad.Matches(Path.GetFileNameWithoutExtension(dll));
+            var css = scripted ? cssLinks : new List<string>();
+
             RoutePackageJs(projectDlls.Contains(dll)
-                ? ExtractProjectDllResources(dll, outputDir, cssLinks, utf8, written)
-                : ExtractEmbeddedJs(dll, outputDir, cssLinks, written));
+                ? ExtractProjectDllResources(dll, outputDir, css, utf8, written)
+                : ExtractEmbeddedJs(dll, outputDir, css, written), scripted);
 
             if (string.Equals(Path.GetFileNameWithoutExtension(dll), "Transpose", StringComparison.OrdinalIgnoreCase))
                 EmitCompilerJs("tps.shim.js", RoslynTranslator.RuntimeShim);
@@ -362,7 +386,7 @@ internal static class OutputBuilder
 
         WriteManifest(manifestPath, outputDir, written, utf8);
 
-        return new SiteBuildResult(outputDir, removed);
+        return new SiteBuildResult(outputDir, removed, dontLoad.Matched, dontLoad.Unmatched);
     }
 
     /// <summary>
@@ -1430,6 +1454,79 @@ internal static class OutputBuilder
                 if (!Directory.EnumerateFileSystemEntries(dir).Any()) Directory.Delete(dir);
             }
             catch { /* ignore: a concurrently-recreated or locked directory is not fatal */ }
+        }
+    }
+
+    /// <summary>
+    /// The tps.json <c>dontLoadReferences</c> list, compiled once per build: which referenced
+    /// assemblies must be extracted into the site but left out of index.html.
+    ///
+    /// A pattern is matched against the reference's <em>assembly name</em> (<c>Tesserae.Plotly</c>, not
+    /// the DLL's path or file name) with <c>*</c>/<c>?</c> wildcards, and always case-insensitively:
+    /// an assembly name is a name, not a path, so the same tps.json must behave the same on every
+    /// operating system.
+    ///
+    /// It records what it matched, so the build can report the references it left unscripted, and what
+    /// it did not — an entry naming an assembly this project does not reference is almost always a typo
+    /// or a dependency that has since been dropped, and its silent failure mode (the library loads
+    /// normally, as if the setting were not there) is exactly the one worth a warning.
+    /// </summary>
+    private sealed class DontLoadReferenceMatcher
+    {
+        private readonly List<(string pattern, System.Text.RegularExpressions.Regex regex)> _patterns;
+        private readonly HashSet<string> _matchedPatterns = new(StringComparer.OrdinalIgnoreCase);
+        private readonly SortedSet<string> _matchedAssemblies = new(StringComparer.OrdinalIgnoreCase);
+
+        public DontLoadReferenceMatcher(IReadOnlyList<string> patterns)
+            => _patterns = patterns
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                // A `.dll` suffix is what the file on disk is called and a natural thing to write, so
+                // accept it rather than silently matching nothing; the pattern is kept as authored for
+                // the "matched nothing" report, which has to echo what the user wrote.
+                .Select(p => (p.Trim(), NameGlobToRegex(TrimDll(p.Trim()))))
+                .ToList();
+
+        private static string TrimDll(string pattern)
+            => pattern.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ? pattern[..^4] : pattern;
+
+        public bool Matches(string assemblyName)
+        {
+            if (_patterns.Count == 0) return false;
+
+            var matched = false;
+            foreach (var (pattern, regex) in _patterns)
+            {
+                if (!regex.IsMatch(assemblyName)) continue;
+                _matchedPatterns.Add(pattern);
+                matched = true;
+            }
+            if (matched) _matchedAssemblies.Add(assemblyName);
+            return matched;
+        }
+
+        /// <summary>The assembly names kept out of index.html, in name order.</summary>
+        public IReadOnlyList<string> Matched => _matchedAssemblies.ToList();
+
+        /// <summary>The declared entries that matched no referenced assembly, in the order written.</summary>
+        public IReadOnlyList<string> Unmatched => _patterns
+            .Select(p => p.pattern)
+            .Where(p => !_matchedPatterns.Contains(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        private static System.Text.RegularExpressions.Regex NameGlobToRegex(string glob)
+        {
+            var sb = new StringBuilder("^");
+            foreach (var c in glob)
+            {
+                if (c == '*') sb.Append(".*");
+                else if (c == '?') sb.Append('.');
+                else sb.Append(System.Text.RegularExpressions.Regex.Escape(c.ToString()));
+            }
+            sb.Append('$');
+            return new System.Text.RegularExpressions.Regex(sb.ToString(),
+                System.Text.RegularExpressions.RegexOptions.CultureInvariant |
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         }
     }
 

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -463,6 +463,15 @@ internal static class ProjectBuild
                          $"{mods.LazyChunkCount} on demand ({mods.LazyTypeCount} type(s) deferred){ChunkSizes(mods)}");
             log.Info($"  index.html: {(config.HtmlDisabled ? "disabled" : "generated")}");
             if (dllPath is not null) log.Info($"  dll:        {dllPath}");
+            if (siteResult.UnscriptedReferences.Count > 0)
+                log.Info($"  not loaded: {string.Join(", ", siteResult.UnscriptedReferences)} " +
+                         "(dontLoadReferences — extracted, but not referenced from index.html)");
+            // An entry that matches nothing fails silently — the library goes on loading as if the
+            // setting were not there — so say so. A warning rather than an error: a dropped dependency
+            // must not break the build of a project that still lists it here.
+            foreach (var pattern in siteResult.UnmatchedDontLoadReferences)
+                MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeDontLoadReferenceUnmatched,
+                    $"tps.json 'dontLoadReferences' entry '{pattern}' matched no referenced assembly.");
             if (siteResult.RemovedStaleFiles.Count > 0)
             {
                 var stale = siteResult.RemovedStaleFiles;

--- a/Transpose/Transpose.Compiler.Core/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler.Core/TransposeJson.cs
@@ -91,6 +91,33 @@ internal sealed class TransposeJson
     /// </summary>
     public bool LoadCompiledOutput { get; init; } = true;
 
+    /// <summary>
+    /// <c>dontLoadReferences</c> — the names of referenced assemblies whose JavaScript this project
+    /// copies into its site but does <em>not</em> reference from the generated <c>index.html</c>.
+    /// Each entry is matched (case-insensitively, with <c>*</c>/<c>?</c> wildcards) against a
+    /// reference's assembly name — <c>Tesserae.Plotly</c>, not <c>Tesserae.Plotly.dll</c>.
+    ///
+    /// It is the consumer-side counterpart of <see cref="LoadCompiledOutput"/>: that flag lets a
+    /// <em>library</em> say "copy my bundle but do not script it", and this one lets an
+    /// <em>application</em> say the same about a library that did not. The use it exists for is a
+    /// heavy binding — a chart or map library — that only one screen needs: the application fetches it
+    /// with <c>Transpose.Require</c> (or <c>Transpose.Modules</c>) the first time that screen opens,
+    /// and pays nothing for it on start-up.
+    ///
+    /// Everything the reference contributes is still extracted into the site — its bundle, its
+    /// authored scripts, its stylesheets, its images — so the files are there to be fetched; the only
+    /// thing suppressed is the <c>&lt;script&gt;</c>/<c>&lt;link&gt;</c> index.html would carry, for
+    /// every resource kind alike (the same reach the resource <c>load</c> flag has). Loading the code
+    /// before it is used is then the application's job: reaching a deferred type without doing so
+    /// fails at run time, exactly as it would for any library the page never loaded.
+    ///
+    /// It names an <em>assembly</em>, so it applies to a NuGet package reference and to a project
+    /// reference consumed as a DLL (<c>--separate-assemblies</c>, which is how the SDK builds). A
+    /// project reference compiled from source into this project's own bundle has no separate bundle to
+    /// leave out, and is unaffected.
+    /// </summary>
+    public List<string> DontLoadReferences { get; init; } = new();
+
     /// <summary>reflection.disabled — when true, no reflection metadata is emitted.</summary>
     public bool ReflectionDisabled { get; init; }
 
@@ -154,6 +181,7 @@ internal sealed class TransposeJson
             CleanOutputFolder = merged.CleanOutputFolder ?? true,
             LoadCompiledOutput = merged.LoadCompiledOutput ?? true,
             CleanOutputFolderExclude = merged.CleanOutputFolderExclude,
+            DontLoadReferences = merged.DontLoadReferences,
             ReflectionDisabled = merged.ReflectionDisabled ?? false,
             ReflectionTarget = merged.ReflectionTarget ?? "file",
             ModuleMinChunkBytes = merged.ModuleMinChunkBytes ?? Emitter.DefaultMinChunkBytes,
@@ -177,6 +205,7 @@ internal sealed class TransposeJson
         public bool? CleanOutputFolder;
         public bool? LoadCompiledOutput;
         public List<string> CleanOutputFolderExclude = new();
+        public List<string> DontLoadReferences = new();
         public bool? ReflectionDisabled;
         public string? ReflectionTarget;
         public int? ModuleMinChunkBytes;
@@ -198,6 +227,7 @@ internal sealed class TransposeJson
                 CleanOutputFolder = o.CleanOutputFolder ?? b.CleanOutputFolder,
                 LoadCompiledOutput = o.LoadCompiledOutput ?? b.LoadCompiledOutput,
                 CleanOutputFolderExclude = b.CleanOutputFolderExclude.Concat(o.CleanOutputFolderExclude).ToList(),
+                DontLoadReferences = b.DontLoadReferences.Concat(o.DontLoadReferences).ToList(),
                 ReflectionDisabled = o.ReflectionDisabled ?? b.ReflectionDisabled,
                 ReflectionTarget = o.ReflectionTarget  ?? b.ReflectionTarget,
                 ModuleMinChunkBytes = o.ModuleMinChunkBytes ?? b.ModuleMinChunkBytes,
@@ -231,6 +261,10 @@ internal sealed class TransposeJson
         var cleanExclude = new List<string>();
         if (root.TryGetProperty("cleanOutputFolderExclude", out var ce) && ce.ValueKind == JsonValueKind.Array)
             cleanExclude.AddRange(ce.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!));
+
+        var dontLoadReferences = new List<string>();
+        if (root.TryGetProperty("dontLoadReferences", out var dlr) && dlr.ValueKind == JsonValueKind.Array)
+            dontLoadReferences.AddRange(dlr.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!));
 
         var resources = new List<ResourceGroup>();
         if (root.TryGetProperty("resources", out var res) && res.ValueKind == JsonValueKind.Array)
@@ -267,6 +301,7 @@ internal sealed class TransposeJson
             CleanOutputFolder = Bool(root, "cleanOutputFolder"),
             LoadCompiledOutput = Bool(root, "loadCompiledOutput"),
             CleanOutputFolderExclude = cleanExclude,
+            DontLoadReferences = dontLoadReferences,
             ReflectionDisabled = reflection.ValueKind == JsonValueKind.Object && reflection.TryGetProperty("disabled", out var rd)
                 ? rd.ValueKind == JsonValueKind.True
                 : (bool?)null,

--- a/Transpose/Transpose.Compiler.Core/TransposeJson.cs
+++ b/Transpose/Transpose.Compiler.Core/TransposeJson.cs
@@ -223,6 +223,7 @@ internal sealed class TransposeJson
                 HtmlTitle        = o.HtmlTitle         ?? b.HtmlTitle,
                 HtmlBody         = o.HtmlBody          ?? b.HtmlBody,
                 HtmlHead         = o.HtmlHead          ?? b.HtmlHead,
+                HtmlMeta         = o.HtmlMeta          ?? b.HtmlMeta,
                 Resources        = b.Resources.Concat(o.Resources).ToList(),
                 CleanOutputFolder = o.CleanOutputFolder ?? b.CleanOutputFolder,
                 LoadCompiledOutput = o.LoadCompiledOutput ?? b.LoadCompiledOutput,

--- a/Transpose/Transpose.Translator.Tests/DontLoadReferenceTests.cs
+++ b/Transpose/Transpose.Translator.Tests/DontLoadReferenceTests.cs
@@ -1,0 +1,247 @@
+using Mono.Cecil;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers the tps.json <c>dontLoadReferences</c> list: the consumer-side counterpart of a library's
+/// <c>loadCompiledOutput: false</c>. An application names a referenced assembly, and everything that
+/// assembly contributes is still extracted into the site — its bundle, its authored scripts, its
+/// stylesheets — while none of it is referenced from the generated <c>index.html</c>. That is what
+/// lets a heavy binding only one screen needs (a chart library, a map) be fetched by the application
+/// itself the first time that screen opens instead of on every page load.
+///
+/// The library needs no cooperation: the flag lives entirely in the consuming project, which is the
+/// whole point — a published package cannot know which of its consumers wants it lazily.
+/// </summary>
+[TestClass]
+public sealed class DontLoadReferenceTests
+{
+    private string _root = "";
+    private string _projectDir = "";
+    private string _libDir = "";
+    private string _outputDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-dontload-ref-" + Guid.NewGuid().ToString("N"));
+        _projectDir = Path.Combine(_root, "app");
+        _libDir = Path.Combine(_root, "lib");
+        _outputDir = Path.Combine(_root, "site");
+        Directory.CreateDirectory(_projectDir);
+        Directory.CreateDirectory(_libDir);
+        Directory.CreateDirectory(_outputDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>Writes <paramref name="tpsJson"/> as the application's tps.json and loads it.</summary>
+    private TransposeJson AppConfig(string tpsJson)
+    {
+        File.WriteAllText(Path.Combine(_projectDir, "tps.json"), tpsJson);
+        var config = TransposeJson.TryLoad(_projectDir, "Debug");
+        Assert.IsNotNull(config, "tps.json must load");
+        return config!;
+    }
+
+    private ResolvedProject Project(params string[] referencePaths) => new()
+    {
+        CsprojPath = Path.Combine(_projectDir, "App.csproj"),
+        ProjectDir = _projectDir,
+        AssemblyName = "App",
+        TargetFramework = "netstandard2.0",
+        Sources = new List<(string, string)>(),
+        ReferencePaths = referencePaths.ToList(),
+        DefineConstants = new List<string>(),
+        LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+        ProjectDirs = new List<string> { _projectDir },
+    };
+
+    /// <summary>
+    /// Builds a package DLL for <paramref name="assemblyName"/> the way <c>tps --emit-package</c> does:
+    /// a compiled bundle (in both variants, tagged), one authored script and one stylesheet. That is
+    /// the shape a real binding package has — Tesserae.Plotly ships its own compiled code plus the
+    /// vendored library it binds to — so the test exercises every kind of file a reference can inject.
+    /// </summary>
+    private string PackageDll(string assemblyName)
+    {
+        var libProjectDir = Path.Combine(_libDir, assemblyName);
+        Directory.CreateDirectory(libProjectDir);
+        File.WriteAllText(Path.Combine(libProjectDir, "vendor.js"), "// the vendored library");
+        File.WriteAllText(Path.Combine(libProjectDir, "lib.css"), ".lib { }");
+        File.WriteAllText(Path.Combine(libProjectDir, "tps.json"), $@"{{
+            ""fileName"": ""{assemblyName}.js"",
+            ""resources"": [
+                {{ ""name"": ""{assemblyName}-vendor.js"", ""files"": [ ""vendor.js"" ] }},
+                {{ ""name"": ""{assemblyName}.css"",      ""files"": [ ""lib.css"" ] }}
+            ]
+        }}");
+        var libConfig = TransposeJson.TryLoad(libProjectDir, "Release")!;
+
+        var items = OutputBuilder.CollectEmbeddableItems(
+            libProjectDir, libConfig, assemblyName + ".js", $"var {assemblyName.Replace('.', '_')} = 1;", null);
+
+        byte[] bytes;
+        using (var asm = AssemblyDefinition.CreateAssembly(
+                   new AssemblyNameDefinition(assemblyName, new Version(1, 0, 0, 0)), assemblyName, ModuleKind.Dll))
+        using (var ms = new MemoryStream())
+        {
+            asm.Write(ms);
+            bytes = ms.ToArray();
+        }
+
+        var path = Path.Combine(_libDir, assemblyName + ".dll");
+        ResourceEmbedder.Embed(path, bytes, items);
+        return path;
+    }
+
+    private OutputBuilder.SiteBuildResult Build(TransposeJson config, ResolvedProject project)
+        => OutputBuilder.Build(project, config, "var app = 1;", _outputDir, "Debug");
+
+    private string IndexHtml()
+    {
+        var html = Path.Combine(_outputDir, "index.html");
+        Assert.IsTrue(File.Exists(html), "the build must generate index.html");
+        return File.ReadAllText(html);
+    }
+
+    private void AssertInOutput(string rel, string because)
+        => Assert.IsTrue(File.Exists(Path.Combine(_outputDir, rel.Replace('/', Path.DirectorySeparatorChar))), because);
+
+    // ---------------------------------------------------------------- parsing
+
+    [TestMethod]
+    public void TheListIsReadFromTpsJsonAndDefaultsToEmpty()
+    {
+        Assert.AreEqual(0, AppConfig(@"{ ""fileName"": ""app.js"" }").DontLoadReferences.Count,
+            "a project that says nothing must load every reference, as it always did");
+
+        var config = AppConfig(@"{
+            ""fileName"": ""app.js"",
+            ""dontLoadReferences"": [ ""Tesserae.Plotly"", ""Tesserae.GraphKit"" ]
+        }");
+
+        CollectionAssert.AreEqual(new[] { "Tesserae.Plotly", "Tesserae.GraphKit" }, config.DontLoadReferences);
+    }
+
+    [TestMethod]
+    public void AConfigurationOverlayAddsToTheList()
+    {
+        // Same rule the other list settings follow (resources, cleanOutputFolderExclude): the overlay
+        // extends the base rather than replacing it, so a Release-only exclusion is one line.
+        File.WriteAllText(Path.Combine(_projectDir, "tps.json"),
+            @"{ ""dontLoadReferences"": [ ""Tesserae.Plotly"" ] }");
+        File.WriteAllText(Path.Combine(_projectDir, "tps.Release.json"),
+            @"{ ""dontLoadReferences"": [ ""Tesserae.GraphKit"" ] }");
+
+        var config = TransposeJson.TryLoad(_projectDir, "Release")!;
+        CollectionAssert.AreEqual(new[] { "Tesserae.Plotly", "Tesserae.GraphKit" }, config.DontLoadReferences);
+    }
+
+    // ---------------------------------------------------------------- site build
+
+    [TestMethod]
+    public void ANamedReferenceIsExtractedButNeverReferencedFromIndexHtml()
+    {
+        var plotly = PackageDll("Tesserae.Plotly");
+        var core = PackageDll("Tesserae");
+
+        var result = Build(AppConfig(@"{
+            ""fileName"": ""app.js"",
+            ""dontLoadReferences"": [ ""Tesserae.Plotly"" ]
+        }"), Project(plotly, core));
+
+        var html = IndexHtml();
+
+        // Every file the suppressed package carries is still on disk — that is what makes it
+        // fetchable at run time — and none of it is in index.html.
+        AssertInOutput("Tesserae.Plotly.js", "the suppressed package's bundle must still be extracted");
+        AssertInOutput("Tesserae.Plotly-vendor.js", "its authored script must still be extracted");
+        AssertInOutput("Tesserae.Plotly.css", "its stylesheet must still be extracted");
+        Assert.IsFalse(html.Contains("Tesserae.Plotly"), "nothing from a dontLoadReferences assembly may appear in index.html");
+
+        // …while the reference next to it is untouched.
+        StringAssert.Contains(html, "src=\"Tesserae.js\"", "an unlisted reference must still be scripted");
+        StringAssert.Contains(html, "src=\"Tesserae-vendor.js\"", "its authored script must still be scripted");
+        StringAssert.Contains(html, "href=\"Tesserae.css\"", "its stylesheet must still be linked");
+
+        CollectionAssert.AreEqual(new[] { "Tesserae.Plotly" }, result.UnscriptedReferences.ToArray(),
+            "the build must report which references it left unscripted");
+        Assert.AreEqual(0, result.UnmatchedDontLoadReferences.Count);
+    }
+
+    [TestMethod]
+    public void TheApplicationsOwnBundleIsUnaffected()
+    {
+        var plotly = PackageDll("Tesserae.Plotly");
+        Build(AppConfig(@"{
+            ""fileName"": ""app.js"",
+            ""dontLoadReferences"": [ ""Tesserae.Plotly"" ]
+        }"), Project(plotly));
+
+        StringAssert.Contains(IndexHtml(), "src=\"app.js\"",
+            "the setting names references; the project's own compiled output is loadCompiledOutput's business");
+    }
+
+    [TestMethod]
+    public void APatternMatchesByWildcardCaseAndTheDllSuffix()
+    {
+        var plotly = PackageDll("Tesserae.Plotly");
+        var graphKit = PackageDll("Tesserae.GraphKit");
+        var core = PackageDll("Tesserae");
+
+        var result = Build(AppConfig(@"{
+            ""fileName"": ""app.js"",
+            ""dontLoadReferences"": [ ""tesserae.PLOTLY"", ""Tesserae.Graph*.dll"" ]
+        }"), Project(plotly, graphKit, core));
+
+        var html = IndexHtml();
+        Assert.IsFalse(html.Contains("Tesserae.Plotly"), "an assembly name is a name, so matching is case-insensitive");
+        Assert.IsFalse(html.Contains("Tesserae.GraphKit"), "a wildcard pattern must match, and a .dll suffix must be tolerated");
+        StringAssert.Contains(html, "src=\"Tesserae.js\"", "a prefix must not match the whole namespace by accident");
+
+        CollectionAssert.AreEqual(new[] { "Tesserae.GraphKit", "Tesserae.Plotly" }, result.UnscriptedReferences.ToArray());
+    }
+
+    [TestMethod]
+    public void AnEntryThatMatchesNoReferenceIsReported()
+    {
+        // The silent failure mode this guards: a typo, or a dependency that has since been dropped,
+        // leaves the library loading exactly as if the setting had never been written.
+        var core = PackageDll("Tesserae");
+
+        var result = Build(AppConfig(@"{
+            ""fileName"": ""app.js"",
+            ""dontLoadReferences"": [ ""Tesserae.Plotly"", ""Tesserae"" ]
+        }"), Project(core));
+
+        CollectionAssert.AreEqual(new[] { "Tesserae.Plotly" }, result.UnmatchedDontLoadReferences.ToArray());
+        CollectionAssert.AreEqual(new[] { "Tesserae" }, result.UnscriptedReferences.ToArray());
+    }
+
+    [TestMethod]
+    public void AReferencedProjectDllIsSuppressedTheSameWay()
+    {
+        // The same reference consumed as a built project output (--separate-assemblies, which is how
+        // the SDK builds a multi-project app) goes through a different extractor. Both must obey.
+        var plotly = PackageDll("Tesserae.Plotly");
+        var project = Project(plotly);
+        project.ReferencedProjectDlls.Add(plotly);
+
+        Build(AppConfig(@"{
+            ""fileName"": ""app.js"",
+            ""dontLoadReferences"": [ ""Tesserae.Plotly"" ]
+        }"), project);
+
+        AssertInOutput("Tesserae.Plotly.js", "a suppressed project DLL's bundle must still be extracted");
+        AssertInOutput("Tesserae.Plotly.css", "its stylesheet must still be extracted");
+        Assert.IsFalse(IndexHtml().Contains("Tesserae.Plotly"), "and none of it may be referenced from index.html");
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/TransposeJsonOverlayTests.cs
+++ b/Transpose/Transpose.Translator.Tests/TransposeJsonOverlayTests.cs
@@ -1,0 +1,112 @@
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Covers the <c>tps.&lt;Configuration&gt;.json</c> overlay: a per-configuration file merged on top of
+/// <c>tps.json</c>, where a scalar the overlay sets wins and everything it says nothing about is
+/// inherited from the base.
+///
+/// The merge is written field by field, so the failure mode a new setting invites is a silent one —
+/// forget to list it and an overlay does not override it, it <em>erases</em> it, because the merged
+/// result starts from a blank draft. That is what happened to <c>html.meta</c>: any project with an
+/// overlay lost the meta tags its base tps.json declared, and index.html simply came out without them.
+/// <see cref="AnOverlayInheritsEverySettingItDoesNotItselfSet"/> is the guard: it declares every
+/// setting in the base, overlays a single unrelated one, and asserts the rest survive.
+/// </summary>
+[TestClass]
+public sealed class TransposeJsonOverlayTests
+{
+    private string _projectDir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _projectDir = Path.Combine(Path.GetTempPath(), "tps-overlay-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_projectDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_projectDir)) Directory.Delete(_projectDir, recursive: true); } catch { }
+    }
+
+    private void Write(string name, string content) => File.WriteAllText(Path.Combine(_projectDir, name), content);
+
+    [TestMethod]
+    public void AnOverlayInheritsEverySettingItDoesNotItselfSet()
+    {
+        Write("tps.json", @"{
+            ""output"": ""$(OutDir)/tps/"",
+            ""outputBy"": ""Module"",
+            ""fileName"": ""app.js"",
+            ""loadCompiledOutput"": false,
+            ""cleanOutputFolder"": false,
+            ""cleanOutputFolderExclude"": [ ""favicon.ico"" ],
+            ""dontLoadReferences"": [ ""Tesserae.Plotly"" ],
+            ""modules"": { ""minChunkSize"": 1234, ""maxChunkSize"": 5678 },
+            ""reflection"": { ""disabled"": true, ""target"": ""inline"" },
+            ""html"": {
+                ""disabled"": true,
+                ""title"": ""Base title"",
+                ""head"": ""<link rel=\""icon\"" href=\""favicon.ico\"">"",
+                ""meta"": ""<meta name=\""viewport\"" content=\""width=device-width\"">"",
+                ""body"": ""<div id=\""app\""></div>""
+            },
+            ""resources"": [ { ""name"": ""site.css"", ""files"": [ ""assets/site.css"" ] } ]
+        }");
+
+        // The overlay speaks about one thing only. Everything else must come through untouched.
+        Write("tps.Release.json", @"{ ""fileName"": ""app.release.js"" }");
+
+        var config = TransposeJson.TryLoad(_projectDir, "Release");
+        Assert.IsNotNull(config);
+
+        Assert.AreEqual("app.release.js", config!.FileName, "the overlay's own setting must win");
+
+        Assert.AreEqual("$(OutDir)/tps/", config.Output);
+        Assert.AreEqual("Module", config.OutputBy);
+        Assert.IsFalse(config.LoadCompiledOutput);
+        Assert.IsFalse(config.CleanOutputFolder);
+        CollectionAssert.AreEqual(new[] { "favicon.ico" }, config.CleanOutputFolderExclude);
+        CollectionAssert.AreEqual(new[] { "Tesserae.Plotly" }, config.DontLoadReferences);
+        Assert.AreEqual(1234, config.ModuleMinChunkBytes);
+        Assert.AreEqual(5678, config.ModuleMaxChunkBytes);
+        Assert.IsTrue(config.ReflectionDisabled);
+        Assert.AreEqual("inline", config.ReflectionTarget);
+        Assert.IsTrue(config.HtmlDisabled);
+        Assert.AreEqual("Base title", config.HtmlTitle);
+        StringAssert.Contains(config.HtmlHead, "favicon.ico");
+        StringAssert.Contains(config.HtmlMeta, "viewport", "html.meta must survive an overlay");
+        StringAssert.Contains(config.HtmlBody, "id=\"app\"");
+        Assert.AreEqual(1, config.Resources.Count);
+    }
+
+    [TestMethod]
+    public void AnOverlayOverridesTheHtmlSettingsItDoesSet()
+    {
+        Write("tps.json", @"{
+            ""html"": { ""title"": ""Base"", ""meta"": ""<meta name=\""env\"" content=\""base\"">"" }
+        }");
+        Write("tps.Release.json", @"{
+            ""html"": { ""meta"": ""<meta name=\""env\"" content=\""release\"">"" }
+        }");
+
+        var config = TransposeJson.TryLoad(_projectDir, "Release")!;
+
+        StringAssert.Contains(config.HtmlMeta, "release");
+        Assert.AreEqual("Base", config.HtmlTitle, "a setting the overlay is silent about stays as the base wrote it");
+    }
+
+    [TestMethod]
+    public void WithNoOverlayForTheConfigurationTheBaseIsUsedAsIs()
+    {
+        Write("tps.json", @"{ ""html"": { ""meta"": ""<meta charset=\""utf-8\"">"" } }");
+        Write("tps.Release.json", @"{ ""fileName"": ""app.release.js"" }");
+
+        var debug = TransposeJson.TryLoad(_projectDir, "Debug")!;
+        StringAssert.Contains(debug.HtmlMeta, "charset");
+        Assert.AreEqual("app.js", debug.FileName, "the Release overlay must not reach a Debug build");
+    }
+}

--- a/docs/compiler-config.md
+++ b/docs/compiler-config.md
@@ -69,6 +69,44 @@ The flag survives packaging. When a library declares `"load": false`, that is re
 the resource manifest embedded in its DLL, so a project *referencing* the library also
 extracts the file into its site without referencing it from its own `index.html`.
 
+### References You Load Yourself
+
+A referenced library is scripted from `index.html` in dependency order, before your own bundle.
+That is right for a library the application needs at start-up and wasteful for one a single
+screen needs — a chart or map binding can be several megabytes on every page load. List such a
+reference in `dontLoadReferences` and the compiler extracts everything it contributes into the
+site as usual but references none of it from `index.html`:
+
+```jsonc
+{
+  "dontLoadReferences": [ "Tesserae.Plotly" ]
+}
+```
+
+- Each entry is matched against a referenced assembly's **name** (`Tesserae.Plotly`, not a path),
+  case-insensitively, with `*`/`?` wildcards; a `.dll` suffix is accepted and ignored.
+- It applies to everything that assembly ships — its compiled bundle, its authored scripts, its
+  stylesheets — for the same reason the resource `load` flag does: the point is that the page
+  loads none of it until the application asks.
+- An entry that matches no referenced assembly is reported as a warning (`TPS0106`), so a typo or
+  a dependency you have since dropped does not silently do nothing.
+
+Loading the library is then your code's job, the first time it needs it:
+
+```csharp
+await Transpose.Require.RequireAsync("plotly.js", "Tesserae.Plotly.js");
+var chart = new Tesserae.Plotly.PlotlyChart().Title("deferred chart");
+```
+
+`Require` falls back between the `.js` and `.min.js` spellings of the same file, so one call
+works in a Debug site (which carries the readable bundle) and in a Release site (the minified
+one) alike. Reaching the deferred code *before* it is loaded fails at run time, exactly as it
+would for any library the page never loaded.
+
+This is the consumer-side counterpart of `loadCompiledOutput: false`, which a *library* sets to
+keep its own bundle out of index.html. Use that when the library knows it is loaded on demand,
+and `dontLoadReferences` when the application decides it for a library that does not.
+
 ### Output Folder Cleanup
 
 Transpose keeps the output folder free of stale artifacts with `cleanOutputFolder`


### PR DESCRIPTION
A referenced library is scripted from the generated index.html in dependency
order, which is right for one the application needs at start-up and wasteful
for one a single screen needs: an app referencing Tesserae.Plotly paid 10.5 MB
(Tesserae.Plotly.js + plotly.js) on every page load whether or not a chart was
ever shown. The library cannot fix this for everyone — `loadCompiledOutput`
lets it opt its own bundle out, but only one of its consumers may want it
lazily — so the decision belongs to the consuming project.

tps.json gains `dontLoadReferences`: a list of referenced assembly names whose
JavaScript the site copies but never scripts. Everything the assembly ships is
still extracted — its bundle, its authored scripts, its stylesheets — and none
of it reaches index.html, the same reach the resource `load` flag has; loading
it is then the application's job (Transpose.Require, Transpose.Modules).
Entries match an assembly name case-insensitively with */? wildcards and a
tolerated .dll suffix, and one that matches no reference is reported as
TPS0106 — its failure mode is otherwise silent, the library loading exactly as
if the setting were absent. The build also prints which references it left
unscripted.

Verified end to end against the published Tesserae.Plotly package in headless
Chromium: at boot neither the Plotly global nor the tss.PlotlyChart binding
exists, the app then awaits Require.RequireAsync("plotly.js",
"Tesserae.Plotly.js"), constructs a PlotlyChart and Plotly renders it — in a
Debug site and in a Release one, where Require's .js/.min.js fallback finds the
minified names the site actually carries.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JWkRCi1uy5d4jmHeVmX5zT