### PR TITLE
Link cross-assembly module imports at the site build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -631,10 +631,29 @@ The short version:
   lazy relative to, so it defers everything (its eager set is just the chunks holding `[Ready]`
   handlers) and publishes a chunk map — emitted type name → chunk file — embedded as
   `Transpose.Modules.json` (embedded but *not* listed in `Transpose.Resources.json`, like the
-  `BuildStamp`, so nothing extracts it into a site). A consuming build merges its references' maps
-  (`ModuleMap.Read`) and emits `import '../<lib>/c<hash>.mjs'` from whichever of its own chunks reaches
-  into a library type — without that the reference would land on the library's stub, which cannot be
-  resolved synchronously. Covered by `ModulePackageTests`.
+  `BuildStamp`, so nothing extracts it into a site). Without an import, a reference into a library
+  would land on its stub, which cannot be resolved synchronously. Covered by `ModulePackageTests`.
+
+  **A cross-assembly import names the type, and the site resolves it.** A chunk file name is the hash
+  of its own text, so a package that had written its dependency's file names into its own chunks went
+  stale the moment that dependency shipped: `Tesserae.GraphKit` compiled against Tesserae 1.0 kept
+  importing `../Tesserae/c0f13a9b….mjs`, Tesserae 1.1 no longer had that file, nothing about GraphKit
+  had changed so nothing rebuilt it, and the app 404'd on the first screen that needed the chunk. So
+  the emitter writes `import 'tps-type:tss.UI';` — the *type*, which does not move — and
+  `ModuleLinker` (`Transpose.Compiler.Core`, driven by `OutputBuilder`) turns each placeholder into a
+  path when the **site** is assembled, reading each reference's published chunk map and walking the
+  assemblies in dependency order. The translator no longer reads those maps at all, so a compilation's
+  output no longer depends on which build of a library is installed. Four consequences: a placeholder
+  nothing in the site defines is simply dropped (the library was taken as a single bundle, so its code
+  is already on the page); a file the link *changes* is renamed to the hash of its new text — and the
+  rename cascades into its importers and the entry module's `Transpose.Modules.register` manifest —
+  so a chunk URL still identifies its bytes; a package built before this existed carries real paths,
+  matches no placeholder and passes through byte-identical; and the DLL always carries the placeholder
+  form while the site always carries the linked one, which is what keeps a package a self-contained,
+  version-independent artifact. `ModuleSpecifier` (`Transpose.Translator/Support`) owns the
+  vocabulary — the prefix, the relative-path arithmetic, and a reader for a module's *leading* import
+  block that works on minified text (a package embeds its chunks already minified). See
+  `TODO.modules.md` §7j and `ModuleLinkTests`.
 
   A fourth load-bearing detail, found the same way as the three above: **a stub is retired in place,
   never deleted.** `Class.set` already copies the members of whatever previously occupied a type's

--- a/TODO.modules.md
+++ b/TODO.modules.md
@@ -654,6 +654,74 @@ Collisions are guarded but not expected: 64 bits is far past the birthday risk f
 chunks an assembly emits, and two chunks cannot legitimately share text at all (a type is emitted into
 exactly one chunk and its define name is part of that text). A collision would take a `-2` suffix.
 
+### 7j. Cross-assembly imports are linked at the site build, not written by the package
+
+§7i names every chunk after the hash of its own text, which is exactly what a *consumer* of a package
+must not depend on. A package that resolved a cross-assembly reference at its own build time wrote
+its dependency's file names into its own chunks:
+
+```js
+// Tesserae.GraphKit's chunk, compiled against Tesserae 1.0
+import '../Tesserae/c0f13a9b4c8d21e7.mjs';
+```
+
+Ship Tesserae 1.1 without touching GraphKit and that file no longer exists. Nothing about GraphKit
+changed, so nothing rebuilds it and nothing warns; the application 404s on the first screen that
+needs the chunk. The two packages are only version-locked because of a *file name*, which is not a
+thing a package should be sensitive to at all.
+
+So a cross-assembly reference is emitted as the **type** it actually is, and resolved when the site is
+assembled:
+
+```js
+// what the package embeds — independent of which build of Tesserae it compiled against
+import 'tps-type:tss.UI';
+// what the site writes
+import '../Tesserae/c21798f619001.mjs';
+```
+
+The vocabulary is `ModuleSpecifier` (`Transpose.Translator/Support/ModuleSpecifier.cs`): the
+`tps-type:` prefix, the relative-path arithmetic, and a reader for a module's **leading** import block
+that works on formatted and minified text alike (a package embeds its chunks already minified).
+Reading only the leading block is what makes the rewrite safe — no string literal in a body can be
+mistaken for a specifier.
+
+`ModuleLinker` (`Transpose.Compiler.Core`) does the resolving, inside `OutputBuilder.Build`, fed one
+assembly at a time in the dependency order the site already places them in — every reference first,
+this project's own chunks last, since they are the ones that reach into the libraries. Each
+assembly's own `Transpose.Modules.json` supplies its type → chunk mapping; the linker re-keys it
+through the renames below and accumulates the lookup the next assembly resolves against.
+
+Four properties are worth stating:
+
+- **A placeholder nothing in the site defines is dropped**, not reported. That is the ordinary case
+  for a library the site took as a single bundle: its code is already on the page and there is no
+  chunk to import. It is also what a *Debug* site does with everything — it takes no package's module
+  variant at all.
+- **Resolving renames.** The text changed, so the chunk is renamed to the hash of what it now
+  contains, or §7i's guarantee would quietly break: two deployments of one application against
+  different Tesserae versions would serve different bytes under one URL, and a browser holding the
+  first would import a chunk that is gone. The rename cascades exactly as it does inside an assembly —
+  into the chunks that import it and into the entry module's `Transpose.Modules.register` manifest,
+  which names chunk files too — which is why chunks are linked in dependency order.
+- **A file the link does not change keeps its name and its bytes.** A package built before this
+  existed carries real paths, no placeholder matches, and it passes through untouched — so old
+  packages keep working exactly as they did (with the staleness they already had). The reverse
+  direction is covered by the `BuildStamp`: a package that emits placeholders raises
+  `minimumCompilerVersion`, so an older `tps` fails with TPS0008 rather than shipping a site full of
+  bare `tps-type:` specifiers.
+- **The DLL always carries the placeholder form; the site always carries the linked form.** The link
+  happens on the way *into a site*, so `CollectEmbeddableItems` embeds what the emitter produced. A
+  package is therefore a self-contained, version-independent artifact, and its published chunk map
+  matches the chunk files inside it.
+
+The translator no longer reads its references' chunk maps at all (`externalChunks` is gone from
+`EmitModules`), which is the reason the fix is worth the indirection: a compilation's output no longer
+depends on which build of a library happens to be installed. `ModuleLinkTests` covers the whole path,
+including the reported scenario end to end — build Lib v1, build a package against it, rebuild Lib
+with different chunk names, assemble a site, and assert every import in every file it wrote points at
+a file that is there.
+
 ### Not done
 
 - **Coalescing across assemblies at the site build** — see §7g. The pass runs per assembly, so a

