### PR TITLE
Raise the BCL and Packages pins to the current release

### DIFF
--- a/BCL/Transpose.BCL/Transpose.BCL.csproj
+++ b/BCL/Transpose.BCL/Transpose.BCL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Transpose</AssemblyName>

--- a/BCL/Transpose.Core/Transpose.Core.csproj
+++ b/BCL/Transpose.Core/Transpose.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Transpose.Core</AssemblyName>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -773,8 +773,9 @@ The short version:
   class resolved from a string: the type joins the eager roots, like the attribute classes the
   metadata constructs. The shipped JSON bindings carry the attribute — Newtonsoft's four
   `DeserializeObject<T>`/`DeserializeAnonymousType<T>` overloads and System.Text.Json's two
-  `Deserialize<TValue>` overloads — so an application needs no declaration of its own; both projects
-  pin `Transpose.BCL` 26.8.4102, the first release carrying the attribute. See
+  `Deserialize<TValue>` overloads — so an application needs no declaration of its own. The attribute
+  first shipped in `Transpose.BCL` 26.8.4102, so that is the floor those two packages need; they pin
+  the current release like everything else here. See
   `Emitter.ReflectionDeps.cs`, `ModuleReflectionDepsTests` and `TODO.modules.md` §7h.
 
   **`[LoadsTypeArguments]` is the same attribute pointing the other way.** A generic call emits its

--- a/Packages/Transpose.Howler/Transpose.Howler.csproj
+++ b/Packages/Transpose.Howler/Transpose.Howler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.Howler</AssemblyName>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3242" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
+++ b/Packages/Transpose.HttpClient/Transpose.HttpClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.HttpClient</AssemblyName>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3242" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
+++ b/Packages/Transpose.Newtonsoft.Json/Transpose.Newtonsoft.Json.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Transpose.Build.Target/26.7.3049">
+﻿<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.Newtonsoft.Json</AssemblyName>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4102" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.P2/Transpose.P2.csproj
+++ b/Packages/Transpose.P2/Transpose.P2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.P2</AssemblyName>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3242" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
+++ b/Packages/Transpose.System.Text.Json/Transpose.System.Text.Json.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.System.Text.Json</AssemblyName>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4102" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
+++ b/Packages/Transpose.WebGL2/Transpose.WebGL2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Transpose.WebGL2</AssemblyName>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3303" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3242" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Every `Transpose.*` reference in `BCL/` and `Packages/`, and the `Transpose.Build.Target` SDK pin on all eight projects, now names the current published release.

| Package | From | To |
| --- | --- | --- |
| `Transpose.BCL` | 26.7.3303 / 26.8.4102 | **26.8.4619** |
| `Transpose.Core` | 26.7.3242 | **26.8.4597** |
| `Transpose.Build.Target` (SDK) | 26.7.3049 | **26.8.4125** |

## What these pins are

They are the floor a consumer of the published package inherits, which is why they had drifted: Newtonsoft.Json and System.Text.Json sat on 26.8.4102 because that is the release `[ConstructsTypeArguments]` landed in, and the rest on 26.7. Raising the floor to the current release is the intended maintenance here, so they now move with everything else.

`CLAUDE.md`'s note on those two packages said they *pin* 26.8.4102; it now records 26.8.4102 as the floor the attribute needs, without also claiming it is the pin.

**Nothing changes for a dev tree.** `bootstrap.sh` never restores these references — it compiles the base and Core into reference assemblies from a synthesized csproj and passes the rest with `--reference`, which is exactly why a dev tree resolves zero references for these projects to begin with.

## Verification

`./bootstrap.sh` transpiles all seven binding libraries as before.

That is not sufficient on its own, though, and the distinction is the point: bootstrap does not exercise the pins at all, so a green bootstrap cannot tell you whether the raised references resolve. Each of the eight projects was therefore also built in **Release** through the real `Transpose.Build.Target` SDK with `tps` 26.8.4618 on `PATH` — the shape CI builds them in, where the references really are restored:

- `Transpose.Core`, `Transpose.Newtonsoft.Json`, `Transpose.System.Text.Json`, `Transpose.Howler`, `Transpose.WebGL2`, `Transpose.P2`, `Transpose.HttpClient` — all pack.
- `Transpose.BCL` still emits the runtime: `OK — built runtime Transpose.dll with 4 embedded bundle(s)`.

## The compiler this needs

`Transpose.BCL` 26.8.4619 carries a build stamp of `26.8.4618`, so anything consuming it needs `Transpose.Compiler` >= 26.8.4618 or the build fails with `TPS0008`. That is the newest published compiler, and every pipeline under `.devops/` installs it with `dotnet tool install --global Transpose.Compiler`. `Transpose.Core` 26.8.4597 sits under the same floor (it stamps 26.8.4595).

Worth flagging that there is no headroom: a `Transpose.BCL` published ahead of its compiler would break these builds.

## Relationship to #149

#149 bumps the `dotnet new` template. The two touch a disjoint set of files and can merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QmFZNQ8Tn48gznUET3t3U)_