### PR TITLE
Read a null document as the target's default

### DIFF
--- a/Packages/Transpose.System.Text.Json.Tests/ErrorHandlingTests.cs
+++ b/Packages/Transpose.System.Text.Json.Tests/ErrorHandlingTests.cs
@@ -51,6 +51,37 @@ public sealed class ErrorHandlingTests : JsonTestBase
                 Try("string",   () => JsonSerializer.Deserialize<T>("{\"Name\":null}").Name ?? "<null>");
         """));
 
+    /// <summary>
+    /// The one deliberate deviation: a null document reads back as the target's default instead of
+    /// raising <c>ArgumentNullException</c>. See the "Known divergences" table in the README — this
+    /// matches <c>Transpose.Newtonsoft.Json</c>, which every front-end moving onto this package was
+    /// written against. An empty or malformed document still throws (asserted by
+    /// <see cref="MalformedInput"/>), so only "no document at all" is affected.
+    /// </summary>
+    [TestMethod]
+    public async Task ANullDocumentReadsBackAsTheDefault() => await RunJs("""
+        using System;
+        using System.Text.Json;
+
+        public static class Program
+        {
+            static void Try(string label, Func<string> f)
+            {
+                try                           { Console.WriteLine(label + ": " + f()); }
+                catch (ArgumentNullException) { Console.WriteLine(label + ": ArgumentNullException"); }
+            }
+
+            public static void Main()
+            {
+                Try("string", () => JsonSerializer.Deserialize<string>((string)null) ?? "<null>");
+                Try("int",    () => JsonSerializer.Deserialize<int>((string)null).ToString());
+                Try("array",  () => JsonSerializer.Deserialize<int[]>((string)null) is null ? "<null>" : "not null");
+            }
+        }
+        """,
+        expected:     "string: <null>\nint: 0\narray: <null>",
+        nativePrints: "string: ArgumentNullException\nint: ArgumentNullException\narray: ArgumentNullException");
+
     [TestMethod]
     public async Task ATypeMismatchIsAnError() => await RunAndCompare(With("""
                 Try("string into int",  () => JsonSerializer.Deserialize<T>("{\"Count\":\"7\"}").Count.ToString());

--- a/Packages/Transpose.System.Text.Json.Tests/README.md
+++ b/Packages/Transpose.System.Text.Json.Tests/README.md
@@ -94,6 +94,7 @@ Each is asserted by the test named beside it, so this list stays true.
 | deserializing to `object` | a `JsonElement` | the raw parsed JavaScript value | `DeserializingToObjectReturnsTheRawParsedValue` |
 | an assembly-qualified `$type` | unrecognised discriminator | also matches the bare type name | `AnAssemblyQualifiedDiscriminatorStillMatchesTheBareName` |
 | an integer written `1.0` / `2e0` | rejected (the token carries a decimal point) | accepted (the value is integral) | `AnIntegralNumberWrittenWithADecimalPointIsAccepted` |
+| a **null** document | `ArgumentNullException` | the target's `default` | `ANullDocumentReadsBackAsTheDefault` |
 
 The first two are inherited from `Transpose.Newtonsoft.Json` on purpose: the Curiosity server's
 `Long`/`ULong`-from-string converters and its `JsonStringEnumConverter` are written against exactly
@@ -102,9 +103,19 @@ deliberately stays a JSON number, because the server has no decimal-from-string 
 
 The `1.0` row is the one nobody chose: System.Text.Json rejects it by reading the token's *text*, while a document here has already been through `JSON.parse`, which resolves `1.0` and `1` to the same JavaScript number. A value with a real fraction (`1.5`) is still rejected, as is one outside the target's range.
 
-The last one exists so a store written by Json.NET's `TypeNameHandling` (which wrote
+The `$type` one exists so a store written by Json.NET's `TypeNameHandling` (which wrote
 `"Some.Type, Some.Assembly"` into `$type`) keeps deserializing against a hierarchy that declares the
 bare type name as its discriminator.
