### PR TITLE
Read each reference assembly once per process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -895,6 +895,19 @@ The short version:
   write its DLL (`IOException`, which is exactly what watch mode used to do on its second rebuild of a
   multi-project app), and resolution is by assembly identity, so a re-read of a rebuilt DLL silently
   returns the copy loaded the first time.
+- **A reference assembly is read once per process (`CompilationBuilder.ReadReference`).** Roslyn decodes
+  a reference's metadata, and caches the symbols it builds from it, against the `MetadataReference`
+  **instance** — so a fresh one per compilation re-reads and re-decodes the whole assembly and holds
+  the result in native memory the GC cannot account for or reclaim. Measured at ~12 MB per compilation
+  for the 10.4 MB base library alone (300 translations: RSS 3.7 GB against a 337 MB managed heap, and
+  an aggressive full collect gave back almost none of it), which is what walked the translator suite's
+  test host into the container's 13 GB limit and had it OOM-killed with ~80 tests still to run. The
+  references are therefore cached by path, and each is read with `CreateFromImage` rather than
+  `CreateFromFile` so nothing keeps the file mapped — the locking failure the bullet above is about.
+  The cache entry carries the file's length and last-write time, because the case that makes caching
+  tempting to get wrong is watch mode rebuilding a referenced project's DLL between two compilations;
+  a stale entry there would bind the previous build, silently. A one-shot `tps` build compiles once and
+  neither gains nor loses. `MetadataReferenceCacheTests` covers all three properties.
 
 A compilation server is still intentionally **out of scope** — though the measurements in
 `TODO.incremental.md` say what it would be worth (the residual cost of an incremental build is almost

--- a/Transpose/Transpose.Translator.Tests/MetadataReferenceCacheTests.cs
+++ b/Transpose/Transpose.Translator.Tests/MetadataReferenceCacheTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// <see cref="CompilationBuilder"/> reads each reference assembly into one
+/// <see cref="MetadataReference"/> and reuses it across compilations.
+///
+/// <para>
+/// Roslyn decodes a reference's metadata — and caches the symbols it builds from it — against the
+/// <see cref="MetadataReference"/> <b>instance</b>, and holds the result in native memory the GC
+/// cannot account for. A fresh instance per compilation therefore leaked ~12 MB per compile for the
+/// 10.4 MB base library alone: measured over 300 translations, RSS grew to 3.7 GB while the managed
+/// heap stayed at 337 MB, and an aggressive full collect gave back almost none of it. That is what
+/// walked this suite's own test host up to the container's 13 GB limit and had it OOM-killed with
+/// ~80 tests still to run. It costs a one-shot <c>tps</c> build nothing (it compiles once) and
+/// matters wherever a process compiles more than once: the suites, <c>tps --watch</c>, and
+/// <c>Transpose.Compiler.Library</c> hosts.
+/// </para>
+///
+/// <para>
+/// The reuse is only sound while a reference that changed <em>on disk</em> is re-read, which is not a
+/// hypothetical: watch mode rebuilds a referenced project's DLL between two compilations and the
+/// second must bind against the new one. That is what the last two tests are about.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class MetadataReferenceCacheTests
+{
+    private string _dir = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "tps-refcache-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    /// <summary>Writes a one-method library to <paramref name="path"/>, overwriting whatever is
+    /// there — which is what a rebuild of a referenced project does.</summary>
+    private static void WriteLibrary(string path, string methodName)
+    {
+        var result = new RoslynTranslator().BuildAssembly(
+            new[] { ("Lib.cs", $"public static class Lib {{ public static int {methodName}() => 1; }}") },
+            "Lib", extraReferencePaths: null, emitAssembly: true);
+
+        Assert.IsNotNull(result.AssemblyBytes,
+            "building the stand-in library failed: "
+            + string.Join("\n", result.Diagnostics.Select(d => d.GetMessage())));
+        File.WriteAllBytes(path, result.AssemblyBytes!);
+    }
+
+    private static string? TranslateAgainst(string libraryPath, string methodName)
+    {
+        var result = new RoslynTranslator().Translate(
+            new[] { ("App.cs", $"public class P {{ public static int M() => Lib.{methodName}(); }}") },
+            "App", new[] { libraryPath });
+        return result.Success ? result.Javascript : null;
+    }
+
+    [TestMethod]
+    public void TheSameReferenceFileIsReadOnceAcrossCompilations()
+    {
+        var first = CompilationBuilder.Build(new[] { ("App.cs", "public class P { }") }, "App");
+        var second = CompilationBuilder.Build(new[] { ("App.cs", "public class Q { }") }, "App");
+
+        var a = first.References.OfType<PortableExecutableReference>().Single();
+        var b = second.References.OfType<PortableExecutableReference>().Single();
+
+        Assert.AreSame(a, b,
+            "two compilations must bind against the SAME MetadataReference for the base library — a "
+            + "fresh one per compilation makes Roslyn re-decode 10 MB of metadata into native memory "
+            + "that nothing reclaims");
+    }
+
+    [TestMethod]
+    public void ARebuiltReferenceIsReReadNotServedStale()
+    {
+        var lib = Path.Combine(_dir, "Lib.dll");
+
+        WriteLibrary(lib, "One");
+        Assert.IsNotNull(TranslateAgainst(lib, "One"), "sanity: the first build's member binds");
+
+        WriteLibrary(lib, "Two");
+
+        Assert.IsNotNull(TranslateAgainst(lib, "Two"),
+            "the rebuilt library's member must bind — a cache that answered from the first read would "
+            + "report it as undefined, which is exactly what watch mode does between two compilations");
+        Assert.IsNull(TranslateAgainst(lib, "One"),
+            "and the member the rebuild removed must be gone, so this is a re-read and not both "
+            + "assemblies at once");
+    }
+
+    [TestMethod]
+    public void ARebuiltReferenceOfIdenticalSizeIsReReadToo()
+    {
+        var lib = Path.Combine(_dir, "Lib.dll");
+
+        WriteLibrary(lib, "One");
+        var size = new FileInfo(lib).Length;
+        Assert.IsNotNull(TranslateAgainst(lib, "One"), "sanity: the first build's member binds");
+
+        // A rename of the same length, so the file's SIZE cannot tell the two builds apart and only
+        // the timestamp is left to. Stamped a second on: a real rebuild is seconds later, and pinning
+        // it here keeps the test off the filesystem's timestamp granularity.
+        WriteLibrary(lib, "Ona");
+        Assert.AreEqual(size, new FileInfo(lib).Length, "the two builds must be the same size for this "
+            + "test to be about the timestamp at all");
+        File.SetLastWriteTimeUtc(lib, DateTime.UtcNow.AddSeconds(1));
+
+        Assert.IsNotNull(TranslateAgainst(lib, "Ona"),
+            "a rebuild the file size cannot distinguish must still be re-read");
+    }
+}

--- a/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
+++ b/Transpose/Transpose.Translator/Compilation/CompilationBuilder.cs
@@ -160,6 +160,77 @@ public static class CompilationBuilder
     private static MetadataReference ReadReference(string path)
     {
         CompileProgress.Report($"reading assembly {Path.GetFullPath(path)}");
-        return MetadataReference.CreateFromFile(path);
+
+        var full = Path.GetFullPath(path);
+        var info = new FileInfo(full);
+        var stamp = (info.Length, info.LastWriteTimeUtc.Ticks);
+
+        lock (_references)
+        {
+            if (_references.TryGetValue(full, out var cached) && cached.Stamp == stamp)
+            {
+                cached.LastUsed = ++_useCounter;
+                return cached.Reference;
+            }
+
+            // CreateFromImage, not CreateFromFile: the reference is cached, and CreateFromFile keeps
+            // the file mapped for as long as it lives — which is the very thing that made a rebuild of
+            // a referenced project fail to write its own DLL (see OutputBuilder.AssemblyResources,
+            // which avoids Assembly.LoadFrom for the same reason). Reading the bytes costs one copy
+            // and leaves nothing holding the file.
+            var reference = MetadataReference.CreateFromImage(File.ReadAllBytes(full), filePath: full);
+            // Keyed by path, so a rebuilt assembly replaces its predecessor rather than accumulating:
+            // a long-running host recompiles the same paths over and over.
+            _references[full] = new Cached(stamp, reference, ++_useCounter);
+
+            // A build binds against a handful of assemblies and asks for the same ones every time, so
+            // the cap is only ever reached by a host that compiles unrelated projects one after
+            // another — the test suites, which build a package DLL under a fresh temp path per test.
+            // Dropping the least recently used entry lets Roslyn release what it decoded from it,
+            // which is the whole point; the working set of an ordinary build never comes close.
+            while (_references.Count > MaxCachedReferences)
+            {
+                var oldest = _references.OrderBy(e => e.Value.LastUsed).First().Key;
+                _references.Remove(oldest);
+            }
+
+            return reference;
+        }
     }
+
+    /// <summary>How many assemblies stay decoded at once — comfortably more than any one project
+    /// binds against, so a real build never evicts anything.</summary>
+    private const int MaxCachedReferences = 64;
+
+    private sealed class Cached((long Length, long Ticks) stamp, MetadataReference reference, long lastUsed)
+    {
+        public (long Length, long Ticks) Stamp { get; } = stamp;
+        public MetadataReference Reference { get; } = reference;
+        public long LastUsed { get; set; } = lastUsed;
+    }
+
+    private static long _useCounter;
+
+    /// <summary>
+    /// One <see cref="MetadataReference"/> per assembly file, reused across compilations.
+    ///
+    /// <para>
+    /// Roslyn decodes a reference's metadata — and caches the symbols it builds from it — against the
+    /// <see cref="MetadataReference"/> INSTANCE. A fresh instance per compilation therefore re-reads
+    /// and re-decodes the whole assembly, and holds the result in native memory the GC cannot account
+    /// for or reclaim: measured at ~12 MB per compilation for the 10.4 MB base library alone, which is
+    /// what walked the translator test suite's host up to the container's 13 GB limit and had it
+    /// OOM-killed partway through. It matters wherever one process compiles more than once — the test
+    /// suites, <c>tps --watch</c>, and <c>Transpose.Compiler.Library</c> hosts like
+    /// <c>curiosity-cli serve --watch</c>. A one-shot <c>tps</c> build compiles once and neither gains
+    /// nor loses.
+    /// </para>
+    ///
+    /// <para>
+    /// The stamp (length + last write time) is what keeps that sound in exactly the case that makes
+    /// caching tempting to get wrong: watch mode rebuilds a referenced project's DLL between
+    /// compilations, and the next build must bind against the new one.
+    /// </para>
+    /// </summary>
+    private static readonly Dictionary<string, Cached> _references = new(StringComparer.Ordinal);
 }