--- a/Transpose/Transpose.Compiler.Core/ModuleLinker.cs
+++ b/Transpose/Transpose.Compiler.Core/ModuleLinker.cs
@@ -1,0 +1,164 @@
+using System.Security.Cryptography;
+using System.Text;
+using Transpose.Translator;
+
+namespace Transpose.Compiler;
+
+/// <summary>One module file on its way into a site: where it lands, and its JavaScript.</summary>
+internal readonly record struct ModuleFile(string Rel, string Text, bool IsChunk);
+
+/// <summary>
+/// Turns the type placeholders an emitted module carries (<c>import "tps-type:tss.UI";</c>) into real
+/// relative imports of the chunks that define those types <em>in the site being assembled</em>.
+///
+/// <para><b>Why the indirection exists.</b> A chunk's file name is the hash of its own text, so every
+/// rebuild of a library renames the chunks whose JavaScript changed. A package that had written its
+/// dependency's file names into its own chunks would therefore go stale the moment that dependency
+/// shipped a new version: <c>Tesserae.GraphKit</c> compiled against Tesserae 1.0 keeps importing
+/// <c>../Tesserae/c0f1….mjs</c>, and Tesserae 1.1 no longer has a file by that name. Nothing about
+/// GraphKit changed, nothing warns, and the application 404s on the first screen that needs it. So a
+/// package names the <em>type</em> it needs — which does not move — and the site build, which can see
+/// both sides, resolves it here.</para>
+///
+/// <para><b>Renaming.</b> Resolving a placeholder changes a file's text, so the file is renamed to the
+/// hash of what it now contains. That keeps the property the naming exists for — a chunk's URL
+/// identifies its bytes, so it can be served immutably — which resolving-without-renaming would
+/// quietly break: two deployments of the same application against different Tesserae versions would
+/// otherwise serve different bytes under one name, and a browser holding the first would import a
+/// chunk that is no longer there. A rename cascades (an importer's text changes too), which is why
+/// chunks are linked in dependency order; a file whose text is unchanged keeps its name.</para>
+///
+/// <para>Assemblies are linked in dependency order — the order the site writes them in — so by the
+/// time a library's placeholders are resolved, every library it depends on has its final names.</para>
+/// </summary>
+internal sealed class ModuleLinker
+{
+    // Define name → the site-relative chunk file that defines it, AFTER linking. Accumulated across
+    // assemblies, which is why the caller must link in dependency order.
+    private readonly Dictionary<string, string> _typeToChunk = new(StringComparer.Ordinal);
+
+    /// <summary>Every type the site can import so far, by emitted define name. A placeholder naming
+    /// anything else is dropped rather than resolved — see <see cref="LinkAssembly"/>.</summary>
+    public IReadOnlyDictionary<string, string> TypeToChunk => _typeToChunk;
+
+    /// <summary>
+    /// Links one assembly's module files. <paramref name="ownTypeToChunk"/> is that assembly's own
+    /// published map (<c>Transpose.Modules.json</c>, or the map the current compilation produced);
+    /// it is re-keyed through the renames below and folded into <see cref="TypeToChunk"/> so later
+    /// assemblies — and this site's own chunks — can import into it.
+    ///
+    /// Returns the files in the order they were given, each with its final path and text.
+    /// </summary>
+    public List<ModuleFile> LinkAssembly(
+        IReadOnlyDictionary<string, string>? ownTypeToChunk, IReadOnlyList<ModuleFile> files)
+    {
+        var chunks = files.Where(f => f.IsChunk).ToList();
+        var linked = new Dictionary<string, ModuleFile>(StringComparer.Ordinal);   // original rel → linked file
+        var renamed = new Dictionary<string, string>(StringComparer.Ordinal);      // original leaf → new leaf
+        var used = new HashSet<string>(chunks.Select(c => Leaf(c.Rel)), StringComparer.Ordinal);
+
+        // Dependency order: a chunk is linked only once every chunk it imports has its final name, so
+        // the rename it may itself trigger is already visible. The emitter guarantees the internal
+        // import graph is acyclic (a chunk is an SCC of the reference graph, and the condensation of
+        // an SCC graph is a DAG), so a depth-first walk terminates; the visited set guards a package
+        // built by some other tool anyway.
+        foreach (var chunk in InDependencyOrder(chunks))
+        {
+            var text = Link(chunk.Rel, chunk.Text, renamed);
+            var rel = chunk.Rel;
+            if (!string.Equals(text, chunk.Text, StringComparison.Ordinal))
+            {
+                var leaf = ChunkLeafName(text, used);
+                var dir = chunk.Rel.LastIndexOf('/');
+                rel = dir < 0 ? leaf : chunk.Rel.Substring(0, dir + 1) + leaf;
+                renamed[Leaf(chunk.Rel)] = leaf;
+            }
+            linked[chunk.Rel] = new ModuleFile(rel, text, IsChunk: true);
+        }
+
+        // The entry module last: it imports the eager chunks and names every deferred one in the
+        // manifest it registers, so it has to see the finished set of names.
+        foreach (var file in files)
+        {
+            if (file.IsChunk) continue;
+            linked[file.Rel] = file with { Text = Link(file.Rel, file.Text, renamed) };
+        }
+
+        // First wins, matching the order the site places these assemblies in: two assemblies claiming
+        // one emitted type name is a collision the compiler cannot resolve, and the dependency-order
+        // reference is the one whose JavaScript loads first.
+        if (ownTypeToChunk is not null)
+            foreach (var (type, chunkRel) in ownTypeToChunk)
+                _typeToChunk.TryAdd(type, linked.TryGetValue(chunkRel, out var f) ? f.Rel : chunkRel);
+
+        return files.Select(f => linked[f.Rel]).ToList();
+    }
+
+    /// <summary>The linked form of one module file: placeholders resolved against everything linked so
+    /// far, then every reference to a chunk this assembly renamed updated — in the import block and in
+    /// the <c>Transpose.Modules.register</c> manifest alike, since both name chunk files.</summary>
+    private string Link(string rel, string js, IReadOnlyDictionary<string, string> renamed)
+    {
+        var linked = ModuleSpecifier.RewriteLeadingImports(js, spec =>
+        {
+            var type = ModuleSpecifier.TypeOf(spec);
+            // Not a placeholder: an import of a sibling chunk, or a real path an older package wrote
+            // before placeholders existed. Either way it is already correct; renames are applied below.
+            if (type is null) return spec;
+            // Nothing in this site defines the type. That is the ordinary outcome for a library the
+            // site took as a single bundle — its code is already on the page and there is nothing to
+            // import — so the placeholder simply goes away.
+            return _typeToChunk.TryGetValue(type, out var file) ? ModuleSpecifier.Relative(rel, file) : null;
+        });
+
+        return renamed.Count == 0 ? linked : ApplyRenames(linked, renamed);
+    }
+
+    /// <summary>Rewrites every chunk file name this assembly renamed, wherever it appears. Done as one
+    /// pass over the text rather than a sequence of replacements, so a chunk renamed <em>to</em> a name
+    /// another chunk was renamed <em>from</em> cannot be rewritten twice.</summary>
+    private static string ApplyRenames(string js, IReadOnlyDictionary<string, string> renamed)
+        => System.Text.RegularExpressions.Regex.Replace(js, @"c[0-9a-f]{16}(?:-\d+)?\.mjs",
+            m => renamed.TryGetValue(m.Value, out var to) ? to : m.Value);
+
+    /// <summary>The chunks, ordered so that each comes after every chunk of this assembly it imports.</summary>
+    private static List<ModuleFile> InDependencyOrder(List<ModuleFile> chunks)
+    {
+        var byRel = chunks.ToDictionary(c => c.Rel, StringComparer.Ordinal);
+        var ordered = new List<ModuleFile>(chunks.Count);
+        var state = new Dictionary<string, int>(StringComparer.Ordinal);   // 1 = visiting, 2 = done
+
+        void Visit(ModuleFile chunk)
+        {
+            if (state.TryGetValue(chunk.Rel, out var s) && s != 0) return;
+            state[chunk.Rel] = 1;
+            foreach (var import in ModuleSpecifier.ReadLeading(chunk.Text))
+            {
+                if (ModuleSpecifier.Resolve(chunk.Rel, import.Specifier) is not { } target) continue;
+                if (byRel.TryGetValue(target, out var dep) && state.GetValueOrDefault(dep.Rel) == 0) Visit(dep);
+            }
+            state[chunk.Rel] = 2;
+            ordered.Add(chunk);
+        }
+
+        foreach (var chunk in chunks) Visit(chunk);
+        return ordered;
+    }
+
+    private static string Leaf(string rel)
+    {
+        var slash = rel.LastIndexOf('/');
+        return slash < 0 ? rel : rel.Substring(slash + 1);
+    }
+
+    /// <summary>The same content-addressed name the emitter gives a chunk (see
+    /// <c>Emitter.ChunkLeafName</c>): <c>c</c> plus the first 16 hex digits of the SHA-256 of the file.
+    /// A linked chunk is renamed with it so its URL still identifies its bytes.</summary>
+    private static string ChunkLeafName(string js, HashSet<string> used)
+    {
+        var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(js)).AsSpan(0, 8));
+        var name = "c" + hash + ".mjs";
+        for (var n = 2; !used.Add(name); n++) name = "c" + hash + "-" + n + ".mjs";
+        return name;
+    }
+}

--- a/Transpose/Transpose.Compiler.Core/ModuleMap.cs
+++ b/Transpose/Transpose.Compiler.Core/ModuleMap.cs
@@ -3,37 +3,28 @@ using System.Text.Json;
 namespace Transpose.Compiler;
 
 /// <summary>
-/// Reads the chunk maps that module-mode packages publish (<c>Transpose.Modules.json</c>, embedded
-/// by <see cref="ResourceEmbedder"/>) and merges them into the single lookup the translator needs:
-/// emitted type name → site-relative chunk file.
+/// Reads what a module-mode package publishes for the next compiler: its chunk map
+/// (<c>Transpose.Modules.json</c> — emitted type name → the site-relative chunk file that defines it)
+/// and its <c>[SkipTypeClustering]</c> member dependency sets, both embedded by
+/// <see cref="ResourceEmbedder"/>.
 ///
-/// A consuming build uses it to turn a reference to a library type into an <c>import</c> of the
-/// chunk that defines it. Without that the reference would resolve to the library's stub, and a stub
-/// cannot be resolved synchronously — which is exactly the failure the module runtime is designed to
-/// report loudly rather than paper over.
+/// The chunk map is what a site build resolves a package's type placeholders through
+/// (<see cref="ModuleLinker"/>): a reference into a library has to become an <c>import</c> of the
+/// chunk defining that type, or it would resolve to the library's stub — and a stub cannot be
+/// resolved synchronously, which is exactly the failure the module runtime reports loudly rather
+/// than papers over.
 /// </summary>
 internal static class ModuleMap
 {
-    /// <summary>Merges the chunk maps of every reference that has one. A later reference never
-    /// overwrites an earlier entry: two assemblies claiming the same type name would be a name
-    /// collision the compiler cannot resolve, and the first (dependency-order) reference wins,
-    /// matching how the site build orders their JavaScript.</summary>
-    public static Dictionary<string, string> Read(IEnumerable<string> referencePaths)
+    /// <summary>One assembly's published chunk map — emitted type name → the site-relative chunk file
+    /// that defines it — or null when it was not built as modules. This is the mapping a consuming
+    /// build resolves a package's type placeholders through (see <see cref="ModuleLinker"/>).</summary>
+    public static Dictionary<string, string>? ReadOne(string referencePath)
     {
-        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var dll in referencePaths)
-        {
-            var json = TryReadResource(dll, ResourceEmbedder.ModuleMapName);
-            if (json is null) continue;
-            try
-            {
-                var map = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                if (map is null) continue;
-                foreach (var kv in map) merged.TryAdd(kv.Key, kv.Value);
-            }
-            catch (JsonException) { /* a malformed map is not worth failing a build over */ }
-        }
-        return merged;
+        var json = TryReadResource(referencePath, ResourceEmbedder.ModuleMapName);
+        if (json is null) return null;
+        try { return JsonSerializer.Deserialize<Dictionary<string, string>>(json); }
+        catch (JsonException) { return null; }   // a malformed map is not worth failing a build over
     }
 
     /// <summary>The <c>[SkipTypeClustering]</c> member dependency sets of every reference that