+
+The **null document** is the one deviation adopted from `Transpose.Newtonsoft.Json` rather than from
+the Curiosity server. Note that *real* Json.NET throws `ArgumentNullException` here too — returning
+`default(T)` is a long-standing behaviour of the Transpose binding, not of Json.NET — but every
+Transpose front-end moving onto this package was written against it, because reading a slot that was
+never written (local storage, a cached response, an unset node field) is an ordinary thing to do and
+answering it with `default(T)` is what those call sites expect. Only "no document at all" is
+affected: an empty or whitespace-only string, and any malformed document, still throw exactly as
+System.Text.Json does — so a slot holding corrupt JSON is still reported rather than silently read
+as nothing.
 
 ## Declaring a hierarchy the attribute cannot reach
 

--- a/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
+++ b/Packages/Transpose.System.Text.Json/Resources/Manual/JsonSerializer.js
@@ -1035,6 +1035,16 @@
                 Deserialize: function (json, type, options) {
                     var o = System.Text.Json.JsonSerializer.opts(options);
 
+                    // A null document reads back as the target's default rather than throwing.
+                    // System.Text.Json raises ArgumentNullException, but Transpose.Newtonsoft.Json —
+                    // which every Transpose front-end reaching for this package is moving off — answers
+                    // default(T), and a caller reading a slot that was never written (local storage, a
+                    // cached response, an unset node field) relies on it. An empty or malformed document
+                    // still throws, so only "no document at all" is affected.
+                    if (json === null || json === undefined) {
+                        return Transpose.getDefaultValue(type);
+                    }
+
                     if (typeof json !== "string") {
                         System.Text.Json.JsonSerializer.fail("The input does not contain any JSON tokens.");
                     }


### PR DESCRIPTION
`JsonSerializer.Deserialize` answers `default(T)` for a null input instead of throwing.

## Why

`Transpose.Newtonsoft.Json` returns `default(T)` for a null document — its `DeserializeObject` reaches `if (raw === null) return def;` as the first arm of its value-dispatch chain. Every Transpose front-end moving onto this package was written against that, because reading a slot that was never written is an ordinary thing to do: local storage, a cached response, an unset node field.

This surfaced in the Curiosity front-end, where `UserStorage.Get<T>` and `LocalStorage.Get<T>` hand the raw slot straight to the deserializer. A key that has never been written is `null` (`undefined`, for `localStorage`), and both had relied on the default coming back.

## Worth being precise about what this deviates from

Real Json.NET throws `ArgumentNullException` here too — returning the default is a long-standing behaviour of the *Transpose binding*, not of Json.NET itself. Both real libraries throw, verified against them directly:

| input | real System.Text.Json | real Json.NET | Transpose.Newtonsoft.Json |
| --- | --- | --- | --- |
| `Deserialize<string>(null)` | `ArgumentNullException` | `ArgumentNullException` | returns `null` |
| `Deserialize<int>(null)` | `ArgumentNullException` | `ArgumentNullException` | returns `0` |

So this is a deliberate deviation adopted from the sibling package rather than from the framework, and it is recorded as one.

## Scope

Only "no document at all" is affected. An empty string, a whitespace-only string, and any malformed document still throw exactly as System.Text.Json does — so a slot holding corrupt JSON is still reported rather than silently read as nothing. `MalformedInput` already pins that and is unchanged.

## Changes

- `JsonSerializer.js` — the guard in `Deserialize`, ahead of the existing non-string and empty-document checks.
- `Transpose.System.Text.Json.Tests/README.md` — a row in the "Known divergences from System.Text.Json" table, plus a paragraph on why this one comes from `Transpose.Newtonsoft.Json` rather than from the Curiosity server, as the first two rows do.
- `ErrorHandlingTests.ANullDocumentReadsBackAsTheDefault` — records both sides: the JS returns the default, native .NET raises `ArgumentNullException`. The README says each divergence is pinned by the test named beside it, so the table stays true.

## Testing

`Transpose.System.Text.Json.Tests` — **166/166 pass** against current master.

## Note on what is *not* here

An earlier version of this branch also carried a numeric range/integrality fix for `readNumber`. Master has since landed an equivalent — `integer(...)`, with a stricter guard that also rejects a non-number — along with four tests covering it (`AnIntegerOutsideTheTargetsRangeThrows`, `AFractionalNumberIntoAnIntegerThrows`, `AnIntegralNumberWrittenWithADecimalPointIsAccepted`, `TheRangeBoundariesThemselvesAreAccepted`). This branch was rebased onto that and the duplicate dropped, so what remains is the null-document change alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7Etwmw4CCavzr2A94R8df

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7Etwmw4CCavzr2A94R8df)_