### PR TITLE
Cache-bust every URL Transpose.Require fetches

### DIFF
--- a/.claude/skills/transpose-performance/SKILL.md
+++ b/.claude/skills/transpose-performance/SKILL.md
@@ -185,6 +185,9 @@ A compiler optimization that changes output is a bug, not an optimization. Befor
    covers both the package build and the site build):
    ```bash
    cd <tesserae>
+   # Each build stamps a fresh cache-busting token into its bundles (Transpose.Require), which is the
+   # one line of the output that is not reproducible. Pin it so the diff is about your change.
+   export TRANSPOSE_CACHE_BUST=fixed
    rm -rf Tesserae/bin Tesserae/obj Tesserae.Tests/bin Tesserae.Tests/obj
    $BASE --project Tesserae.Tests/Tesserae.Tests.csproj -c Debug -q
    cp -r Tesserae.Tests/bin/Debug/netstandard2.0/tps /tmp/out-base
@@ -193,9 +196,12 @@ A compiler optimization that changes output is a bug, not an optimization. Befor
    cp -r Tesserae.Tests/bin/Debug/netstandard2.0/tps /tmp/out-new
    diff -r /tmp/out-base /tmp/out-new
    ```
-   Output is byte-reproducible as of the enumerator-naming fix, so `diff -r` should be silent. If you
-   are comparing against a compiler older than that fix, normalise `$e<hex>` names first
-   (see [`scripts/compare-site.sh`](scripts/compare-site.sh)).
+   Output is byte-reproducible as of the enumerator-naming fix, so `diff -r` should be silent — with
+   `TRANSPOSE_CACHE_BUST` pinned; without it every bundle differs by its `Transpose.Require.cacheBust`
+   line and the diff tells you nothing. A baseline compiler predating cache-busting emits no such line
+   at all, so compare that one with `TRANSPOSE_CACHE_BUST=` (empty, i.e. busting off) instead. If you
+   are comparing against a compiler older than the enumerator-naming fix, normalise `$e<hex>` names
+   first (see [`scripts/compare-site.sh`](scripts/compare-site.sh)).
 3. **Touching `UnsupportedFeatureScanner`**: also diff the diagnostics of a file exercising every rule
    (pointers, `unsafe`, `checked`, `nint`, P/Invoke, `System.IO`/`System.Threading` types, a using
    alias and a static import) — see the scanner section of `TODO.optimization.md`.

--- a/BCL/Transpose.BCL/Resources/Require.js
+++ b/BCL/Transpose.BCL/Resources/Require.js
@@ -19,6 +19,13 @@
     //     once cannot know which build is consuming it, so asking for either name has to work;
     //   * remembers what it loaded, so N callers share one fetch — and forgets what failed, so a
     //     later caller can retry rather than inheriting a poisoned result forever.
+    //   * busts the browser/CDN cache: every URL it injects carries this build's token as a query
+    //     ("assets/js/graph-kit.min.js?1q9v3k2abc"), so a redeployed page never serves the copy the
+    //     browser kept of a file whose NAME did not change. The token is stamped into each compiled
+    //     assembly's prelude (Transpose.Require.cacheBust), so it moves when a build moves and stands
+    //     still when nothing was rebuilt. It is applied at injection only — everything that identifies
+    //     a URL (the shared-fetch table, isLoaded, "index.html already carries this file") still works
+    //     on the URL as asked for.
     //
     // Loading is sequential when several URLs are given: a plugin that extends a library has to
     // arrive after it, and that is the common case (d3 then d3.lasso). A caller that genuinely wants
@@ -29,6 +36,9 @@
         $pending: {},
         // resolved url -> true once it is on the page
         $loaded: {},
+        // this page's cache-busting token, appended to every URL that is actually fetched. Set by the
+        // prelude of each compiled assembly; "" (nothing stamped it) means no busting at all.
+        $bust: "",
 
         /// Loads one or more URLs, in order, and completes when the last one has run. `kind` is one
         /// of Transpose.Require.kinds; 0 (auto) picks the element from the URL.
@@ -53,6 +63,16 @@
         },
 
         kinds: { auto: 0, script: 1, module: 2, style: 3 },
