### PR TITLE
Bring the dotnet new template's package pins up to date

### DIFF
--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.3049">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <!-- Inherits LangVersion=latest from the Transpose.Build.Target SDK; pin an older
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
-        <PackageReference Include="Transpose.Core" Version="26.7.3106" />
-        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.3066" />
+        <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+        <PackageReference Include="Transpose.Core" Version="26.8.4597" />
+        <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4599" />
         <PackageReference Include="Tesserae" Version="2026.7.68468" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
The scaffolded project still asked for Transpose.BCL 26.7.3104, Transpose.Core 26.7.3106, Transpose.Newtonsoft.Json 26.7.3066 and the Transpose.Build.Target 26.7.3049 SDK, so `dotnet new` handed a new user a 26.7 runtime to be compiled by whatever `dotnet tool install Transpose.Compiler` had just given them - the exact pairing the minimum-compiler stamp cannot catch, because the check only fires when a reference needs a *newer* compiler. The other direction fails at run time instead: the compiler emits a call into tps.js that the older runtime does not carry, and the page comes up blank with one console error.

Now 26.8.4619 / 26.8.4597 / 26.8.4599 / 26.8.4125, the current releases.

The deliberate floors elsewhere in the tree are left alone - the Packages/* and BCL/Transpose.Core pins are the minimum a consumer needs (Newtonsoft.Json and System.Text.Json pin 26.8.4102 for [ConstructsTypeArguments], for instance), and raising them would raise that floor for no reason. The template is not a floor; it is what a new project starts on.

Verified by building the template's own csproj and Program.cs standalone in Release.


Claude-Session: https://claude.ai/code/session_011QmFZNQ8Tn48gznUET3t3U