### PR TITLE
Update the dotnet new template's Tesserae to 2026.8.70157

### DIFF
--- a/Transpose/Transpose.Template/templates/MyProject.csproj
+++ b/Transpose/Transpose.Template/templates/MyProject.csproj
@@ -9,6 +9,6 @@
         <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
         <PackageReference Include="Transpose.Core" Version="26.8.4597" />
         <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4599" />
-        <PackageReference Include="Tesserae" Version="2026.7.68468" />
+        <PackageReference Include="Tesserae" Version="2026.8.70157" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
`Tesserae` 2026.7.68468 → **2026.8.70157** in the `dotnet new` template — the one pin #149 deliberately left behind.

## Why this is stacked on #149 rather than opened against `master`

It is not optional any more. Tesserae 2026.8.70157 declares `Transpose.BCL >= 26.8.4619`, which is exactly what #149 makes the template pin. On `master`, where the template still asks for `Transpose.BCL` 26.7.3104, restoring this Tesserae fails:

```
error NU1605: Detected package downgrade: Transpose.BCL from 26.8.4619 to 26.7.3104
```

So the two belong in that order, and this is based on #149's branch. Merge #149 first and GitHub will retarget this to `master`.

Worth noting the reverse coupling too: #149 on its own scaffolds a project pinning current Transpose packages beside a 2026.7 Tesserae, which restores fine but is an odd pairing to hand a new user. Together they scaffold a project that is current on both.

## Verification

Copied `templates/MyProject.csproj` and `templates/Program.cs` into a clean directory and built in **Release** against compiler 26.8.4618 — restore clean, no NU1605, no warnings, no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QmFZNQ8Tn48gznUET3t3U)_