### PR DESCRIPTION
The translator test suite has been ending in `Test host process crashed` partway through. It is an **OOM kill**, and the cause is a per-compilation Roslyn metadata leak that also affects `tps --watch` and `Transpose.Compiler.Library` hosts.

## Diagnosis

`dmesg` names it outright:

```
Memory cgroup out of memory: Killed process (dotnet) anon-rss:13188240kB
```

The container's limit is 13.34 GB. Sampling the test host's RSS across a run:

| elapsed | RSS |
| --- | --- |
| 0s | 272 MB |
| 60s | 5,332 MB |
| 181s | 11,965 MB |
| 301s | 13,371 MB → killed |

Monotone growth, pinned at the limit, killed with ~80 of 1,066 tests still to run.

**It is not the GC.** A standalone harness doing 300 translations in-process:

```
  300 translations | RSS 3,661 MB | GC heap 337 MB | committed 433 MB
done: RSS 3,468 MB | GC heap 248 MB   ← after GC.Collect(2, Aggressive, blocking, compacting)
```

~3.2 GB is native memory an aggressive full collect cannot release — ~12 MB per compilation, which is about the size of `Transpose.dll` (10.4 MB). `DOTNET_GCHeapHardLimitPercent` made no difference, as expected once the memory is not on the managed heap.