+
+        /// Registers a build's cache-busting token. A page can carry several compiled assemblies, each
+        /// stamped when *it* was built and loading in whatever order index.html (or an import graph)
+        /// puts them in, so the greatest token wins rather than the last one: the compiler mints them
+        /// as a fixed-width base-36 time stamp plus a random tail, which makes "greater" mean "newer
+        /// build". Assigning $bust directly overrides that, which is what a host or a test does.
+        cacheBust: function (token) {
+            if (typeof token === "string" && token > require.$bust) require.$bust = token;
+            return require.$bust;
+        },
 
         $one: function (url, kind) {
             if (typeof document === "undefined") {
@@ -147,6 +167,24 @@
             return null;
         },
 
+        /// The URL as it is fetched: the one that was asked for plus this build's token, as a query
+        /// with no value ("x.js?1q9v3k2abc", "x.js?v=7&1q9v3k2abc"). Only http(s) — and a URL that was
+        /// never resolved to a scheme at all — is served by something that caches; a data:/blob:
+        /// payload carries its own bytes and a query would corrupt it.
+        $bustUrl: function (url) {
+            if (!require.$bust) return url;
+            var colon = url.indexOf(":");
+            if (colon > 0) {
+                var scheme = url.substring(0, colon).toLowerCase();
+                if (scheme !== "http" && scheme !== "https") return url;
+            }
+            // A fragment stays at the end, where the browser expects it.
+            var hash = url.indexOf("#");
+            var head = hash >= 0 ? url.substring(0, hash) : url;
+            var tail = hash >= 0 ? url.substring(hash) : "";
+            return head + (head.indexOf("?") >= 0 ? "&" : "?") + require.$bust + tail;
+        },
+
         /// The element already serving this URL, if any. Compared on the resolved src/href — the
         /// attribute is whatever spelling the page was written with, the property is absolute.
         $find: function (resolved) {
@@ -181,16 +219,21 @@
 
         $inject: function (url, kind) {
             return new Promise(function (resolve, reject) {
+                // The cache-busting token goes on here and nowhere else: $pending, $loaded, isLoaded and
+                // $find all key off the URL as the caller asked for it, so a token changing between
+                // builds never turns one file into two entries, and a file index.html already carries
+                // (without a token) is still recognised rather than fetched a second time.
+                var fetched = require.$bustUrl(url);
                 var element;
                 if (kind === require.kinds.style) {
                     element = document.createElement("link");
                     element.rel = "stylesheet";
-                    element.href = url;
+                    element.href = fetched;
                 } else {
                     element = document.createElement("script");
                     if (kind === require.kinds.module) element.type = "module";
                     else element.type = "text/javascript";
-                    element.src = url;
+                    element.src = fetched;
                 }
 
                 element.addEventListener("load", function () { resolve(true); });

--- a/BCL/Transpose.BCL/Resources/Require.js
+++ b/BCL/Transpose.BCL/Resources/Require.js
@@ -67,8 +67,9 @@
         /// Registers a build's cache-busting token. A page can carry several compiled assemblies, each
         /// stamped when *it* was built and loading in whatever order index.html (or an import graph)
         /// puts them in, so the greatest token wins rather than the last one: the compiler mints them
-        /// as a fixed-width base-36 time stamp plus a random tail, which makes "greater" mean "newer
-        /// build". Assigning $bust directly overrides that, which is what a host or a test does.
+        /// as a fixed-width base-36 time stamp (plus a random tail that only keeps two builds apart),
+        /// which makes "greater" mean "newer build". Assigning $bust directly overrides that, which is
+        /// what a host or a test does.
         cacheBust: function (token) {
             if (typeof token === "string" && token > require.$bust) require.$bust = token;
             return require.$bust;

--- a/BCL/Transpose.BCL/Transpose/Require.cs
+++ b/BCL/Transpose.BCL/Transpose/Require.cs
@@ -47,6 +47,24 @@ namespace Transpose
     /// (<c>d3.js</c> then <c>d3.lasso.js</c>), which is the common case. Ask in separate calls, and
     /// await them together, when they are genuinely independent.
     /// </para>
+    ///
+    /// <para>
+    /// Every URL it fetches carries the build's cache-busting token as a query —
+    /// <c>my-library.min.js?1q9v3k2abc</c> — so a page that has been rebuilt and redeployed never
+    /// serves the copy a browser or a CDN kept of a file whose <em>name</em> did not change. The
+    /// compiler stamps one token per build into each assembly it emits and the newest one on the page
+    /// wins, so it moves when a build moves and stands still when nothing was rebuilt. Set
+    /// <c>TRANSPOSE_CACHE_BUST</c> to pin the token, or to empty to switch this off, when a build's
+    /// output has to be byte-identical to another's.
+    /// </para>
+    ///
+    /// <para>
+    /// The token is added where the element is created and nowhere else, so it changes nothing about
+    /// a URL's identity: three spellings of one file are still one fetch,
+    /// <see cref="IsLoaded(string)"/> answers about the URL as it was asked for, and a file
+    /// <c>index.html</c> already carries — written there without a token — is still recognised rather
+    /// than fetched a second time.
+    /// </para>
     /// </summary>
     /// <example>
     /// <code>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -844,6 +844,7 @@ The short version:
   entries. And it is minted **monotonically** (8 base-36 digits of the build time + 3 random), because
   a page carries several assemblies stamped at different times and loading in an order nobody
   controls: the runtime keeps the *greatest* token it is given, so the newest build on the page wins.
+  The time stamp is what orders — the random tail only keeps two builds apart.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 - **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
   reuses the previous build of a project: nothing at all is compiled when every input hashes the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,9 @@ The short version:
   build. Do not "tidy them away".
 - Any change here must keep the emitted site **byte-identical** — output is reproducible, so
   `diff -r` against a baseline compiler is the gate. The emitted **assembly** is reproducible as well
-  (`deterministic: true`), so the DLL is diffable too. The test suite is the other gate.
+  (`deterministic: true`), so the DLL is diffable too. The test suite is the other gate. One line of a
+  bundle is deliberately *not* reproducible — the per-build `Transpose.Require.cacheBust("…")` stamp
+  (see the Require section) — so export `TRANSPOSE_CACHE_BUST=fixed` for both builds before diffing.
 - The benchmark corpus is the **tesserae** submodule at `benchmarks/tesserae`
   (`git submodule update --init benchmarks/tesserae`). Recorded reports live in `docs/perf/`.
 - **Debug and Release are structurally different builds.** Debug emits a *metadata-only* assembly
@@ -822,6 +824,26 @@ The short version:
   above: a library published once cannot know which build is consuming it, so asking for either name
   has to work. Several URLs load in order, because a plugin has to arrive after the library it
   extends. Covered by `RequireLoaderTests`, which runs the real runtime against a DOM stub.
+
+  **Everything it fetches is cache-busted per build.** A file `Require` loads is fetched by a URL the
+  compiler does not version — `assets/js/graph-kit.min.js` is the same URL after the bytes behind it
+  changed — so a browser or a CDN holding the previous copy has no reason to ask again. Every build
+  therefore mints one token (`Transpose.Translator/Support/CacheBust.cs`) and stamps it into each
+  assembly's prelude as `Transpose.Require.cacheBust("…")`, next to the `Transpose.assemblyVersion`
+  call and in the entry module in module mode; the loader appends it as a query to every URL it
+  injects (`my-library.min.js?1q9v3k2abc`, `Admin.js?v=7&1q9v3k2abc`). `TRANSPOSE_CACHE_BUST` pins the
+  token, or switches busting off when set to empty/`0`/`none` — which is what a build whose output has
+  to be **byte-identical** to a baseline's (the reproducibility gate under Performance above) sets.
+
+  Three details are load-bearing. The token is registered **once per assembly**, not baked into each
+  call site: the emitted JavaScript of a type is then the same build over build, which is what lets
+  `--incremental` splice a cached type's JS back in, and a computed URL is busted as readily as a
+  literal one. It is applied **at injection only** (`$inject`), never in what identifies a URL — so
+  the shared-fetch table, `IsLoaded` and "index.html already carries this file" all keep working on
+  the URL as it was asked for, and a token that moves between builds never turns one file into two
+  entries. And it is minted **monotonically** (8 base-36 digits of the build time + 3 random), because
+  a page carries several assemblies stamped at different times and loading in an order nobody
+  controls: the runtime keeps the *greatest* token it is given, so the newest build on the page wins.
 - **Wider `tps.json` surface** (outputBy, module formats, locales, before/after build, etc.).
 - **Incremental compilation (done for body-level edits; on by default via the SDK).** `--incremental`
   reuses the previous build of a project: nothing at all is compiled when every input hashes the same

--- a/Transpose/Transpose.Translator.Tests/CacheBustTests.cs
+++ b/Transpose/Transpose.Translator.Tests/CacheBustTests.cs
@@ -1,0 +1,98 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// <see cref="CacheBust"/>: the token a build stamps into every bundle it emits, which
+    /// <c>Transpose.Require</c> then appends to each URL it fetches, so a redeployed page does not
+    /// serve a browser's cached copy of a file whose name did not change.
+    ///
+    /// <para>
+    /// The suite pins the token (<see cref="TestAssemblySetup"/>) so that comparing two compilations
+    /// means something; these tests take the pin off and put it back, which is safe because MSTest runs
+    /// this assembly sequentially.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class CacheBustTests
+    {
+        private string? _pinned;
+
+        [TestInitialize]
+        public void Unpin()
+        {
+            _pinned = Environment.GetEnvironmentVariable(CacheBust.EnvVar);
+            Environment.SetEnvironmentVariable(CacheBust.EnvVar, null);
+        }
+
+        [TestCleanup]
+        public void Repin() => Environment.SetEnvironmentVariable(CacheBust.EnvVar, _pinned);
+
+        [TestMethod]
+        public void AMintedTokenIsFixedWidthAndOrdersByBuildTime()
+        {
+            var first = CacheBust.NewToken();
+            var second = CacheBust.NewToken();
+
+            Assert.AreEqual(11, first.Length, "8 base-36 digits of the build time plus 3 random ones");
+            Assert.AreEqual(11, second.Length, "every token is the same width — which is what makes "
+                + "comparing two of them as strings mean 'which build is newer'");
+            foreach (var c in first)
+                Assert.IsTrue(char.IsAsciiDigit(c) || (c >= 'a' && c <= 'z'),
+                    $"'{c}' is not a base-36 digit; the token goes into a URL query and a JS string "
+                    + "literal, so it has to need escaping in neither");
+
+            // The two were minted in the same run, so the later one is never the smaller: the runtime
+            // keeps the greatest token a page's assemblies give it, and that has to be the newest build.
+            Assert.IsTrue(string.CompareOrdinal(second, first) >= 0,
+                $"'{second}' minted after '{first}' must not sort before it");
+        }
+
+        [TestMethod]
+        public void TwoBuildsGetDifferentTokens()
+        {
+            // A millisecond stamp alone repeats when two builds land in the same millisecond, which is
+            // exactly what a test loop does; the random tail is what keeps them apart.
+            var tokens = new System.Collections.Generic.HashSet<string>();
+            for (var i = 0; i < 200; i++) tokens.Add(CacheBust.NewToken());
+
+            Assert.IsTrue(tokens.Count > 190,
+                $"200 tokens minted back to back produced only {tokens.Count} distinct values");
+        }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("   ")]
+        [DataRow("0")]
+        [DataRow("none")]
+        [DataRow("FALSE")]
+        public void TheEnvironmentVariableCanSwitchBustingOff(string value)
+        {
+            Environment.SetEnvironmentVariable(CacheBust.EnvVar, value);
+
+            Assert.AreEqual("", CacheBust.NewToken(),
+                "an empty token emits no cacheBust call at all, which is what a build whose output has "
+                + "to be byte-identical to another's asks for");
+        }
+
+        [TestMethod]
+        public void TheEnvironmentVariablePinsTheToken()
+        {
+            Environment.SetEnvironmentVariable(CacheBust.EnvVar, " v2.1_rc-3 ");
+
+            Assert.AreEqual("v2.1_rc-3", CacheBust.NewToken(),
+                "a pinned token is taken as given, trimmed");
+        }
+
+        [TestMethod]
+        public void APinnedTokenIsStrippedOfWhatWouldNeedEscaping()
+        {
+            Environment.SetEnvironmentVariable(CacheBust.EnvVar, "a\"b&c d/e");
+
+            Assert.AreEqual("abcde", CacheBust.NewToken(),
+                "the token is written into a JS string literal and into a URL's query, so anything that "
+                + "would have to be escaped in either is dropped rather than trusted");
+        }
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/CacheBustTests.cs
+++ b/Transpose/Transpose.Translator.Tests/CacheBustTests.cs
@@ -43,10 +43,13 @@ namespace Transpose.Translator.Tests
                     $"'{c}' is not a base-36 digit; the token goes into a URL query and a JS string "
                     + "literal, so it has to need escaping in neither");
 
-            // The two were minted in the same run, so the later one is never the smaller: the runtime
-            // keeps the greatest token a page's assemblies give it, and that has to be the newest build.
-            Assert.IsTrue(string.CompareOrdinal(second, first) >= 0,
-                $"'{second}' minted after '{first}' must not sort before it");
+            // What orders is the 8-digit TIME STAMP, and only that: the runtime keeps the greatest token
+            // a page's assemblies give it, and that has to be the newest build. The 3-character tail is
+            // random and orders nothing — it is there to keep two builds apart, and two tokens minted
+            // in the same millisecond (which is what this loop does, and what no two builds do) can
+            // therefore compare either way.
+            Assert.IsTrue(string.CompareOrdinal(second.Substring(0, 8), first.Substring(0, 8)) >= 0,
+                $"'{second}' minted after '{first}' must not stamp an earlier time");
         }
 
         [TestMethod]

--- a/Transpose/Transpose.Translator.Tests/RequireLoaderTests.cs
+++ b/Transpose/Transpose.Translator.Tests/RequireLoaderTests.cs
@@ -12,6 +12,11 @@ namespace Transpose.Translator.Tests
     /// and can be told which URLs 404. That is what lets the two behaviours worth guarding be asserted
     /// without a browser: which element a URL is loaded with, and the <c>.js</c> ⇄ <c>.min.js</c>
     /// fallback that lets a library published once work in a site built either way.
+    ///
+    /// The stub also pins the cache-busting token (<c>Transpose.Require.$bust</c>) to <c>b1</c>, so the
+    /// query every fetched URL carries is the same in every run — the real one is minted per build and
+    /// would otherwise differ each time. What that token does to a URL, and what it deliberately does
+    /// NOT do to the loader's idea of a URL's identity, is asserted here alongside everything else.
     /// </summary>
     [TestClass]
     public class RequireLoaderTests : TranslatorTestBase
@@ -47,6 +52,10 @@ public static class Dom
                 },
                 getElementsByTagName: function (tag) { return byTag[tag] || []; }
             };
+            // The token the compiled bundle stamped is a fresh one per build; keep it (one test is
+            // about it) and pin a fixed one, so what a request URL looks like can be written down.
+            globalThis.__stamped = Transpose.Require.$bust;
+            Transpose.Require.$bust = 'b1';
             document.head = {
                 appendChild: function (element) {
                     var url = element.src || element.href;
@@ -68,6 +77,12 @@ public static class Dom
     public static void Missing(string url) => Script.Write(""__missing[{0}] = true;"", url);
 
     public static string Requested => Script.Write<string>(""__requested.join('\\n')"");
+
+    /// The token the compiler stamped into this bundle's prelude, before Install() pinned it.
+    public static string Stamped => Script.Write<string>(""__stamped"");
+
+    /// Puts the compiler's own token back, for the one test that is about it.
+    public static void UsedStampedCacheBust() => Script.Write(""Transpose.Require.$bust = __stamped;"");
 }
 ";
 
@@ -93,13 +108,15 @@ public class Program
 }", skipRoslyn: true);
 
             Assert.AreEqual(
-                "style https://site.test/app/assets/css/site.css\n"
-                + "script https://site.test/app/assets/js/d3.js\n"
-                + "module https://site.test/app/chunks/c0.mjs\n"
-                + "module https://site.test/app/Admin.js?v=7",
+                "style https://site.test/app/assets/css/site.css?b1\n"
+                + "script https://site.test/app/assets/js/d3.js?b1\n"
+                + "module https://site.test/app/chunks/c0.mjs?b1\n"
+                + "module https://site.test/app/Admin.js?v=7&b1",
                 output,
                 "a .css is a stylesheet link, a .mjs a module, anything else a classic script — and an "
-                + "explicit kind wins over the extension");
+                + "explicit kind wins over the extension. Every one of them is fetched with the build's "
+                + "cache-busting token appended — as the query when there is none, and after the "
+                + "caller's own query when there is one");
         }
 
         [TestMethod]
