### PR TITLE
Bring the dotnet new template's package pins up to date

### DIFF
--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <!-- Inherits LangVersion=latest from the Transpose.Build.Target SDK; pin an older
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
-        <PackageReference Include="Transpose.Core" Version="26.7.3106" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.3066" />
+        <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+        <PackageReference Include="Transpose.Core" Version="26.8.4597" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4599" />
         <PackageReference Include="Tesserae" Version="2026.7.68468" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
The `dotnet new` template was scaffolding a 26.7 project.

| Package | From | To |
| --- | --- | --- |
| `Transpose.BCL` | 26.7.3104 | **26.8.4619** |
| `Transpose.Core` | 26.7.3106 | **26.8.4597** |
| `Transpose.Newtonsoft.Json` | 26.7.3066 | **26.8.4599** |
| `Transpose.Build.Target` (SDK) | 26.7.3049 | **26.8.4125** |

## Why this one matters more than an ordinary stale pin

`dotnet new` hands a new user a 26.7 runtime, and the compiler they installed a minute earlier with `dotnet tool install --global Transpose.Compiler` is 26.8.4618. That pairing is exactly the direction the `Transpose.Build.json` stamp cannot catch: `TPS0008` fires when a *reference* needs a newer compiler, not when a newer compiler is fed an older runtime. The latter fails at run time instead — the compiler emits a call into `tps.js` that the pinned runtime does not carry, and the page comes up blank with one console error. It is a bad first five minutes with the product, and it gets worse every release.

## Scope

Only the template. The floors in `BCL/` and `Packages/` are raised separately in #151, which touches a disjoint set of files — the two can merge in either order.

## Verification

Copied `templates/MyProject.csproj` and `templates/Program.cs` into a clean directory and built in **Release** against compiler 26.8.4618: succeeded, no warnings and no errors.

`Transpose.BCL` 26.8.4619 carries a build stamp of `26.8.4618`, so it needs `Transpose.Compiler` >= 26.8.4618 — the newest published compiler, which is what the install line in the template's own getting-started path provides.

The `Tesserae` reference in the template is left at 2026.7.68468 — it is not a Transpose package, and an older assembly is always safe to consume (the stamp check only rejects a reference that needs a *newer* compiler). Worth a separate bump.