The cause: `CompilationBuilder.ReadReference` called `MetadataReference.CreateFromFile` on **every** compilation. Roslyn decodes a reference's metadata — and caches the symbols it builds from it — against the `MetadataReference` *instance*, so a fresh instance per compilation re-reads and re-decodes the whole assembly into native memory that nothing reclaims.

## Fix

Cache one `MetadataReference` per assembly file. Same harness, after:

```
  300 translations | RSS 160 MB | GC heap 63 MB | committed 63 MB
done: RSS 122 MB | GC heap 31 MB
```

**3,661 MB → 160 MB, flat instead of growing, and 16s → 6s.**

Three details:

- **`CreateFromImage`, not `CreateFromFile`.** A cached `CreateFromFile` reference keeps the file mapped for as long as it lives — the locking failure `OutputBuilder.AssemblyResources` already avoids `Assembly.LoadFrom` for, and the one that made watch mode fail to write a referenced project's DLL on its second rebuild. Reading the bytes costs one copy and leaves nothing holding the file.
- **The entry carries the file's length and last-write time.** The case that makes caching tempting to get wrong is watch mode rebuilding a referenced project's DLL between two compilations; a stale entry there would bind the previous build, silently.
- **Bounded at 64 entries, least-recently-used evicted.** No real build comes close (it binds a handful of assemblies and asks for the same ones every time); it keeps a host that compiles unrelated projects one after another — or a suite that builds a package DLL under a fresh temp path per test — from accumulating.

A one-shot `tps` build compiles once and neither gains nor loses. This matters wherever a process compiles more than once: the test suites, `tps --watch`, and `Transpose.Compiler.Library` hosts such as `curiosity-cli serve --watch`.

## Tests

`MetadataReferenceCacheTests` covers one property each: the same file is read once across compilations; a reference rebuilt on disk is re-read rather than served stale; and a rebuild of *identical size* is re-read too, so the timestamp half of the stamp carries its own weight.

Both halves were sabotage-checked, per the repo's own discipline:

| sabotage | result |
| --- | --- |
| remove the cache entirely | `TheSameReferenceFileIsReadOnceAcrossCompilations` fails |
| key the cache on path only, ignoring the stamp | both re-read tests fail |

## Verification

- **Full suite: 1069 tests, 0 failures — and for the first time it runs to completion**, with no abort. Peak RSS 3.8 GB against the 13.3 GB limit (previously 13.4 GB and killed at ~985 tests).
- **Emitted output is byte-identical**: a site build diffed (`diff -r`, DLL and embedded JS) against one from the unmodified compiler, plus the suite's own tests that compile the same sources twice and compare byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDrzutgiL7k5mu8KWvavge

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDrzutgiL7k5mu8KWvavge)_