@@ -113,8 +130,8 @@ public class Program
     public static async Task Main()
     {
         Dom.Install();
-        Dom.Missing(""https://site.test/app/assets/js/graph-kit.min.js"");
-        Dom.Missing(""https://site.test/app/assets/js/only-minified.js"");
+        Dom.Missing(""https://site.test/app/assets/js/graph-kit.min.js?b1"");
+        Dom.Missing(""https://site.test/app/assets/js/only-minified.js?b1"");
 
         await Require.RequireAsync(""assets/js/graph-kit.min.js"");
         await Require.RequireAsync(""assets/js/only-minified.js"");
@@ -124,10 +141,10 @@ public class Program
 }", skipRoslyn: true);
 
             Assert.AreEqual(
-                "script https://site.test/app/assets/js/graph-kit.min.js\n"
-                + "script https://site.test/app/assets/js/graph-kit.js\n"
-                + "script https://site.test/app/assets/js/only-minified.js\n"
-                + "script https://site.test/app/assets/js/only-minified.min.js",
+                "script https://site.test/app/assets/js/graph-kit.min.js?b1\n"
+                + "script https://site.test/app/assets/js/graph-kit.js?b1\n"
+                + "script https://site.test/app/assets/js/only-minified.js?b1\n"
+                + "script https://site.test/app/assets/js/only-minified.min.js?b1",
                 output,
                 "the fallback goes both ways: a site keeps whichever variant its own build called for");
         }
@@ -149,8 +166,8 @@ public class Program
         await Require.RequireAsync(""https://site.test/app/assets/js/lib.js"");
         Console.WriteLine(""loaded: "" + Require.IsLoaded(""assets/js/lib.js""));
 
-        Dom.Missing(""https://site.test/app/gone.js"");
-        Dom.Missing(""https://site.test/app/gone.min.js"");
+        Dom.Missing(""https://site.test/app/gone.js?b1"");
+        Dom.Missing(""https://site.test/app/gone.min.js?b1"");
         for (var attempt = 0; attempt < 2; attempt++)
         {
             try
@@ -172,15 +189,17 @@ public class Program
                 "loaded: True\n"
                 + "failed: Transpose.Require: failed to load 'https://site.test/app/gone.js'.\n"
                 + "failed: Transpose.Require: failed to load 'https://site.test/app/gone.js'.\n"
-                + "script https://site.test/app/assets/js/lib.js\n"
-                + "script https://site.test/app/gone.js\n"
-                + "script https://site.test/app/gone.min.js\n"
-                + "script https://site.test/app/gone.js\n"
-                + "script https://site.test/app/gone.min.js",
+                + "script https://site.test/app/assets/js/lib.js?b1\n"
+                + "script https://site.test/app/gone.js?b1\n"
+                + "script https://site.test/app/gone.min.js?b1\n"
+                + "script https://site.test/app/gone.js?b1\n"
+                + "script https://site.test/app/gone.min.js?b1",
                 output,
                 "a successful load is shared by every later caller; a failed one is forgotten, so the "
                 + "second attempt really tries again — and it reports the URL that was asked for, not "
-                + "the counterpart it also tried");
+                + "the counterpart it also tried, nor the token appended to fetch it. Three spellings "
+                + "of one file are still one fetch: the token is applied where the element is created, "
+                + "so it never turns one entry into two");
         }
 
         [TestMethod]
@@ -207,7 +226,44 @@ public class Program
 }", skipRoslyn: true);
 
             Assert.AreEqual("loaded before: True\nrequests: []", output,
-                "a file the page already carries is waited on, never fetched a second time");
+                "a file the page already carries is waited on, never fetched a second time — index.html "
+                + "wrote it without a cache-busting token, and busting happens at injection, so the "
+                + "element is still recognised");
+        }
+
+        /// <summary>
+        /// The token itself: the compiler stamps one into every bundle it emits, and it is what the
+        /// loader appends. The other tests pin it so their URLs can be written down; this one puts the
+        /// real one back, which is what a deployed page carries — a file whose name did not change is
+        /// still asked for under a URL nothing has cached.
+        /// </summary>
+        [TestMethod]
+        public async Task EveryFetchCarriesTheTokenThisBuildStampedAsync()
+        {
+            var output = await RunTest(Preamble + @"
+public class Program
+{
+    public static async Task Main()
+    {
+        Dom.Install();
+        Dom.UsedStampedCacheBust();
+
+        await Require.RequireAsync(""assets/js/lib.js"");
+
+        // A cache-busting query says nothing about what kind of file it is, and nothing about which
+        // file it is: the element is still picked from the extension, and asking again is still free.
+        await Require.RequireAsync(""assets/js/lib.js"");
+        Console.WriteLine(""stamped: "" + (Dom.Stamped.Length > 0));
+        Console.WriteLine(""loaded: "" + Require.IsLoaded(""assets/js/lib.js""));
+        Console.WriteLine(Dom.Requested == ""script https://site.test/app/assets/js/lib.js?"" + Dom.Stamped);
+    }
+}", skipRoslyn: true);
+
+            Assert.AreEqual("stamped: True\nloaded: True\nTrue", output,
+                "the compiler stamps this build's token into the bundle it emits (CacheBustTests covers "
+                + "what one looks like; the suite pins it), the loader appends it to what it fetches, "
+                + "and nothing else about the loader notices — one fetch, and IsLoaded still answers "
+                + "for the URL as it was asked for");
         }
     }
 }

--- a/Transpose/Transpose.Translator.Tests/TestAssemblySetup.cs
+++ b/Transpose/Transpose.Translator.Tests/TestAssemblySetup.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests
+{
+    /// <summary>
+    /// Suite-wide setup.
+    ///
+    /// <para>
+    /// Every build mints a fresh cache-busting token and stamps it into the bundle it emits
+    /// (<c>Transpose.Require.cacheBust("…")</c> — see <see cref="CacheBust"/>), which is the one thing
+    /// about the emitted JavaScript that is deliberately different every time. Several tests here
+    /// compile the same sources twice and compare the two bundles byte for byte — that a full build and
+    /// an incremental one agree, that a different build of the base library changes nothing, that
+    /// synthesized temp names are stable — so the token is pinned for the whole suite and those
+    /// comparisons go back to being about the compiler.
+    /// </para>
+    ///
+    /// <para>
+    /// <see cref="CacheBustTests"/> is what covers the minting itself; it saves and restores the
+    /// variable around each case, which is safe because MSTest runs this assembly's tests sequentially.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public static class TestAssemblySetup
+    {
+        [AssemblyInitialize]
+        public static void Initialize(TestContext _) =>
+            Environment.SetEnvironmentVariable(CacheBust.EnvVar, "testbuild");
+    }
+}

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -218,11 +218,16 @@ public sealed class RoslynTranslator
         TranslationException? emitterFailure = null;
         try
         {
+            // One token for this build, shared by every emitter it runs (module entry and bundle are
+            // two walks of the same compilation and must agree). CacheBust.NewToken mints a fresh one
+            // per build, so a redeployed page re-fetches whatever Transpose.Require loads at run time.
+            var cacheBustToken = CacheBust.NewToken();
             Emitter NewEmitter() => new Emitter(compilation, assemblyName, models, incremental)
             {
                 ReflectionEnabled = reflectionEnabled,
                 MetadataTarget = metadataTarget,
                 AssemblyVersion = string.IsNullOrWhiteSpace(assemblyVersion) ? "1.0.0.0" : assemblyVersion!,
+                CacheBustToken = cacheBustToken,
             };
             var emitter = NewEmitter();
             if (emitModules)

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -475,6 +475,10 @@ public sealed partial class Emitter
 
         if (!string.IsNullOrEmpty(AssemblyVersion))
             sb.Append("Transpose.assemblyVersion(\"").Append(_assemblyName).Append("\", \"").Append(AssemblyVersion).Append("\");\n");
+        // This build's cache-busting token — see the same call in Emitter.Emit's prelude. The entry
+        // module is the one place a module-mode assembly runs eagerly, so it is where it belongs.
+        if (!string.IsNullOrEmpty(CacheBustToken))
+            sb.Append("Transpose.Require && Transpose.Require.cacheBust && Transpose.Require.cacheBust(\"").Append(CacheBustToken).Append("\");\n");
         sb.Append("Transpose.$useAssembly(\"").Append(_assemblyName).Append("\");\n\n");
 
         // Reflection metadata describes declarations only, so it is always eager and always covers

--- a/Transpose/Transpose.Translator/Emit/Emitter.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.cs
@@ -60,6 +60,13 @@ public sealed partial class Emitter
     /// <summary>Assembly version string emitted into a separate metadata file's header.</summary>
     public string AssemblyVersion { get; set; } = "1.0.0.0";
 
+    /// <summary>
+    /// This build's cache-busting token (<see cref="CacheBust"/>), handed to the runtime loader in the
+    /// assembly prelude so every URL <c>Transpose.Require</c> fetches at run time carries it as a
+    /// query — <c>my-library.min.js?<em>token</em></c>. Empty turns cache-busting off.
+    /// </summary>
+    public string CacheBustToken { get; set; } = "";
+
     /// <summary>When <see cref="MetadataTarget"/> is File/Assembly, the standalone metadata
     /// script (a full Transpose.assembly wrapper) produced by the last <see cref="Emit"/>; else null.</summary>
     public string? MetadataScript { get; private set; }
@@ -130,6 +137,19 @@ public sealed partial class Emitter
         // assembly body.
         if (!string.IsNullOrEmpty(AssemblyVersion))
             _w.WriteLine($"Transpose.assemblyVersion(\"{_assemblyName}\", \"{AssemblyVersion}\");");
+
+        // This build's cache-busting token. Transpose.Require appends it to every URL it fetches, so a
+        // redeployed page never gets a stale copy of a vendored bundle or stylesheet whose name did not
+        // change. It is registered once per assembly rather than baked into each call site: the URLs
+        // stay identical build over build (which is what lets --incremental splice in a cached type's
+        // JavaScript), and the loader keeps dedupe, IsLoaded and "index.html already carries this file"
+        // working on the un-busted URL. The runtime keeps the greatest token it is given, so on a page
+        // carrying several assemblies the newest build wins whatever order the bundles load in.
+        // The call is guarded because a site can be built by this compiler against an OLDER runtime
+        // (BuildStamp only rules out the reverse), and an unbustable page is a missing optimisation
+        // where a TypeError in the prelude is a blank one.
+        if (!string.IsNullOrEmpty(CacheBustToken))
+            _w.WriteLine($"Transpose.Require && Transpose.Require.cacheBust && Transpose.Require.cacheBust(\"{CacheBustToken}\");");
 
         _w.Write($"Transpose.assembly(\"{_assemblyName}\", function ($asm, globals) ");
         _w.Block(() =>

--- a/Transpose/Transpose.Translator/Support/CacheBust.cs
+++ b/Transpose/Transpose.Translator/Support/CacheBust.cs
@@ -20,7 +20,8 @@ namespace Transpose.Translator;
 /// characters — because a page can carry several assemblies, each stamped when *it* was built, and the
 /// runtime keeps the greatest one it is given (see <c>Resources/Require.js</c>). That makes the newest
 /// build on the page win whatever order the bundles happen to load in, which a plain random value
-/// could not do.
+/// could not do. The stamp is what orders; the random tail only keeps two builds apart, so two tokens
+/// minted in the same millisecond compare either way — which no two builds ever are.
 /// </para>
 /// </summary>
 public static class CacheBust

--- a/Transpose/Transpose.Translator/Support/CacheBust.cs
+++ b/Transpose/Transpose.Translator/Support/CacheBust.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// The cache-busting token a build stamps into its JavaScript, so that a page rebuilt and
+/// redeployed never serves a stale copy of a file <c>Transpose.Require</c> fetches at run time.
+///
+/// <para>
+/// A vendored bundle, a stylesheet or a lazily-loaded library is fetched by a URL the compiler does
+/// not version — <c>assets/js/graph-kit.min.js</c> is the same URL after the file behind it changed —
+/// so a browser or a CDN that cached the previous copy has no reason to ask for it again. Every build
+/// therefore mints one token and every URL <c>Require</c> injects carries it as a query
+/// (<c>graph-kit.min.js?<em>token</em></c>): unchanged after a build that changed nothing, different
+/// after one that did.
+/// </para>
+///
+/// <para>
+/// The token is <b>monotonic</b> — a fixed-width base-36 millisecond stamp followed by three random
+/// characters — because a page can carry several assemblies, each stamped when *it* was built, and the
+/// runtime keeps the greatest one it is given (see <c>Resources/Require.js</c>). That makes the newest
+/// build on the page win whatever order the bundles happen to load in, which a plain random value
+/// could not do.
+/// </para>
+/// </summary>
+public static class CacheBust
+{
+    /// <summary>
+    /// Pins the token (any value) or turns cache-busting off entirely (empty / <c>0</c> / <c>none</c>).
+    /// A build whose output has to be byte-identical to another one — the reproducibility gate the
+    /// performance work leans on, a diff against a baseline compiler — sets this.
+    /// </summary>
+    public const string EnvVar = "TRANSPOSE_CACHE_BUST";
+
+    /// <summary>Base-36 milliseconds are counted from here, so eight digits carry the stamp until
+    /// well past 2100 and every token this compiler mints is the same width (which is what makes
+    /// "greater string" mean "newer build").</summary>
+    private static readonly DateTime Epoch = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private const string Digits = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+    /// <summary>
+    /// The token for one build: the environment override when there is one, else a fresh
+    /// <c>&lt;8 base-36 digits of the build time&gt;&lt;3 random&gt;</c> id. Empty means "do not bust".
+    /// </summary>
+    public static string NewToken()
+    {
+        var pinned = Environment.GetEnvironmentVariable(EnvVar);
+        if (pinned is not null)
+        {
+            pinned = pinned.Trim();
+            if (pinned.Length == 0 || pinned == "0" || string.Equals(pinned, "none", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(pinned, "false", StringComparison.OrdinalIgnoreCase))
+                return "";
+            return Sanitize(pinned);
+        }
+
+        var ms = (long)(DateTime.UtcNow - Epoch).TotalMilliseconds;
+        if (ms < 0) ms = 0;
+        return Base36(ms, 8) + Base36(Random.Shared.NextInt64(0, 36 * 36 * 36), 3);
+    }
+
+    private static string Base36(long value, int width)
+    {
+        var buffer = new char[width];
+        for (var i = width - 1; i >= 0; i--)
+        {
+            buffer[i] = Digits[(int)(value % 36)];
+            value /= 36;
+        }
+        return new string(buffer);
+    }
+
+    /// <summary>A pinned token goes into a URL's query and into a JS string literal, so keep it to
+    /// characters that need no escaping in either.</summary>
+    private static string Sanitize(string token)
+    {
+        var buffer = new char[token.Length];
+        var n = 0;
+        foreach (var c in token)
+            if (char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_') buffer[n++] = c;
+        return new string(buffer, 0, n);
+    }
+}


### PR DESCRIPTION
A file `Transpose.Require` loads at run time — a vendored bundle, a stylesheet, a lazily-loaded library — is fetched by a URL the compiler does not version, so a browser or a CDN holding the previous copy has no reason to ask for it again once the site is rebuilt and redeployed.

Every build now mints one token and stamps it into each assembly it emits, and the loader appends it as a query to every URL it injects:

```
assets/js/my-library.min.js?2ohyhfq9iy1
Admin.js?v=7&2ohyhfq9iy1
```

## How it works

`CacheBust.NewToken()` (`Transpose.Translator/Support/CacheBust.cs`) mints one token per compilation; `RoslynTranslator` hands it to every emitter that build runs, and the emitter writes it into the prelude next to the `Transpose.assemblyVersion` call — and into the entry module in module mode:

```js
Transpose.assemblyVersion("App", "1.0.0.0");
Transpose.Require && Transpose.Require.cacheBust && Transpose.Require.cacheBust("2ohyhfq9iy1");
```

`Resources/Require.js` keeps the token in `$bust` and appends it in `$inject`.

## Three details are load-bearing

- **Registered once per assembly, not baked into each call site.** A type's emitted JavaScript is then the same build over build, which is what lets `--incremental` splice a cached type's JS back in (a token baked at the call site would go stale for every type a body-only edit did not touch). It also busts a computed URL as readily as a literal one.
- **Applied at injection only**, never in what identifies a URL. The shared-fetch table, `IsLoaded` and "index.html already carries this file" all keep working on the URL as it was asked for — so a token that moves between builds never turns one file into two entries, and a file `index.html` scripted without a token is still recognised rather than fetched a second time.
- **Minted monotonically** — 8 base-36 digits of the build time plus 3 random — and the runtime keeps the *greatest* token it is given. A page carries several assemblies stamped at different times and loading in an order nobody controls, so this makes the newest build on the page win rather than whichever bundle happened to load last.

The call is guarded (`Require && Require.cacheBust &&`) because a site can be built by this compiler against an older runtime — `BuildStamp` only rules out the reverse — and an unbustable page is a missing optimisation where a `TypeError` in the prelude is a blank one.

## Escape hatch

`TRANSPOSE_CACHE_BUST` pins the token, or switches busting off when set to empty / `0` / `none`. That is what a build whose output has to be **byte-identical** to a baseline's needs — the reproducibility gate the performance work leans on — and the `transpose-performance` skill's `diff -r` recipe now sets it.

## Tests

- `CacheBustTests` — minting: fixed width, base-36 only, ordered by build time, distinct across 200 back-to-back builds, and both forms of the environment override.
- `RequireLoaderTests` — every existing case now asserts the busted request URL (including `?v=7&…`, the `.js` ⇄ `.min.js` fallback and the retry-after-failure path), plus a new case that puts the compiler's own stamped token back and checks the URL carries exactly it while one file is still one fetch. The "index.html already carries this file" case is unchanged, which is the point.
- `TestAssemblySetup` pins the token for the suite, so the six tests that compile the same sources twice and compare byte for byte (`EmitDeterminismTests`, `IncrementalEmitTests`, `ModuleEmitTests`, `OutputIsDeterministic`) still mean something.

Docs updated: `CLAUDE.md` (the Require section and the byte-identical gate), the `Require` API doc, and the `transpose-performance` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDrzutgiL7k5mu8KWvavge

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDrzutgiL7k5mu8KWvavge)_