--- a/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
+++ b/Transpose/Transpose.Compiler.Core/MsBuildDiagnostic.cs
@@ -63,6 +63,7 @@ internal static class MsBuildDiagnostic
     public const string CodeWatchServerFailed       = "TPS0104";
     public const string CodeTypeSizesJsonNotWritten = "TPS0105";
     public const string CodeDontLoadReferenceUnmatched = "TPS0106";
+    public const string CodeDanglingModuleImport    = "TPS0107";
 
     /// <summary>Formats a Roslyn diagnostic, pointing at its source location when it has one.</summary>
     public static string Format(Diagnostic d)

--- a/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
+++ b/Transpose/Transpose.Compiler.Core/OutputBuilder.cs
@@ -97,12 +97,19 @@ internal static class OutputBuilder
     /// kept out of index.html (extracted, but not scripted), and <see cref="UnmatchedDontLoadReferences"/>
     /// the entries of that list which matched no reference at all — a typo or a dependency that has
     /// since been dropped, which would otherwise do nothing silently. Both are reported by the caller;
-    /// the site build itself writes no diagnostics.</summary>
+    /// the site build itself writes no diagnostics.
+    ///
+    /// <see cref="DanglingModuleImports"/> names every <c>import</c> in a module the site wrote whose
+    /// target is not in the site — a 404 at run time, on whichever screen first needs the chunk. A
+    /// current package cannot produce one (its cross-assembly imports are type placeholders resolved
+    /// against this build), but a package built before that could, and the failure is otherwise
+    /// completely silent until someone clicks the wrong thing.</summary>
     public readonly record struct SiteBuildResult(
         string OutputDir,
         IReadOnlyList<string> RemovedStaleFiles,
         IReadOnlyList<string> UnscriptedReferences,
-        IReadOnlyList<string> UnmatchedDontLoadReferences);
+        IReadOnlyList<string> UnmatchedDontLoadReferences,
+        IReadOnlyList<string> DanglingModuleImports);
 
     /// <summary>
     /// One stylesheet a site build produces <em>from files on disk</em> — a <c>tps.json</c> resource
@@ -131,6 +138,14 @@ internal static class OutputBuilder
         // Whether this site is itself chunked. A package's module entry + chunks are only worth
         // extracting when they are — otherwise its classic bundle is the right payload.
         var siteIsChunked = modules is not null;
+        // Resolves the type placeholders every emitted module carries into imports of the chunks that
+        // define those types in THIS site. Fed one assembly at a time, in the dependency order the
+        // loop below already walks, and finally this project's own chunks — which import into the
+        // libraries linked before them. See ModuleLinker for why a package cannot write the paths.
+        var linker = new ModuleLinker();
+        // Every ES module this build writes, site-relative path → its JavaScript, so the imports can be
+        // checked against what actually landed once the site is complete (see DanglingModuleImports).
+        var modulesWritten = new List<(string rel, string js)>();
 
         var jsOuts = new List<JsOut>();    // JS in load order (runtime → libs → resources → app)
         var cssLinks = new List<string>();
@@ -179,9 +194,13 @@ internal static class OutputBuilder
         // keeps exactly one of those sets — the one its own profile calls for. A package that offers
         // no module variant falls back to its minified/formatted bundle even in a chunked site, which
         // is how a plain library (Transpose.Newtonsoft.Json, a vendored binding) keeps working.
-        void RouteTaggedPackageJs(IReadOnlyList<EmbeddedJs> jsFiles, bool scripted)
+        void RouteTaggedPackageJs(IReadOnlyList<EmbeddedJs> jsFiles, bool scripted, string? dllPath)
         {
             var takeModules = siteIsChunked && jsFiles.Any(f => f.Variant == JsVariant.ModuleEntry);
+            // Only a package whose modules this site actually takes is linked: one consumed as a
+            // single bundle contributes no chunk to import into, and registering its types would have
+            // another library's placeholders resolve to files that are not in the site.
+            if (takeModules && dllPath is not null) jsFiles = LinkPackageModules(jsFiles, dllPath);
 
             foreach (var f in jsFiles)
             {
@@ -199,6 +218,7 @@ internal static class OutputBuilder
                 }
 
                 WriteText(f.Rel, f.Text);
+                if (f.Variant is JsVariant.ModuleChunk or JsVariant.ModuleEntry) modulesWritten.Add((f.Rel, f.Text));
                 if (!f.Load || !scripted) continue;
                 jsOuts.Add(new JsOut
                 {
@@ -210,6 +230,21 @@ internal static class OutputBuilder
                     IsMinified = f.Variant == JsVariant.Minified,
                 });
             }
+        }
+
+        // Hands a package's module entry and chunks to the linker and takes back their final names and
+        // text. Everything else the package ships passes through untouched.
+        IReadOnlyList<EmbeddedJs> LinkPackageModules(IReadOnlyList<EmbeddedJs> jsFiles, string dllPath)
+        {
+            var modular = jsFiles.Where(f => f.Variant is JsVariant.ModuleChunk or JsVariant.ModuleEntry).ToList();
+            var linked = linker.LinkAssembly(
+                ModuleMap.ReadOne(dllPath),
+                modular.Select(f => new ModuleFile(f.Rel, f.Text, f.Variant == JsVariant.ModuleChunk)).ToList());
+
+            var byRel = new Dictionary<string, EmbeddedJs>(StringComparer.Ordinal);
+            for (var i = 0; i < modular.Count; i++)
+                byRel[modular[i].Rel] = modular[i] with { Rel = linked[i].Rel, Text = linked[i].Text };
+            return jsFiles.Select(f => byRel.TryGetValue(f.Rel, out var l) && f.Variant == l.Variant ? l : f).ToList();
         }
 
         // Routes a package's embedded JS into the output — the runtime bundles and compiled library
@@ -231,7 +266,7 @@ internal static class OutputBuilder
         // `scripted` is the consumer-side `dontLoadReferences` verdict for the assembly these files
         // came from: false writes every one of them into the site exactly as usual and injects none of
         // them into index.html, so the application can fetch the library itself when it first needs it.
-        void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles, bool scripted = true)
+        void RoutePackageJs(IReadOnlyList<EmbeddedJs> jsFiles, bool scripted = true, string? dllPath = null)
         {
             // A package says which of ITS OWN compiled files are interchangeable and what each one is
             // for, so those are chosen by a filter rather than a guess. Its authored resources carry no
@@ -241,7 +276,7 @@ internal static class OutputBuilder
             var tagged = jsFiles.Where(f => f.Variant is not null).ToList();
             if (tagged.Count > 0)
             {
-                RouteTaggedPackageJs(tagged, scripted);
+                RouteTaggedPackageJs(tagged, scripted, dllPath);
                 jsFiles = jsFiles.Where(f => f.Variant is null).ToList();
                 if (jsFiles.Count == 0) return;
             }
@@ -311,7 +346,7 @@ internal static class OutputBuilder
 
             RoutePackageJs(projectDlls.Contains(dll)
                 ? ExtractProjectDllResources(dll, outputDir, css, utf8, written)
-                : ExtractEmbeddedJs(dll, outputDir, css, written), scripted);
+                : ExtractEmbeddedJs(dll, outputDir, css, written), scripted, dll);
 
             if (string.Equals(Path.GetFileNameWithoutExtension(dll), "Transpose", StringComparison.OrdinalIgnoreCase))
                 EmitCompilerJs("tps.shim.js", RoslynTranslator.RuntimeShim);
@@ -352,16 +387,27 @@ internal static class OutputBuilder
         // site, so there is no build that wants to read one, and no .min sibling to switch to.
         if (modules is not null)
         {
-            foreach (var (rel, chunkJs) in modules.Chunks)
+            // This project's own modules are linked last, against every library already placed: its
+            // chunks are the ones that reach into them. The entry module (`javascript` here) is part
+            // of the same link — it imports the eager chunks and names the deferred ones — so it is
+            // handed in with them and taken back rewritten.
+            var own = new List<ModuleFile>(modules.Chunks.Count + 1);
+            foreach (var (rel, chunkJs) in modules.Chunks) own.Add(new ModuleFile(rel, chunkJs, IsChunk: true));
+            own.Add(new ModuleFile(config.FileName, javascript, IsChunk: false));
+
+            foreach (var file in linker.LinkAssembly(modules.TypeToChunk, own))
             {
-                var dest = Path.Combine(outputDir, rel.Replace('/', Path.DirectorySeparatorChar));
+                if (!file.IsChunk) { javascript = file.Text; continue; }   // the entry, written below
+                var dest = Path.Combine(outputDir, file.Rel.Replace('/', Path.DirectorySeparatorChar));
                 Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-                File.WriteAllText(dest, MinifyModule(chunkJs, rel), utf8);
+                File.WriteAllText(dest, MinifyModule(file.Text, file.Rel), utf8);
                 written.Add(Path.GetFullPath(dest));
+                modulesWritten.Add((file.Rel, file.Text));
             }
         }
 
         EmitCompilerJs(config.FileName, javascript, isModule: modules is not null);
+        if (modules is not null) modulesWritten.Add((config.FileName, javascript));
 
         // 3b. Reflection metadata as a separate file (reflection.target: "file") — loads right
         //     after the bundle whose types it describes, matching the existing compiler.
@@ -379,6 +425,24 @@ internal static class OutputBuilder
         //    from its own manifest — then persist the current file list as the next manifest. Files
         //    other projects/packages/tools placed in a shared output folder are never in this project's
         //    manifest, so they are never touched.
+        // 4b. Every import in every module written above has to name a file that is here. A current
+        //     package's cross-assembly imports are type placeholders resolved against this build, so it
+        //     cannot produce a dangling one; a package built before that wrote its dependency's chunk
+        //     FILE names, which stop existing the moment that dependency ships a new version. The
+        //     failure mode is a 404 on whichever screen first needs the chunk and nothing at build
+        //     time, so it is worth one line of check.
+        var dangling = new List<string>();
+        foreach (var (rel, js) in modulesWritten)
+            foreach (var import in ModuleSpecifier.ReadLeading(js))
+            {
+                if (dangling.Count >= 50) break;
+                var target = ModuleSpecifier.Resolve(rel, import.Specifier);
+                if (target is not null
+                    && written.Contains(Path.GetFullPath(Path.Combine(outputDir, target.Replace('/', Path.DirectorySeparatorChar)))))
+                    continue;
+                dangling.Add($"{rel} imports '{import.Specifier}', which this build did not write");
+            }
+
         var manifestPath = ManifestPath(outputDir, project.AssemblyName);
         var removed = config.CleanOutputFolder
             ? PruneStaleFiles(outputDir, written, ReadManifest(manifestPath, outputDir), config.CleanOutputFolderExclude)
@@ -386,7 +450,7 @@ internal static class OutputBuilder
 
         WriteManifest(manifestPath, outputDir, written, utf8);
 
-        return new SiteBuildResult(outputDir, removed, dontLoad.Matched, dontLoad.Unmatched);
+        return new SiteBuildResult(outputDir, removed, dontLoad.Matched, dontLoad.Unmatched, dangling);
     }
 
     /// <summary>

--- a/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
+++ b/Transpose/Transpose.Compiler.Core/ProjectBuild.cs
@@ -360,10 +360,12 @@ internal static class ProjectBuild
         var chunkOracle = wantsModules ? ChunkOracle.TryLoad(project.ProjectDir) : null;
         if (chunkOracle is { IsEmpty: false })
             log.Info($"  chunks:     {ChunkOracle.FileName} — {chunkOracle.Groups.Count} measured group(s)");
-        // Every referenced assembly that was itself built as modules contributes its type → chunk map.
-        var externalChunks = wantsModules ? ModuleMap.Read(project.ReferencePaths) : null;
-        // ...and, for a [SkipTypeClustering] facade in one of them, the per-member dependency sets a
-        // call site here has to turn into imports (the facade's own chunk carries none of them).
+        // A [SkipTypeClustering] facade in a referenced assembly publishes per-member dependency sets,
+        // which a call site here has to turn into imports (the facade's own chunk carries none of them).
+        //
+        // Its chunk FILE names are deliberately not read: a cross-assembly reference is emitted as a
+        // type placeholder and resolved when the site is assembled, so what this compilation emits does
+        // not depend on which build of a library happens to be installed. See ModuleLinker.
         var externalSkipDeps = wantsModules ? ModuleMap.ReadSkipClusterDeps(project.ReferencePaths) : null;
 
         var translator = new RoslynTranslator();
@@ -386,7 +388,6 @@ internal static class ProjectBuild
                 emitModules: wantsModules,
                 // Per assembly, so two module-mode assemblies in one site cannot collide.
                 chunkDirectory: "chunks/" + project.AssemblyName,
-                externalChunks: externalChunks,
                 externalSkipClusterDeps: externalSkipDeps,
                 // A library has no entry point to be lazy relative to: nothing is eager beyond its
                 // [Ready] handlers, and its consumers pull in what they actually use.
@@ -472,6 +473,12 @@ internal static class ProjectBuild
             foreach (var pattern in siteResult.UnmatchedDontLoadReferences)
                 MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeDontLoadReferenceUnmatched,
                     $"tps.json 'dontLoadReferences' entry '{pattern}' matched no referenced assembly.");
+            // An import naming a file the site does not have is a 404 on whichever screen first needs
+            // that chunk, and nothing says so at build time. The usual cause is a package built by a
+            // compiler that wrote its dependency's chunk file names instead of type placeholders, and
+            // whose dependency has since been updated — rebuilding that package fixes it.
+            foreach (var dangling in siteResult.DanglingModuleImports)
+                MsBuildDiagnostic.WriteWarning(MsBuildDiagnostic.CodeDanglingModuleImport, dangling + ".");
             if (siteResult.RemovedStaleFiles.Count > 0)
             {
                 var stale = siteResult.RemovedStaleFiles;
@@ -871,7 +878,6 @@ internal static class ProjectBuild
                 // a single bundle here, silently replacing the chunked DLL its own build produced.
                 emitModules: tpscfg is { OutputByModule: true },
                 chunkDirectory: "chunks/" + project.AssemblyName,
-                externalChunks: tpscfg is { OutputByModule: true } ? ModuleMap.Read(project.ReferencePaths) : null,
                 externalSkipClusterDeps: tpscfg is { OutputByModule: true } ? ModuleMap.ReadSkipClusterDeps(project.ReferencePaths) : null,
                 packageModules: true,
                 minChunkBytes: MinChunkBytes(options, tpscfg),

--- a/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleEmitTests.cs
@@ -26,7 +26,6 @@ namespace Transpose.Translator.Tests
         internal static Emitter.ModuleOutput Emit(
             string source,
             bool packageModules = false,
-            IReadOnlyDictionary<string, string>? externalChunks = null,
             string chunkDirectory = "chunks",
             int minChunkBytes = 0,
             int maxChunkBytes = 0,
@@ -36,7 +35,7 @@ namespace Transpose.Translator.Tests
                 new[] { ("App.cs", source) }, CompilationBuilder.DefaultAssemblyName,
                 extraReferencePaths: null, preprocessorSymbols: new[] { "DEBUG", "TRACE" },
                 emitAssembly: false, emitModules: true,
-                chunkDirectory: chunkDirectory, externalChunks: externalChunks, packageModules: packageModules,
+                chunkDirectory: chunkDirectory, packageModules: packageModules,
                 minChunkBytes: minChunkBytes, maxChunkBytes: maxChunkBytes, chunkOracle: chunkOracle);
             if (!result.Success)
                 Assert.Fail("translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));

--- a/Transpose/Transpose.Translator.Tests/ModuleLinkTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModuleLinkTests.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Transpose.Compiler;
+
+namespace Transpose.Translator.Tests;
+
+/// <summary>
+/// Cross-assembly module imports: a package names the <em>type</em> it needs, and the site build
+/// resolves that to the chunk defining it in the build of the library it is actually assembling.
+///
+/// <para>The bug this exists for: a chunk's file name is the hash of its own text, so every rebuild of
+/// a library renames the chunks whose JavaScript changed. When a package wrote its dependency's file
+/// names into its own chunks, updating that dependency alone — Tesserae under an unchanged
+/// Tesserae.GraphKit — left the package importing chunks that no longer existed. Nothing about the
+/// package had changed, so nothing rebuilt it and nothing warned; the application 404'd on the first
+/// screen that needed it.</para>
+/// </summary>
+[TestClass]
+public sealed class ModuleLinkTests
+{
+    private string _root = "";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "tps-modlink-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ------------------------------------------------------------------ the import block itself
+
+    [TestMethod]
+    public void TheLeadingImportBlockIsReadFromFormattedAndMinifiedText()
+    {
+        var formatted = "/** banner */\nimport './c1.mjs';\nimport 'tps-type:Lib.Widget';\nTranspose.define(\"A\", {});\n";
+        CollectionAssert.AreEqual(new[] { "./c1.mjs", "tps-type:Lib.Widget" },
+            ModuleSpecifier.ReadLeading(formatted).Select(i => i.Specifier).ToArray());
+
+        // A package embeds its chunks already minified, so the parser has to read that shape too.
+        var minified = "import\"./c1.mjs\";import\"tps-type:Lib.Widget\";Transpose.define(\"A\",{});";
+        CollectionAssert.AreEqual(new[] { "./c1.mjs", "tps-type:Lib.Widget" },
+            ModuleSpecifier.ReadLeading(minified).Select(i => i.Specifier).ToArray());
+    }
+
+    [TestMethod]
+    public void ReadingStopsAtTheFirstStatementThatIsNotAnImport()
+    {
+        // Anything after the import block is code, and a string in it must never be mistaken for a
+        // specifier — which is the whole reason only the LEADING block is read.
+        var js = "import './c1.mjs';\nvar s = \"import './evil.mjs';\";\n";
+        CollectionAssert.AreEqual(new[] { "./c1.mjs" },
+            ModuleSpecifier.ReadLeading(js).Select(i => i.Specifier).ToArray());
+    }
+
+    [TestMethod]
+    public void RewritingLeavesAFileThatChangesNothingByteIdentical()
+    {
+        // What lets a package built before placeholders existed — real paths already in it — pass
+        // through the linker untouched.
+        var js = "import './c1.mjs';\nTranspose.define(\"A\", {});\n";
+        Assert.AreEqual(js, ModuleSpecifier.RewriteLeadingImports(js, s => s));
+    }
+
+    [TestMethod]
+    public void RewritingDropsAnUnresolvedImportAndDeduplicatesTheRest()
+    {
+        var js = "import 'tps-type:A';\nimport 'tps-type:B';\nimport 'tps-type:C';\nTranspose.define(\"X\", {});\n";
+        var linked = ModuleSpecifier.RewriteLeadingImports(js, s => s switch
+        {
+            "tps-type:A" => "../lib/c1.mjs",
+            "tps-type:B" => "../lib/c1.mjs",     // two types, one chunk
+            _ => null,                            // nothing in the site defines C
+        });
+        Assert.AreEqual("import '../lib/c1.mjs';\nTranspose.define(\"X\", {});\n", linked);
+    }
+
+    // ------------------------------------------------------------------ what the emitter writes
+
+    [TestMethod]
+    public void APackageImportsALibraryTypeByNameNotByChunkFile()
+    {
+        var lib = BuildLibraryPackage("Widget", "public int N;");
+        var mid = EmitAgainst(lib.Dll, "public class Panel { public Lib.Widget W = new Lib.Widget(); }", packageModules: true);
+
+        var chunk = mid.Chunks.Single(c => c.js.Contains("Panel"));
+        StringAssert.Contains(chunk.js, "import 'tps-type:Lib.Widget';");
+        // The library's own chunk names appear nowhere: that is what makes the package independent of
+        // which build of the library it happened to compile against.
+        foreach (var (_, js) in mid.Chunks)
+            Assert.IsFalse(Regex.IsMatch(js, @"import\s*'\.\./Lib/"),
+                "a package must not write its dependency's chunk paths:\n" + js);
+    }
+
+    [TestMethod]
+    public void APackagesJavaScriptDoesNotChangeWhenOnlyTheLibraryIsRebuilt()
+    {
+        // The regression itself. Two builds of Lib whose chunk file names differ; the package compiled
+        // against each must come out byte-identical, so nothing about it goes stale when Lib ships.
+        var v1 = BuildLibraryPackage("Widget", "public int N;");
+        var v2 = BuildLibraryPackage("Widget", "public int N; public string S; public double D;");
+        CollectionAssert.AreNotEquivalent(
+            v1.Modules.Chunks.Select(c => c.relPath).ToList(),
+            v2.Modules.Chunks.Select(c => c.relPath).ToList(),
+            "the two library builds are supposed to differ in their chunk names");
+
+        const string source = "public class Panel { public Lib.Widget W = new Lib.Widget(); }";
+        var against1 = EmitAgainst(v1.Dll, source, packageModules: true);
+        var against2 = EmitAgainst(v2.Dll, source, packageModules: true);
+
+        CollectionAssert.AreEqual(
+            against1.Chunks.Select(c => c.relPath + "\n" + c.js).ToList(),
+            against2.Chunks.Select(c => c.relPath + "\n" + c.js).ToList());
+        Assert.AreEqual(against1.EntryJs, against2.EntryJs);
+    }
+
+    // ------------------------------------------------------------------ what the site build resolves
+
+    [TestMethod]
+    public void TheSiteResolvesAPlaceholderToTheChunkThatDefinesTheTypeNow()
+    {
+        var lib = BuildLibraryPackage("Widget", "public int N;");
+        var mid = BuildConsumerPackage("Mid", lib.Dll, "public class Panel { public Lib.Widget W = new Lib.Widget(); }");
+
+        var site = BuildSite(new[] { lib.Dll, mid.Dll });
+
+        var widgetChunk = lib.Modules.TypeToChunk["Lib.Widget"];
+        Assert.IsTrue(File.Exists(Path.Combine(site, widgetChunk.Replace('/', Path.DirectorySeparatorChar))));
+
+        var panel = FindChunkDefining(site, "Mid.Panel");
+        StringAssert.Contains(File.ReadAllText(panel.path),
+            ModuleSpecifier.Relative(panel.rel, widgetChunk),
+            "the package's placeholder should have become an import of the library chunk in this site");
+        Assert.IsFalse(File.ReadAllText(panel.path).Contains(ModuleSpecifier.TypePrefix),
+            "no placeholder may survive into the site");
+    }
+
+    [TestMethod]
+    public void APackageBuiltAgainstAnOlderLibraryStillLinksAgainstTheNewOne()
+    {
+        // The scenario reported: Mid is compiled against Lib v1 and never rebuilt; the site is then
+        // assembled with Lib v2, whose chunks have different names.
+        var v1 = BuildLibraryPackage("Widget", "public int N;");
+        var mid = BuildConsumerPackage("Mid", v1.Dll, "public class Panel { public Lib.Widget W = new Lib.Widget(); }");
+        var v2 = BuildLibraryPackage("Widget", "public int N; public string S; public double D;");
+
+        var site = BuildSite(new[] { v2.Dll, mid.Dll });
+
+        // Every import in every module the site wrote points at a file that is actually there. Before
+        // the placeholder indirection this is precisely what failed: Mid's chunk still named a v1 file.
+        AssertEveryImportResolves(site);
+
+        var panel = FindChunkDefining(site, "Mid.Panel");
+        StringAssert.Contains(File.ReadAllText(panel.path),
+            ModuleSpecifier.Relative(panel.rel, v2.Modules.TypeToChunk["Lib.Widget"]));
+    }
+
+    [TestMethod]
+    public void AnApplicationsOwnChunksImportIntoBothLibraries()
+    {
+        var lib = BuildLibraryPackage("Widget", "public int N;");
+        var mid = BuildConsumerPackage("Mid", lib.Dll, "public class Panel { public Lib.Widget W = new Lib.Widget(); }");
+
+        var app = EmitAgainst(new[] { lib.Dll, mid.Dll },
+            "public class Screen { public Mid.Panel P = new Mid.Panel(); }\n" +
+            "public class Program { public static void Main() { System.Console.WriteLine(new Screen()); } }",
+            packageModules: false);
+
+        var site = BuildSite(new[] { lib.Dll, mid.Dll }, app);
+        AssertEveryImportResolves(site);
+
+        var screen = FindChunkDefining(site, "Screen");
+        StringAssert.Contains(File.ReadAllText(screen.path),
+            ModuleSpecifier.Relative(screen.rel, FindChunkDefining(site, "Mid.Panel").rel));
+    }
+
+    [TestMethod]
+    public void RenamingALinkedChunkFollowsThroughToItsImportersAndTheManifest()
+    {
+        // Resolving a placeholder changes a chunk's text, so it is renamed to the hash of what it now
+        // contains — otherwise one URL would serve different bytes in two deployments and a browser
+        // holding the first would import a chunk that is gone. The rename has to reach the chunks that
+        // import it and the entry module's Transpose.Modules manifest, or the site breaks at load.
+        var lib = BuildLibraryPackage("Widget", "public int N;");
+        var mid = BuildConsumerPackage("Mid", lib.Dll,
+            "public class Panel { public Lib.Widget W = new Lib.Widget(); }\n" +
+            "public class Board { public Panel P = new Panel(); }");
+
+        var site = BuildSite(new[] { lib.Dll, mid.Dll });
+
+        var panel = FindChunkDefining(site, "Mid.Panel");
+        Assert.AreNotEqual(mid.Modules.TypeToChunk["Mid.Panel"], panel.rel,
+            "a chunk whose text the link changed must be renamed to match its new contents");
+
+        AssertEveryImportResolves(site);
+        // The manifest the entry registers names chunk files too, and it is read at run time.
+        foreach (Match m in Regex.Matches(File.ReadAllText(Path.Combine(site, "Mid.js")), @"m:\s*""\./([^""]+)"""))
+            Assert.IsTrue(File.Exists(Path.Combine(site, m.Groups[1].Value.Replace('/', Path.DirectorySeparatorChar))),
+                "the entry module registers " + m.Groups[1].Value + ", which is not in the site");
+    }
+
+    [TestMethod]
+    public void APlaceholderNothingInTheSiteDefinesIsDropped()
+    {
+        // A library the site took as a single bundle has no chunk to import — its code is already on
+        // the page — so the placeholder simply goes away rather than becoming a dangling import.
+        var linker = new ModuleLinker();
+        var linked = linker.LinkAssembly(
+            new Dictionary<string, string> { ["Mid.Panel"] = "chunks/Mid/c0.mjs" },
+            new[]
+            {
+                new ModuleFile("chunks/Mid/c0.mjs", "import 'tps-type:Lib.Widget';\nTranspose.define(\"Mid.Panel\", {});\n", IsChunk: true),
+            });
+
+        Assert.AreEqual("Transpose.define(\"Mid.Panel\", {});\n", linked[0].Text);
+    }
+
+    [TestMethod]
+    public void AnImportNamingAFileTheSiteDoesNotHaveIsReported()
+    {
+        // What a package built by a compiler that wrote chunk FILE names leaves behind once its
+        // dependency ships a new version. Nothing can repair it here — the file name says nothing
+        // about which type was wanted — but the build should not stay silent about a guaranteed 404.
+        var utf8 = new UTF8Encoding(false);
+        var stale = PackageDll("Stale", new[]
+        {
+            new EmbeddedItem("c0.mjs", utf8.GetBytes("import '../Gone/c9c9c9c9c9c9c9c9.mjs';\nTranspose.define(\"Stale.X\", {});\n"),
+                             "chunks/Stale", Load: false, Variant: JsVariant.ModuleChunk),
+            new EmbeddedItem("Stale.mjs", utf8.GetBytes("Transpose.Modules.register({});\n"), null,
+                             Load: true, Module: true, Variant: JsVariant.ModuleEntry, SiteName: "Stale.js"),
+        }, new Dictionary<string, string> { ["Stale.X"] = "chunks/Stale/c0.mjs" });
+
+        BuildSite(new[] { stale }, out var result);
+
+        Assert.AreEqual(1, result.DanglingModuleImports.Count,
+            "expected exactly one report, got: " + string.Join("; ", result.DanglingModuleImports));
+        StringAssert.Contains(result.DanglingModuleImports[0], "../Gone/c9c9c9c9c9c9c9c9.mjs");
+    }
+
+    // ---------------------------------------------------------------------------------- helpers
+
+    private sealed record Package(string Dll, Emitter.ModuleOutput Modules);
+
+    private static Emitter.ModuleOutput EmitAgainst(string reference, string source, bool packageModules)
+        => EmitAgainst(new[] { reference }, source, packageModules);
+
+    private static Emitter.ModuleOutput EmitAgainst(IReadOnlyList<string>? references, string source, bool packageModules)
+        => Build("App", references, source, packageModules).Modules!;
+
+    private static AssemblyBuildResult Build(string assemblyName, IReadOnlyList<string>? references, string source, bool packageModules)
+    {
+        var result = new RoslynTranslator().BuildAssembly(
+            new[] { (assemblyName + ".cs", source) }, assemblyName, references,
+            preprocessorSymbols: new[] { "DEBUG", "TRACE" },
+            emitAssembly: true, emitModules: true,
+            chunkDirectory: "chunks/" + assemblyName,
+            packageModules: packageModules,
+            minChunkBytes: 0, maxChunkBytes: 0,
+            alsoEmitBundle: packageModules);
+        if (!result.Success)
+            Assert.Fail("translation failed:\n" + string.Join("\n", result.Errors.Select(d => d.GetMessage())));
+        return result;
+    }
+
+    /// <summary>A module-mode package on disk, exactly as <c>tps --emit-package</c> writes one: every
+    /// variant of its compiled JavaScript embedded and tagged, plus its published chunk map.</summary>
+    private Package BuildLibraryPackage(string typeName, string members)
+        => Pack("Lib", null, $"namespace Lib {{ public class {typeName} {{ {members} }} }}");
+
+    private Package BuildConsumerPackage(string assemblyName, string reference, string source)
+        => Pack(assemblyName, new[] { reference }, "namespace " + assemblyName + " {\n" + source + "\n}");
+
+    /// <summary>A package DLL assembled by hand, for a shape the current compiler no longer emits.</summary>
+    private string PackageDll(string assemblyName, IReadOnlyList<EmbeddedItem> items, IReadOnlyDictionary<string, string> moduleMap)
+    {
+        var result = Build(assemblyName, null, $"namespace {assemblyName} {{ public class X {{ }} }}", packageModules: true);
+        var dir = Path.Combine(_root, assemblyName);
+        Directory.CreateDirectory(dir);
+        var dll = Path.Combine(dir, assemblyName + ".dll");
+        ResourceEmbedder.Embed(dll, result.AssemblyBytes!, items, referencePaths: null, moduleMap: moduleMap);
+        return dll;
+    }
+
+    private Package Pack(string assemblyName, IReadOnlyList<string>? references, string source)
+    {
+        var result = Build(assemblyName, references, source, packageModules: true);
+        var dir = Path.Combine(_root, assemblyName + "-" + Guid.NewGuid().ToString("N").Substring(0, 6));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "tps.json"), $@"{{ ""fileName"": ""{assemblyName}.js"", ""outputBy"": ""Module"" }}");
+        var config = TransposeJson.TryLoad(dir, "Release")!;
+
+        var items = OutputBuilder.CollectEmbeddableItems(
+            dir, config, assemblyName + ".js", result.Javascript!, result.MetadataJavascript,
+            minifyLocalVariables: false, modules: result.Modules);
+
+        var dll = Path.Combine(dir, assemblyName + ".dll");
+        ResourceEmbedder.Embed(dll, result.AssemblyBytes!, items, referencePaths: references,
+                               moduleMap: result.Modules!.TypeToChunk, skipClusterMap: result.Modules.SkipClusterDeps);
+        return new Package(dll, result.Modules);
+    }
+
+    private string BuildSite(IReadOnlyList<string> references, Emitter.ModuleOutput? app = null)
+        => BuildSite(references, out _, app);
+
+    /// <summary>Assembles a Release site — the only shape that takes a package's module variant.</summary>
+    private string BuildSite(IReadOnlyList<string> references, out OutputBuilder.SiteBuildResult result, Emitter.ModuleOutput? app = null)
+    {
+        app ??= EmitAgainst(references, "public class Program { public static void Main() { } }", packageModules: false);
+
+        var appDir = Path.Combine(_root, "app");
+        var outDir = Path.Combine(_root, "site-" + Guid.NewGuid().ToString("N").Substring(0, 6));
+        Directory.CreateDirectory(appDir);
+        File.WriteAllText(Path.Combine(appDir, "tps.json"), @"{ ""fileName"": ""app.js"", ""outputBy"": ""Module"" }");
+        var config = TransposeJson.TryLoad(appDir, "Release")!;
+
+        var project = new ResolvedProject
+        {
+            CsprojPath = Path.Combine(appDir, "App.csproj"),
+            ProjectDir = appDir,
+            AssemblyName = "App",
+            TargetFramework = "netstandard2.0",
+            Sources = new List<(string, string)>(),
+            ReferencePaths = references.ToList(),
+            DefineConstants = new List<string>(),
+            LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest,
+            ProjectDirs = new List<string> { appDir },
+        };
+
+        result = OutputBuilder.Build(project, config, app.EntryJs, outDir, "Release", modules: app);
+        return outDir;
+    }
+
+    /// <summary>The site file whose JavaScript defines a type, and its site-relative path.</summary>
+    private static (string path, string rel) FindChunkDefining(string site, string defineName)
+    {
+        var define = new Regex(@"Transpose\.definei?\(""" + Regex.Escape(defineName) + @"""");
+        foreach (var path in Directory.EnumerateFiles(site, "*.mjs", SearchOption.AllDirectories))
+            if (define.IsMatch(File.ReadAllText(path)))
+                return (path, Path.GetRelativePath(site, path).Replace(Path.DirectorySeparatorChar, '/'));
+        Assert.Fail("no chunk in the site defines " + defineName);
+        return default;
+    }
+
+    /// <summary>Every <c>import</c> in every module the site wrote points at a file that exists.</summary>
+    private static void AssertEveryImportResolves(string site)
+    {
+        var checkedAny = false;
+        foreach (var path in Directory.EnumerateFiles(site, "*.*", SearchOption.AllDirectories))
+        {
+            if (!path.EndsWith(".mjs", StringComparison.Ordinal) && !path.EndsWith(".js", StringComparison.Ordinal)) continue;
+            var rel = Path.GetRelativePath(site, path).Replace(Path.DirectorySeparatorChar, '/');
+            foreach (var import in ModuleSpecifier.ReadLeading(File.ReadAllText(path)))
+            {
+                checkedAny = true;
+                var target = ModuleSpecifier.Resolve(rel, import.Specifier);
+                Assert.IsNotNull(target, rel + " imports '" + import.Specifier + "', which is not a path");
+                Assert.IsTrue(File.Exists(Path.Combine(site, target!.Replace('/', Path.DirectorySeparatorChar))),
+                              rel + " imports '" + import.Specifier + "', which is not in the site");
+            }
+        }
+        Assert.IsTrue(checkedAny, "the site has no module imports at all — the scenario did not build");
+    }
+}

--- a/Transpose/Transpose.Translator.Tests/ModulePackageTests.cs
+++ b/Transpose/Transpose.Translator.Tests/ModulePackageTests.cs
@@ -57,7 +57,7 @@ public sealed class ModulePackageTests
         var dll = LibraryPackage(out var map);
 
         // Read back exactly the way a consuming build does.
-        var read = ModuleMap.Read(new[] { dll });
+        var read = ModuleMap.ReadOne(dll)!;
         CollectionAssert.AreEquivalent(map.Keys.ToList(), read.Keys.ToList());
         foreach (var kv in map) Assert.AreEqual(kv.Value, read[kv.Key]);
     }
@@ -80,19 +80,21 @@ public sealed class ModulePackageTests
         // An ordinary single-bundle package: reading its (absent) map must be empty rather than
         // throwing, so a site can mix module-mode and single-bundle references.
         var plain = PackageDll("Plain", new List<EmbeddedItem> { new("Plain.js", System.Text.Encoding.UTF8.GetBytes("var p = 1;"), null) }, moduleMap: null);
-        Assert.AreEqual(0, ModuleMap.Read(new[] { plain }).Count);
+        Assert.IsNull(ModuleMap.ReadOne(plain));
     }
 
     [TestMethod]
     public void MapsFromSeveralReferencesMerge()
     {
-        var a = PackageDll("A", new List<EmbeddedItem>(), new Dictionary<string, string> { ["A.One"] = "chunks/A/c0.mjs" });
-        var b = PackageDll("B", new List<EmbeddedItem>(), new Dictionary<string, string> { ["B.Two"] = "chunks/B/c3.mjs" });
+        // The site build accumulates one lookup as it places each reference in dependency order, which
+        // is what lets a package's placeholder name a type from any of them.
+        var linker = new ModuleLinker();
+        linker.LinkAssembly(new Dictionary<string, string> { ["A.One"] = "chunks/A/c0.mjs" }, Array.Empty<ModuleFile>());
+        linker.LinkAssembly(new Dictionary<string, string> { ["B.Two"] = "chunks/B/c3.mjs" }, Array.Empty<ModuleFile>());
 
-        var merged = ModuleMap.Read(new[] { a, b });
-        Assert.AreEqual(2, merged.Count);
-        Assert.AreEqual("chunks/A/c0.mjs", merged["A.One"]);
-        Assert.AreEqual("chunks/B/c3.mjs", merged["B.Two"]);
+        Assert.AreEqual(2, linker.TypeToChunk.Count);
+        Assert.AreEqual("chunks/A/c0.mjs", linker.TypeToChunk["A.One"]);
+        Assert.AreEqual("chunks/B/c3.mjs", linker.TypeToChunk["B.Two"]);
     }
 
     // ---------------------------------------------------------------- helpers

--- a/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
+++ b/Transpose/Transpose.Translator/Compilation/RoslynTranslator.cs
@@ -87,7 +87,6 @@ public sealed class RoslynTranslator
         IncrementalPlan? incremental = null,
         bool emitModules = false,
         string chunkDirectory = "chunks",
-        IReadOnlyDictionary<string, string>? externalChunks = null,
         bool packageModules = false,
         IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
         int minChunkBytes = Emitter.DefaultMinChunkBytes,
@@ -237,7 +236,7 @@ public sealed class RoslynTranslator
                 // metadata script and the "javascript" of this build is the entry module.
                 CompileProgress.Report("emitting JavaScript modules");
                 moduleOutput = PhaseTimings.Measure("emit JavaScript (modules)",
-                    () => emitter.EmitModules(chunkDirectory, externalChunks, packageModules, externalSkipClusterDeps,
+                    () => emitter.EmitModules(chunkDirectory, packageModules, externalSkipClusterDeps,
                                               minChunkBytes, maxChunkBytes, chunkOracle));
                 js = moduleOutput.EntryJs;
             }

--- a/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
+++ b/Transpose/Transpose.Translator/Emit/Emitter.Modules.cs
@@ -59,8 +59,6 @@ public sealed partial class Emitter
     /// </summary>
     /// <param name="chunkDirectory">Site-relative folder the chunk files go in. Per assembly, so two
     /// module-mode assemblies in one site cannot collide.</param>
-    /// <param name="externalChunks">Define name → site-relative chunk file, merged from every
-    /// referenced assembly that was itself built as modules.</param>
     /// <param name="packageMode">A library: nothing is eager beyond what its own [Ready] handlers
     /// need, because there is no entry point to be lazy relative to — the consumer's chunks import
     /// what they use, and everything else stays a stub until something asks for it.</param>
@@ -73,7 +71,6 @@ public sealed partial class Emitter
     /// <see cref="ChunkOracle"/>.</param>
     public ModuleOutput EmitModules(
         string chunkDirectory = "chunks",
-        IReadOnlyDictionary<string, string>? externalChunks = null,
         bool packageMode = false,
         IReadOnlyDictionary<string, List<string>>? externalSkipClusterDeps = null,
         int minChunkBytes = DefaultMinChunkBytes,
@@ -103,12 +100,12 @@ public sealed partial class Emitter
                 Parallel.ForEach(types, type =>
                 {
                     var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-                    var ext = externalChunks is null ? null : new HashSet<string>(StringComparer.Ordinal);
+                    var ext = new HashSet<string>(StringComparer.Ordinal);
                     bodies[type] = EmitOnlyType(this, type, seen, ext).ToString();
                     TypeSizeReport.Record(_assemblyName, type.ToDisplayString(), bodies[type]);
                     seen.Remove(type);
                     refs[type] = ClusterRefsFor(type, seen);
-                    if (ext is not null) extRefs[type] = ext;
+                    extRefs[type] = ext;
                 }));
         }
         catch (AggregateException ex) when (ex.Flatten().InnerExceptions.OfType<TranslationException>().FirstOrDefault() is { } te)
@@ -240,19 +237,22 @@ public sealed partial class Emitter
             // two builds of the same sources produce byte-identical files.
             foreach (var d in chunks.Deps[i].OrderBy(x => x))
                 w.Append("import '").Append(ChunkImport(ChunkFile(d))).Append("';\n");
-            // Cross-assembly: a referenced module-mode assembly's chunk holding a type this one uses.
-            // Without it the reference would resolve to that assembly's stub, and a stub cannot be
+            // Cross-assembly: a type of a referenced assembly this chunk reaches into. Without an
+            // import the reference would resolve to that assembly's stub, and a stub cannot be
             // resolved synchronously.
-            if (externalChunks is not null)
-            {
-                var wanted = new SortedSet<string>(StringComparer.Ordinal);
-                foreach (var t in chunks.Members[i])
-                    if (extRefs.TryGetValue(t, out var names))
-                        foreach (var n in names)
-                            if (externalChunks.TryGetValue(n, out var file)) wanted.Add(file);
-                foreach (var file in wanted)
-                    w.Append("import '").Append(ChunkImport(file)).Append("';\n");
-            }
+            //
+            // It is written as a TYPE, not as the chunk file that holds the type today: a chunk's name
+            // is the hash of its own text, so it moves on every rebuild of the library, and a package
+            // that had written its dependency's file names in here would point at chunks that no
+            // longer exist the moment that dependency shipped a new version. The site build resolves
+            // each placeholder against the chunk map of the library it is actually assembling — see
+            // ModuleSpecifier and ModuleLinker.
+            var wanted = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var t in chunks.Members[i])
+                if (extRefs.TryGetValue(t, out var names))
+                    foreach (var n in names) wanted.Add(n);
+            foreach (var name in wanted)
+                w.Append("import '").Append(ModuleSpecifier.ForType(name)).Append("';\n");
             // A bare Transpose.define outside the Transpose.assembly(...) wrapper has no ambient
             // assembly, so each chunk names its own before defining anything.
             w.Append("Transpose.$useAssembly(\"").Append(_assemblyName).Append("\");\n");
@@ -272,7 +272,7 @@ public sealed partial class Emitter
 
         var result = new ModuleOutput
         {
-            EntryJs = BuildEntryModule(types, chunks, eager, lazyTypes, ChunkFile, externalChunks),
+            EntryJs = BuildEntryModule(types, chunks, eager, lazyTypes, ChunkFile),
             EagerChunkCount = eager.Count,
             LazyChunkCount = chunks.Members.Count - eager.Count,
             LazyTypeCount = lazyTypes.Count,
@@ -404,23 +404,22 @@ public sealed partial class Emitter
         return new ChunkGraph(components, deps, indexOf);
     }
 
-    /// <summary>The chunk files of the attribute classes the metadata records that come from a
-    /// referenced module-mode assembly, sorted so the entry module is byte-identical run to run.
-    /// Empty when reflection is off or no reference was built as modules.</summary>
-    private IEnumerable<string> ExternalMetadataAttributeChunks(
-        List<INamedTypeSymbol> types, IReadOnlyDictionary<string, string>? externalChunks)
+    /// <summary>The attribute classes the metadata records that come from a referenced assembly, as
+    /// type placeholders the site build turns into imports of the chunks that define them. Sorted, so
+    /// the entry module is byte-identical run to run; empty when reflection is off.</summary>
+    private IEnumerable<string> ExternalMetadataAttributeTypes(List<INamedTypeSymbol> types)
     {
-        if (!ReflectionEnabled || externalChunks is null) return Array.Empty<string>();
+        if (!ReflectionEnabled) return Array.Empty<string>();
 
         var mine = new HashSet<INamedTypeSymbol>(types, SymbolEqualityComparer.Default);
-        var files = new SortedSet<string>(StringComparer.Ordinal);
+        var names = new SortedSet<string>(StringComparer.Ordinal);
 
         void Collect(IEnumerable<AttributeData> attrs)
         {
             foreach (var a in ReflectableAttributes(attrs))
                 if (a.AttributeClass?.OriginalDefinition is INamedTypeSymbol ac && !mine.Contains(ac)
-                    && externalChunks.TryGetValue(DefineName(ac), out var file))
-                    files.Add(file);
+                    && TransposeNaming.IsTransposeCompiledSource(ac))
+                    names.Add(DefineName(ac));
         }
 
         foreach (var t in types)
@@ -428,7 +427,7 @@ public sealed partial class Emitter
             Collect(t.GetAttributes());
             foreach (var m in t.GetMembers()) Collect(m.GetAttributes());
         }
-        return files;
+        return names;
     }
 
     /// <summary>Every attribute class this compilation emits that the reflection metadata records —
@@ -459,8 +458,7 @@ public sealed partial class Emitter
     /// <em>every</em> type, and starts the runtime.</summary>
     private string BuildEntryModule(
         List<INamedTypeSymbol> types, ChunkGraph chunks, HashSet<int> eager,
-        List<INamedTypeSymbol> lazyTypes, Func<int, string> chunkFile,
-        IReadOnlyDictionary<string, string>? externalChunks)
+        List<INamedTypeSymbol> lazyTypes, Func<int, string> chunkFile)
     {
         var sb = new StringBuilder();
         sb.Append("/**\n * Transpose.Translator generated output (module entry).\n */\n");
@@ -469,8 +467,8 @@ public sealed partial class Emitter
         // An attribute class the metadata constructs can live in a referenced module-mode assembly,
         // where it is no more constructible from a stub than a local one is - and no chunk of this
         // assembly imports it, since the metadata takes no part in chunking.
-        foreach (var file in ExternalMetadataAttributeChunks(types, externalChunks))
-            sb.Append("import './").Append(file).Append("';\n");
+        foreach (var name in ExternalMetadataAttributeTypes(types))
+            sb.Append("import '").Append(ModuleSpecifier.ForType(name)).Append("';\n");
         sb.Append('\n');
 
         if (!string.IsNullOrEmpty(AssemblyVersion))
@@ -604,23 +602,9 @@ public sealed partial class Emitter
         return string.Join("\n", lines);
     }
 
-    /// <summary>
-    /// An ES module specifier from one site-relative file to another. Both may sit in different
-    /// per-assembly chunk folders (a consumer importing a library's chunk), so this walks up with
-    /// <c>../</c> as needed. Always explicitly relative — a bare name would be a bare specifier,
-    /// which the browser resolves through the import map rather than as a path.
-    /// </summary>
-    internal static string RelativeImport(string from, string to)
-    {
-        var fromParts = from.Split('/');
-        var toParts = to.Split('/');
-        var common = 0;
-        while (common < fromParts.Length - 1 && common < toParts.Length - 1
-               && string.Equals(fromParts[common], toParts[common], StringComparison.Ordinal)) common++;
-        var up = fromParts.Length - 1 - common;
-        var prefix = up == 0 ? "./" : string.Concat(Enumerable.Repeat("../", up));
-        return prefix + string.Join("/", toParts.Skip(common));
-    }
+    /// <summary>An ES module specifier from one site-relative file to another — see
+    /// <see cref="ModuleSpecifier.Relative"/>, which the site build's linker uses for the same job.</summary>
+    internal static string RelativeImport(string from, string to) => ModuleSpecifier.Relative(from, to);
 }
 
 internal static class ModuleOutputExtensions

--- a/Transpose/Transpose.Translator/Support/ModuleSpecifier.cs
+++ b/Transpose/Transpose.Translator/Support/ModuleSpecifier.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Transpose.Translator;
+
+/// <summary>
+/// The vocabulary of an emitted ES module's import block — shared by the emitter that writes one and
+/// the linker that finalises it when a site is assembled (<c>ModuleLinker</c> in Transpose.Compiler.Core).
+///
+/// <para>A chunk's imports come in two shapes. An import of a chunk of the <em>same</em> assembly is a
+/// real relative path, decided and final at emit time. A reference into <em>another</em> assembly is a
+/// <b>type placeholder</b> — <c>import "tps-type:tss.UI";</c> — naming the type rather than the file
+/// that happens to hold it today.</para>
+///
+/// <para>The placeholder exists because a chunk file name is the hash of its own text, so it moves
+/// whenever the library is rebuilt. A package that wrote its dependency's file names into its own
+/// chunks would go stale the moment that dependency shipped a new version — the imports would point at
+/// chunks that no longer exist — even though nothing about the package itself changed. Naming the type
+/// is version-independent: the site build knows which chunk of which build of the library defines it
+/// (every module-mode package publishes that map as <c>Transpose.Modules.json</c>) and rewrites the
+/// placeholder into a path on the way into the site.</para>
+/// </summary>
+public static class ModuleSpecifier
+{
+    /// <summary>Marks an import specifier as a reference to a TYPE in another assembly rather than a
+    /// path. Never reaches a browser: the site build rewrites every one of these into a relative path,
+    /// or drops it when nothing in the site defines the type (the library was consumed as a single
+    /// bundle, so its code is already there).</summary>
+    public const string TypePrefix = "tps-type:";
+
+    /// <summary>The placeholder specifier for a type, by its emitted define name — the same key a
+    /// package's chunk map is keyed by.</summary>
+    public static string ForType(string defineName) => TypePrefix + defineName;
+
+    /// <summary>The define name behind a placeholder specifier, or null when it is an ordinary path.</summary>
+    public static string? TypeOf(string specifier)
+        => specifier.StartsWith(TypePrefix, StringComparison.Ordinal) ? specifier.Substring(TypePrefix.Length) : null;
+
+    /// <summary>
+    /// An ES module specifier from one site-relative file to another. Both may sit in different
+    /// per-assembly chunk folders (a consumer importing a library's chunk), so this walks up with
+    /// <c>../</c> as needed. Always explicitly relative — a bare name would be a bare specifier,
+    /// which the browser resolves through the import map rather than as a path.
+    /// </summary>
+    public static string Relative(string from, string to)
+    {
+        var fromParts = from.Split('/');
+        var toParts = to.Split('/');
+        var common = 0;
+        while (common < fromParts.Length - 1 && common < toParts.Length - 1
+               && string.Equals(fromParts[common], toParts[common], StringComparison.Ordinal)) common++;
+        var up = fromParts.Length - 1 - common;
+        var prefix = up == 0 ? "./" : string.Concat(Enumerable.Repeat("../", up));
+        return prefix + string.Join("/", toParts.Skip(common));
+    }
+
+    /// <summary>The site-relative file a relative specifier written in <paramref name="from"/> points
+    /// at — the inverse of <see cref="Relative"/>. Returns null for a specifier that is not a path
+    /// (a placeholder, a bare specifier) or that climbs above the site root.</summary>
+    public static string? Resolve(string from, string specifier)
+    {
+        if (specifier.Length == 0 || specifier[0] != '.') return null;
+        var parts = new List<string>(from.Split('/'));
+        parts.RemoveAt(parts.Count - 1);                       // the importing file itself
+        foreach (var seg in specifier.Split('/'))
+        {
+            if (seg is "." or "") continue;
+            if (seg == "..")
+            {
+                if (parts.Count == 0) return null;
+                parts.RemoveAt(parts.Count - 1);
+                continue;
+            }
+            parts.Add(seg);
+        }
+        return string.Join("/", parts);
+    }
+
+    /// <summary>One side-effect <c>import</c> at the top of an emitted module, with the spans needed to
+    /// rewrite its specifier in place or to cut the whole statement out.</summary>
+    public readonly record struct Import(string Specifier, int Start, int End, int SpecifierStart, int SpecifierLength);
+
+    /// <summary>
+    /// The leading side-effect imports of an emitted module, in order.
+    ///
+    /// Deliberately reads only the <em>leading</em> block and stops at the first statement that is not
+    /// one: everything the emitter writes puts its imports first, and stopping there means no string
+    /// literal in the body can ever be mistaken for an import. Whitespace and comments (the entry
+    /// module opens with a banner) are skipped. Works on minified text as well as formatted, which
+    /// matters because a package's chunks are embedded already minified.
+    /// </summary>
+    public static List<Import> ReadLeading(string js)
+    {
+        var found = new List<Import>();
+        var i = 0;
+        while (true)
+        {
+            i = SkipTrivia(js, i);
+            if (i + 6 > js.Length || string.CompareOrdinal(js, i, "import", 0, 6) != 0) return found;
+
+            var start = i;
+            var j = SkipTrivia(js, i + 6);
+            if (j >= js.Length || (js[j] != '"' && js[j] != '\'')) return found;    // `import x from …` — not ours
+            var quote = js[j];
+            var specStart = j + 1;
+            var specEnd = js.IndexOf(quote, specStart);
+            if (specEnd < 0) return found;
+
+            var end = SkipTrivia(js, specEnd + 1);
+            if (end < js.Length && js[end] == ';') end++;
+
+            found.Add(new Import(js.Substring(specStart, specEnd - specStart), start, end, specStart, specEnd - specStart));
+            i = end;
+        }
+    }
+
+    private static int SkipTrivia(string js, int i)
+    {
+        while (i < js.Length)
+        {
+            if (char.IsWhiteSpace(js[i])) { i++; continue; }
+            if (js[i] == '/' && i + 1 < js.Length && js[i + 1] == '*')
+            {
+                var close = js.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                if (close < 0) return js.Length;
+                i = close + 2;
+                continue;
+            }
+            if (js[i] == '/' && i + 1 < js.Length && js[i + 1] == '/')
+            {
+                var nl = js.IndexOf('\n', i);
+                if (nl < 0) return js.Length;
+                i = nl + 1;
+                continue;
+            }
+            return i;
+        }
+        return i;
+    }
+
+    /// <summary>
+    /// Rewrites the leading import block: <paramref name="resolve"/> maps each specifier to the one it
+    /// should carry in the site, or to null for an import that has to go away entirely (nothing in the
+    /// site defines the type it names). A specifier that resolves to one already emitted is dropped as
+    /// a duplicate — several types of one library commonly land in one chunk.
+    ///
+    /// Every specifier that keeps its text leaves the file byte-identical, which is what lets an
+    /// unlinked module (an older package with real paths already in it) pass through untouched.
+    /// </summary>
+    public static string RewriteLeadingImports(string js, Func<string, string?> resolve)
+    {
+        var imports = ReadLeading(js);
+        if (imports.Count == 0) return js;
+
+        var sb = new StringBuilder(js.Length);
+        var emitted = new HashSet<string>(StringComparer.Ordinal);
+        var pos = 0;
+        foreach (var import in imports)
+        {
+            var to = resolve(import.Specifier);
+            if (to is not null && emitted.Add(to))
+            {
+                sb.Append(js, pos, import.SpecifierStart - pos).Append(to);
+                pos = import.SpecifierStart + import.SpecifierLength;
+                continue;
+            }
+            // Cut the statement, and the newline after it, so a formatted file does not grow a blank line.
+            sb.Append(js, pos, import.Start - pos);
+            pos = import.End;
+            if (pos < js.Length && js[pos] == '\r') pos++;
+            if (pos < js.Length && js[pos] == '\n') pos++;
+        }
+        sb.Append(js, pos, js.Length - pos);
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
A chunk file is named after the hash of its own text, so every rebuild of a
library renames the chunks whose JavaScript changed. A package that resolved a
cross-assembly reference at its own build time wrote those file names into its
own chunks — so shipping Tesserae 1.1 under an unchanged Tesserae.GraphKit left
GraphKit importing `../Tesserae/c0f13a9b….mjs`, a file that no longer existed.
Nothing about GraphKit had changed, so nothing rebuilt it and nothing warned;
the application 404'd on the first screen that needed the chunk.

A cross-assembly reference is now emitted as the TYPE it actually is —
`import 'tps-type:tss.UI';` — and resolved when the site is assembled, against
the build of the library actually being assembled.

- ModuleSpecifier (Transpose.Translator/Support) owns the vocabulary: the
  prefix, the relative-path arithmetic (moved off Emitter.RelativeImport), and
  a reader/rewriter for a module's LEADING import block. Reading only that
  block is what makes the rewrite safe — no string literal in a body can be
  mistaken for a specifier — and it works on minified text, since a package
  embeds its chunks already minified. A file that changes nothing comes back
  byte-identical, so a package built before this passes through untouched.
- ModuleLinker (Transpose.Compiler.Core), driven by OutputBuilder, resolves the
  placeholders one assembly at a time in the dependency order the site already
  places them in, reading each reference's published Transpose.Modules.json and
  finally this project's own chunks. A placeholder nothing in the site defines
  is dropped: that is the ordinary case for a library taken as a single bundle.
- Resolving renames. The text changed, so the chunk is renamed to the hash of
  what it now contains, or a chunk URL would stop identifying its bytes and the
  same staleness would come back through the HTTP cache. The rename cascades
  into the chunks that import it and into the entry module's
  Transpose.Modules.register manifest, which names chunk files too.
- The DLL always carries the placeholder form and the site the linked form, so
  a package stays a self-contained, version-independent artifact.
- The translator no longer reads its references' chunk maps at all
  (externalChunks is gone from EmitModules), which is the point: what a
  compilation emits no longer depends on which build of a library is installed.
- TPS0107 warns when any import in a module the site wrote names a file the
  build did not produce. Nothing current can produce one; a package built by an
  older compiler can, and that failure was otherwise silent.

ModuleLinkTests covers the import-block reader/rewriter, what the emitter
writes, and the reported scenario end to end: build Lib v1, build a package
against it, rebuild Lib with different chunk names, assemble a site, and assert
every import in every file it wrote points at a file that is there.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wvk4E83VtoV1sES5FfgU1h